### PR TITLE
Fix broken `make lint` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,14 +111,15 @@ fmt:
 
 .PHONY: .linter
 .linter:
-	@if ! command golint; then \
+	@if ! PATH=$$PATH:$(GOPATH)/bin command -v golint > /dev/null; then \
+	  echo "===> Installing Golint <==="; \
 	  go get -u golang.org/x/lint/golint; \
 	fi
 
 .PHONY: lint
 lint: export GOOS=linux
 lint: .linter
-	@golint ./cmd/... ./pkg/...
+	@PATH=$$PATH:$(GOPATH)/bin golint ./cmd/... ./pkg/...
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -109,9 +109,16 @@ fmt:
 	@echo "===> Formatting Go files <==="
 	@gofmt -s -l -w $(GO_FILES)
 
+.PHONY: .linter
+.linter:
+	@if ! command golint; then \
+	  go get -u golang.org/x/lint/golint; \
+	fi
+
 .PHONY: lint
-lint:
-	golint $$(go list ./...)
+lint: export GOOS=linux
+lint: .linter
+	@golint ./cmd/... ./pkg/...
 
 .PHONY: clean
 clean:

--- a/pkg/agent/util/ethtool/doc.go
+++ b/pkg/agent/util/ethtool/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ethtool provides functions that make antrea to run on Kind.
+package ethtool

--- a/pkg/agent/util/ethtool/doc.go
+++ b/pkg/agent/util/ethtool/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package ethtool provides functions that make antrea to run on Kind.
+// Package ethtool provides Go wrappers for ioctl ethtool system calls on Linux
 package ethtool


### PR DESCRIPTION
- Install golint if it not exists
- Run `make lint` with env var `GOOS=linux`

Resolve #169 