### PR TITLE
Do not include dockerfiles in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,1 @@
-build/images/Dockerfile*
 .cache


### PR DESCRIPTION
Otherwise the `git status --porcelain` command we run in versioning.mk
will mark the version as "dirty" on the master branch. This means that
we need to make sure that all version-controlled files are always
included in the docker context. If that proves to be an issue, we can
come up with alternative solutions. In particular, it is inconvenient to
*not* be able to ignore the .git folder...