### PR TITLE
Create the working directory if not exists

### DIFF
--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -514,10 +515,13 @@ func (s *CNIServer) Run(stopCh <-chan struct{}) {
 
 	// remove before bind to avoid "address already in use" errors
 	os.Remove(s.cniSocket)
+
+	if err := os.MkdirAll(filepath.Dir(s.cniSocket), 0755); err != nil {
+		klog.Fatalf("Failed to create directory %s: %v", filepath.Dir(s.cniSocket), err)
+	}
 	listener, err := net.Listen("unix", s.cniSocket)
 	if err != nil {
-		klog.Errorf("Failed to bind on %s: %v", s.cniSocket, err)
-		os.Exit(1)
+		klog.Fatalf("Failed to bind on %s: %v", s.cniSocket, err)
 	}
 	rpcServer := grpc.NewServer()
 


### PR DESCRIPTION
This patch ensures the required working directory exist before binding
on sockets under it.

Related to https://github.com/vmware-tanzu/antrea/pull/141#issuecomment-559516591