### PR TITLE
Get and populate ovs_version

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -121,7 +121,7 @@ func run(o *Options) error {
 
 	go networkPolicyController.Run(stopCh)
 
-	agentMonitor := monitor.NewAgentMonitor(crdClient, o.config.OVSBridge, nodeConfig.Name, nodeConfig.PodCIDR.String(), ifaceStore, ofClient)
+	agentMonitor := monitor.NewAgentMonitor(crdClient, o.config.OVSBridge, nodeConfig.Name, nodeConfig.PodCIDR.String(), ifaceStore, ofClient, ovsBridgeClient)
 
 	go agentMonitor.Run(stopCh)
 

--- a/pkg/monitor/querier.go
+++ b/pkg/monitor/querier.go
@@ -18,7 +18,8 @@ import (
 	"os"
 	"strconv"
 
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
+	"k8s.io/klog"
 )
 
 const (
@@ -57,6 +58,15 @@ func (monitor *agentMonitor) GetSelfNode() v1.ObjectReference {
 		return v1.ObjectReference{}
 	}
 	return v1.ObjectReference{Kind: "Node", Name: monitor.nodeName}
+}
+
+func (monitor *agentMonitor) GetOVSVersion() string {
+	version, err := monitor.ovsBridgeClient.GetOVSVersion()
+	if err != nil {
+		klog.Errorf("Failed to get OVS client version: %v", err)
+		return ""
+	}
+	return version
 }
 
 func (monitor *agentMonitor) GetOVSFlowTable() map[string]int32 {

--- a/pkg/ovs/ovsconfig/interfaces.go
+++ b/pkg/ovs/ovsconfig/interfaces.go
@@ -39,4 +39,5 @@ type OVSBridgeClient interface {
 	GetPortData(portUUID, ifName string) (*OVSPortData, Error)
 	GetPortList() ([]OVSPortData, Error)
 	SetInterfaceMTU(name string, MTU int) error
+	GetOVSVersion() (string, Error)
 }

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -586,3 +586,25 @@ func (br *OVSBridge) SetInterfaceMTU(name string, MTU int) error {
 
 	return nil
 }
+
+func (br *OVSBridge) GetOVSVersion() (string, Error) {
+	tx := br.ovsdb.Transaction(openvSwitchSchema)
+
+	tx.Select(dbtransaction.Select{
+		Table:   openvSwitchSchema,
+		Columns: []string{"ovs_version"},
+	})
+
+	res, err, temporary := tx.Commit()
+
+	if err != nil {
+		klog.Error("Transaction failed: ", err)
+		return "", NewTransactionError(err, temporary)
+	}
+	if len(res[0].Rows) == 0 {
+		klog.Warning("Could not find ovs_version")
+		return "", nil
+	}
+
+	return res[0].Rows[0].(map[string]interface{})["ovs_version"].(string), nil
+}

--- a/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
+++ b/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
@@ -194,6 +194,21 @@ func (mr *MockOVSBridgeClientMockRecorder) GetOFPort(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOFPort", reflect.TypeOf((*MockOVSBridgeClient)(nil).GetOFPort), arg0)
 }
 
+// GetOVSVersion mocks base method
+func (m *MockOVSBridgeClient) GetOVSVersion() (string, ovsconfig.Error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOVSVersion")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(ovsconfig.Error)
+	return ret0, ret1
+}
+
+// GetOVSVersion indicates an expected call of GetOVSVersion
+func (mr *MockOVSBridgeClientMockRecorder) GetOVSVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOVSVersion", reflect.TypeOf((*MockOVSBridgeClient)(nil).GetOVSVersion))
+}
+
 // GetPortData mocks base method
 func (m *MockOVSBridgeClient) GetPortData(arg0, arg1 string) (*ovsconfig.OVSPortData, ovsconfig.Error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Get ovs_version from OVSDB and populate monitoring CRD
AntreaAgentInfo field Version in OVSInfo during CRD creation.

Fixes #42 