### PR TITLE
Revert "Allow Node access all local Pods to perform probes (#104)"

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -93,7 +93,7 @@ func run(o *Options) error {
 		ofClient,
 		nodeConfig)
 
-	networkPolicyController := networkpolicy.NewNetworkPolicyController(antreaClient, ofClient, ifaceStore, nodeConfig.Name, nodeConfig.IP.String())
+	networkPolicyController := networkpolicy.NewNetworkPolicyController(antreaClient, ofClient, ifaceStore, nodeConfig.Name)
 
 	cniServer := cniserver.New(
 		o.config.CNISocket,

--- a/pkg/agent/controller/networkpolicy/cache.go
+++ b/pkg/agent/controller/networkpolicy/cache.go
@@ -96,10 +96,6 @@ type ruleCache struct {
 	rules cache.Indexer
 	// dirtyRuleHandler is a callback that is run upon finding a rule out-of-sync.
 	dirtyRuleHandler func(string)
-
-	// defaultFromAddresses is a list of addresses which will be in the FromAddresses of
-	// all Ingress rules.
-	defaultFromAddresses []string
 }
 
 // ruleKeyFunc knows how to get key of a *rule.
@@ -133,17 +129,16 @@ func policyIndexFunc(obj interface{}) ([]string, error) {
 }
 
 // newRuleCache returns a new *ruleCache.
-func newRuleCache(dirtyRuleHandler func(string), defaultFromAddresses []string) *ruleCache {
+func newRuleCache(dirtyRuleHandler func(string)) *ruleCache {
 	rules := cache.NewIndexer(
 		ruleKeyFunc,
 		cache.Indexers{addressGroupIndex: addressGroupIndexFunc, appliedToGroupIndex: appliedToGroupIndexFunc, policyIndex: policyIndexFunc},
 	)
 	return &ruleCache{
-		podSetByGroup:        make(map[string]podSet),
-		addressSetByGroup:    make(map[string]sets.String),
-		rules:                rules,
-		dirtyRuleHandler:     dirtyRuleHandler,
-		defaultFromAddresses: defaultFromAddresses,
+		podSetByGroup:     make(map[string]podSet),
+		addressSetByGroup: make(map[string]sets.String),
+		rules:             rules,
+		dirtyRuleHandler:  dirtyRuleHandler,
 	}
 }
 
@@ -316,12 +311,6 @@ func (c *ruleCache) GetCompletedRule(ruleID string) (completedRule *CompletedRul
 	var fromAddresses, toAddresses sets.String
 	if r.Direction == v1beta1.DirectionIn {
 		fromAddresses, completed = c.unionAddressGroups(r.From.AddressGroups)
-
-		if completed {
-			for _, address := range c.defaultFromAddresses {
-				fromAddresses.Insert(address)
-			}
-		}
 	} else {
 		toAddresses, completed = c.unionAddressGroups(r.To.AddressGroups)
 	}

--- a/pkg/agent/controller/networkpolicy/cache_test.go
+++ b/pkg/agent/controller/networkpolicy/cache_test.go
@@ -170,7 +170,7 @@ func TestRuleCacheAddAddressGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			recorder := newDirtyRuleRecorder()
-			c := newRuleCache(recorder.Record, []string{"192.168.1.1"})
+			c := newRuleCache(recorder.Record)
 			for _, rule := range tt.rules {
 				c.rules.Add(rule)
 			}
@@ -240,7 +240,7 @@ func TestRuleCacheAddAppliedToGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			recorder := newDirtyRuleRecorder()
-			c := newRuleCache(recorder.Record, []string{"192.168.1.1"})
+			c := newRuleCache(recorder.Record)
 			for _, rule := range tt.rules {
 				c.rules.Add(rule)
 			}
@@ -307,7 +307,7 @@ func TestRuleCacheAddNetworkPolicy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			recorder := newDirtyRuleRecorder()
-			c := newRuleCache(recorder.Record, []string{"192.168.1.1"})
+			c := newRuleCache(recorder.Record)
 			c.AddNetworkPolicy(tt.args)
 			actualRules := c.rules.List()
 			if !assert.ElementsMatch(t, tt.expectedRules, actualRules) {
@@ -371,7 +371,7 @@ func TestRuleCacheDeleteNetworkPolicy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			recorder := newDirtyRuleRecorder()
-			c := newRuleCache(recorder.Record, []string{"192.168.1.1"})
+			c := newRuleCache(recorder.Record)
 			for _, rule := range tt.rules {
 				c.rules.Add(rule)
 			}
@@ -389,8 +389,8 @@ func TestRuleCacheDeleteNetworkPolicy(t *testing.T) {
 }
 
 func TestRuleCacheGetCompletedRule(t *testing.T) {
-	addressGroup1 := sets.NewString("1.1.1.1", "1.1.1.2", "192.168.1.1")
-	addressGroup2 := sets.NewString("1.1.1.2", "1.1.1.3", "192.168.1.1")
+	addressGroup1 := sets.NewString("1.1.1.1", "1.1.1.2")
+	addressGroup2 := sets.NewString("1.1.1.2", "1.1.1.3")
 	appliedToGroup1 := newPodSet(v1beta1.PodReference{"pod1", "ns1"}, v1beta1.PodReference{"pod2", "ns1"})
 	appliedToGroup2 := newPodSet(v1beta1.PodReference{"pod2", "ns1"}, v1beta1.PodReference{"pod3", "ns1"})
 	rule1 := &rule{
@@ -460,7 +460,7 @@ func TestRuleCacheGetCompletedRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			recorder := newDirtyRuleRecorder()
-			c := newRuleCache(recorder.Record, []string{"192.168.1.1"})
+			c := newRuleCache(recorder.Record)
 			c.addressSetByGroup["addressGroup1"] = addressGroup1
 			c.addressSetByGroup["addressGroup2"] = addressGroup2
 			c.podSetByGroup["appliedToGroup1"] = appliedToGroup1
@@ -543,7 +543,7 @@ func TestRuleCachePatchAppliedToGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			recorder := newDirtyRuleRecorder()
-			c := newRuleCache(recorder.Record, []string{"192.168.1.1"})
+			c := newRuleCache(recorder.Record)
 			c.podSetByGroup = tt.podSetByGroup
 			for _, rule := range tt.rules {
 				c.rules.Add(rule)
@@ -623,7 +623,7 @@ func TestRuleCachePatchAddressGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			recorder := newDirtyRuleRecorder()
-			c := newRuleCache(recorder.Record, []string{"192.168.1.1"})
+			c := newRuleCache(recorder.Record)
 			c.addressSetByGroup = tt.addressSetByGroup
 			for _, rule := range tt.rules {
 				c.rules.Add(rule)
@@ -699,7 +699,7 @@ func TestRuleCacheUpdateNetworkPolicy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			recorder := newDirtyRuleRecorder()
-			c := newRuleCache(recorder.Record, []string{"192.168.1.1"})
+			c := newRuleCache(recorder.Record)
 			for _, rule := range tt.rules {
 				c.rules.Add(rule)
 			}

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -66,15 +66,14 @@ type Controller struct {
 }
 
 // NewNetworkPolicyController returns a new *Controller.
-func NewNetworkPolicyController(antreaClient versioned.Interface, ofClient openflow.Client, ifaceStore interfacestore.InterfaceStore, nodeName string, gatewayIP string) *Controller {
+func NewNetworkPolicyController(antreaClient versioned.Interface, ofClient openflow.Client, ifaceStore interfacestore.InterfaceStore, nodeName string) *Controller {
 	c := &Controller{
 		antreaClient: antreaClient,
 		nodeName:     nodeName,
 		queue:        workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "networkpolicyrule"),
 		reconciler:   newReconciler(ofClient, ifaceStore),
 	}
-	// Set Node gateway IP as the defaultFromAddresses so that Node to Pod traffic will always be allowed.
-	c.ruleCache = newRuleCache(c.enqueueRule, []string{gatewayIP})
+	c.ruleCache = newRuleCache(c.enqueueRule)
 	return c
 }
 

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -30,12 +30,10 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned/fake"
 )
 
-const gatewayIP = "10.10.10.1"
-
 func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 	clientset := &fake.Clientset{}
 
-	controller := NewNetworkPolicyController(clientset, nil, nil, "node1", gatewayIP)
+	controller := NewNetworkPolicyController(clientset, nil, nil, "node1")
 	reconciler := newMockReconciler()
 	controller.reconciler = reconciler
 	return controller, clientset, reconciler
@@ -126,7 +124,7 @@ func TestAddSingleGroupRule(t *testing.T) {
 	services := []v1beta1.Service{{Protocol: &protocolTCP, Port: &port}}
 	desiredRule := &CompletedRule{
 		rule:          &rule{Direction: v1beta1.DirectionIn, Services: services},
-		FromAddresses: sets.NewString("1.1.1.1", "2.2.2.2", gatewayIP),
+		FromAddresses: sets.NewString("1.1.1.1", "2.2.2.2"),
 		ToAddresses:   sets.NewString(),
 		Pods:          newPodSet(v1beta1.PodReference{"pod1", "ns1"}),
 	}
@@ -189,7 +187,7 @@ func TestAddMultipleGroupsRule(t *testing.T) {
 	services := []v1beta1.Service{{Protocol: &protocolTCP, Port: &port}}
 	desiredRule := &CompletedRule{
 		rule:          &rule{Direction: v1beta1.DirectionIn, Services: services},
-		FromAddresses: sets.NewString("1.1.1.1", "2.2.2.2", "3.3.3.3", gatewayIP),
+		FromAddresses: sets.NewString("1.1.1.1", "2.2.2.2", "3.3.3.3"),
 		ToAddresses:   sets.NewString(),
 		Pods:          newPodSet(v1beta1.PodReference{"pod1", "ns1"}, v1beta1.PodReference{"pod2", "ns2"}),
 	}


### PR DESCRIPTION
I ran into this issue while writing documentation for the OVS pipeline
so I thought I would take care of it.

Had to revert manually because of a conflict.

This reverts commit fe0736758f6ff1506f5793b608122210a3a93ee9.