### PR TITLE
Add performance bench test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,10 +35,12 @@ require (
 	github.com/stretchr/testify v1.3.0
 	github.com/vishvananda/netlink v1.0.0
 	github.com/vmware/octant v0.8.0
-	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
-	golang.org/x/net v0.0.0-20190628185345-da137c7871d7 // indirect
+	golang.org/x/crypto v0.0.0-20191128160524-b544559bb6d1
+	golang.org/x/exp v0.0.0-20190121172915-509febef88a4
+	golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
-	golang.org/x/sys v0.0.0-20190710143415-6ec70d6a5542
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
+	golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	google.golang.org/grpc v1.22.0
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -350,8 +350,9 @@ golang.org/x/crypto v0.0.0-20181009213950-7c1a557ab941/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181025213731-e84da0312774/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
-golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191128160524-b544559bb6d1 h1:anGSYQpPhQwXlwsu5wmfq0nWkCNaMEMUwAv13Y92hd8=
+golang.org/x/crypto v0.0.0-20191128160524-b544559bb6d1/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/exp v0.0.0-20190121172915-509febef88a4 h1:c2HOrn5iMezYjSlGPncknSEr/8x5LELb/ilJbXi9DEA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -371,8 +372,8 @@ golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20190628185345-da137c7871d7 h1:rTIdg5QFRR7XCaK4LCjBiPbx8j4DQRpdYMnGn/bJUEU=
-golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933 h1:e6HwijUxhDe+hPNjZQQn9bA5PW3vNmnN64U2ZW759Lk=
+golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -382,8 +383,9 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -396,8 +398,8 @@ golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190710143415-6ec70d6a5542 h1:6ZQFf1D2YYDDI7eSwW8adlkkavTB9sw5I24FVtEvNUQ=
-golang.org/x/sys v0.0.0-20190710143415-6ec70d6a5542/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9 h1:ZBzSG/7F4eNKz2L3GE9o300RX0Az1Bw5HF7PDraD+qU=
+golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -121,7 +121,7 @@ The above command uses `-run=XXX` to deselect all `Test` and uses `-bench=.` to 
 would need quite a while to be finished, you need extend the time out duration `-timeout` from the default `10m`
 to a longer duration like `30m`.
 
-If you would like to run the performance test in a different scale, you could run:
+If you would like to run the performance tests a a different scale, you could run:
 ```bash
 go test -v -timeout=30m -run=XXX -bench=BenchmarkCustomize \
     --performance.http.times=5000 \

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -133,7 +133,7 @@ This command would run only the customized performance test with 5000 https requ
 
 All flags of the performance tests includes:
 - `performance.http.concurrency (int)`: Number of multiple requests to make at a time (default 1)
-- `performance.http.times (int)`: Times of http requests
+- `performance.http.times (int)`: Total number of http requests
 - `performance.http.workload (int)`: Number of network policy workloads
 - `performance.realize.timeout (duration)`: Timeout of the realization of network policies (default 5m0s)
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -117,24 +117,23 @@ go test -v -timeout=30m -run=XXX -bench=. \
     --performance.http.concurrency=16 \
     github.com/vmware-tanzu/antrea/test/e2e 
 ```
-The above command uses `-run=XXX` to deselect all `Test` and uses `-bench=.` to select all `Benchmark`. Since the performance test
-would need quite a while to be finished, you need extend the time out duration `-timeout` from the default `10m`
-to a longer duration like `30m`.
+The above command uses `-run=XXX` to deselect all `Test*` tests and uses `-bench=.` to select
+all `Benchmark*` tests. Since performance tests take a while to complete, you need to extend
+the timeout duration `-timeout` from the default `10m` to a longer one like `30m`.
 
-If you would like to run the performance tests a a different scale, you could run:
+If you would like to run the performance tests in a different scale, you could run:
 ```bash
 go test -v -timeout=30m -run=XXX -bench=BenchmarkCustomize \
-    --performance.http.times=5000 \
-    --performance.http.workload=1000 \
+    --performance.http.requsts=5000 \
+    --performance.http.workloads=1000 \
     --performance.http.concurrency=16 \
     github.com/vmware-tanzu/antrea/test/e2e
 ```
-This command would run only the customized performance test with 5000 https requests in concurrency 16 under a 1000 CIDRs network policy. 
 
-All flags of the performance tests includes:
-- `performance.http.concurrency (int)`: Number of multiple requests to make at a time (default 1)
-- `performance.http.times (int)`: Total number of http requests
-- `performance.http.workload (int)`: Number of network policy workloads
+All flags of performance tests includes:
+- `performance.http.concurrency (int)`: Number of allowed concurrent http requests (default 1)
+- `performance.http.requsts (int)`: Total Number of http requests
+- `performance.http.workloads (int)`: Number of CIDRs in the workload network policy
 - `performance.realize.timeout (duration)`: Timeout of the realization of network policies (default 5m0s)
 
 ## Tests to be added

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -110,6 +110,33 @@ also need to copy the Antrea manifest to the master Docker container:
 go test -v github.com/vmware-tanzu/antrea/test/e2e -provider=kind
 ```
 
+## Running the performance test
+To run all benchmarks excepts e2e tests:
+```bash
+go test -v -timeout=30m -run=XXX -bench=. \
+    --performance.http.concurrency=16 \
+    github.com/vmware-tanzu/antrea/test/e2e 
+```
+The above command uses `-run=XXX` to deselect all `Test` and uses `-bench=.` to select all `Benchmark`. Since the performance test
+would need quite a while to be finished, you need extend the time out duration `-timeout` from the default `10m`
+to a longer duration like `30m`.
+
+If you would like to run the performance test in a different scale, you could run:
+```bash
+go test -v -timeout=30m -run=XXX -bench=BenchmarkCustomize \
+    --performance.http.times=5000 \
+    --performance.http.workload=1000 \
+    --performance.http.concurrency=16 \
+    github.com/vmware-tanzu/antrea/test/e2e
+```
+This command would run only the customized performance test with 5000 https requests in concurrency 16 under a 1000 CIDRs network policy. 
+
+All flags of the performance tests includes:
+- `performance.http.concurrency (int)`: Number of multiple requests to make at a time (default 1)
+- `performance.http.times (int)`: Times of http requests
+- `performance.http.workload (int)`: Number of network policy workloads
+- `performance.realize.timeout (duration)`: Timeout of the realization of network policies (default 5m0s)
+
 ## Tests to be added
 
  * Network policy tests

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -111,7 +111,7 @@ go test -v github.com/vmware-tanzu/antrea/test/e2e -provider=kind
 ```
 
 ## Running the performance test
-To run all benchmarks excepts e2e tests:
+To run all benchmarks, without the standard e2e tests:
 ```bash
 go test -v -timeout=30m -run=XXX -bench=. \
     --performance.http.concurrency=16 \

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -114,8 +114,8 @@ go test -v github.com/vmware-tanzu/antrea/test/e2e -provider=kind
 To run all benchmarks, without the standard e2e tests:
 ```bash
 go test -v -timeout=30m -run=XXX -bench=. \
-    --performance.http.concurrency=16 \
-    github.com/vmware-tanzu/antrea/test/e2e 
+    github.com/vmware-tanzu/antrea/test/e2e \
+    --performance.http.concurrency=16
 ```
 The above command uses `-run=XXX` to deselect all `Test*` tests and uses `-bench=.` to select
 all `Benchmark*` tests. Since performance tests take a while to complete, you need to extend
@@ -124,10 +124,10 @@ the timeout duration `-timeout` from the default `10m` to a longer one like `30m
 If you would like to run the performance tests in a different scale, you could run:
 ```bash
 go test -v -timeout=30m -run=XXX -bench=BenchmarkCustomize \
+    github.com/vmware-tanzu/antrea/test/e2e \
     --performance.http.requests=5000 \
     --performance.http.policy_rules=1000 \
-    --performance.http.concurrency=16 \
-    github.com/vmware-tanzu/antrea/test/e2e
+    --performance.http.concurrency=16
 ```
 
 All flags of performance tests includes:

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -132,7 +132,7 @@ go test -v -timeout=30m -run=XXX -bench=BenchmarkCustomize \
 
 All flags of performance tests includes:
 - `performance.http.concurrency (int)`: Number of allowed concurrent http requests (default 1)
-- `performance.http.requsts (int)`: Total Number of http requests
+- `performance.http.requests (int)`: Total Number of http requests
 - `performance.http.workloads (int)`: Number of CIDRs in the workload network policy
 - `performance.realize.timeout (duration)`: Timeout of the realization of network policies (default 5m0s)
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -124,8 +124,8 @@ the timeout duration `-timeout` from the default `10m` to a longer one like `30m
 If you would like to run the performance tests in a different scale, you could run:
 ```bash
 go test -v -timeout=30m -run=XXX -bench=BenchmarkCustomize \
-    --performance.http.requsts=5000 \
-    --performance.http.workloads=1000 \
+    --performance.http.requests=5000 \
+    --performance.http.policy_rules=1000 \
     --performance.http.concurrency=16 \
     github.com/vmware-tanzu/antrea/test/e2e
 ```
@@ -133,7 +133,7 @@ go test -v -timeout=30m -run=XXX -bench=BenchmarkCustomize \
 All flags of performance tests includes:
 - `performance.http.concurrency (int)`: Number of allowed concurrent http requests (default 1)
 - `performance.http.requests (int)`: Total Number of http requests
-- `performance.http.workloads (int)`: Number of CIDRs in the workload network policy
+- `performance.http.policy_rules (int)`: Number of CIDRs in the network policy
 - `performance.realize.timeout (duration)`: Timeout of the realization of network policies (default 5m0s)
 
 ## Tests to be added

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -43,7 +43,7 @@ const AntreaDaemonSet string = "antrea-agent"
 
 const testNamespace string = "antrea-test"
 
-const defaultContainerName string = "busybox"
+const busyboxContainerName string = "busybox"
 
 const nameSuffixLength int = 8
 
@@ -384,15 +384,14 @@ func (data *TestData) deleteAntrea(timeout time.Duration) error {
 
 // createPodOnNode creates a pod in the test namespace with a container whose type is decided by imageName.
 // Pod will be scheduled on the specified Node (if nodeName is not empty).
-func (data *TestData) createPodOnNode(name string, nodeName string, imageName string) error {
-	sleepDuration := 3600 // seconds
+func (data *TestData) createPodOnNode(name string, nodeName string, imageName string, command []string) error {
 	podSpec := v1.PodSpec{
 		Containers: []v1.Container{
 			{
-				Name:            defaultContainerName,
+				Name:            imageName,
 				Image:           imageName,
 				ImagePullPolicy: v1.PullIfNotPresent,
-				Command:         []string{"sleep", strconv.Itoa(sleepDuration)},
+				Command:         command,
 			},
 		},
 		RestartPolicy: v1.RestartPolicyNever,
@@ -430,7 +429,8 @@ func (data *TestData) createPodOnNode(name string, nodeName string, imageName st
 // createBusyboxPodOnNode creates a Pod in the test namespace with a single busybox container. The
 // Pod will be scheduled on the specified Node (if nodeName is not empty).
 func (data *TestData) createBusyboxPodOnNode(name string, nodeName string) error {
-	return data.createPodOnNode(name, nodeName, "busybox")
+	sleepDuration := 3600 // seconds
+	return data.createPodOnNode(name, nodeName, "busybox", []string{"sleep", strconv.Itoa(sleepDuration)})
 }
 
 // createBusyboxPod creates a Pod in the test namespace with a single busybox container.
@@ -441,7 +441,7 @@ func (data *TestData) createBusyboxPod(name string) error {
 // createNginxPodOnNode creates a Pod in the test namespace with a single nginx container. The
 // Pod will be scheduled on the specified Node (if nodeName is not empty).
 func (data *TestData) createNginxPodOnNode(name string, nodeName string) error {
-	return data.createPodOnNode(name, nodeName, "nginx")
+	return data.createPodOnNode(name, nodeName, "nginx", []string{})
 }
 
 // createNginxPod creates a Pod in the test namespace with a single nginx container.
@@ -752,6 +752,6 @@ func (data *TestData) forAllAntreaPods(fn func(nodeName, podName string) error) 
 
 func (data *TestData) runPingCommandFromTestPod(podName string, targetIP string, count int) error {
 	cmd := []string{"ping", "-c", strconv.Itoa(count), targetIP}
-	_, _, err := data.runCommandFromPod(testNamespace, podName, defaultContainerName, cmd)
+	_, _, err := data.runCommandFromPod(testNamespace, podName, busyboxContainerName, cmd)
 	return err
 }

--- a/test/e2e/performance_test.go
+++ b/test/e2e/performance_test.go
@@ -92,7 +92,7 @@ func randCidr(rndSrc rand.Source) string {
 }
 
 // createPerformanceTestPodSpec creates Pod description for the performance test.
-// The Pod would be scheduled to the master Node.
+// The Pod will be scheduled on the master Node.
 func createPerformanceTestPodSpec(name, containerName, image string) *v1.Pod {
 	podSpec := v1.PodSpec{
 		Containers: []v1.Container{

--- a/test/e2e/performance_test.go
+++ b/test/e2e/performance_test.go
@@ -135,7 +135,7 @@ func createPerformanceNginx(data *TestData, b *testing.B) (string, error) {
 	return data.podWaitForIP(defaultTimeout, benchNginxPodName)
 }
 
-// createPerformanceAB creates the apache-bench Pod and wait it to be ready.
+// createPerformanceAB creates the apache-bench Pod and waits for it to be ready.
 func createPerformanceAB(data *TestData, b *testing.B) (string, error) {
 	b.Logf("Creating an apache-bench test Pod")
 	sleepDuration := "3600" // seconds

--- a/test/e2e/performance_test.go
+++ b/test/e2e/performance_test.go
@@ -1,0 +1,365 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"flag"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/exp/rand"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	v1 "k8s.io/api/core/v1"
+	networkv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	seed                            uint64 = 0xA1E47 // Use a specific rand seed to make the generated workloads always same
+	performanceAppLabel                    = "antrea-performance-test"
+	podsConnectionNetworkPolicyName        = "pods.ingress"
+	workloadNetworkPolicyName              = "workloads.ingress"
+	abImage                                = "antrea/apache-bench"
+	nginxImage                             = "nginx"
+	abContainerName                        = "apache-bench"
+	nginxContainerName                     = "nginx"
+)
+
+var (
+	benchNginxPodName = randName(abContainerName + "-")
+	benchABPodName    = randName(nginxContainerName + "-")
+
+	customizeTimes    = flag.Int("performance.http.times", 0, "Times of http requests")
+	customizeWorkload = flag.Int("performance.http.workload", 0, "Number of network policy workloads")
+	httpConcurrency   = flag.Int("performance.http.concurrency", 1, "Number of multiple requests to make at a time")
+	realizeTimeout    = flag.Duration("performance.realize.timeout", 5*time.Minute, "Timeout of the realization of network policies")
+)
+
+func BenchmarkHTTPRequest(b *testing.B) {
+	for _, scale := range []struct{ times, workloads int }{
+		{100000, 0},
+		{1000000, 0},
+		{100000, 5000},
+		{100000, 10000},
+		{100000, 15000},
+	} {
+		b.Run(fmt.Sprintf("Request%dWorkloads%d", scale.times, scale.workloads), func(b *testing.B) {
+			withPerformanceTestSetup(func(data *TestData) { httpRequest(scale.times, scale.workloads, data, b) }, b)
+		})
+	}
+}
+
+func BenchmarkRealizeNetworkPolicy(b *testing.B) {
+	for _, scale := range []int{5000, 10000, 15000} {
+		b.Run(fmt.Sprintf("RealizeNetworkPolicy%d", scale), func(b *testing.B) {
+			withPerformanceTestSetup(func(data *TestData) { networkPolicyRealize(scale, data, b) }, b)
+		})
+	}
+}
+
+func BenchmarkCustomizeHTTPRequest(b *testing.B) {
+	if *customizeTimes == 0 {
+		b.Skip("The value of performance.http.times=0, skipped")
+	}
+	withPerformanceTestSetup(func(data *TestData) { httpRequest(*customizeTimes, *customizeWorkload, data, b) }, b)
+}
+
+func BenchmarkCustomizeRealizeNetworkPolicy(b *testing.B) {
+	if *customizeWorkload == 0 {
+		b.Skip("The value of performance.http.workload=0, skipped")
+	}
+	withPerformanceTestSetup(func(data *TestData) { networkPolicyRealize(*customizeWorkload, data, b) }, b)
+}
+
+func randCidr(rndSrc rand.Source) string {
+	return fmt.Sprintf("%d.%d.%d.%d/32", rndSrc.Uint64()%255+1, rndSrc.Uint64()%255+1, rndSrc.Uint64()%255+1, rndSrc.Uint64()%255+1)
+}
+
+// createPerformanceTestPodSpec creates Pod description for the performance test.
+// The Pod would be scheduled to the master Node.
+func createPerformanceTestPodSpec(name, containerName, image string) *v1.Pod {
+	podSpec := v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Name:            containerName,
+				Image:           image,
+				ImagePullPolicy: v1.PullIfNotPresent,
+			},
+		},
+		RestartPolicy: v1.RestartPolicyNever,
+	}
+	podSpec.NodeSelector = map[string]string{
+		"kubernetes.io/hostname": masterNodeName(),
+	}
+	// tolerate NoSchedule taint to let the Pod run on master Node
+	noScheduleToleration := v1.Toleration{
+		Key:      "node-role.kubernetes.io/master",
+		Operator: v1.TolerationOpExists,
+		Effect:   v1.TaintEffectNoSchedule,
+	}
+	podSpec.Tolerations = []v1.Toleration{noScheduleToleration}
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{"app": performanceAppLabel},
+		},
+		Spec: podSpec,
+	}
+	return pod
+}
+
+// createPerformanceNginx creates the nginx Pod and wait it to be ready.
+func createPerformanceNginx(data *TestData, b *testing.B) (string, error) {
+	b.Logf("Creating a nginx test Pod")
+	nginxPod := createPerformanceTestPodSpec(benchNginxPodName, nginxContainerName, nginxImage)
+	if _, err := data.clientset.CoreV1().Pods(testNamespace).Create(nginxPod); err != nil {
+		b.Fatalf("Error when creating nginx test pod: %v", err)
+	}
+	b.Logf("Waiting IP assignment of the nginx test Pod")
+	return data.podWaitForIP(defaultTimeout, benchNginxPodName)
+}
+
+// createPerformanceAB creates the apache-bench Pod and wait it to be ready.
+func createPerformanceAB(data *TestData, b *testing.B) (string, error) {
+	b.Logf("Creating an apache-bench test Pod")
+	sleepDuration := "3600" // seconds
+	abPod := createPerformanceTestPodSpec(benchABPodName, abContainerName, abImage)
+	abPod.Spec.Containers[0].Command = []string{"sleep", sleepDuration}
+	if _, err := data.clientset.CoreV1().Pods(testNamespace).Create(abPod); err != nil {
+		b.Fatalf("Error when creating apache-bench test Pod: %v", err)
+	}
+	b.Logf("Waiting IP assignment of the apache-bench test Pod")
+	return data.podWaitForIP(defaultTimeout, benchABPodName)
+}
+
+// setupPerformanceTestPodsConnection applies the network policy which enable connectivity between test Pods to the cluster.
+func setupPerformanceTestPodsConnection(data *TestData) error {
+	npSpec := networkv1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": performanceAppLabel}},
+		Ingress: []networkv1.NetworkPolicyIngressRule{
+			{
+				From: []networkv1.NetworkPolicyPeer{
+					{
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": performanceAppLabel},
+						},
+					},
+				},
+			},
+		},
+		PolicyTypes: []networkv1.PolicyType{networkv1.PolicyTypeIngress},
+	}
+	np := &networkv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: podsConnectionNetworkPolicyName},
+		Spec:       npSpec,
+	}
+	_, err := data.clientset.NetworkingV1().NetworkPolicies(testNamespace).Create(np)
+	return err
+}
+
+func generateWorkload(amount int) *networkv1.NetworkPolicy {
+	var ingressRules []networkv1.NetworkPolicyPeer
+	rndSrc := rand.NewSource(seed)
+	existed := make(map[string]struct{}) // ensure no duplicated cidrs
+	for len(ingressRules) < amount {
+		cidr := randCidr(rndSrc)
+		if _, ok := existed[cidr]; ok {
+			continue
+		} else {
+			existed[cidr] = struct{}{}
+		}
+		ingressRules = append(ingressRules, networkv1.NetworkPolicyPeer{IPBlock: &networkv1.IPBlock{CIDR: cidr}})
+	}
+	npSpec := networkv1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": performanceAppLabel}},
+		Ingress:     []networkv1.NetworkPolicyIngressRule{{From: ingressRules}},
+		PolicyTypes: []networkv1.PolicyType{networkv1.PolicyTypeIngress},
+	}
+	return &networkv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: workloadNetworkPolicyName},
+		Spec:       npSpec,
+	}
+}
+
+func populateWorkload(np *networkv1.NetworkPolicy, data *TestData) error {
+	_, err := data.clientset.NetworkingV1().NetworkPolicies(testNamespace).Create(np)
+	return err
+}
+
+func setupPerformanceTestPods(data *TestData, b *testing.B) (nginxPodIP, abPodIP string) {
+	var err error
+	nginxPodIP, err = createPerformanceNginx(data, b)
+	if err != nil {
+		b.Fatalf("Error when waiting for IP assignment of nginx test Pod: %v", err)
+	}
+
+	abPodIP, err = createPerformanceAB(data, b)
+	if err != nil {
+		b.Fatalf("Error when waiting for IP assignment of apache-bench test Pod: %v", err)
+	}
+	return nginxPodIP, abPodIP
+}
+
+// httpRequest runs the benchmark of intra-node HTTP requests performance. It creates one Apache-Bench
+// Pod and one Nginx Pod on the Master Node. The Apache-Bench would make `times` requests in the
+// `--http.performance.concurrency` concurrency to the Nginx Pod. `workloads` indicates how many CIDRs
+// in the workload network policy should be generated.
+func httpRequest(times int, workloads int, data *TestData, b *testing.B) {
+	nginxPodIP, _ := setupPerformanceTestPods(data, b)
+	// enable Pods connectivity policy first
+	if err := setupPerformanceTestPodsConnection(data); err != nil {
+		b.Fatalf("Error when adding network policy to set up connection between performance test Pods")
+	}
+	b.Log("Populating performance test workloads")
+	if err := populateWorkload(generateWorkload(workloads), data); err != nil {
+		b.Fatalf("Error when populating workloads: %v", err)
+	}
+
+	if err := waitNetworkPolicyRealize(workloads, data); err != nil {
+		b.Fatalf("Checking network policies realization failed: %v", err)
+	} else {
+		b.Log("Network policy realized")
+	}
+
+	serverURL := &url.URL{Scheme: "http", Host: nginxPodIP, Path: "/"}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		b.Logf("Running http request bench %d/%d", i+1, b.N)
+		cmd := []string{"ab", "-n", fmt.Sprint(times), "-c", fmt.Sprint(*httpConcurrency), serverURL.String()}
+		if stdout, stderr, err := data.runCommandFromPod(testNamespace, benchABPodName, abContainerName, cmd); err != nil {
+			b.Errorf("Error when running http request %dx: %v, stdout: %s, stderr: %s\n", times, err, stdout, stderr)
+		}
+	}
+}
+
+// networkPolicyRealize runs the benchmark of time cost of a network policy with `workloads` amount CIDRs
+// to be realized into flow entries. In order to have entities for the network policy to apply to, we
+// create two dummy Pods: apache-bench and Nginx, they don't have activity during the benchmark test.
+func networkPolicyRealize(workloads int, data *TestData, b *testing.B) {
+	setupPerformanceTestPods(data, b)
+	for i := 0; i < b.N; i++ {
+		go func() {
+			if err := populateWorkload(generateWorkload(workloads), data); err != nil {
+				b.Fatalf("Error when populating workload: %v", err)
+			}
+		}()
+
+		b.StartTimer()
+		if err := waitNetworkPolicyRealize(workloads, data); err != nil {
+			b.Fatalf("Checking network policies realization failed: %v", err)
+		} else {
+			b.Log("Network policy realized")
+		}
+		b.StopTimer()
+
+		if err := data.clientset.NetworkingV1().NetworkPolicies(testNamespace).Delete(workloadNetworkPolicyName, new(metav1.DeleteOptions)); err != nil {
+			b.Fatalf("Error when cleaning up network policies after running one bench iteration: %v", err)
+		}
+	}
+}
+
+func dumpFlows(data *TestData) (string, error) {
+	antreaPodName, err := data.getAntreaPodOnNode(masterNodeName())
+	if err != nil {
+		return "", err
+	}
+	cmd := []string{"ovs-ofctl", "dump-flows", "br-int"}
+	stdout, _, err := data.runCommandFromPod(AntreaNamespace, antreaPodName, "antrea-agent", cmd)
+	if err != nil {
+		return "", err
+	}
+	return stdout, nil
+}
+
+func waitNetworkPolicyRealize(workloads int, data *TestData) error {
+	done := make(chan struct{})
+	return wait.WaitFor(
+		func(stopCh <-chan struct{}) <-chan struct{} {
+			checkCh := make(chan struct{})
+			timeout := time.After(*realizeTimeout)
+			go func() {
+				defer close(done)
+				for {
+					select {
+					case <-stopCh: // realized
+						break
+					case <-timeout: // timeout
+						break
+					case checkCh <- struct{}{}: // signal next check
+					}
+				}
+			}()
+			return checkCh
+		},
+		func() (bool, error) { return checkRealize(workloads, data) },
+		done,
+	)
+}
+
+func checkRealize(workloads int, data *TestData) (bool, error) {
+	flowNums, err := countFlows(data)
+	if err != nil {
+		return false, fmt.Errorf("dumping flow keeps failed")
+	}
+	return flowNums > workloads, nil
+}
+
+func countFlows(data *TestData) (int, error) {
+	output, err := dumpFlows(data)
+	if err != nil {
+		return 0, err
+	}
+	return strings.Count(output, "\n"), nil
+}
+
+// withPerformanceTestSetup provides the fn a clean test environment.
+// It ensures no stale flow rules in ovs and the bench timer is stopped and reset.
+func withPerformanceTestSetup(fn func(data *TestData), b *testing.B) {
+	b.StopTimer()
+	b.ResetTimer()
+
+	data, err := setupTest(b)
+	if err != nil {
+		b.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(b, data)
+
+	b.Logf("Deleting Antrea Agent DaemonSet to flush ovs cache")
+	if err := data.deleteAntrea(defaultTimeout); err != nil {
+		b.Fatalf("Error when deleting Antrea DaemonSet: %v", err)
+	}
+	b.Logf("Applying Antrea YAML")
+	if err := data.deployAntrea(); err != nil {
+		b.Fatalf("Error when restarting Antrea: %v", err)
+	}
+	b.Logf("Waiting for all Antrea DaemonSet Pods")
+	if err := data.waitForAntreaDaemonSetPods(defaultTimeout); err != nil {
+		b.Fatalf("Error when restarting Antrea: %v", err)
+	}
+	defer func() {
+		if flowNum, err := countFlows(data); err != nil {
+			b.Fatalf("Error when counting flow number: %v", err)
+		} else {
+			b.Logf("Flow entries: %d", flowNum)
+		}
+	}()
+
+	fn(data)
+	b.StopTimer()
+}

--- a/test/e2e/performance_test.go
+++ b/test/e2e/performance_test.go
@@ -328,7 +328,7 @@ func countFlows(data *TestData) (int, error) {
 	return strings.Count(output, "\n"), nil
 }
 
-// withPerformanceTestSetup provides the fn a clean test environment.
+// withPerformanceTestSetup runs function fn in a clean test environment.
 // It ensures no stale flow rules in ovs and the bench timer is stopped and reset.
 func withPerformanceTestSetup(fn func(data *TestData), b *testing.B) {
 	b.StopTimer()

--- a/test/e2e/performance_test.go
+++ b/test/e2e/performance_test.go
@@ -91,7 +91,7 @@ func randCidr(rndSrc rand.Source) string {
 	return fmt.Sprintf("%d.%d.%d.%d/32", rndSrc.Uint64()%255+1, rndSrc.Uint64()%255+1, rndSrc.Uint64()%255+1, rndSrc.Uint64()%255+1)
 }
 
-// createPerformanceTestPodSpec creates Pod description for the performance test.
+// createPerformanceTestPodSpec creates the Pod specification for the performance test.
 // The Pod will be scheduled on the master Node.
 func createPerformanceTestPodSpec(name, containerName, image string) *v1.Pod {
 	podSpec := v1.PodSpec{

--- a/test/e2e/performance_test.go
+++ b/test/e2e/performance_test.go
@@ -150,8 +150,8 @@ func createPerformanceAB(data *TestData, b *testing.B) (string, error) {
 	return data.podWaitForIP(defaultTimeout, benchABPodName)
 }
 
-// setupPerformanceTestPodsConnection applies the network policy which enables connectivity between test Pods in the cluster.
-func setupPerformanceTestPodsConnection(data *TestData) error {
+// setupTestPodsConnection applies the network policy which enables connectivity between test Pods in the cluster.
+func setupTestPodsConnection(data *TestData) error {
 	npSpec := networkv1.NetworkPolicySpec{
 		PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": performanceAppLabel}},
 		Ingress: []networkv1.NetworkPolicyIngressRule{
@@ -203,7 +203,7 @@ func populateWorkloads(np *networkv1.NetworkPolicy, data *TestData) error {
 	return err
 }
 
-func setupPerformanceTestPods(data *TestData, b *testing.B) (nginxPodIP, abPodIP string) {
+func setupTestPods(data *TestData, b *testing.B) (nginxPodIP, abPodIP string) {
 	var err error
 	nginxPodIP, err = createPerformanceNginx(data, b)
 	if err != nil {
@@ -222,9 +222,9 @@ func setupPerformanceTestPods(data *TestData, b *testing.B) (nginxPodIP, abPodIP
 // the `--http.performance.concurrency` concurrency to the Nginx Pod. `workloadsNum` indicates how many CIDRs
 // in the workload network policy should be generated.
 func httpRequest(times int, workloadsNum int, data *TestData, b *testing.B) {
-	nginxPodIP, _ := setupPerformanceTestPods(data, b)
+	nginxPodIP, _ := setupTestPods(data, b)
 
-	err := setupPerformanceTestPodsConnection(data) // enable Pods connectivity policy first
+	err := setupTestPodsConnection(data) // enable Pods connectivity policy first
 	if err != nil {
 		b.Fatalf("Error when adding network policy to set up connection between performance test Pods")
 	}
@@ -258,7 +258,7 @@ func httpRequest(times int, workloadsNum int, data *TestData, b *testing.B) {
 // to be realized into flow entries. In order to have entities for the network policy to apply to, we
 // create two dummy Pods: apache-bench and Nginx, they don't have activity during the benchmark test.
 func networkPolicyRealize(workloadsNum int, data *TestData, b *testing.B) {
-	setupPerformanceTestPods(data, b)
+	setupTestPods(data, b)
 	for i := 0; i < b.N; i++ {
 		go func() {
 			err := populateWorkloads(generateWorkloads(workloadsNum), data)


### PR DESCRIPTION
This CL:
- Add intra-node pods http request bench tests
- Add network policies realization bench tests

The performance bench test accepts four new flags:
- `performance.http.requests`: Number of http requests for customized scale bench test (default 0, skip customized scale test)
- `performance.http.workloads`: Number of CIDRs in the network policy (default 0, skip customized scale test)
- `performance.http.concurrency`: number of multiple requests to make at a time (default 1)
- `performance.realize.timeout`: timeout of the realization of network policies (default 5m0s)

Signed-off-by: Weiqiang TANG <weiqiangt@vmware.com>