### PR TITLE
Add e2e network policy test: IPBlock with Except field

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -43,4 +43,4 @@ jobs:
     - name: Run e2e tests
       run: |
         ./hack/generate-manifest.sh --kind | docker exec -i kind-control-plane dd of=/root/antrea.yml
-        go test github.com/vmware-tanzu/antrea/test/e2e -provider=kind
+        go test -short github.com/vmware-tanzu/antrea/test/e2e -provider=kind

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -1,0 +1,148 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"testing"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIPBlockWithExcept(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping TestIPBlockWithExcept in short mode")
+	}
+
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	workerNode := workerNodeName(1)
+
+	nginxPodName := randName("test-pod-nginx-")
+	if err = data.createNginxPodOnNode(nginxPodName, workerNode); err != nil {
+		t.Fatalf("Error when creating nginx pod: %v", err)
+	}
+	defer deletePodWrapper(t, data, nginxPodName)
+	if _, err := data.podWaitForIP(defaultTimeout, nginxPodName); err != nil {
+		t.Fatalf("Error when waiting for IP for Pod '%s': %v", nginxPodName, err)
+	}
+
+	svcName := randName("test-svc-nginx-")
+	if err = data.createNginxService(svcName); err != nil {
+		t.Fatalf("Error when creating nginx service: %v", err)
+	}
+	defer func() {
+		if err = data.deleteService(svcName); err != nil {
+			t.Fatalf("delete nginx service error: %v", err)
+		}
+	}()
+
+	npDenyAll := "test-networkpolicy-deny-all"
+	denyAllPolicy, err := data.createNetworkPolicyDenyAll(npDenyAll)
+	if err != nil {
+		t.Fatalf("Error when creating network policy: %v", err)
+	}
+	defer func() {
+		if err = data.deleteNetworkpolicy(denyAllPolicy); err != nil {
+			t.Fatalf("Error when deleting network policy: %v", err)
+		}
+	}()
+
+	podName0 := randName("test-pod-networkpolicy-")
+	if err := data.createBusyboxPodOnNode(podName0, workerNode); err != nil {
+		t.Fatalf("Error when creating busybox test Pod: %v", err)
+	}
+	defer deletePodWrapper(t, data, podName0)
+	if _, err := data.podWaitForIP(defaultTimeout, podName0); err != nil {
+		t.Fatalf("Error when waiting for IP for Pod '%s': %v", podName0, err)
+	}
+
+	podName1 := randName("test-pod-networkpolicy-")
+	if err := data.createBusyboxPodOnNode(podName1, workerNode); err != nil {
+		t.Fatalf("Error when creating busybox test Pod: %v", err)
+	}
+	defer deletePodWrapper(t, data, podName1)
+	podIP1, err := data.podWaitForIP(defaultTimeout, podName1)
+	if err != nil {
+		t.Fatalf("Error when waiting for IP for Pod '%s': %v", podName1, err)
+	}
+
+	// Two pods cannot wget to service.
+	if err = data.runWgetCommandFromTestPod(podName0, svcName); err == nil {
+		t.Fatalf("Pod %s should not be able to connect Service %s, but was able to connect", podName0, svcName)
+	}
+	if err = data.runWgetCommandFromTestPod(podName1, svcName); err == nil {
+		t.Fatalf("Pod %s should not be able to connect Service %s, but was able to connect", podName1, svcName)
+	}
+
+	npIPblockExcept := "test-networkpolicy-ipblock-except"
+	IPBlockExceptPolicy, err := data.createNetworkPolicyIPBlockWithExcept(npIPblockExcept, podIP1)
+	if err != nil {
+		t.Fatalf("Error when creating network policy: %v", err)
+	}
+	defer func() {
+		if err = data.deleteNetworkpolicy(IPBlockExceptPolicy); err != nil {
+			t.Fatalf("Error when deleting network policy: %v", err)
+		}
+	}()
+
+	// pod0 can wget to service.
+	if err = data.runWgetCommandFromTestPod(podName0, svcName); err != nil {
+		t.Fatalf("Pod %s should be able to connect Service %s, but was not able to connect", podName0, svcName)
+	}
+	// pod1 cannot wget to service.
+	if err = data.runWgetCommandFromTestPod(podName1, svcName); err == nil {
+		t.Fatalf("Pod %s should not be able to connect Service %s, but was able to connect", podName1, svcName)
+	}
+}
+
+// createNetworkPolicyDenyAll creates a network policy with IPBlock's Except field.
+func (data *TestData) createNetworkPolicyDenyAll(name string) (*networkingv1.NetworkPolicy, error) {
+	spec := &networkingv1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{},
+		Ingress:     []networkingv1.NetworkPolicyIngressRule{},
+	}
+	return data.createNetworkPolicy(name, spec)
+}
+
+// createNetworkPolicyIPBlockWithExcept creates a network policy with IPBlock's Except field.
+func (data *TestData) createNetworkPolicyIPBlockWithExcept(name string, exceptIP string) (*networkingv1.NetworkPolicy, error) {
+	spec := &networkingv1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app": "nginx",
+			},
+		},
+		Ingress: []networkingv1.NetworkPolicyIngressRule{
+			{
+				From: []networkingv1.NetworkPolicyPeer{
+					{
+						IPBlock: &networkingv1.IPBlock{
+							CIDR: clusterInfo.podNetworkCIDR,
+							Except: []string{
+								exceptIP + "/32",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return data.createNetworkPolicy(name, spec)
+}


### PR DESCRIPTION
This PR adds an e2e network policy test on cases that include IPBlock with Except field. Such testcase is not in conformance test and helps verify #71 .