### PR TITLE
Avoid downloading go packages repeatedly when "make build"

### DIFF
--- a/build/images/Dockerfile.build.ubuntu
+++ b/build/images/Dockerfile.build.ubuntu
@@ -9,9 +9,13 @@ RUN mkdir -p /opt/cni/bin && \
 
 FROM golang:1.12 as antrea-build
 
-COPY . /antrea
-
 WORKDIR /antrea
+
+COPY go.mod /antrea/go.mod
+
+RUN go mod download
+
+COPY . /antrea
 
 RUN make bin
 


### PR DESCRIPTION
Optimize the binaries build steps in `Dockerfile.build.ubuntu`:
1. COPY go.mod
2. Download dependencies per go.mod
3. build binaries

If the go.mod file have no change. The step-1 and step-2 will not be
excuted and use docker layer cache instead. Thus we can skip downloading
go packages repeatedly if no dependencies change. The total build time
will be reduced.

Fixes #67