### PR TITLE
Update antrea/openvswitch base image periodically

### DIFF
--- a/.github/workflows/update_ovs_image.yml
+++ b/.github/workflows/update_ovs_image.yml
@@ -1,9 +1,9 @@
-name: Update the antrea/openvswitch image every 6 hours
+name: Update the antrea/openvswitch image every 12 hours
 
 on:
   schedule:
-    # every 6 hours
-    - cron: '0 */6 * * *'
+    # every 12 hours
+    - cron: '0 */12 * * *'
 
 jobs:
   build:
@@ -17,5 +17,7 @@ jobs:
         OVS_VERSION: 2.11.1
       run: |
         cd build/images/ovs/
+        docker pull antrea/openvswitch-debs:$OVS_VERSION || true
+        docker pull antrea/openvswitch:$OVS_VERSION || true
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         ./build_and_push.sh

--- a/.github/workflows/update_ovs_image.yml
+++ b/.github/workflows/update_ovs_image.yml
@@ -1,0 +1,21 @@
+name: Update the antrea/openvswitch image every 6 hours
+
+on:
+  schedule:
+    # every 6 hours
+    - cron: '0 */6 * * *'
+
+jobs:
+  build:
+    runs-on: [ubuntu-18.04]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build antrea/openvswitch Docker image and push to registry
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        OVS_VERSION: 2.11.1
+      run: |
+        cd build/images/ovs/
+        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        ./build_and_push.sh

--- a/build/images/ovs/Dockerfile
+++ b/build/images/ovs/Dockerfile
@@ -10,10 +10,12 @@ RUN apt-get update && \
 
 # Download OVS source code and build debs
 RUN wget -q -O - https://www.openvswitch.org/releases/openvswitch-$OVS_VERSION.tar.gz  | tar xz -C /tmp && \
+    rm -rf openvswitch-$OVS_VERSION.tar.gz && \
     cd /tmp/openvswitch* && DEB_BUILD_OPTIONS='parallel=8 nocheck' fakeroot debian/rules binary && \
     cd /tmp && mkdir ovs-debs && \
     mv libopenvswitch_*.deb openvswitch-common_*.deb openvswitch-switch_*.deb python-openvswitch_*.deb \
-       openvswitch-ipsec_*.deb ovs-debs/
+       openvswitch-ipsec_*.deb ovs-debs/ && \
+    cd / && rm -rf /tmp/openvswitch*
 
 
 FROM ubuntu:18.04

--- a/build/images/ovs/README.md
+++ b/build/images/ovs/README.md
@@ -6,15 +6,19 @@ of Antrea (such as IPSec) require a recent version of OVS, more recent than the
 version included in Ubuntu 18.04. The built image is then used as the base image
 for the Antrea main Docker image.
 
-The image is re-built and pushed to Dockerhub periodically (every 6 hours) by a
-[Github workflow](/.github/workflows/update_ovs_image.yml).
+The image is re-built and pushed to Dockerhub periodically (every 12 hours) by a
+[Github workflow](/.github/workflows/update_ovs_image.yml). Therefore, there
+should be no need to update the registry image manually. If it's needed for any
+reason, you can follow the instructions below.
 
 ## Manually building the image and pushing it to Dockerhub
 
 Choose the version of OVS you want to build by setting the `OVS_VERSION`
-environment variable. Then run the `build_and_push.sh` script. For example:
+environment variable. Then run the `build_and_push.sh` script included in this
+directory. For example:
 
 ```bash
+cd build/images/ovs
 OVS_VERSION=2.11.1 ./build_and_push.sh
 ```
 

--- a/build/images/ovs/README.md
+++ b/build/images/ovs/README.md
@@ -6,13 +6,16 @@ of Antrea (such as IPSec) require a recent version of OVS, more recent than the
 version included in Ubuntu 18.04. The built image is then used as the base image
 for the Antrea main Docker image.
 
-## Building the image and pushing it to Dockerhub
+The image is re-built and pushed to Dockerhub periodically (every 6 hours) by a
+[Github workflow](/.github/workflows/update_ovs_image.yml).
+
+## Manually building the image and pushing it to Dockerhub
 
 Choose the version of OVS you want to build by setting the `OVS_VERSION`
 environment variable. Then run the `build_and_push.sh` script. For example:
 
 ```bash
-OVS_VERSION=2.11.1 ./ovs/build_and_push.sh
+OVS_VERSION=2.11.1 ./build_and_push.sh
 ```
 
 The image will be pushed to Dockerhub as `antrea/openvswitch:$OVS_VERSION`.


### PR DESCRIPTION
Because this is the base image used for the Antrea image, it is good to
build and push it periodically so that Ubuntu security updates can be
picked up.