### PR TITLE
UUIDNamespace constant must be locally scoped

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,12 +15,10 @@ require (
 	github.com/google/gofuzz v1.0.0 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.3.1 // indirect
-	github.com/gorilla/context v1.1.1 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/j-keck/arping v1.0.0
 	github.com/json-iterator/go v1.1.6 // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd
-	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 // indirect
 	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -61,12 +61,12 @@ const (
 var (
 	keyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
 
-	// UUIDNamespace is a uuid.UUID type generated from a string to be
+	// uuidNamespace is a uuid.UUID type generated from a string to be
 	// used to generate uuid.UUID for internal Antrea objects like
 	// AppliedToGroup, AddressGroup etc.
 	// 5a5e7dd9-e3fb-49bb-b263-9bab25c95841 was generated using
 	// uuid.NewV4() function.
-	UUIDNamespace = uuid.FromStringOrNil("5a5e7dd9-e3fb-49bb-b263-9bab25c95841")
+	uuidNamespace = uuid.FromStringOrNil("5a5e7dd9-e3fb-49bb-b263-9bab25c95841")
 )
 
 // NetworkPolicyController is responsible for synchronizing the Namespaces and Pods
@@ -241,7 +241,7 @@ func selectorToString(selector *metav1.LabelSelector) string {
 // For example, it can be used to generate keys using normalized selectors
 // unique within the Namespace by adding the constant UID.
 func getNormalizedUID(name string) string {
-	return uuid.NewV5(UUIDNamespace, name).String()
+	return uuid.NewV5(uuidNamespace, name).String()
 }
 
 // generateNormalizedName generates a string, based on the selectors, in


### PR DESCRIPTION
In NetworkPolicy controller, the UUIDNamespace constant does not
need to be globally scoped. This patch converts it to a locally
scoped constant within the networkpolicy package.