### PR TITLE
Remove GOPROXY variable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ GOFLAGS         :=
 BINDIR          := $(CURDIR)/bin
 GO_FILES        := $(shell find . -type d -name '.cache' -prune -o -type f -name '*.go' -print)
 GOPATH          ?= $$(go env GOPATH)
-GOPROXY         ?= $$(go env GOPROXY)
 DOCKER_CACHE    := $(CURDIR)/.cache
 
 .PHONY: all
@@ -49,7 +48,6 @@ DOCKER_ENV := \
 	@docker run --rm -u $$(id -u):$$(id -g) \
 		-e "GOCACHE=/tmp/gocache" \
 		-e "GOPATH=/tmp/gopath" \
-		-e "GOPROXY=$(GOPROXY)" \
 		-w /usr/src/github.com/vmware-tanzu/antrea \
 		-v $(DOCKER_CACHE)/gopath:/tmp/gopath \
 		-v $(DOCKER_CACHE)/gocache:/tmp/gocache \

--- a/hack/tidy-check.sh
+++ b/hack/tidy-check.sh
@@ -38,7 +38,11 @@ function echoerr {
 
 function general_help {
   echoerr "Please run the following command to generate a new go.mod & go.sum:"
-  echoerr "  \$ make tidy"
+  if [ -n "$GO" ] && [[ "$($GO version|awk '{print $3}')" == $TARGET_GO_VERSION_PATTERN ]]; then
+    echoerr "  \$ make tidy"
+  else
+    echoerr "  \$ make docker-tidy"
+  fi
 }
 
 function precheck {


### PR DESCRIPTION
- Omit to set the GOPROXY environment variable in Makefile
- Tell developer to use `make docker-tidy` instead `make tidy` if there is no Go installation or the 
Go version is not the expected

Fixes #142

Signed-off-by: Weiqiang TANG <weiqiangt@vmware.com>