### PR TITLE
Allow Node probe all local Pods

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -184,6 +184,8 @@ func (c *client) InstallGatewayFlows(gatewayAddr net.IP, gatewayMAC net.Hardware
 		return err
 	} else if err := c.flowOperations.Add(c.l2ForwardCalcFlow(gatewayMAC, gatewayOFPort)); err != nil {
 		return err
+	} else if err := c.flowOperations.Add(c.localProbeFlow(gatewayAddr)); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -452,6 +452,14 @@ func (c *client) defaultDropFlow(tableID binding.TableIDType, matchKey int, matc
 		Action().Drop().Done()
 }
 
+// localProbeFlow generates the flow to resubmit packets to l2ForwardingOutTable. The packets are sent from Node to probe the liveness/readiness of local Pods.
+func (c *client) localProbeFlow(localGatewayIP net.IP) binding.Flow {
+	return c.pipeline[ingressRuleTable].BuildFlow().Priority(priorityHigh).
+		MatchProtocol(binding.ProtocolIP).
+		MatchSrcIP(localGatewayIP).
+		Action().Resubmit(emptyPlaceholderStr, l2ForwardingOutTable).Done()
+}
+
 // NewClient is the constructor of the Client interface.
 func NewClient(bridgeName string) Client {
 	bridge := binding.NewBridge(bridgeName)

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -526,6 +526,14 @@ func prepareGatewayFlows(gwIP net.IP, gwMAC net.HardwareAddr, gwOFPort uint32) [
 					fmt.Sprintf("load:0x%x->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],resubmit(,90)", gwOFPort)},
 			},
 		},
+		{
+			uint8(90),
+			[]*ofTestUtils.ExpectFlow{
+				{
+					fmt.Sprintf("priority=210,ip,nw_src=%s", gwIP.String()),
+					"resubmit(,110)"},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
Install Openflow entry on ingress rule table to allow the liveness probe traffic
that is sent from node to local Pods. The flow entry is installed on the ingress
rule table, matching local gateway IP as the source address, and the action is
to resubmit the packets to L2 forwarding output table.

Fixes #176 