### PR TITLE
Add apache-bench image for testing

### DIFF
--- a/build/images/apache-bench/Dockerfile
+++ b/build/images/apache-bench/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:18.04
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="A Docker image based on Ubuntu 18.04 which includes the ApacheBench tool."
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends apache2-utils && \
+    rm -rf /var/cache/apt/* /var/lib/apt/lists/*

--- a/build/images/apache-bench/README.md
+++ b/build/images/apache-bench/README.md
@@ -1,0 +1,17 @@
+# images/apache-bench
+
+This Docker image is a very lightweight image based on Ubuntu 18.04 which
+includes the apache2-utils package, and in particular the
+[ApacheBench](https://httpd.apache.org/docs/2.4/programs/ab.html) program.
+
+If you need to build a new version of the image and push it to Dockerhub, you
+can run the following:
+
+```bash
+cd build/images/apache-bench
+docker build -t antrea/apache-bench:latest .
+docker push antrea/apache-bench:latest
+```
+
+The `docker push` command will fail if you do not have permission to push to the
+`antrea` Dockerhub repository.


### PR DESCRIPTION
The image includes the ApacheBench ("ab") HTTP benchmark utility program
from Apache. We actually install the entire apache2-utils package but we
only care about ApacheBench for testing. We may rename the image in the
future if appropriate.