### PR TITLE
Drop packets from unknown interfaces in classifier table

### DIFF
--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -45,7 +45,7 @@ const (
 	priorityHigh   = uint16(210)
 	priorityNormal = uint16(200)
 	priorityLow    = uint16(190)
-	priorityMiss   = uint16(80)
+	priorityMiss   = uint16(0)
 
 	// Traffic marks
 	markTrafficFromTunnel  = 0
@@ -134,7 +134,7 @@ func (c *client) Delete(flow binding.Flow) error {
 // defaultFlows generates the default flows of all tables.
 func (c *client) defaultFlows() (flows []binding.Flow) {
 	for _, table := range c.pipeline {
-		flowBuilder := table.BuildFlow(priorityMiss).MatchProtocol(binding.ProtocolIP)
+		flowBuilder := table.BuildFlow(priorityMiss)
 		switch table.GetMissAction() {
 		case binding.TableMissActionNext:
 			flowBuilder = flowBuilder.Action().ResubmitToTable(table.GetNext())
@@ -462,7 +462,7 @@ func NewClient(bridgeName string) Client {
 	c := &client{
 		bridge: bridge,
 		pipeline: map[binding.TableIDType]binding.Table{
-			classifierTable:       bridge.CreateTable(classifierTable, spoofGuardTable, binding.TableMissActionNext),
+			classifierTable:       bridge.CreateTable(classifierTable, spoofGuardTable, binding.TableMissActionDrop),
 			spoofGuardTable:       bridge.CreateTable(spoofGuardTable, conntrackTable, binding.TableMissActionDrop),
 			conntrackTable:        bridge.CreateTable(conntrackTable, conntrackStateTable, binding.TableMissActionNone),
 			conntrackStateTable:   bridge.CreateTable(conntrackStateTable, dnatTable, binding.TableMissActionNext),

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -597,17 +597,17 @@ func prepareDefaultFlows() []expectTableFlows {
 	return []expectTableFlows{
 		{
 			uint8(0),
-			[]*ofTestUtils.ExpectFlow{{"priority=80,ip", "resubmit(,10)"}},
+			[]*ofTestUtils.ExpectFlow{{"priority=0", "drop"}},
 		},
 		{
 			uint8(10),
-			[]*ofTestUtils.ExpectFlow{{"priority=80,ip", "drop"}},
+			[]*ofTestUtils.ExpectFlow{{"priority=0", "drop"}},
 		},
 		{
 			uint8(20),
 			[]*ofTestUtils.ExpectFlow{
 				{"priority=190,arp", "NORMAL"},
-				{"priority=80,ip", "drop"},
+				{"priority=0", "drop"},
 			},
 		},
 		{
@@ -621,44 +621,43 @@ func prepareDefaultFlows() []expectTableFlows {
 			[]*ofTestUtils.ExpectFlow{
 				{"priority=210,ct_state=-new+trk,ct_mark=0x20,ip,reg0=0x1/0xffff", "resubmit(,40)"},
 				{"priority=200,ct_state=+inv+trk,ip", "drop"},
-				{"priority=80,ip", "resubmit(,40)"},
+				{"priority=0", "resubmit(,40)"},
 			},
 		},
 		{
 			uint8(40),
-			[]*ofTestUtils.ExpectFlow{{"priority=80,ip", "resubmit(,50)"}},
+			[]*ofTestUtils.ExpectFlow{{"priority=0", "resubmit(,50)"}},
 		},
 		{
 			uint8(50),
-			[]*ofTestUtils.ExpectFlow{{"priority=80,ip", "resubmit(,60)"}},
+			[]*ofTestUtils.ExpectFlow{{"priority=0", "resubmit(,60)"}},
 		},
 		{
 			uint8(60),
-			[]*ofTestUtils.ExpectFlow{{"priority=80,ip", "resubmit(,70)"}},
+			[]*ofTestUtils.ExpectFlow{{"priority=0", "resubmit(,70)"}},
 		},
 		{
 			uint8(70),
-			[]*ofTestUtils.ExpectFlow{{"priority=80,ip", "resubmit(,80)"}},
+			[]*ofTestUtils.ExpectFlow{{"priority=0", "resubmit(,80)"}},
 		},
 		{
 			uint8(80),
-			[]*ofTestUtils.ExpectFlow{{"priority=80,ip", "resubmit(,90)"}},
+			[]*ofTestUtils.ExpectFlow{{"priority=0", "resubmit(,90)"}},
 		},
 		{
 			uint8(90),
-			[]*ofTestUtils.ExpectFlow{{"priority=80,ip", "resubmit(,100)"}},
+			[]*ofTestUtils.ExpectFlow{{"priority=0", "resubmit(,100)"}},
 		},
 		{
 			uint8(100),
-			[]*ofTestUtils.ExpectFlow{{"priority=80,ip", "resubmit(,105)"}},
+			[]*ofTestUtils.ExpectFlow{{"priority=0", "resubmit(,105)"}},
 		},
 		{
 			uint8(105),
 			[]*ofTestUtils.ExpectFlow{
 				{"priority=200,ct_state=+new+trk,ip,reg0=0x1/0xffff", "ct(commit,table=110,zone=65520,exec(load:0x20->NXM_NX_CT_MARK[])"},
 				{"priority=190,ct_state=+new+trk,ip", "ct(commit,table=110,zone=65520)"},
-				{"priority=80,ip", "resubmit(,110)"},
-			},
+				{"priority=0", "resubmit(,110)"}},
 		},
 		{
 			uint8(110),


### PR DESCRIPTION
1. Change the priority of tableMiss from 80 to 0. Otherwise there would be
   another flow entry with action "Normal" added by OVS automatically after
   the bridge is created.
2. Change the default action of classifier table to drop packets.

Fixes #195 

Signed-off-by: wenyingd <wenyingd@vmware.com>