### PR TITLE
Add label for resource in antrea-e2e test

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -419,8 +419,13 @@ func (data *TestData) createBusyboxPodOnNode(name string, nodeName string) error
 		podSpec.Tolerations = []v1.Toleration{noScheduleToleration}
 	}
 	pod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Spec:       podSpec,
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"antrea-e2e": name,
+			},
+		},
+		Spec: podSpec,
 	}
 	if _, err := data.clientset.CoreV1().Pods(testNamespace).Create(pod); err != nil {
 		return err


### PR DESCRIPTION
This patch is to add label for resource in antrea-e2e test. It should be helpful for CI to get all antrea-e2e related resources with command like: ```kubectl get all -o wide -A -l 'antrea-e2e'```.

Currently, all resources are in namespace "antrea-test". But testcases using more namespaces are expected.