### PR TITLE
Implement cookie allocator to mark flow by cookie id

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -64,7 +64,7 @@ func run(o *Options) error {
 
 	ovsBridgeClient := ovsconfig.NewOVSBridge(o.config.OVSBridge, o.config.OVSDatapathType, ovsdbConnection)
 
-	ofClient := openflow.NewClient(o.config.OVSBridge)
+	ofClient := openflow.NewClient(ovsBridgeClient)
 
 	// Create an ifaceStore that caches network interfaces managed by this node.
 	ifaceStore := agent.NewInterfaceStore()

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -16,11 +16,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 	"io/ioutil"
 	"net"
 
 	"github.com/vmware-tanzu/antrea/pkg/cni"
+	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
@@ -76,7 +76,7 @@ func (o *Options) validate(args []string) error {
 	if err != nil {
 		return fmt.Errorf("service CIDR %s is invalid", o.config.ServiceCIDR)
 	}
-	if o.config.TunnelType != ovsconfig.VXLAN_TUNNEL && o.config.TunnelType != ovsconfig.GENEVE_TUNNEL {
+	if o.config.TunnelType != ovsconfig.VXLANTunnel && o.config.TunnelType != ovsconfig.GeneveTunnel {
 		return fmt.Errorf("tunnel type %s is invalid", o.config.TunnelType)
 	}
 	if o.config.OVSDatapathType != ovsconfig.OVSDatapathSystem && o.config.OVSDatapathType != ovsconfig.OVSDatapathNetdev {
@@ -113,7 +113,7 @@ func (o *Options) setDefaults() {
 		o.config.HostGateway = defaultHostGateway
 	}
 	if o.config.TunnelType == "" {
-		o.config.TunnelType = ovsconfig.VXLAN_TUNNEL
+		o.config.TunnelType = ovsconfig.VXLANTunnel
 	}
 	if o.config.HostProcPathPrefix == "" {
 		o.config.HostProcPathPrefix = defaultHostProcPathPrefix
@@ -122,9 +122,9 @@ func (o *Options) setDefaults() {
 		o.config.ServiceCIDR = defaultServiceCIDR
 	}
 	if o.config.DefaultMTU == 0 {
-		if o.config.TunnelType == ovsconfig.VXLAN_TUNNEL {
+		if o.config.TunnelType == ovsconfig.VXLANTunnel {
 			o.config.DefaultMTU = defaultMTUVxlan
-		} else if o.config.TunnelType == ovsconfig.GENEVE_TUNNEL {
+		} else if o.config.TunnelType == ovsconfig.GeneveTunnel {
 			o.config.DefaultMTU = defaultMTUGeneve
 		}
 	}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -315,9 +315,9 @@ func (i *Initializer) setupTunnelInterface(tunnelPortName string) error {
 	var err error
 	var tunnelPortUUID string
 	switch i.tunnelType {
-	case ovsconfig.GENEVE_TUNNEL:
+	case ovsconfig.GeneveTunnel:
 		tunnelPortUUID, err = i.ovsBridgeClient.CreateGenevePort(tunnelPortName, tunOFPort, "")
-	case ovsconfig.VXLAN_TUNNEL:
+	case ovsconfig.VXLANTunnel:
 		tunnelPortUUID, err = i.ovsBridgeClient.CreateVXLANPort(tunnelPortName, tunOFPort, "")
 	default:
 		err = fmt.Errorf("unsupported tunnel type %s", i.tunnelType)

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -25,7 +25,9 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	oftest "github.com/vmware-tanzu/antrea/pkg/agent/openflow/testing"
+	ovscfgtest "github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig/testing"
 )
 
 const bridgeName = "dummy-br"
@@ -70,8 +72,12 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
+			brClient := ovscfgtest.NewMockOVSBridgeClient(ctrl)
+			brClient.EXPECT().Name().Return(bridgeName).AnyTimes()
+			brClient.EXPECT().GetExternalIDs().Return(map[string]string{roundNumKey: "0"}, nil).AnyTimes()
+			brClient.EXPECT().SetExternalIDs(gomock.Any()).Return(nil).AnyTimes()
 			m := oftest.NewMockFlowOperations(ctrl)
-			ofClient := NewClient(bridgeName)
+			ofClient := NewClient(brClient)
 			client := ofClient.(*client)
 			client.flowOperations = m
 
@@ -105,8 +111,12 @@ func TestFlowInstallationPartialSuccess(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
+			brClient := ovscfgtest.NewMockOVSBridgeClient(ctrl)
+			brClient.EXPECT().Name().Return(bridgeName).AnyTimes()
+			brClient.EXPECT().GetExternalIDs().Return(map[string]string{roundNumKey: "0"}, nil).AnyTimes()
+			brClient.EXPECT().SetExternalIDs(gomock.Any()).Return(nil).AnyTimes()
 			m := oftest.NewMockFlowOperations(ctrl)
-			ofClient := NewClient(bridgeName)
+			ofClient := NewClient(brClient)
 			client := ofClient.(*client)
 			client.flowOperations = m
 
@@ -147,8 +157,12 @@ func TestConcurrentFlowInstallation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
+			brClient := ovscfgtest.NewMockOVSBridgeClient(ctrl)
+			brClient.EXPECT().Name().Return(bridgeName).AnyTimes()
+			brClient.EXPECT().GetExternalIDs().Return(map[string]string{roundNumKey: "0"}, nil).AnyTimes()
+			brClient.EXPECT().SetExternalIDs(gomock.Any()).Return(nil).AnyTimes()
 			m := oftest.NewMockFlowOperations(ctrl)
-			ofClient := NewClient(bridgeName)
+			ofClient := NewClient(brClient)
 			client := ofClient.(*client)
 			client.flowOperations = m
 

--- a/pkg/agent/openflow/cookie/allocator.go
+++ b/pkg/agent/openflow/cookie/allocator.go
@@ -1,0 +1,112 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cookie
+
+import (
+	"fmt"
+)
+
+const (
+	BitwidthRound    = 16
+	BitwidthCategory = 8
+	BitwidthReserved = 64 - BitwidthCategory - BitwidthRound
+)
+
+// Category represents the flow entry category.
+type Category uint64
+
+const (
+	Default Category = iota
+	Gateway
+	Node
+	Pod
+	Service
+	Policy
+)
+
+func (c Category) String() string {
+	switch c {
+	case Default:
+		return "Default"
+	case Gateway:
+		return "Gateway"
+	case Node:
+		return "Node"
+	case Pod:
+		return "Pod"
+	case Service:
+		return "Service"
+	case Policy:
+		return "Policy"
+	default:
+		return "Invalid"
+	}
+}
+
+// ID defines segments a cookie ID contains. An ID is composed like:
+//
+// |------------------------- ID --------------------------|
+//
+// |- round 16bits -|- category 8bits -|- reserved 40bits -|
+// The round segment represents the round id.
+// The category segment represents the category of flow this ID belongs.
+
+type ID uint64
+
+func newID(round uint64, cat Category) ID {
+	r := uint64(0)
+	r |= round << (64 - BitwidthRound)
+	r |= (uint64(cat) << (BitwidthReserved + BitwidthRound)) >> (BitwidthRound)
+	return ID(r)
+}
+
+func (i ID) Raw() uint64 {
+	return uint64(i)
+}
+
+func (i ID) Round() uint64 {
+	return uint64(i) >> (64 - BitwidthRound)
+}
+
+func (i ID) Category() Category {
+	return Category((uint64(i) << BitwidthRound) >> (64 - BitwidthCategory))
+}
+
+func (i ID) String() string {
+	return fmt.Sprintf("<round:%d,category:%s>", i.Round(), i.Category().String())
+}
+
+// Allocator defines operations of a cookie ID allocator.
+type Allocator interface {
+	// Request cookie IDs of flow categories.
+	Request(cat Category) ID
+}
+
+type allocator struct {
+	round uint64
+}
+
+func (a *allocator) Request(cat Category) ID {
+	return newID(a.round, cat)
+}
+
+// Mask returns a mask to match specific category of flows.
+func (a *allocator) Mask(cat Category) uint64 {
+	return newID(a.round, cat).Raw()
+}
+
+func NewAllocator(round uint64) Allocator {
+	return &allocator{round: round}
+}

--- a/pkg/agent/openflow/cookie/allocator_test.go
+++ b/pkg/agent/openflow/cookie/allocator_test.go
@@ -1,0 +1,75 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cookie
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var result ID // Ensures that the call to Request is not optimized-out by the compiler.
+
+func BenchmarkIDAllocate(b *testing.B) {
+	a := NewAllocator(0)
+	for i := 0; i < b.N; i++ {
+		result = a.Request(Default)
+	}
+}
+
+// TestConcurrentAllocate spawns multiple goroutines to ensure that the allocator is thread-safe.
+func TestConcurrentAllocate(t *testing.T) {
+	eachTotal := 10000
+	concurrentNum := 8
+
+	rand.Seed(time.Now().UnixNano())
+	round := rand.Uint64() >> (64 - BitwidthRound)
+	a := NewAllocator(round)
+
+	eachGoroutine := func() {
+		var seq []Category
+
+		for i := 0; i < eachTotal; i++ {
+			seq = append(seq, Pod, Node, Default)
+		}
+		rand.Shuffle(len(seq), func(a, b int) { seq[a], seq[b] = seq[b], seq[a] })
+
+		for i := 0; i < eachTotal/2; i++ {
+			id := a.Request(seq[i])
+			assert.Equal(t, round, id.Round(), id.String())
+			assert.Equal(t, seq[i].String(), id.Category().String(), id.String())
+		}
+
+		for i := 0; i < eachTotal; i++ {
+			id := a.Request(seq[i])
+			assert.Equal(t, round, id.Round(), id.String())
+			assert.Equal(t, seq[i].String(), id.Category().String(), id.String())
+		}
+
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < concurrentNum; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			eachGoroutine()
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/agent/openflow/cookie/doc.go
+++ b/pkg/agent/openflow/cookie/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cookie implements a cookie allocator.
+// The allocated cookies are used to classify flows in the vSwitch, which simplifies management of these flows.
+package cookie

--- a/pkg/ovs/openflow/cmd_builder_test.go
+++ b/pkg/ovs/openflow/cmd_builder_test.go
@@ -46,7 +46,7 @@ func TestBasic(t *testing.T) {
 			t.Fatalf("Flow <%s> adding failed, err: %s", flow.String(), err)
 		}
 	})
-	expectedCommand := "ovs-ofctl add-flow ut0 -OOpenflow13 table=0,priority=0,FIELD=VALUE,actions=resubmit(,10)"
+	expectedCommand := "ovs-ofctl add-flow ut0 -OOpenflow13 table=0,priority=0,cookie=0,FIELD=VALUE,actions=resubmit(,10)"
 	if executedCommand != expectedCommand {
 		t.Fatalf("Expected running <%s>, got <%s>", expectedCommand, executedCommand)
 	}

--- a/pkg/ovs/openflow/cmd_flow.go
+++ b/pkg/ovs/openflow/cmd_flow.go
@@ -23,8 +23,18 @@ type commandFlow struct {
 	table    Table
 	bridge   string
 	priority uint32
+	cookie   uint64
 	matchers []string
 	actions  []string
+}
+
+func (f *commandFlow) SetCookie(id uint64) Flow {
+	f.cookie = id
+	return f
+}
+
+func (f *commandFlow) Cookie() uint64 {
+	return f.cookie
 }
 
 func (f *commandFlow) GetTable() Table {
@@ -38,6 +48,7 @@ func (f *commandFlow) format(withActions bool) string {
 		repr += fmt.Sprintf(",priority=%d", f.priority)
 	}
 	if len(f.matchers) > 0 {
+		repr += fmt.Sprintf(",cookie=%d", f.cookie)
 		repr += fmt.Sprintf(",%s", strings.Join(f.matchers, ","))
 	}
 	if withActions && len(f.actions) > 0 {

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -105,6 +105,8 @@ type Flow interface {
 	Add() error
 	Modify() error
 	Delete() error
+	SetCookie(id uint64) Flow
+	Cookie() uint64
 	String() string
 	MatchString() string
 	GetTable() Table

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -263,6 +263,20 @@ func (mr *MockFlowMockRecorder) Add() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockFlow)(nil).Add))
 }
 
+// Cookie mocks base method
+func (m *MockFlow) Cookie() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Cookie")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// Cookie indicates an expected call of Cookie
+func (mr *MockFlowMockRecorder) Cookie() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cookie", reflect.TypeOf((*MockFlow)(nil).Cookie))
+}
+
 // CopyToBuilder mocks base method
 func (m *MockFlow) CopyToBuilder() openflow.FlowBuilder {
 	m.ctrl.T.Helper()
@@ -331,6 +345,20 @@ func (m *MockFlow) Modify() error {
 func (mr *MockFlowMockRecorder) Modify() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Modify", reflect.TypeOf((*MockFlow)(nil).Modify))
+}
+
+// SetCookie mocks base method
+func (m *MockFlow) SetCookie(arg0 uint64) openflow.Flow {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetCookie", arg0)
+	ret0, _ := ret[0].(openflow.Flow)
+	return ret0
+}
+
+// SetCookie indicates an expected call of SetCookie
+func (mr *MockFlowMockRecorder) SetCookie(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCookie", reflect.TypeOf((*MockFlow)(nil).SetCookie), arg0)
 }
 
 // String mocks base method

--- a/pkg/ovs/ovsconfig/interfaces.go
+++ b/pkg/ovs/ovsconfig/interfaces.go
@@ -15,8 +15,8 @@
 package ovsconfig
 
 const (
-	GENEVE_TUNNEL = "geneve"
-	VXLAN_TUNNEL  = "vxlan"
+	GeneveTunnel = "geneve"
+	VXLANTunnel  = "vxlan"
 
 	OVSDatapathSystem = "system"
 	OVSDatapathNetdev = "netdev"
@@ -25,6 +25,7 @@ const (
 //go:generate mockgen -copyright_file ../../../hack/boilerplate/license_header.raw.txt -destination testing/mock_ovsconfig.go -package=testing github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig OVSBridgeClient
 
 type OVSBridgeClient interface {
+	Name() string
 	Create() Error
 	Delete() Error
 	GetExternalIDs() (map[string]string, Error)

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -92,6 +92,11 @@ func NewOVSBridge(bridgeName string, ovsDatapathType string, ovsdb *ovsdb.OVSDB)
 	return &OVSBridge{ovsdb, bridgeName, ovsDatapathType, ""}
 }
 
+// Name returns the name of the OVSBridge.
+func (br *OVSBridge) Name() string {
+	return br.name
+}
+
 // Create looks up or creates the bridge. If the bridge with name bridgeName
 // does not exist, it will be created. Openflow protocol version 1.0 and 1.3
 // will be enabled for the bridge.

--- a/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
+++ b/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
@@ -239,6 +239,20 @@ func (mr *MockOVSBridgeClientMockRecorder) GetPortList() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPortList", reflect.TypeOf((*MockOVSBridgeClient)(nil).GetPortList))
 }
 
+// Name mocks base method
+func (m *MockOVSBridgeClient) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name
+func (mr *MockOVSBridgeClientMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockOVSBridgeClient)(nil).Name))
+}
+
 // SetExternalIDs mocks base method
 func (m *MockOVSBridgeClient) SetExternalIDs(arg0 map[string]interface{}) ovsconfig.Error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
- Added a cookie allocator to mark flow by cookie id
- Added function `roundNum` to `pipeline.go` to read roundNum from ovsdb
- Updated related mocks and unit tests
- Fixed some typos

Signed-off-by: Weiqiang TANG <weiqiangt@vmware.com>