### PR TITLE
Also run CI jobs (Go / Kind) on push events

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,10 @@ on:
     branches:
     - master
     - release-*
+  push:
+    branches:
+    - master
+    - release-*
 jobs:
 
 

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -4,6 +4,10 @@ on:
     branches:
     - master
     - release-*
+  push:
+    branches:
+    - master
+    - release-*
 jobs:
   test-unit:
     name: E2e tests on a Kind cluster on Linux


### PR DESCRIPTION
Otherwise we may not detect a situation where a PR is merged and even
though the CI was "green" for the PR, the master branch is broken. An
alternative would be to require PRs to always be up-to-date before
merging but IMO that doesn't scale very well and starts being painful
even with a few PRs a day.

This change will also ensure that the CI badge we display in the README
is accurate.