### PR TITLE
Remove stale CRDs

### DIFF
--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -100,6 +100,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
   - pods
   - namespaces
   verbs:
@@ -122,6 +123,13 @@ rules:
   - get
   - create
   - update
+  - delete
+- apiGroups:
+  - clusterinformation.crd.antrea.io
+  resources:
+  - antreaagentinfos
+  verbs:
+  - list
   - delete
 - apiGroups:
   - authentication.k8s.io

--- a/build/yamls/base/controller-rbac.yml
+++ b/build/yamls/base/controller-rbac.yml
@@ -13,6 +13,7 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - nodes
       - pods
       - namespaces
     verbs:
@@ -35,6 +36,13 @@ rules:
       - get
       - create
       - update
+      - delete
+  - apiGroups:
+      - clusterinformation.crd.antrea.io
+    resources:
+      - antreaagentinfos
+    verbs:
+      - list
       - delete
   - apiGroups:
       - authentication.k8s.io

--- a/cmd/antrea-agent/main.go
+++ b/cmd/antrea-agent/main.go
@@ -35,6 +35,7 @@ func main() {
 	command := newAgentCommand()
 
 	if err := command.Execute(); err != nil {
+		logs.FlushLogs()
 		os.Exit(1)
 	}
 }

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -50,6 +50,7 @@ func run(o *Options) error {
 	podInformer := informerFactory.Core().V1().Pods()
 	namespaceInformer := informerFactory.Core().V1().Namespaces()
 	networkPolicyInformer := informerFactory.Networking().V1().NetworkPolicies()
+	nodeInformer := informerFactory.Core().V1().Nodes()
 
 	// Create Antrea object storage.
 	addressGroupStore := store.NewAddressGroupStore()
@@ -83,7 +84,7 @@ func run(o *Options) error {
 
 	informerFactory.Start(stopCh)
 
-	controllerMonitor := monitor.NewControllerMonitor(crdClient)
+	controllerMonitor := monitor.NewControllerMonitor(crdClient, nodeInformer)
 	go controllerMonitor.Run(stopCh)
 
 	go networkPolicyController.Run(stopCh)

--- a/cmd/antrea-controller/main.go
+++ b/cmd/antrea-controller/main.go
@@ -35,6 +35,7 @@ func main() {
 	command := newControllerCommand()
 
 	if err := command.Execute(); err != nil {
+		logs.FlushLogs()
 		os.Exit(1)
 	}
 }

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -18,7 +18,11 @@ import (
 	"time"
 
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
@@ -34,7 +38,10 @@ type monitor interface {
 }
 
 type controllerMonitor struct {
-	client clientset.Interface
+	client       clientset.Interface
+	nodeInformer coreinformers.NodeInformer
+	// nodeListerSynced is a function which returns true if the node shared informer has been synced at least once.
+	nodeListerSynced cache.InformerSynced
 }
 
 type agentMonitor struct {
@@ -47,8 +54,15 @@ type agentMonitor struct {
 	ovsBridgeClient ovsconfig.OVSBridgeClient
 }
 
-func NewControllerMonitor(client clientset.Interface) *controllerMonitor {
-	return &controllerMonitor{client: client}
+func NewControllerMonitor(client clientset.Interface, nodeInformer coreinformers.NodeInformer) *controllerMonitor {
+	m := &controllerMonitor{client: client, nodeInformer: nodeInformer, nodeListerSynced: nodeInformer.Informer().HasSynced}
+	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    nil,
+		UpdateFunc: nil,
+		DeleteFunc: m.deleteStaleAgentCRD,
+	})
+
+	return m
 }
 
 func NewAgentMonitor(client clientset.Interface, ovsBridge string, nodeName string, nodeSubnet string, interfaceStore interfacestore.InterfaceStore, ofClient openflow.Client, ovsBridgeClient ovsconfig.OVSBridgeClient) *agentMonitor {
@@ -59,66 +73,92 @@ func NewAgentMonitor(client clientset.Interface, ovsBridge string, nodeName stri
 // Then updates AntreaControllerInfo CRD every 60 seconds if there is any change.
 func (monitor *controllerMonitor) Run(stopCh <-chan struct{}) {
 	klog.Info("Starting Antrea Controller Monitor")
-	controllerCRD := monitor.getControllerCRD()
+	crdName := "antrea-controller"
+
+	// Initialize controller monitoring CRD.
+	controllerCRD := monitor.getControllerCRD(crdName)
 	var err error = nil
-	for {
-		if controllerCRD == nil {
-			controllerCRD, err = monitor.createControllerCRD()
-			if err != nil {
-				klog.Errorf("Failed to create controller monitoring CRD %v : %v", controllerCRD, err)
-			}
-		} else {
-			controllerCRD, err = monitor.updateControllerCRD(controllerCRD)
-			if err != nil {
-				klog.Errorf("Failed to update controller monitoring CRD %v : %v", controllerCRD, err)
-			}
+	if controllerCRD == nil {
+		controllerCRD, err = monitor.createControllerCRD(crdName)
+		if err != nil {
+			klog.Errorf("Failed to create controller monitoring CRD %v : %v", controllerCRD, err)
+			return
 		}
-		time.Sleep(60 * time.Second)
+	} else {
+		controllerCRD, err = monitor.updateControllerCRD(controllerCRD)
+		if err != nil {
+			klog.Errorf("Failed to update controller monitoring CRD %v : %v", controllerCRD, err)
+			return
+		}
 	}
-	<-stopCh
+
+	klog.Info("Waiting for node synced for Controller Monitor")
+	if !cache.WaitForCacheSync(stopCh, monitor.nodeListerSynced) {
+		klog.Error("Unable to sync node for Controller Monitor")
+		return
+	}
+	monitor.deleteStaleAgentCRDs()
+
+	// Update controller monitoring CRD variables every 60 seconds util stopCh is closed.
+	wait.PollUntil(60*time.Second, func() (done bool, err error) {
+		controllerCRD, err = monitor.partialUpdateControllerCRD(controllerCRD)
+		if err != nil {
+			klog.Errorf("Failed to partially update controller monitoring CRD %v : %v", controllerCRD, err)
+			return true, err
+		}
+		return false, nil
+	}, stopCh)
 }
 
 // Run creates AntreaAgentInfo CRD first after controller is running.
 // Then updates AntreaAgentInfo CRD every 60 seconds.
 func (monitor *agentMonitor) Run(stopCh <-chan struct{}) {
 	klog.Info("Starting Antrea Agent Monitor")
-	agentCRD := monitor.getAgentCRD()
+	crdName := monitor.GetSelfNode().Name
+	agentCRD := monitor.getAgentCRD(crdName)
 	var err error = nil
-	for {
-		if agentCRD == nil {
-			agentCRD, err = monitor.createAgentCRD()
-			if err != nil {
-				klog.Errorf("Failed to create agent monitoring CRD %v : %v", agentCRD, err)
-				break
-			}
-		} else {
-			agentCRD, err = monitor.updateAgentCRD(agentCRD)
-			if err != nil {
-				klog.Errorf("Failed to update agent monitoring CRD %v : %v", agentCRD, err)
-				break
-			}
+
+	// Initialize agent monitoring CRD.
+	if agentCRD == nil {
+		agentCRD, err = monitor.createAgentCRD(crdName)
+		if err != nil {
+			klog.Errorf("Failed to create agent monitoring CRD %v : %v", agentCRD, err)
+			return
 		}
-		time.Sleep(60 * time.Second)
+	} else {
+		agentCRD, err = monitor.updateAgentCRD(agentCRD)
+		if err != nil {
+			klog.Errorf("Failed to update agent monitoring CRD %v : %v", agentCRD, err)
+			return
+		}
 	}
-	<-stopCh
+
+	// Update agent monitoring CRD variables every 60 seconds util stopCh is closed.
+	wait.PollUntil(60*time.Second, func() (done bool, err error) {
+		agentCRD, err = monitor.partialUpdateAgentCRD(agentCRD)
+		if err != nil {
+			klog.Errorf("Failed to partially update agent monitoring CRD %v : %v", agentCRD, err)
+			return true, err
+		}
+		return false, nil
+	}, stopCh)
 }
 
 // getControllerCRD is used to check the existence of controller monitoring CRD.
 // So when the pod restarts, it will update this monitoring CRD instead of creating a new one.
-func (monitor *controllerMonitor) getControllerCRD() *v1beta1.AntreaControllerInfo {
-	podName := monitor.GetSelfPod().Name
-	controllerCRD, err := monitor.client.ClusterinformationV1beta1().AntreaControllerInfos().Get(podName, metav1.GetOptions{})
+func (monitor *controllerMonitor) getControllerCRD(crdName string) *v1beta1.AntreaControllerInfo {
+	controllerCRD, err := monitor.client.ClusterinformationV1beta1().AntreaControllerInfos().Get(crdName, metav1.GetOptions{})
 	if err != nil {
-		klog.V(2).Infof("Controller monitoring CRD named %v doesn't exist, will create one", podName)
+		klog.V(2).Infof("Controller monitoring CRD named %s doesn't exist, will create one", crdName)
 		return nil
 	}
 	return controllerCRD
 }
 
-func (monitor *controllerMonitor) createControllerCRD() (*v1beta1.AntreaControllerInfo, error) {
+func (monitor *controllerMonitor) createControllerCRD(crdName string) (*v1beta1.AntreaControllerInfo, error) {
 	controllerCRD := &v1beta1.AntreaControllerInfo{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: monitor.GetSelfPod().Name,
+			Name: crdName,
 		},
 		Version:    version.GetFullVersion(),
 		PodRef:     monitor.GetSelfPod(),
@@ -132,13 +172,16 @@ func (monitor *controllerMonitor) createControllerCRD() (*v1beta1.AntreaControll
 			},
 		},
 	}
-	klog.V(2).Infof("Creating controller monitor CRD %v", controllerCRD)
+	klog.V(2).Infof("Creating controller monitoring CRD %v", controllerCRD)
 	return monitor.client.ClusterinformationV1beta1().AntreaControllerInfos().Create(controllerCRD)
 }
 
-// TODO: Update network policy related fields when the upstreaming is ready
+// updateControllerCRD updates all the fields of existing monitoring CRD.
 func (monitor *controllerMonitor) updateControllerCRD(controllerCRD *v1beta1.AntreaControllerInfo) (*v1beta1.AntreaControllerInfo, error) {
-	klog.V(2).Infof("Updating controller monitor CRD %v", controllerCRD)
+	controllerCRD.Version = version.GetFullVersion()
+	controllerCRD.PodRef = monitor.GetSelfPod()
+	controllerCRD.NodeRef = monitor.GetSelfNode()
+	controllerCRD.ServiceRef = monitor.GetService()
 	controllerCRD.ControllerConditions = []v1beta1.ControllerCondition{
 		{
 			Type:              v1beta1.ControllerHealthy,
@@ -146,25 +189,67 @@ func (monitor *controllerMonitor) updateControllerCRD(controllerCRD *v1beta1.Ant
 			LastHeartbeatTime: metav1.Now(),
 		},
 	}
+	klog.V(2).Infof("Updating controller monitoring CRD %v", controllerCRD)
 	return monitor.client.ClusterinformationV1beta1().AntreaControllerInfos().Update(controllerCRD)
+}
+
+// partialUpdateControllerCRD only updates the variables.
+func (monitor *controllerMonitor) partialUpdateControllerCRD(controllerCRD *v1beta1.AntreaControllerInfo) (*v1beta1.AntreaControllerInfo, error) {
+	controllerCRD.ControllerConditions = []v1beta1.ControllerCondition{
+		{
+			Type:              v1beta1.ControllerHealthy,
+			Status:            v1.ConditionTrue,
+			LastHeartbeatTime: metav1.Now(),
+		},
+	}
+	klog.V(2).Infof("Partially updating controller monitoring CRD %v", controllerCRD)
+	return monitor.client.ClusterinformationV1beta1().AntreaControllerInfos().Update(controllerCRD)
+}
+
+func (monitor *controllerMonitor) deleteStaleAgentCRDs() {
+	crds, err := monitor.client.ClusterinformationV1beta1().AntreaAgentInfos().List(metav1.ListOptions{})
+	if err != nil {
+		klog.Errorf("Failed to list agent monitoring CRDs : %v", err)
+		return
+	}
+	// Delete stale agent monitoring CRD based on existing nodes.
+	nodeLister := monitor.nodeInformer.Lister()
+	for _, crd := range crds.Items {
+		_, err := nodeLister.Get(crd.Name)
+		if errors.IsNotFound(err) {
+			monitor.deleteAgentCRD(crd.Name)
+		}
+	}
+}
+
+func (monitor *controllerMonitor) deleteStaleAgentCRD(old interface{}) {
+	node := old.(*v1.Node)
+	monitor.deleteAgentCRD(node.Name)
+}
+
+func (monitor *controllerMonitor) deleteAgentCRD(name string) {
+	klog.Infof("Deleting agent monitoring CRD %s", name)
+	err := monitor.client.ClusterinformationV1beta1().AntreaAgentInfos().Delete(name, &metav1.DeleteOptions{})
+	if err != nil {
+		klog.Errorf("Failed to delete agent monitoring CRD %s : %v", name, err)
+	}
 }
 
 // getAgentCRD is used to check the existence of agent monitoring CRD.
 // So when the pod restarts, it will update this monitoring CRD instead of creating a new one.
-func (monitor *agentMonitor) getAgentCRD() *v1beta1.AntreaAgentInfo {
-	podName := monitor.GetSelfPod().Name
-	agentCRD, err := monitor.client.ClusterinformationV1beta1().AntreaAgentInfos().Get(podName, metav1.GetOptions{})
+func (monitor *agentMonitor) getAgentCRD(crdName string) *v1beta1.AntreaAgentInfo {
+	agentCRD, err := monitor.client.ClusterinformationV1beta1().AntreaAgentInfos().Get(crdName, metav1.GetOptions{})
 	if err != nil {
-		klog.V(2).Infof("Agent monitoring CRD named %v doesn't exist, will create one", podName)
+		klog.V(2).Infof("Agent monitoring CRD named %s doesn't exist, will create one", crdName)
 		return nil
 	}
 	return agentCRD
 }
 
-func (monitor *agentMonitor) createAgentCRD() (*v1beta1.AntreaAgentInfo, error) {
+func (monitor *agentMonitor) createAgentCRD(crdName string) (*v1beta1.AntreaAgentInfo, error) {
 	agentCRD := &v1beta1.AntreaAgentInfo{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: monitor.GetSelfPod().Name,
+			Name: crdName,
 		},
 		Version:     version.GetFullVersion(),
 		PodRef:      monitor.GetSelfPod(),
@@ -180,11 +265,31 @@ func (monitor *agentMonitor) createAgentCRD() (*v1beta1.AntreaAgentInfo, error) 
 			},
 		},
 	}
-	klog.V(2).Infof("Creating agent monitor CRD %v", agentCRD)
+	klog.V(2).Infof("Creating agent monitoring CRD %v", agentCRD)
 	return monitor.client.ClusterinformationV1beta1().AntreaAgentInfos().Create(agentCRD)
 }
 
+// updateAgentCRD updates all the fields of existing monitoring CRD.
 func (monitor *agentMonitor) updateAgentCRD(agentCRD *v1beta1.AntreaAgentInfo) (*v1beta1.AntreaAgentInfo, error) {
+	agentCRD.Version = version.GetFullVersion()
+	agentCRD.PodRef = monitor.GetSelfPod()
+	agentCRD.NodeRef = monitor.GetSelfNode()
+	agentCRD.NodeSubnet = []string{monitor.nodeSubnet}
+	agentCRD.OVSInfo = v1beta1.OVSInfo{Version: monitor.GetOVSVersion(), BridgeName: monitor.ovsBridge, FlowTable: monitor.GetOVSFlowTable()}
+	agentCRD.LocalPodNum = monitor.GetLocalPodNum()
+	agentCRD.AgentConditions = []v1beta1.AgentCondition{
+		{
+			Type:              v1beta1.AgentHealthy,
+			Status:            v1.ConditionTrue,
+			LastHeartbeatTime: metav1.Now(),
+		},
+	}
+	klog.V(2).Infof("Updating agent monitoring CRD %v", agentCRD)
+	return monitor.client.ClusterinformationV1beta1().AntreaAgentInfos().Update(agentCRD)
+}
+
+// partialUpdateAgentCRD only updates the variables.
+func (monitor *agentMonitor) partialUpdateAgentCRD(agentCRD *v1beta1.AntreaAgentInfo) (*v1beta1.AntreaAgentInfo, error) {
 	// LocalPodNum and FlowTable can be changed, so reset these fields.
 	agentCRD.LocalPodNum = monitor.GetLocalPodNum()
 	agentCRD.OVSInfo.FlowTable = monitor.GetOVSFlowTable()
@@ -195,6 +300,6 @@ func (monitor *agentMonitor) updateAgentCRD(agentCRD *v1beta1.AntreaAgentInfo) (
 			LastHeartbeatTime: metav1.Now(),
 		},
 	}
-	klog.V(2).Infof("Updating agent monitor CRD %v", agentCRD)
+	klog.V(2).Infof("Partially updating agent monitoring CRD %v", agentCRD)
 	return monitor.client.ClusterinformationV1beta1().AntreaAgentInfos().Update(agentCRD)
 }

--- a/pkg/signals/signals.go
+++ b/pkg/signals/signals.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+
+	"k8s.io/klog"
 )
 
 var capturedSignals = []os.Signal{syscall.SIGTERM, syscall.SIGINT}
@@ -34,6 +36,8 @@ func RegisterSignalHandlers() <-chan struct{} {
 		<-notifyCh
 		close(stopCh)
 		<-notifyCh
+		klog.Warning("Received second signal, will force exit")
+		klog.Flush()
 		os.Exit(1)
 	}()
 


### PR DESCRIPTION
Remove stale AntreaAgentInfo

1. Let Antrea Controller to cleanup stale AntreaAgentInfo after
removing a K8s node or starting/restarting Controller.
2. Rename monitorig CRDs.
3. Refactor code for monitoring module.

Fixes #128