### PR TITLE
typo fixed

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,7 +44,7 @@ given release `<TAG>` (e.g. `v0.1.0`), you can deploy Antrea as follows:
 kubectl apply -f https://github.com/vmware-tanzu/antrea/releases/download/<TAG>/antrea.yml
 ```
 
-To deploy the latest version of Antrea (built from the mater branch), use the
+To deploy the latest version of Antrea (built from the master branch), use the
 checked-in [deployment yaml](/build/yamls/antrea.yml):
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/vmware-tanzu/antrea/master/build/yamls/antrea.yml


### PR DESCRIPTION
changed (built from mater) to (built from master) on the Getting Started Guide