### PR TITLE
Fix rule for INVALID packets in conntrackStateTable

### DIFF
--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -224,7 +224,7 @@ func (c *client) connectionTrackFlows() (flows []binding.Flow) {
 	flows = append(flows, nonGatewaySendFlow)
 
 	invCTFlow := connectionTrackStateTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
-		MatchCTStateNew(true).MatchCTStateInv(true).
+		MatchCTStateInv(true).MatchCTStateTrk(true).
 		Action().Drop().
 		Done()
 	flows = append(flows, invCTFlow)

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -617,7 +617,7 @@ func prepareDefaultFlows() []expectTableFlows {
 				{"priority=210,ct_state=-new+trk,ct_mark=0x20,ip,reg0=0x1/0xffff", "resubmit(,40)"},
 				{"priority=200,ct_state=+new+trk,ip,reg0=0x1/0xffff", "ct(commit,table=40,zone=65520,exec(load:0x20->NXM_NX_CT_MARK[],move:NXM_OF_ETH_SRC[]->NXM_NX_CT_LABEL[0..47]))"},
 				{"priority=200,ct_state=-new+trk,ct_mark=0x20,ip", "move:NXM_NX_CT_LABEL[0..47]->NXM_OF_ETH_DST[],resubmit(,40)"},
-				{"priority=200,ct_state=+new+inv,ip", "drop"},
+				{"priority=200,ct_state=+inv+trk,ip", "drop"},
 				{"priority=190,ct_state=+new+trk,ip", "ct(commit,table=40,zone=65520)"},
 				{"priority=80,ip", "resubmit(,40)"},
 			},


### PR DESCRIPTION
Before this change, the flow was matching on ct_state=+new+inv and
dropping all matching packets. According to the OVS documentation:
>If inv is set, only the trk flag is also set.

Which makes sense because an invalid packet is a packet whose state
cannot be determined. Therefore it seems that in its current state, the
rule can never be matched. It should be changed to match on
ct_state=+inv+trk (should be equivalent to ct_state=+inv, but I added
+trk to match the style of other flows).