### PR TITLE
Run integration tests as part of CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,23 @@
+name: Integration
+on:
+  pull_request:
+    branches:
+    - master
+    - release-*
+  push:
+    branches:
+    - master
+    - release-*
+jobs:
+  test-unit:
+    name: Integration tests
+    runs-on: [ubuntu-18.04]
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-go@v1
+      with:
+        go-version: 1.12
+    - name: Install OVS
+      run: sudo apt-get install openvswitch-switch
+    - name: Run integration tests
+      run: sudo make test-integration

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -356,6 +356,7 @@ func (tester *cmdAddDelTester) cmdAddTest(tc testCase, dataDir string) (*current
 
 	link, err := linkByName(tester.testNS, result.Interfaces[0].Name)
 	testRequire.Nil(err)
+	tester.vethName = result.Interfaces[0].Name
 
 	testRequire.IsType(&netlink.Veth{}, link)
 	testRequire.Equal(hostIfaceName, link.Attrs().Name)
@@ -450,13 +451,13 @@ func (tester *cmdAddDelTester) cmdDelTest(tc testCase, dataDir string) {
 
 	var link netlink.Link
 
-	// Make sure the host veth has been deleted.
-	link, err = netlink.LinkByName(IFName)
+	// Make sure the container veth has been deleted
+	link, err = linkByName(tester.targetNS, IFName)
 	testRequire.NotNil(err)
 	testRequire.Nil(link)
 
-	// Make sure the container veth has been deleted
-	link, err = netlink.LinkByName(tester.vethName)
+	// Make sure the host veth has been deleted.
+	link, err = linkByName(tester.testNS, tester.vethName)
 	testRequire.NotNil(err)
 	testRequire.Nil(link)
 }


### PR DESCRIPTION
This required fixing yet another error in the CNI server test: when
checking for interface deletion, the test was not using the correct
network namespaces / interface names. This was going unnoticed on dev
machines when there was no "eth0" interface. However, the Github CI
worker VM seems to have an eth0 interface. When checking for container
interface deletion, the test would look for an "eth0" interface in the
root namespace (instead of the container namespace) and expect not to
find it. But because of the network configuration for the Github CI
worker VM - i.e. because of the presence of an eth0 interface - the test
was failing (for the wrong reason).

Fixes #179