### PR TITLE
Add a new e2e provider to make test running on remote cluster

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -115,6 +115,7 @@ func initProvider() error {
 	providerFactory := map[string]func(string) (providers.ProviderInterface, error){
 		"vagrant": providers.NewVagrantProvider,
 		"kind":    providers.NewKindProvider,
+		"remote":  providers.NewRemoteProvider,
 	}
 	if fn, ok := providerFactory[testOptions.providerName]; ok {
 		if newProvider, err := fn(testOptions.providerConfigPath); err != nil {
@@ -179,7 +180,7 @@ func collectClusterInfo() error {
 		cmd := "kubectl cluster-info dump | grep cluster-cidr"
 		rc, stdout, _, err := RunCommandOnNode(clusterInfo.masterNodeName, cmd)
 		if err != nil || rc != 0 {
-			return fmt.Errorf("error when running the following command on master Node: %s", stdout)
+			return fmt.Errorf("error when running the following command `%s` on master Node: %v, %s", cmd, err, stdout)
 		}
 		re := regexp.MustCompile(`cluster-cidr=([^"]+)`)
 		if matches := re.FindStringSubmatch(stdout); len(matches) == 0 {

--- a/test/e2e/providers/remote.go
+++ b/test/e2e/providers/remote.go
@@ -65,7 +65,7 @@ func (p *RemoteProvider) GetKubeconfigPath() (string, error) {
 	return *remoteKubeconfig, nil
 }
 
-NewRemoteProvider returns an implementation of ProviderInterface which enables tests to run on a remote cluster.
+// NewRemoteProvider returns an implementation of ProviderInterface which enables tests to run on a remote cluster.
 // configPath is unused for the remote provider
 //noinspection GoUnusedParameter
 func NewRemoteProvider(configPath string) (ProviderInterface, error) {

--- a/test/e2e/providers/remote.go
+++ b/test/e2e/providers/remote.go
@@ -65,7 +65,7 @@ func (p *RemoteProvider) GetKubeconfigPath() (string, error) {
 	return *remoteKubeconfig, nil
 }
 
-// NewRemoteProvider returns an implementation of ProviderInterface which enable test to run on a remote cluster.
+NewRemoteProvider returns an implementation of ProviderInterface which enables tests to run on a remote cluster.
 // configPath is unused for the remote provider
 //noinspection GoUnusedParameter
 func NewRemoteProvider(configPath string) (ProviderInterface, error) {

--- a/test/e2e/providers/remote.go
+++ b/test/e2e/providers/remote.go
@@ -1,0 +1,78 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/kevinburke/ssh_config"
+
+	"github.com/vmware-tanzu/antrea/test/e2e/providers/exec"
+)
+
+var (
+	homedir, _       = os.UserHomeDir()
+	sshConfig        = flag.String("remote.sshconfig", path.Join(homedir, ".ssh", "config"), "Path of the sshconfig")
+	remoteKubeconfig = flag.String("remote.kubeconfig", path.Join(homedir, ".kube", "config"), "Path of the kubeconfig of the cluster in local")
+)
+
+func getSSHConfig() (*ssh_config.Config, error) {
+	if info, err := os.Stat(*sshConfig); err != nil {
+		return nil, err
+	} else if info.IsDir() {
+		return nil, errors.New(fmt.Sprintf("%s is not a file", *sshConfig))
+	} else if f, err := os.Open(*sshConfig); err != nil {
+		return nil, err
+	} else {
+		defer f.Close()
+		if config, err := ssh_config.Decode(f); err != nil {
+			return nil, err
+		} else {
+			return config, nil
+		}
+	}
+}
+
+type RemoteProvider struct {
+	sshConfig *ssh_config.Config
+}
+
+func (p *RemoteProvider) RunCommandOnNode(nodeName string, cmd string) (code int, stdout string, stderr string, err error) {
+	host, clientCfg, err := convertConfig(p.sshConfig, nodeName)
+	if err != nil {
+		return 0, "", "", err
+	}
+	return exec.RunSSHCommand(host, clientCfg, cmd)
+}
+
+func (p *RemoteProvider) GetKubeconfigPath() (string, error) {
+	return *remoteKubeconfig, nil
+}
+
+// NewRemoteProvider returns an implementation of ProviderInterface which enable test to run on a remote cluster.
+// configPath is unused for the remote provider
+//noinspection GoUnusedParameter
+func NewRemoteProvider(configPath string) (ProviderInterface, error) {
+	sshConfig, err := getSSHConfig()
+	if err != nil {
+		return nil, err
+	} else {
+		return &RemoteProvider{sshConfig: sshConfig}, nil
+	}
+}


### PR DESCRIPTION
Implemented the remote provider which accepts sshconfig file and kubeconfig file to run the e2e test on a remote Kubernetes cluster.

The provider accept two new flags:
- `remote.kubeconfig`: Path of the kubeconfig of the cluster in local machine
- `remote.sshconfig`: Path of the sshconfig