### PR TITLE
Add documentation for Antrea's OVS pipeline

### DIFF
--- a/docs/assets/ovs-pipeline.svg
+++ b/docs/assets/ovs-pipeline.svg
@@ -1,0 +1,4152 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="297mm"
+   height="210mm"
+   viewBox="0 0 297 210"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="ovs-pipeline.svg"
+   inkscape:export-filename="/home/abas/vmware/antrea/docs/assets/ovs-pipeline.svg.png"
+   inkscape:export-xdpi="300"
+   inkscape:export-ydpi="300">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker2819"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path2817" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker2617"
+       style="overflow:visible;"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path2615"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker2421"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path2419" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker2231"
+       style="overflow:visible;"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path2229"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker2318"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path2316" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker1669"
+       style="overflow:visible;"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path1667"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1080"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker3234"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path3232" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker3086"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path3084" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker2944"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path2942" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker2808"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path2806" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker2678"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path2676" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker2554"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path2552" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker2436"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path2434" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker2324"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path2322" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker2218"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path2216" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker2118"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path2116" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker2024"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path2022" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker1936"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path1934" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker1854"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path1852" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker1778"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path1776" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker1708"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path1706" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker1644"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path1642" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker1586"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path1584" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker1534"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path1532" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker1488"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path1486" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker1448"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path1446" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker1414"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path1412" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker1386"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path1384" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker1364"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path1362" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lend"
+       style="overflow:visible;"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path1083"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="530.82352"
+     inkscape:cy="375.083"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g1791"
+     showgrid="true"
+     showguides="false"
+     inkscape:window-width="1613"
+     inkscape:window-height="995"
+     inkscape:window-x="67"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid815" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-87)"
+     style="display:inline" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Boxes"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <rect
+       y="41.724995"
+       x="67.733444"
+       height="14.816679"
+       width="40.216602"
+       id="rect1356"
+       style="display:inline;opacity:1;fill:#326ce5;fill-opacity:1;stroke:#326ce5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-avoid="true" />
+    <rect
+       y="25.849995"
+       x="124.88338"
+       height="14.816679"
+       width="40.216602"
+       id="rect1403"
+       style="display:inline;opacity:1;fill:#326ce5;fill-opacity:1;stroke:#326ce5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       y="57.070847"
+       x="125.41257"
+       height="14.816679"
+       width="40.216602"
+       id="rect1405"
+       style="display:inline;opacity:1;fill:#326ce5;fill-opacity:1;stroke:#326ce5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       y="57.070847"
+       x="180.97493"
+       height="14.816679"
+       width="44.450104"
+       id="rect1407"
+       style="display:inline;opacity:1;fill:#326ce5;fill-opacity:1;stroke:#326ce5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       y="57.070847"
+       x="239.71243"
+       height="14.816679"
+       width="40.216602"
+       id="rect1409"
+       style="display:inline;opacity:1;fill:#326ce5;fill-opacity:1;stroke:#326ce5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       y="99.93335"
+       x="5.2916727"
+       height="14.816679"
+       width="44.979153"
+       id="rect1411"
+       style="display:inline;opacity:1;fill:#326ce5;fill-opacity:1;stroke:#326ce5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       y="99.933357"
+       x="75.670883"
+       height="14.816679"
+       width="40.216602"
+       id="rect1413"
+       style="display:inline;opacity:1;fill:#326ce5;fill-opacity:1;stroke:#326ce5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       y="114.75002"
+       x="136.52525"
+       height="14.816679"
+       width="40.216602"
+       id="rect1415"
+       style="display:inline;opacity:1;fill:#326ce5;fill-opacity:1;stroke:#326ce5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-avoid="true" />
+    <rect
+       y="99.93335"
+       x="196.85022"
+       height="14.816679"
+       width="40.216602"
+       id="rect1417"
+       style="display:inline;opacity:1;fill:#326ce5;fill-opacity:1;stroke:#326ce5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       y="184.07002"
+       x="7.937552"
+       height="14.816679"
+       width="40.216602"
+       id="rect1419"
+       style="display:inline;opacity:1;fill:#326ce5;fill-opacity:1;stroke:#326ce5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       y="168.7244"
+       x="75.670883"
+       height="14.816679"
+       width="40.216602"
+       id="rect1421"
+       style="display:inline;opacity:1;fill:#326ce5;fill-opacity:1;stroke:#326ce5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       y="184.0701"
+       x="138.11264"
+       height="14.816679"
+       width="45.508503"
+       id="rect1423"
+       style="display:inline;opacity:1;fill:#326ce5;fill-opacity:1;stroke:#326ce5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       style="display:inline;opacity:1;fill:#326ce5;fill-opacity:1;stroke:#326ce5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect819"
+       width="40.216602"
+       height="14.816679"
+       x="5.2917385"
+       y="42.254162" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker3086)"
+       d="m 75.670883,107.34169 -25.400058,0"
+       id="path894"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1413"
+       inkscape:connection-end="#rect1411" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2944)"
+       d="m 27.804548,114.75003 0.218006,69.31999"
+       id="path896"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1411"
+       inkscape:connection-end="#rect1419" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2808)"
+       d="m 48.154154,186.92264 27.516729,-6.23418"
+       id="path898"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1419"
+       inkscape:connection-end="#rect1421" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2678)"
+       d="m 115.88749,180.87366 22.22515,5.24002"
+       id="path900"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1421"
+       inkscape:connection-end="#rect1423" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2554)"
+       d="M 259.82073,71.887526 V 107.34169 H 237.06682"
+       id="path908"
+       inkscape:connector-type="orthogonal"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1409"
+       inkscape:connection-end="#rect1417" />
+    <ellipse
+       style="opacity:1;fill:#32b6e5;fill-opacity:1;stroke:#32b6e5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path885"
+       cx="88.370842"
+       cy="15.947037"
+       rx="16.252975"
+       ry="8.3154755" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2324)"
+       d="m 196.85022,107.34169 -80.96273,1e-5"
+       id="path895"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1417"
+       inkscape:connection-end="#rect1413" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2218)"
+       d="m 196.85022,112.28058 -20.10836,4.9389"
+       id="path897"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1417"
+       inkscape:connection-end="#rect1415" />
+    <ellipse
+       ry="8.3154755"
+       rx="16.252975"
+       cy="145.81958"
+       cx="95.250038"
+       id="ellipse901"
+       style="opacity:1;fill:#32b6e5;fill-opacity:1;stroke:#32b6e5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2118)"
+       d="m 95.779189,168.7244 1.1e-5,-14.59389"
+       id="path903"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1421"
+       inkscape:connection-end="#ellipse901" />
+    <ellipse
+       ry="8.3154755"
+       rx="16.252975"
+       cy="32.275612"
+       cx="202.89763"
+       id="ellipse926"
+       style="opacity:1;fill:#32b6e5;fill-opacity:1;stroke:#32b6e5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <ellipse
+       ry="8.3154755"
+       rx="16.252975"
+       cy="175.45291"
+       cx="274.1839"
+       id="ellipse928"
+       style="opacity:1;fill:#32b6e5;fill-opacity:1;stroke:#32b6e5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <ellipse
+       ry="8.3154755"
+       rx="16.252975"
+       cy="199.64343"
+       cx="274.25952"
+       id="ellipse930"
+       style="opacity:1;fill:#32b6e5;fill-opacity:1;stroke:#32b6e5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <ellipse
+       ry="8.3154755"
+       rx="16.252975"
+       cy="92.071434"
+       cx="145.59644"
+       id="ellipse932"
+       style="opacity:1;fill:#32b6e5;fill-opacity:1;stroke:#32b6e5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1778)"
+       d="M 45.508341,49.492092 67.733444,49.303744"
+       id="path938"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect819"
+       inkscape:connection-end="#rect1356" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Lstart);marker-end:url(#marker1708)"
+       d="m 145.54116,71.887526 0.0325,11.868504"
+       id="path946"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1405"
+       inkscape:connection-end="#ellipse932" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1644)"
+       d="m 165.62917,64.479186 h 15.34576"
+       id="path948"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1405"
+       inkscape:connection-end="#rect1407" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1586)"
+       d="m 225.42503,64.479186 h 14.2874"
+       id="path950"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1407"
+       inkscape:connection-end="#rect1409" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1534)"
+       d="M 203.13043,57.070847 202.9757,40.590842"
+       id="path952"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1407"
+       inkscape:connection-end="#ellipse926" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1488)"
+       d="M 107.95005,43.547688 124.88338,38.84398"
+       id="path962"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1356"
+       inkscape:connection-end="#rect1403" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1448)"
+       d="M 87.959858,41.724995 88.238273,24.262096"
+       id="path904"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1356"
+       inkscape:connection-end="#path885" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1414)"
+       d="m 25.40004,57.070841 v 7.408345 h 100.01253"
+       id="path909"
+       inkscape:connector-type="orthogonal"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect819"
+       inkscape:connection-end="#rect1405" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1386)"
+       d="m 107.95005,54.48326 17.46252,4.646001"
+       id="path913"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1356"
+       inkscape:connection-end="#rect1405" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1364)"
+       d="m 48.154154,191.47837 89.958486,6e-5"
+       id="path915"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1419"
+       inkscape:connection-end="#rect1423" />
+    <ellipse
+       style="opacity:1;fill:#32b6e5;fill-opacity:1;stroke:#32b6e5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="ellipse1058"
+       cx="274.48633"
+       cy="123.2922"
+       rx="16.252975"
+       ry="8.3154755" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
+       d="m 261.66808,71.887526 10.76141,43.156194"
+       id="path1064"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1409"
+       inkscape:connection-end="#ellipse1058" />
+    <rect
+       style="display:inline;opacity:1;fill:#326ce5;fill-opacity:1;stroke:#326ce5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1072"
+       width="40.216602"
+       height="14.816679"
+       x="255.05841"
+       y="141.20833" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker3234)"
+       d="m 274.70971,131.60682 0.25796,9.60151"
+       id="path1074"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#ellipse1058"
+       inkscape:connection-end="#rect1072" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1669)"
+       d="m 136.52525,117.26244 -20.63776,-5.02483"
+       id="path1659"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1415"
+       inkscape:connection-end="#rect1413" />
+    <rect
+       style="display:inline;opacity:1;fill:#326ce5;fill-opacity:1;stroke:#326ce5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1869"
+       width="45.508503"
+       height="14.816679"
+       x="196.32019"
+       y="184.0701" />
+    <ellipse
+       style="opacity:1;fill:#32b6e5;fill-opacity:1;stroke:#32b6e5;stroke-width:0.52899998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="ellipse2195"
+       cx="156.86015"
+       cy="149.59933"
+       rx="16.252975"
+       ry="8.3154755" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2318)"
+       d="m 156.69473,129.5667 0.0968,11.71737"
+       id="path2201"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1415"
+       inkscape:connection-end="#ellipse2195" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker2231)"
+       d="m 101.51023,114.75004 53.62561,69.32006"
+       id="path2203"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1413"
+       inkscape:connection-end="#rect1423" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker2421)"
+       d="m 183.62114,191.47844 h 12.69905"
+       id="path2205"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1423"
+       inkscape:connection-end="#rect1869" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker2617)"
+       d="m 241.82869,184.86163 18.22521,-5.29979"
+       id="path2207"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1869"
+       inkscape:connection-end="#ellipse928" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker2819)"
+       d="m 241.82869,194.84508 16.81768,2.48828"
+       id="path2209"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect1869"
+       inkscape:connection-end="#ellipse930" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Text"
+     style="display:none"
+     sodipodi:insensitive="true">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="25.761269"
+       y="49.127995"
+       id="text1230-7"><tspan
+         sodipodi:role="line"
+         id="tspan1228-4"
+         x="25.761269"
+         y="49.127995"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332">ClassifierTable</tspan><tspan
+         sodipodi:role="line"
+         x="25.761269"
+         y="55.301605"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1232-3">#0</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="87.466988"
+       y="48.115978"
+       id="text1257"><tspan
+         sodipodi:role="line"
+         id="tspan1255"
+         x="87.466988"
+         y="48.115978"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332">SpoofGuardTable</tspan><tspan
+         sodipodi:role="line"
+         x="87.466988"
+         y="54.289589"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1259">#10</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="145.00087"
+       y="32.806389"
+       id="text1263"><tspan
+         sodipodi:role="line"
+         id="tspan1261"
+         x="145.00087"
+         y="32.806389"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332">ArpResponderTable</tspan><tspan
+         sodipodi:role="line"
+         x="145.00087"
+         y="38.98"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1265">#20</tspan><tspan
+         sodipodi:role="line"
+         x="145.00087"
+         y="45.15361"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1267" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="146.42584"
+       y="63.649162"
+       id="text1271"><tspan
+         sodipodi:role="line"
+         id="tspan1269"
+         x="146.42584"
+         y="63.649162"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332">ConntrackTable</tspan><tspan
+         sodipodi:role="line"
+         x="146.42584"
+         y="69.822777"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1273">#30</tspan><tspan
+         sodipodi:role="line"
+         x="146.42584"
+         y="75.996384"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1275" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="203.40659"
+       y="64.068199"
+       id="text1279"><tspan
+         sodipodi:role="line"
+         id="tspan1277"
+         x="203.40659"
+         y="64.068199"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332">ConntrackStateTable</tspan><tspan
+         sodipodi:role="line"
+         x="203.40659"
+         y="70.241814"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1281">#31</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="259.74954"
+       y="63.85601"
+       id="text1285"><tspan
+         sodipodi:role="line"
+         id="tspan1283"
+         x="259.74954"
+         y="63.85601"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332">DnatTable</tspan><tspan
+         sodipodi:role="line"
+         x="259.74954"
+         y="70.029625"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1287">#40</tspan><tspan
+         sodipodi:role="line"
+         x="259.74954"
+         y="76.203232"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1289" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="216.91811"
+       y="106.6312"
+       id="text1293"><tspan
+         sodipodi:role="line"
+         id="tspan1291"
+         x="216.91811"
+         y="106.6312"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332">EgressRuleTable</tspan><tspan
+         sodipodi:role="line"
+         x="216.91811"
+         y="112.80482"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1295">#50</tspan><tspan
+         sodipodi:role="line"
+         x="216.91811"
+         y="118.97842"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1297" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="156.90335"
+       y="121.44521"
+       id="text1301"><tspan
+         sodipodi:role="line"
+         id="tspan1299"
+         x="156.90335"
+         y="121.44521"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332">EgressDefaultTable</tspan><tspan
+         sodipodi:role="line"
+         x="156.90335"
+         y="127.61883"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1303">#60</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="95.399055"
+       y="106.65405"
+       id="text1307"><tspan
+         sodipodi:role="line"
+         id="tspan1305"
+         x="95.399055"
+         y="106.65405"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332">L3ForwardingTable</tspan><tspan
+         sodipodi:role="line"
+         x="95.399055"
+         y="112.82767"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1309">#70</tspan><tspan
+         sodipodi:role="line"
+         x="95.399055"
+         y="119.00127"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1311" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="27.806725"
+       y="106.57745"
+       id="text1315"><tspan
+         sodipodi:role="line"
+         id="tspan1313"
+         x="27.806725"
+         y="106.57745"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332">L2ForwardingCalcTable</tspan><tspan
+         sodipodi:role="line"
+         x="27.806725"
+         y="112.75107"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1317">#80</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="27.915535"
+       y="190.43074"
+       id="text1321"><tspan
+         sodipodi:role="line"
+         id="tspan1319"
+         x="27.915535"
+         y="190.43074"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332">IngressRuleTable</tspan><tspan
+         sodipodi:role="line"
+         x="27.915535"
+         y="196.60435"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1323">#90</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="95.237946"
+       y="174.84334"
+       id="text1327"><tspan
+         sodipodi:role="line"
+         id="tspan1325"
+         x="95.237946"
+         y="174.84334"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332">IngressDefaultTable</tspan><tspan
+         sodipodi:role="line"
+         x="95.237946"
+         y="181.01695"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1329">#100</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="161.01057"
+       y="190.99077"
+       id="text1333"><tspan
+         sodipodi:role="line"
+         id="tspan1331"
+         x="161.01057"
+         y="190.99077"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332">ConntrackCommitTable</tspan><tspan
+         sodipodi:role="line"
+         x="161.01057"
+         y="197.16438"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1335">#105</tspan></text>
+    <text
+       id="text1026"
+       y="17.75597"
+       x="87.824959"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         id="tspan1024"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         y="17.75597"
+         x="87.824959"
+         sodipodi:role="line">drop</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="203.1077"
+       y="34.008945"
+       id="text1032"><tspan
+         sodipodi:role="line"
+         x="203.1077"
+         y="34.008945"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1030">drop</tspan></text>
+    <text
+       id="text1036"
+       y="147.17505"
+       x="94.326164"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         id="tspan1034"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         y="147.17505"
+         x="94.326164"
+         sodipodi:role="line">drop</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="273.56244"
+       y="201.45241"
+       id="text1040"><tspan
+         sodipodi:role="line"
+         x="273.56244"
+         y="201.45241"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan1038">drop</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="145.5208"
+       y="94.112495"
+       id="text1052"><tspan
+         sodipodi:role="line"
+         id="tspan1050"
+         x="145.5208"
+         y="94.112495"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332">ct</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="274.63739"
+       y="177.19162"
+       id="text1056"><tspan
+         sodipodi:role="line"
+         id="tspan1054"
+         x="274.63739"
+         y="177.19162"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332">output</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="274.1084"
+       y="125.33333"
+       id="text1062"><tspan
+         sodipodi:role="line"
+         id="tspan1060"
+         x="274.1084"
+         y="125.33333"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332">output: gw</tspan></text>
+    <text
+       id="text1078"
+       y="150.43094"
+       x="275.16675"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         y="150.43094"
+         x="275.16675"
+         id="tspan1076"
+         sodipodi:role="line">kube-proxy</tspan></text>
+    <text
+       id="text1875"
+       y="190.99077"
+       x="219.74728"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         y="190.99077"
+         x="219.74728"
+         id="tspan1871"
+         sodipodi:role="line">L2ForwardingOutTable</tspan><tspan
+         id="tspan1873"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         y="197.16438"
+         x="219.74728"
+         sodipodi:role="line">#110</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="155.93628"
+       y="150.9548"
+       id="text2199"><tspan
+         sodipodi:role="line"
+         x="155.93628"
+         y="150.9548"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan2197">drop</tspan></text>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer5"
+     inkscape:label="TextPath"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <g
+       aria-label="ClassifierTable
+#0"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4184">
+      <path
+         d="m 13.296825,49.182322 q -0.439562,0 -0.691445,-0.172861 -0.246944,-0.172861 -0.345722,-0.469194 -0.09878,-0.301272 -0.09878,-0.691445 v -1.427339 q 0,-0.409927 0.09878,-0.7112 0.09878,-0.301272 0.345722,-0.464255 0.251883,-0.162984 0.691445,-0.162984 0.414866,0 0.646994,0.143228 0.237067,0.138289 0.335845,0.40005 0.09878,0.261761 0.09878,0.607484 v 0.335844 h -0.701322 v -0.345722 q 0,-0.167922 -0.01975,-0.306211 -0.01482,-0.138289 -0.09384,-0.217311 -0.07408,-0.08396 -0.261762,-0.08396 -0.187677,0 -0.276577,0.0889 -0.08396,0.08396 -0.108656,0.232128 -0.02469,0.143228 -0.02469,0.325967 v 1.738489 q 0,0.217311 0.03457,0.360539 0.03457,0.138289 0.123472,0.212372 0.09384,0.06914 0.251883,0.06914 0.182739,0 0.256823,-0.08396 0.07902,-0.0889 0.09878,-0.232127 0.01975,-0.143228 0.01975,-0.321028 v -0.360539 h 0.701322 v 0.321028 q 0,0.3556 -0.09384,0.632177 -0.09384,0.271639 -0.330905,0.429684 -0.232128,0.153105 -0.656872,0.153105 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4310"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 14.882517,49.127995 v -4.000501 h 0.66675 v 4.000501 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4312"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 16.635591,49.172445 q -0.192617,0 -0.330906,-0.09878 -0.138289,-0.103717 -0.212372,-0.256822 -0.07408,-0.158045 -0.07408,-0.325967 0,-0.2667 0.09878,-0.449439 0.09878,-0.182739 0.261761,-0.306211 0.162983,-0.123472 0.370416,-0.212372 0.207434,-0.09384 0.419806,-0.167923 v -0.246944 q 0,-0.123472 -0.01976,-0.207433 -0.01482,-0.08396 -0.06421,-0.128412 -0.04445,-0.04445 -0.143228,-0.04445 -0.08396,0 -0.138289,0.03951 -0.04939,0.03951 -0.07408,0.113594 -0.01976,0.06914 -0.0247,0.162983 l -0.0099,0.172861 -0.637117,-0.02469 q 0.01482,-0.493889 0.242005,-0.726017 0.232128,-0.237066 0.701323,-0.237066 0.429683,0 0.6223,0.237066 0.197555,0.237067 0.197555,0.642056 v 1.318683 q 0,0.158045 0.0049,0.286456 0.0099,0.128411 0.01976,0.232128 0.01482,0.103716 0.02469,0.182739 h -0.602544 q -0.01482,-0.09878 -0.03951,-0.22225 -0.01976,-0.128412 -0.02963,-0.187678 -0.04939,0.172861 -0.187678,0.316089 -0.138288,0.138289 -0.375355,0.138289 z m 0.246944,-0.498828 q 0.06421,0 0.118534,-0.02963 0.05927,-0.03457 0.103716,-0.07902 0.04445,-0.04445 0.06421,-0.07902 v -0.795161 q -0.108656,0.06421 -0.207433,0.128411 -0.09384,0.06421 -0.167923,0.143228 -0.06914,0.07408 -0.108655,0.162983 -0.03457,0.0889 -0.03457,0.207433 0,0.158045 0.05927,0.251884 0.06421,0.0889 0.172861,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4314"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 19.086129,49.172445 q -0.360539,0 -0.592667,-0.192617 -0.232128,-0.192617 -0.330905,-0.563033 l 0.498827,-0.192617 q 0.05927,0.232128 0.158045,0.3556 0.09878,0.123472 0.256822,0.123472 0.118533,0 0.1778,-0.05927 0.05927,-0.05927 0.05927,-0.162983 0,-0.118533 -0.07408,-0.212372 -0.06914,-0.09878 -0.242005,-0.242006 l -0.345722,-0.291394 q -0.187678,-0.162984 -0.306212,-0.330906 -0.113594,-0.172861 -0.113594,-0.429683 0,-0.232128 0.103717,-0.395111 0.108655,-0.167922 0.291394,-0.256822 0.187678,-0.09384 0.414867,-0.09384 0.345722,0 0.553155,0.207433 0.212373,0.202494 0.271639,0.5334 l -0.439561,0.187678 q -0.02469,-0.118534 -0.07408,-0.217311 -0.04445,-0.103717 -0.118534,-0.167923 -0.07408,-0.0642 -0.172861,-0.0642 -0.103716,0 -0.167922,0.0642 -0.05927,0.06421 -0.05927,0.162984 0,0.08396 0.06915,0.172861 0.07408,0.0889 0.207433,0.202494 l 0.350661,0.316089 q 0.113595,0.09878 0.217312,0.212373 0.103716,0.113594 0.172861,0.256822 0.06914,0.138289 0.06914,0.321028 0,0.246944 -0.113594,0.414866 -0.108656,0.167922 -0.301273,0.256822 -0.187677,0.08396 -0.419805,0.08396 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4316"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 21.063614,49.172445 q -0.360539,0 -0.592667,-0.192617 -0.232127,-0.192617 -0.330905,-0.563033 l 0.498828,-0.192617 q 0.05927,0.232128 0.158044,0.3556 0.09878,0.123472 0.256822,0.123472 0.118534,0 0.1778,-0.05927 0.05927,-0.05927 0.05927,-0.162983 0,-0.118533 -0.07408,-0.212372 -0.06914,-0.09878 -0.242006,-0.242006 l -0.345722,-0.291394 q -0.187678,-0.162984 -0.306211,-0.330906 -0.113595,-0.172861 -0.113595,-0.429683 0,-0.232128 0.103717,-0.395111 0.108655,-0.167922 0.291394,-0.256822 0.187678,-0.09384 0.414867,-0.09384 0.345722,0 0.553156,0.207433 0.212372,0.202494 0.271638,0.5334 l -0.439561,0.187678 q -0.02469,-0.118534 -0.07408,-0.217311 -0.04445,-0.103717 -0.118533,-0.167923 -0.07408,-0.0642 -0.172861,-0.0642 -0.103717,0 -0.167923,0.0642 -0.05927,0.06421 -0.05927,0.162984 0,0.08396 0.06914,0.172861 0.07408,0.0889 0.207433,0.202494 l 0.350662,0.316089 q 0.113594,0.09878 0.217311,0.212373 0.103716,0.113594 0.172861,0.256822 0.06914,0.138289 0.06914,0.321028 0,0.246944 -0.113594,0.414866 -0.108656,0.167922 -0.301272,0.256822 -0.187678,0.08396 -0.419806,0.08396 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4318"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 22.285449,49.127995 v -2.854678 h 0.671689 v 2.854678 z m 0,-3.309056 v -0.558095 h 0.671689 v 0.558095 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4320"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 23.61918,49.127995 v -2.385484 h -0.306211 v -0.469194 h 0.306211 v -0.182739 q 0,-0.271639 0.06421,-0.459317 0.06421,-0.187678 0.22225,-0.286455 0.158044,-0.09878 0.434622,-0.09878 0.07408,0 0.153105,0.0099 0.07902,0.0049 0.162984,0.01482 v 0.474134 q -0.03457,-0.0049 -0.07408,-0.0099 -0.03951,-0.0049 -0.07408,-0.0049 -0.113594,0 -0.167922,0.06914 -0.04939,0.06421 -0.04939,0.232128 v 0.242006 h 1.249539 v 2.854678 h -0.66675 v -2.385484 h -0.582789 v 2.385484 z m 1.303867,-3.309056 v -0.558095 h 0.6223 v 0.558095 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4322"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 26.930627,49.172445 q -0.321027,0 -0.523522,-0.118534 -0.202494,-0.123472 -0.301272,-0.3556 -0.09384,-0.237066 -0.09384,-0.567972 v -0.859367 q 0,-0.340783 0.09384,-0.572911 0.09878,-0.232128 0.301272,-0.350661 0.207433,-0.118533 0.523522,-0.118533 0.340784,0 0.528462,0.128411 0.192616,0.128411 0.271638,0.375355 0.08396,0.242006 0.08396,0.592667 v 0.404989 h -1.135945 v 0.563033 q 0,0.138289 0.02469,0.227189 0.02963,0.0889 0.0889,0.128411 0.05927,0.03951 0.143228,0.03951 0.0889,0 0.143228,-0.03951 0.05433,-0.04445 0.07902,-0.123472 0.0247,-0.08396 0.0247,-0.207433 V 48.08095 h 0.627239 v 0.192617 q 0,0.434622 -0.217311,0.66675 -0.217312,0.232128 -0.661812,0.232128 z m -0.251883,-1.773062 h 0.503767 v -0.271639 q 0,-0.148166 -0.0247,-0.237066 -0.02469,-0.09384 -0.07902,-0.13335 -0.05433,-0.04445 -0.153106,-0.04445 -0.0889,0 -0.143227,0.04445 -0.05433,0.04445 -0.07902,0.148166 -0.02469,0.103717 -0.02469,0.296334 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4324"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 28.280487,49.127995 v -2.854678 h 0.671689 v 0.439561 q 0.148166,-0.251884 0.296333,-0.360539 0.148167,-0.113595 0.325967,-0.113595 0.02963,0 0.04939,0.0049 0.02469,0 0.05433,0.0049 v 0.696384 q -0.05927,-0.0247 -0.13335,-0.03951 -0.06914,-0.01975 -0.143228,-0.01975 -0.13335,0 -0.242006,0.06421 -0.108655,0.06421 -0.207433,0.212373 v 1.965678 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4326"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 30.456146,49.127995 v -3.462162 h -0.637117 v -0.538339 h 1.995311 v 0.538339 h -0.627239 v 3.462162 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4328"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 32.387946,49.172445 q -0.192616,0 -0.330905,-0.09878 -0.138289,-0.103717 -0.212373,-0.256822 -0.07408,-0.158045 -0.07408,-0.325967 0,-0.2667 0.09878,-0.449439 0.09878,-0.182739 0.261761,-0.306211 0.162983,-0.123472 0.370417,-0.212372 0.207433,-0.09384 0.419805,-0.167923 v -0.246944 q 0,-0.123472 -0.01975,-0.207433 -0.01482,-0.08396 -0.06421,-0.128412 -0.04445,-0.04445 -0.143228,-0.04445 -0.08396,0 -0.138289,0.03951 -0.04939,0.03951 -0.07408,0.113594 -0.01976,0.06914 -0.02469,0.162983 l -0.0099,0.172861 -0.637117,-0.02469 q 0.01482,-0.493889 0.242006,-0.726017 0.232128,-0.237066 0.701322,-0.237066 0.429683,0 0.6223,0.237066 0.197556,0.237067 0.197556,0.642056 v 1.318683 q 0,0.158045 0.0049,0.286456 0.0099,0.128411 0.01976,0.232128 0.01482,0.103716 0.02469,0.182739 h -0.602544 q -0.01482,-0.09878 -0.03951,-0.22225 -0.01976,-0.128412 -0.02963,-0.187678 -0.04939,0.172861 -0.187678,0.316089 -0.138289,0.138289 -0.375356,0.138289 z m 0.246945,-0.498828 q 0.0642,0 0.118533,-0.02963 0.05927,-0.03457 0.103717,-0.07902 0.04445,-0.04445 0.06421,-0.07902 v -0.795161 q -0.108655,0.06421 -0.207433,0.128411 -0.09384,0.06421 -0.167922,0.143228 -0.06914,0.07408 -0.108656,0.162983 -0.03457,0.0889 -0.03457,0.207433 0,0.158045 0.05927,0.251884 0.06421,0.0889 0.172861,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4330"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 35.292861,49.172445 q -0.158045,0 -0.296334,-0.07408 -0.138288,-0.07408 -0.256822,-0.182739 v 0.212373 h -0.671689 v -4.000501 h 0.671689 v 1.363134 q 0.123472,-0.118534 0.2667,-0.187678 0.148167,-0.07408 0.316089,-0.07408 0.192617,0 0.316089,0.0889 0.123472,0.0889 0.192617,0.237066 0.06914,0.143228 0.09384,0.31115 0.02963,0.162984 0.02963,0.316089 v 0.968023 q 0,0.281516 -0.06914,0.513644 -0.06421,0.232128 -0.212372,0.370417 -0.143228,0.138289 -0.380294,0.138289 z M 35.036039,48.70325 q 0.108655,0 0.158044,-0.06914 0.05433,-0.07408 0.06914,-0.192617 0.01976,-0.123472 0.01976,-0.2667 v -1.02235 q 0,-0.13335 -0.01976,-0.237067 -0.01976,-0.108655 -0.07408,-0.172861 -0.04939,-0.06421 -0.158044,-0.06421 -0.07902,0 -0.153106,0.03951 -0.07408,0.03457 -0.138289,0.07902 v 1.802694 q 0.06421,0.04445 0.138289,0.07408 0.07902,0.02963 0.158045,0.02963 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4332"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 36.461217,49.127995 v -4.000501 h 0.66675 v 4.000501 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4334"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 38.525442,49.172445 q -0.321028,0 -0.523523,-0.118534 -0.202494,-0.123472 -0.301272,-0.3556 -0.09384,-0.237066 -0.09384,-0.567972 v -0.859367 q 0,-0.340783 0.09384,-0.572911 0.09878,-0.232128 0.301272,-0.350661 0.207434,-0.118533 0.523523,-0.118533 0.340783,0 0.528461,0.128411 0.192616,0.128411 0.271639,0.375355 0.08396,0.242006 0.08396,0.592667 v 0.404989 h -1.135945 v 0.563033 q 0,0.138289 0.0247,0.227189 0.02963,0.0889 0.0889,0.128411 0.05927,0.03951 0.143228,0.03951 0.0889,0 0.143227,-0.03951 0.05433,-0.04445 0.07902,-0.123472 0.02469,-0.08396 0.02469,-0.207433 V 48.08095 h 0.627239 v 0.192617 q 0,0.434622 -0.217311,0.66675 -0.217311,0.232128 -0.661811,0.232128 z m -0.251884,-1.773062 h 0.503767 v -0.271639 q 0,-0.148166 -0.02469,-0.237066 -0.0247,-0.09384 -0.07902,-0.13335 -0.05433,-0.04445 -0.153105,-0.04445 -0.0889,0 -0.143228,0.04445 -0.05433,0.04445 -0.07902,0.148166 -0.0247,0.103717 -0.0247,0.296334 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4336"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 23.442653,55.301606 0.1778,-1.37795 h -0.242005 l 0.0049,-0.449439 h 0.301273 l 0.06914,-0.528461 h -0.360539 l 0.0049,-0.459317 h 0.429683 l 0.153106,-1.185333 h 0.523522 l -0.153105,1.185333 h 0.409928 L 24.9193,51.301106 h 0.518583 l -0.158044,1.185333 h 0.237067 l -0.0099,0.459317 h -0.296334 l -0.06914,0.528461 h 0.350661 l -0.0049,0.449439 h -0.409928 l -0.182738,1.37795 h -0.523523 l 0.182739,-1.37795 h -0.409928 l -0.1778,1.37795 z m 0.760589,-1.827389 h 0.414867 l 0.06914,-0.528461 h -0.409928 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4338"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 27.026897,55.360872 q -0.350661,0 -0.582788,-0.148166 -0.227189,-0.148167 -0.345723,-0.409928 -0.113594,-0.261761 -0.113594,-0.602544 v -1.773062 q 0,-0.350661 0.108655,-0.612422 0.113595,-0.2667 0.340784,-0.414867 0.232128,-0.148166 0.592666,-0.148166 0.360539,0 0.587728,0.148166 0.232128,0.148167 0.340784,0.414867 0.113594,0.261761 0.113594,0.612422 v 1.773062 q 0,0.340783 -0.118533,0.602544 -0.113595,0.261761 -0.345723,0.409928 -0.227188,0.148166 -0.57785,0.148166 z m 0,-0.587727 q 0.153106,0 0.227189,-0.09384 0.07408,-0.09384 0.09878,-0.227189 0.0247,-0.13335 0.0247,-0.261761 V 52.43705 q 0,-0.138289 -0.0247,-0.271639 -0.01975,-0.138289 -0.09384,-0.232127 -0.07408,-0.09384 -0.232128,-0.09384 -0.158044,0 -0.232127,0.09384 -0.07408,0.09384 -0.09878,0.232127 -0.01976,0.13335 -0.01976,0.271639 v 1.753306 q 0,0.128411 0.0247,0.261761 0.02963,0.13335 0.103716,0.227189 0.07408,0.09384 0.22225,0.09384 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4340"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="SpoofGuardTable
+#10"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4190">
+      <path
+         d="m 72.801574,48.170306 q -0.360539,0 -0.602544,-0.138289 Q 71.957024,47.888789 71.833552,47.61715 71.71008,47.345512 71.695263,46.9504 l 0.627239,-0.123472 q 0.0099,0.232128 0.05433,0.409928 0.04939,0.1778 0.143227,0.276578 0.09878,0.09384 0.256823,0.09384 0.1778,0 0.251883,-0.103717 0.07408,-0.108656 0.07408,-0.271639 0,-0.261761 -0.118533,-0.429683 -0.118533,-0.167922 -0.316089,-0.335845 l -0.503767,-0.4445 q -0.212371,-0.18274 -0.340782,-0.40499 -0.123472,-0.227189 -0.123472,-0.558094 0,-0.474133 0.276578,-0.730956 0.276577,-0.256822 0.75565,-0.256822 0.281516,0 0.469194,0.0889 0.187678,0.08396 0.296333,0.237067 0.113595,0.153105 0.167923,0.350661 0.05433,0.192617 0.06914,0.409928 l -0.6223,0.108655 q -0.0099,-0.187678 -0.04445,-0.335844 -0.02963,-0.148167 -0.113594,-0.232128 -0.07902,-0.08396 -0.237067,-0.08396 -0.162983,0 -0.251883,0.108655 -0.08396,0.103717 -0.08396,0.261762 0,0.202494 0.08396,0.335844 0.08396,0.128411 0.242005,0.2667 l 0.498828,0.439561 q 0.246944,0.207434 0.419805,0.48895 0.1778,0.276578 0.1778,0.671689 0,0.286456 -0.128411,0.508706 -0.123472,0.22225 -0.350661,0.350661 -0.22225,0.123472 -0.523522,0.123472 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4343"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 74.112926,49.054367 V 45.2613 h 0.671689 v 0.217312 q 0.123472,-0.118534 0.271639,-0.187678 0.148167,-0.07408 0.31115,-0.07408 0.192617,0 0.316089,0.0889 0.123472,0.0889 0.192617,0.237067 0.06914,0.143228 0.09384,0.31115 0.02963,0.162983 0.02963,0.316089 v 0.968022 q 0,0.281517 -0.06915,0.513645 -0.06421,0.232127 -0.212372,0.370416 -0.143228,0.138289 -0.385233,0.138289 -0.153106,0 -0.291395,-0.07408 -0.13335,-0.07408 -0.256822,-0.187678 v 1.1557 z m 0.968023,-1.363133 q 0.108655,0 0.158044,-0.06914 0.05433,-0.07408 0.06914,-0.192616 0.01976,-0.123473 0.01976,-0.2667 v -1.02235 q 0,-0.13335 -0.01976,-0.237067 -0.01976,-0.108656 -0.07408,-0.172861 -0.05433,-0.06421 -0.158044,-0.06421 -0.07902,0 -0.158045,0.03951 -0.07408,0.03457 -0.13335,0.08396 v 1.802694 q 0.06421,0.04445 0.138289,0.07408 0.07408,0.0247 0.158046,0.0247 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4345"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 77.330921,48.160428 q -0.31115,0 -0.513644,-0.113594 -0.202495,-0.118534 -0.306212,-0.340784 -0.09878,-0.22225 -0.09878,-0.538338 v -0.958145 q 0,-0.316089 0.09878,-0.538339 0.103717,-0.22225 0.306212,-0.335844 0.202494,-0.118534 0.513644,-0.118534 0.31115,0 0.513644,0.118534 0.207434,0.113594 0.306212,0.335844 0.103716,0.22225 0.103716,0.538339 v 0.958145 q 0,0.316088 -0.103716,0.538338 -0.09878,0.22225 -0.306212,0.340784 -0.202494,0.113594 -0.513644,0.113594 z m 0.0049,-0.464255 q 0.113594,0 0.167922,-0.06421 0.05433,-0.06421 0.06915,-0.172861 0.01482,-0.113594 0.01482,-0.246944 v -1.047045 q 0,-0.13335 -0.01482,-0.242005 -0.01482,-0.108656 -0.06915,-0.172862 -0.05433,-0.06914 -0.167922,-0.06914 -0.113595,0 -0.167922,0.06914 -0.05433,0.06421 -0.07408,0.172862 -0.01482,0.108655 -0.01482,0.242005 v 1.047045 q 0,0.13335 0.01482,0.246944 0.01976,0.108656 0.07408,0.172861 0.05433,0.06421 0.167922,0.06421 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4347"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 79.578502,48.160428 q -0.31115,0 -0.513645,-0.113594 -0.202494,-0.118534 -0.306211,-0.340784 -0.09878,-0.22225 -0.09878,-0.538338 v -0.958145 q 0,-0.316089 0.09878,-0.538339 0.103717,-0.22225 0.306211,-0.335844 0.202495,-0.118534 0.513645,-0.118534 0.31115,0 0.513644,0.118534 0.207433,0.113594 0.306211,0.335844 0.103717,0.22225 0.103717,0.538339 v 0.958145 q 0,0.316088 -0.103717,0.538338 -0.09878,0.22225 -0.306211,0.340784 -0.202494,0.113594 -0.513644,0.113594 z m 0.0049,-0.464255 q 0.113595,0 0.167923,-0.06421 0.05433,-0.06421 0.06914,-0.172861 0.01482,-0.113594 0.01482,-0.246944 v -1.047045 q 0,-0.13335 -0.01482,-0.242005 -0.01482,-0.108656 -0.06914,-0.172862 -0.05433,-0.06914 -0.167923,-0.06914 -0.113594,0 -0.167922,0.06914 -0.05433,0.06421 -0.07408,0.172862 -0.01482,0.108655 -0.01482,0.242005 v 1.047045 q 0,0.13335 0.01482,0.246944 0.01975,0.108656 0.07408,0.172861 0.05433,0.06421 0.167922,0.06421 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4349"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 81.100064,48.115978 V 45.730495 H 80.793853 V 45.2613 h 0.306211 v -0.182739 q 0,-0.256822 0.04445,-0.4445 0.04939,-0.192616 0.197556,-0.296333 0.153106,-0.103717 0.459317,-0.103717 0.09384,0 0.1778,0.0099 0.08396,0.0049 0.187677,0.01976 v 0.498828 q -0.03951,-0.0099 -0.09384,-0.01482 -0.04939,-0.0099 -0.09384,-0.0099 -0.118534,0 -0.162984,0.07408 -0.04445,0.07408 -0.04445,0.217312 V 45.2613 h 0.395111 v 0.469195 H 81.77175 v 2.385483 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4351"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 83.513638,48.170306 q -0.395111,0 -0.627239,-0.167922 -0.232128,-0.167922 -0.335844,-0.474134 -0.09878,-0.31115 -0.09878,-0.730955 v -1.343378 q 0,-0.429683 0.09878,-0.740833 0.09878,-0.31115 0.345722,-0.474134 0.251883,-0.167922 0.691444,-0.167922 0.409928,0 0.651934,0.138289 0.242005,0.138289 0.345722,0.40005 0.108655,0.256822 0.108655,0.627239 v 0.207433 H 83.997649 V 45.21685 q 0,-0.192616 -0.02963,-0.330905 -0.0247,-0.138289 -0.108656,-0.207434 -0.07902,-0.07408 -0.261761,-0.07408 -0.192617,0 -0.281517,0.09384 -0.08396,0.09384 -0.108655,0.246944 -0.01976,0.153106 -0.01976,0.335845 v 1.674283 q 0,0.207434 0.03457,0.360539 0.03457,0.153106 0.128411,0.237067 0.09384,0.07902 0.2667,0.07902 0.1778,0 0.271639,-0.0889 0.09384,-0.0889 0.128411,-0.246944 0.03951,-0.158045 0.03951,-0.375356 v -0.375355 h -0.429684 v -0.459317 h 1.086556 v 2.029883 h -0.469194 l -0.05433,-0.395111 q -0.07902,0.197556 -0.242006,0.325967 -0.158044,0.123472 -0.434622,0.123472 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4353"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 85.684743,48.160428 q -0.167922,0 -0.276578,-0.08396 -0.108655,-0.0889 -0.158044,-0.232128 -0.04939,-0.148166 -0.04939,-0.31115 V 45.2613 h 0.671689 v 2.148417 q 0,0.128411 0.03951,0.202495 0.04445,0.06914 0.158044,0.06914 0.07408,0 0.148167,-0.03951 0.07902,-0.03951 0.153106,-0.09384 V 45.2613 h 0.671689 v 2.854678 h -0.671689 v -0.271639 q -0.143228,0.138289 -0.316089,0.227189 -0.172861,0.0889 -0.370417,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4355"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 88.112978,48.160428 q -0.192616,0 -0.330905,-0.09878 -0.138289,-0.103716 -0.212372,-0.256822 -0.07408,-0.158044 -0.07408,-0.325966 0,-0.2667 0.09878,-0.449439 0.09878,-0.182739 0.261761,-0.306211 0.162983,-0.123473 0.370417,-0.212373 0.207433,-0.09384 0.419805,-0.167922 v -0.246944 q 0,-0.123473 -0.01976,-0.207434 -0.01482,-0.08396 -0.06421,-0.128411 -0.04445,-0.04445 -0.143228,-0.04445 -0.08396,0 -0.138288,0.03951 -0.04939,0.03951 -0.07408,0.113595 -0.01976,0.06914 -0.02469,0.162983 l -0.0099,0.172861 -0.637117,-0.02469 q 0.01482,-0.493889 0.242006,-0.726017 0.232128,-0.237067 0.701322,-0.237067 0.429684,0 0.6223,0.237067 0.197556,0.237067 0.197556,0.642056 v 1.318683 q 0,0.158044 0.0049,0.286456 0.0099,0.128411 0.01976,0.232127 0.01482,0.103717 0.02469,0.182739 H 88.7451 q -0.01482,-0.09878 -0.03951,-0.22225 -0.01976,-0.128411 -0.02963,-0.187678 -0.04939,0.172862 -0.187678,0.316089 -0.138289,0.138289 -0.375356,0.138289 z M 88.359923,47.6616 q 0.06421,0 0.118533,-0.02963 0.05927,-0.03457 0.103717,-0.07902 0.04445,-0.04445 0.06421,-0.07902 v -0.795161 q -0.108655,0.06421 -0.207433,0.128411 -0.09384,0.06421 -0.167922,0.143227 -0.06915,0.07408 -0.108656,0.162984 -0.03457,0.0889 -0.03457,0.207433 0,0.158045 0.05927,0.251883 0.06421,0.0889 0.172861,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4357"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 89.802928,48.115978 V 45.2613 h 0.671689 v 0.439562 q 0.148167,-0.251884 0.296333,-0.360539 0.148167,-0.113595 0.325967,-0.113595 0.02963,0 0.04939,0.0049 0.02469,0 0.05433,0.0049 v 0.696383 q -0.05927,-0.02469 -0.13335,-0.03951 -0.06915,-0.01976 -0.143228,-0.01976 -0.13335,0 -0.242006,0.06421 -0.108655,0.06421 -0.207433,0.212372 v 1.965678 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4359"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 92.156848,48.160428 q -0.340784,0 -0.518584,-0.242005 -0.172861,-0.242006 -0.172861,-0.775406 v -0.874183 q 0,-0.296334 0.06421,-0.5334 0.06914,-0.237067 0.217311,-0.375356 0.148167,-0.143228 0.40005,-0.143228 0.153106,0 0.281517,0.06421 0.13335,0.05927 0.242005,0.158044 v -1.323622 h 0.671689 v 4.0005 h -0.671689 v -0.202494 q -0.113594,0.113594 -0.242005,0.182739 -0.128411,0.06421 -0.271639,0.06421 z m 0.246944,-0.464255 q 0.05433,0 0.123472,-0.0247 0.06914,-0.02469 0.143228,-0.06914 v -1.832328 q -0.05927,-0.03951 -0.128411,-0.06421 -0.06914,-0.02963 -0.143228,-0.02963 -0.143227,0 -0.202494,0.13335 -0.05433,0.128411 -0.05433,0.316089 v 1.0668 q 0,0.143228 0.01976,0.256822 0.01975,0.113595 0.07408,0.182739 0.05927,0.06421 0.167922,0.06421 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4361"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 94.29369,48.115978 v -3.462161 h -0.637116 v -0.538339 h 1.995311 v 0.538339 h -0.627239 v 3.462161 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4363"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 96.225489,48.160428 q -0.192617,0 -0.330906,-0.09878 -0.138288,-0.103716 -0.212372,-0.256822 -0.07408,-0.158044 -0.07408,-0.325966 0,-0.2667 0.09878,-0.449439 0.09878,-0.182739 0.261761,-0.306211 0.162983,-0.123473 0.370417,-0.212373 0.207433,-0.09384 0.419805,-0.167922 v -0.246944 q 0,-0.123473 -0.01975,-0.207434 -0.01482,-0.08396 -0.06421,-0.128411 -0.04445,-0.04445 -0.143228,-0.04445 -0.08396,0 -0.138289,0.03951 -0.04939,0.03951 -0.07408,0.113595 -0.01976,0.06914 -0.02469,0.162983 l -0.0099,0.172861 -0.637117,-0.02469 q 0.01482,-0.493889 0.242006,-0.726017 0.232127,-0.237067 0.701322,-0.237067 0.429683,0 0.6223,0.237067 0.197555,0.237067 0.197555,0.642056 v 1.318683 q 0,0.158044 0.0049,0.286456 0.0099,0.128411 0.01976,0.232127 0.01482,0.103717 0.02469,0.182739 h -0.602544 q -0.01482,-0.09878 -0.03951,-0.22225 -0.01976,-0.128411 -0.02963,-0.187678 -0.04939,0.172862 -0.187677,0.316089 -0.138289,0.138289 -0.375356,0.138289 z M 96.472434,47.6616 q 0.0642,0 0.118533,-0.02963 0.05927,-0.03457 0.103717,-0.07902 0.04445,-0.04445 0.06421,-0.07902 v -0.795161 q -0.108655,0.06421 -0.207433,0.128411 -0.09384,0.06421 -0.167922,0.143227 -0.06914,0.07408 -0.108656,0.162984 -0.03457,0.0889 -0.03457,0.207433 0,0.158045 0.05927,0.251883 0.06421,0.0889 0.172862,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4365"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 99.130406,48.160428 q -0.158045,0 -0.296334,-0.07408 -0.138289,-0.07408 -0.256822,-0.182739 v 0.212372 h -0.671689 v -4.0005 h 0.671689 v 1.363134 q 0.123472,-0.118534 0.2667,-0.187678 0.148167,-0.07408 0.316089,-0.07408 0.192617,0 0.316089,0.0889 0.123472,0.0889 0.192616,0.237067 0.06914,0.143228 0.09384,0.31115 0.02963,0.162983 0.02963,0.316089 v 0.968022 q 0,0.281517 -0.06914,0.513645 -0.06421,0.232127 -0.212372,0.370416 -0.143228,0.138289 -0.380294,0.138289 z m -0.256823,-0.469194 q 0.108656,0 0.158045,-0.06914 0.05433,-0.07408 0.06914,-0.192616 0.01976,-0.123473 0.01976,-0.2667 v -1.02235 q 0,-0.13335 -0.01976,-0.237067 -0.01976,-0.108656 -0.07408,-0.172861 -0.04939,-0.06421 -0.158045,-0.06421 -0.07902,0 -0.153105,0.03951 -0.07408,0.03457 -0.138289,0.07902 v 1.802694 q 0.0642,0.04445 0.138289,0.07408 0.07902,0.02963 0.158044,0.02963 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4367"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 100.29876,48.115978 v -4.0005 h 0.66675 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4369"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 102.36299,48.160428 q -0.32103,0 -0.52353,-0.118533 -0.20249,-0.123472 -0.30127,-0.3556 -0.0938,-0.237067 -0.0938,-0.567972 v -0.859367 q 0,-0.340783 0.0938,-0.572911 0.0988,-0.232128 0.30127,-0.350661 0.20744,-0.118534 0.52353,-0.118534 0.34078,0 0.52846,0.128411 0.19261,0.128412 0.27164,0.375356 0.084,0.242006 0.084,0.592667 v 0.404989 h -1.13595 v 0.563033 q 0,0.138289 0.0247,0.227189 0.0296,0.0889 0.0889,0.128411 0.0593,0.03951 0.14323,0.03951 0.0889,0 0.14322,-0.03951 0.0543,-0.04445 0.079,-0.123472 0.0247,-0.08396 0.0247,-0.207434 v -0.237066 h 0.62724 v 0.192616 q 0,0.434623 -0.21731,0.66675 -0.21731,0.232128 -0.66181,0.232128 z m -0.25189,-1.773061 h 0.50377 v -0.271639 q 0,-0.148166 -0.0247,-0.237066 -0.0247,-0.09384 -0.079,-0.13335 -0.0543,-0.04445 -0.1531,-0.04445 -0.0889,0 -0.14323,0.04445 -0.0543,0.04445 -0.079,0.148166 -0.0247,0.103717 -0.0247,0.296334 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4371"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 84.178922,54.28959 0.1778,-1.377951 h -0.242005 l 0.0049,-0.449438 h 0.301272 l 0.06914,-0.528462 H 84.12949 l 0.0049,-0.459316 h 0.429684 l 0.153105,-1.185334 h 0.523522 l -0.153105,1.185334 h 0.409928 l 0.158044,-1.185334 h 0.518583 l -0.158044,1.185334 h 0.237067 l -0.0099,0.459316 h -0.296333 l -0.06915,0.528462 h 0.350661 l -0.0049,0.449438 h -0.409927 l -0.182739,1.377951 h -0.523523 l 0.182739,-1.377951 h -0.409928 l -0.1778,1.377951 z m 0.760589,-1.827389 h 0.414867 l 0.06914,-0.528462 H 85.01359 Z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4373"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 87.190255,54.28959 v -3.244851 q -0.02963,0.01482 -0.118533,0.04445 -0.08396,0.02963 -0.187678,0.05927 -0.103716,0.02469 -0.192616,0.04939 -0.08396,0.02469 -0.118534,0.03951 v -0.508705 q 0.06914,-0.0247 0.172861,-0.06914 0.103717,-0.04445 0.217312,-0.09878 0.118533,-0.05927 0.217311,-0.128411 0.103716,-0.06914 0.167922,-0.143228 h 0.523522 v 4.000501 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4375"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 89.702066,54.348856 q -0.350661,0 -0.582789,-0.148166 -0.227188,-0.148167 -0.345722,-0.409928 -0.113594,-0.261761 -0.113594,-0.602545 v -1.773061 q 0,-0.350661 0.108655,-0.612422 0.113595,-0.2667 0.340784,-0.414867 0.232127,-0.148166 0.592666,-0.148166 0.360539,0 0.587728,0.148166 0.232128,0.148167 0.340783,0.414867 0.113595,0.261761 0.113595,0.612422 v 1.773061 q 0,0.340784 -0.118533,0.602545 -0.113595,0.261761 -0.345723,0.409928 -0.227189,0.148166 -0.57785,0.148166 z m 0,-0.587728 q 0.153106,0 0.227189,-0.09384 0.07408,-0.09384 0.09878,-0.227189 0.02469,-0.13335 0.02469,-0.261762 v -1.753305 q 0,-0.138289 -0.02469,-0.271639 -0.01976,-0.138289 -0.09384,-0.232128 -0.07408,-0.09384 -0.232128,-0.09384 -0.158044,0 -0.232127,0.09384 -0.07408,0.09384 -0.09878,0.232128 -0.01976,0.13335 -0.01976,0.271639 v 1.753305 q 0,0.128412 0.02469,0.261762 0.02963,0.13335 0.103716,0.227189 0.07408,0.09384 0.22225,0.09384 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4377"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="ArpResponderTable
+#20
+"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4198">
+      <path
+         d="m 126.77656,32.806389 0.8001,-4.0005 h 0.78035 l 0.8001,4.0005 h -0.67663 l -0.15805,-0.923572 h -0.69638 l -0.16298,0.923572 z m 0.92357,-1.387828 h 0.54328 l -0.27164,-1.679222 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4380"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 129.48639,32.806389 v -2.854678 h 0.67169 v 0.439561 q 0.14817,-0.251883 0.29633,-0.360539 0.14817,-0.113594 0.32597,-0.113594 0.0296,0 0.0494,0.0049 0.0247,0 0.0543,0.0049 V 30.6234 q -0.0593,-0.0247 -0.13335,-0.03951 -0.0692,-0.01976 -0.14323,-0.01976 -0.13335,0 -0.24201,0.06421 -0.10865,0.06421 -0.20743,0.212372 v 1.965678 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4382"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 131.21755,33.744778 v -3.793067 h 0.67169 v 0.217311 q 0.12347,-0.118533 0.27164,-0.187678 0.14816,-0.07408 0.31115,-0.07408 0.19261,0 0.31609,0.0889 0.12347,0.0889 0.19261,0.237067 0.0692,0.143227 0.0938,0.31115 0.0296,0.162983 0.0296,0.316089 v 0.968022 q 0,0.281517 -0.0691,0.513644 -0.0642,0.232128 -0.21237,0.370417 -0.14323,0.138289 -0.38524,0.138289 -0.1531,0 -0.29139,-0.07408 -0.13335,-0.07408 -0.25682,-0.187678 v 1.1557 z m 0.96802,-1.363134 q 0.10866,0 0.15805,-0.06914 0.0543,-0.07408 0.0691,-0.192617 0.0198,-0.123472 0.0198,-0.2667 v -1.02235 q 0,-0.13335 -0.0198,-0.237066 -0.0198,-0.108656 -0.0741,-0.172862 -0.0543,-0.06421 -0.15805,-0.06421 -0.079,0 -0.15804,0.03951 -0.0741,0.03457 -0.13335,0.08396 v 1.802695 q 0.0642,0.04445 0.13829,0.07408 0.0741,0.02469 0.15804,0.02469 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4384"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 133.61569,32.806389 v -4.0005 h 0.95814 q 0.40499,0 0.68157,0.09878 0.28152,0.09384 0.42474,0.325966 0.14817,0.232128 0.14817,0.632178 0,0.242006 -0.0444,0.434622 -0.0445,0.192617 -0.1531,0.330906 -0.10372,0.13335 -0.2914,0.207433 l 0.5581,1.970617 h -0.73096 l -0.48401,-1.832328 h -0.33585 v 1.832328 z m 0.73095,-2.291645 h 0.22719 q 0.21238,0 0.33585,-0.05927 0.12841,-0.06421 0.18274,-0.197556 0.0543,-0.138289 0.0543,-0.350661 0,-0.301272 -0.11359,-0.449439 -0.10866,-0.153105 -0.41981,-0.153105 h -0.2667 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4386"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 137.19438,32.850839 q -0.32103,0 -0.52353,-0.118533 -0.20249,-0.123473 -0.30127,-0.3556 -0.0938,-0.237067 -0.0938,-0.567973 v -0.859366 q 0,-0.340784 0.0938,-0.572912 0.0988,-0.232127 0.30127,-0.350661 0.20744,-0.118533 0.52353,-0.118533 0.34078,0 0.52846,0.128411 0.19261,0.128411 0.27164,0.375356 0.084,0.242005 0.084,0.592666 v 0.404989 h -1.13595 v 0.563034 q 0,0.138289 0.0247,0.227189 0.0296,0.0889 0.0889,0.128411 0.0593,0.03951 0.14323,0.03951 0.0889,0 0.14322,-0.03951 0.0543,-0.04445 0.079,-0.123473 0.0247,-0.08396 0.0247,-0.207433 v -0.237067 h 0.62724 v 0.192617 q 0,0.434622 -0.21731,0.66675 -0.21731,0.232128 -0.66181,0.232128 z m -0.25189,-1.773061 h 0.50377 v -0.271639 q 0,-0.148167 -0.0247,-0.237067 -0.0247,-0.09384 -0.079,-0.13335 -0.0543,-0.04445 -0.1531,-0.04445 -0.0889,0 -0.14323,0.04445 -0.0543,0.04445 -0.079,0.148167 -0.0247,0.103716 -0.0247,0.296333 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4388"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 139.30483,32.850839 q -0.36054,0 -0.59267,-0.192617 -0.23213,-0.192616 -0.33091,-0.563033 l 0.49883,-0.192617 q 0.0593,0.232128 0.15805,0.3556 0.0988,0.123472 0.25682,0.123472 0.11853,0 0.1778,-0.05927 0.0593,-0.05927 0.0593,-0.162984 0,-0.118533 -0.0741,-0.212372 -0.0691,-0.09878 -0.242,-0.242005 l -0.34573,-0.291395 q -0.18767,-0.162983 -0.30621,-0.330905 -0.11359,-0.172862 -0.11359,-0.429684 0,-0.232128 0.10371,-0.395111 0.10866,-0.167922 0.2914,-0.256822 0.18768,-0.09384 0.41487,-0.09384 0.34572,0 0.55315,0.207433 0.21237,0.202495 0.27164,0.5334 l -0.43956,0.187678 q -0.0247,-0.118533 -0.0741,-0.217311 -0.0444,-0.103717 -0.11854,-0.167922 -0.0741,-0.06421 -0.17286,-0.06421 -0.10372,0 -0.16792,0.06421 -0.0593,0.06421 -0.0593,0.162983 0,0.08396 0.0691,0.172861 0.0741,0.0889 0.20743,0.202495 l 0.35066,0.316089 q 0.1136,0.09878 0.21731,0.212372 0.10372,0.113594 0.17286,0.256822 0.0692,0.138289 0.0692,0.321028 0,0.246944 -0.1136,0.414867 -0.10865,0.167922 -0.30127,0.256822 -0.18768,0.08396 -0.4198,0.08396 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4390"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 140.5069,33.744778 v -3.793067 h 0.67169 v 0.217311 q 0.12348,-0.118533 0.27164,-0.187678 0.14817,-0.07408 0.31115,-0.07408 0.19262,0 0.31609,0.0889 0.12347,0.0889 0.19262,0.237067 0.0691,0.143227 0.0938,0.31115 0.0296,0.162983 0.0296,0.316089 v 0.968022 q 0,0.281517 -0.0691,0.513644 -0.0642,0.232128 -0.21238,0.370417 -0.14322,0.138289 -0.38523,0.138289 -0.15311,0 -0.29139,-0.07408 -0.13335,-0.07408 -0.25683,-0.187678 v 1.1557 z m 0.96803,-1.363134 q 0.10865,0 0.15804,-0.06914 0.0543,-0.07408 0.0692,-0.192617 0.0197,-0.123472 0.0197,-0.2667 v -1.02235 q 0,-0.13335 -0.0197,-0.237066 -0.0198,-0.108656 -0.0741,-0.172862 -0.0543,-0.06421 -0.15804,-0.06421 -0.079,0 -0.15805,0.03951 -0.0741,0.03457 -0.13335,0.08396 v 1.802695 q 0.0642,0.04445 0.13829,0.07408 0.0741,0.02469 0.15805,0.02469 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4392"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 143.7249,32.850839 q -0.31115,0 -0.51365,-0.113595 -0.20249,-0.118533 -0.30621,-0.340783 -0.0988,-0.22225 -0.0988,-0.538339 v -0.958144 q 0,-0.316089 0.0988,-0.538339 0.10372,-0.22225 0.30621,-0.335845 0.2025,-0.118533 0.51365,-0.118533 0.31115,0 0.51364,0.118533 0.20744,0.113595 0.30622,0.335845 0.10371,0.22225 0.10371,0.538339 v 0.958144 q 0,0.316089 -0.10371,0.538339 -0.0988,0.22225 -0.30622,0.340783 -0.20249,0.113595 -0.51364,0.113595 z m 0.005,-0.464256 q 0.11359,0 0.16792,-0.06421 0.0543,-0.06421 0.0692,-0.172861 0.0148,-0.113595 0.0148,-0.246945 v -1.047044 q 0,-0.13335 -0.0148,-0.242006 -0.0148,-0.108655 -0.0692,-0.172861 -0.0543,-0.06914 -0.16792,-0.06914 -0.1136,0 -0.16792,0.06914 -0.0543,0.06421 -0.0741,0.172861 -0.0148,0.108656 -0.0148,0.242006 v 1.047044 q 0,0.13335 0.0148,0.246945 0.0198,0.108655 0.0741,0.172861 0.0543,0.06421 0.16792,0.06421 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4394"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 145.10818,32.806389 v -2.854678 h 0.67168 v 0.286456 q 0.15311,-0.148167 0.32103,-0.237067 0.17286,-0.09384 0.37042,-0.09384 0.1778,0 0.28152,0.0889 0.10371,0.08396 0.1531,0.227189 0.0494,0.143228 0.0494,0.31115 v 2.271889 h -0.67169 V 30.66785 q 0,-0.128411 -0.0395,-0.197556 -0.0395,-0.06914 -0.15311,-0.06914 -0.0691,0 -0.1531,0.03951 -0.079,0.03951 -0.15805,0.09878 v 2.26695 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4396"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 148.09427,32.850839 q -0.34078,0 -0.51858,-0.242006 -0.17286,-0.242005 -0.17286,-0.775405 v -0.874184 q 0,-0.296333 0.0642,-0.5334 0.0692,-0.237066 0.21731,-0.375355 0.14817,-0.143228 0.40005,-0.143228 0.15311,0 0.28152,0.06421 0.13335,0.05927 0.24201,0.158044 v -1.323622 h 0.67169 v 4.0005 h -0.67169 v -0.202495 q -0.1136,0.113595 -0.24201,0.182739 -0.12841,0.06421 -0.27164,0.06421 z m 0.24695,-0.464256 q 0.0543,0 0.12347,-0.02469 0.0691,-0.0247 0.14323,-0.06914 v -1.832327 q -0.0593,-0.03951 -0.12841,-0.06421 -0.0692,-0.02963 -0.14323,-0.02963 -0.14323,0 -0.2025,0.13335 -0.0543,0.128411 -0.0543,0.316089 v 1.0668 q 0,0.143227 0.0197,0.256822 0.0198,0.113594 0.0741,0.182739 0.0593,0.06421 0.16793,0.06421 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4398"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 150.65092,32.850839 q -0.32103,0 -0.52352,-0.118533 -0.2025,-0.123473 -0.30128,-0.3556 -0.0938,-0.237067 -0.0938,-0.567973 v -0.859366 q 0,-0.340784 0.0938,-0.572912 0.0988,-0.232127 0.30128,-0.350661 0.20743,-0.118533 0.52352,-0.118533 0.34078,0 0.52846,0.128411 0.19262,0.128411 0.27164,0.375356 0.084,0.242005 0.084,0.592666 v 0.404989 h -1.13594 v 0.563034 q 0,0.138289 0.0247,0.227189 0.0296,0.0889 0.0889,0.128411 0.0593,0.03951 0.14323,0.03951 0.0889,0 0.14323,-0.03951 0.0543,-0.04445 0.079,-0.123473 0.0247,-0.08396 0.0247,-0.207433 v -0.237067 h 0.62724 v 0.192617 q 0,0.434622 -0.21731,0.66675 -0.21731,0.232128 -0.66181,0.232128 z m -0.25188,-1.773061 h 0.50376 v -0.271639 q 0,-0.148167 -0.0247,-0.237067 -0.0247,-0.09384 -0.079,-0.13335 -0.0543,-0.04445 -0.15311,-0.04445 -0.0889,0 -0.14323,0.04445 -0.0543,0.04445 -0.079,0.148167 -0.0247,0.103716 -0.0247,0.296333 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4400"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 152.00078,32.806389 v -2.854678 h 0.67169 v 0.439561 q 0.14817,-0.251883 0.29633,-0.360539 0.14817,-0.113594 0.32597,-0.113594 0.0296,0 0.0494,0.0049 0.0247,0 0.0543,0.0049 V 30.6234 q -0.0593,-0.0247 -0.13335,-0.03951 -0.0692,-0.01976 -0.14323,-0.01976 -0.13335,0 -0.24201,0.06421 -0.10865,0.06421 -0.20743,0.212372 v 1.965678 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4402"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 154.17644,32.806389 v -3.462161 h -0.63712 v -0.538339 h 1.99531 v 0.538339 h -0.62724 v 3.462161 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4404"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 156.10824,32.850839 q -0.19262,0 -0.33091,-0.09878 -0.13829,-0.103717 -0.21237,-0.256822 -0.0741,-0.158045 -0.0741,-0.325967 0,-0.2667 0.0988,-0.449439 0.0988,-0.182739 0.26177,-0.306211 0.16298,-0.123472 0.37041,-0.212372 0.20744,-0.09384 0.41981,-0.167922 v -0.246945 q 0,-0.123472 -0.0198,-0.207433 -0.0148,-0.08396 -0.0642,-0.128411 -0.0445,-0.04445 -0.14323,-0.04445 -0.084,0 -0.13829,0.03951 -0.0494,0.03951 -0.0741,0.113594 -0.0198,0.06914 -0.0247,0.162984 l -0.01,0.172861 -0.63711,-0.0247 q 0.0148,-0.493889 0.242,-0.726016 0.23213,-0.237067 0.70133,-0.237067 0.42968,0 0.6223,0.237067 0.19755,0.237066 0.19755,0.642055 v 1.318684 q 0,0.158044 0.005,0.286455 0.01,0.128411 0.0198,0.232128 0.0148,0.103717 0.0247,0.182739 h -0.60254 q -0.0148,-0.09878 -0.0395,-0.22225 -0.0197,-0.128411 -0.0296,-0.187678 -0.0494,0.172861 -0.18768,0.316089 -0.13829,0.138289 -0.37535,0.138289 z m 0.24694,-0.498828 q 0.0642,0 0.11854,-0.02963 0.0593,-0.03457 0.10371,-0.07902 0.0445,-0.04445 0.0642,-0.07902 V 31.36918 q -0.10866,0.06421 -0.20744,0.128411 -0.0938,0.06421 -0.16792,0.143228 -0.0691,0.07408 -0.10865,0.162983 -0.0346,0.0889 -0.0346,0.207434 0,0.158044 0.0593,0.251883 0.0642,0.0889 0.17286,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4406"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 159.01315,32.850839 q -0.15804,0 -0.29633,-0.07408 -0.13829,-0.07408 -0.25682,-0.182739 v 0.212372 h -0.67169 v -4.0005 H 158.46 v 1.363133 q 0.12347,-0.118533 0.2667,-0.187678 0.14816,-0.07408 0.31609,-0.07408 0.19261,0 0.31608,0.0889 0.12348,0.0889 0.19262,0.237067 0.0692,0.143227 0.0938,0.31115 0.0296,0.162983 0.0296,0.316089 v 0.968022 q 0,0.281517 -0.0691,0.513644 -0.0642,0.232128 -0.21237,0.370417 -0.14323,0.138289 -0.3803,0.138289 z m -0.25682,-0.469195 q 0.10866,0 0.15804,-0.06914 0.0543,-0.07408 0.0692,-0.192617 0.0197,-0.123472 0.0197,-0.2667 v -1.02235 q 0,-0.13335 -0.0197,-0.237066 -0.0198,-0.108656 -0.0741,-0.172862 -0.0494,-0.06421 -0.15805,-0.06421 -0.079,0 -0.1531,0.03951 -0.0741,0.03457 -0.13829,0.07902 v 1.802695 q 0.0642,0.04445 0.13829,0.07408 0.079,0.02963 0.15804,0.02963 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4408"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 160.18151,32.806389 v -4.0005 h 0.66675 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4410"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 162.24574,32.850839 q -0.32103,0 -0.52353,-0.118533 -0.20249,-0.123473 -0.30127,-0.3556 -0.0938,-0.237067 -0.0938,-0.567973 v -0.859366 q 0,-0.340784 0.0938,-0.572912 0.0988,-0.232127 0.30127,-0.350661 0.20744,-0.118533 0.52353,-0.118533 0.34078,0 0.52846,0.128411 0.19261,0.128411 0.27164,0.375356 0.084,0.242005 0.084,0.592666 v 0.404989 h -1.13595 v 0.563034 q 0,0.138289 0.0247,0.227189 0.0296,0.0889 0.0889,0.128411 0.0593,0.03951 0.14322,0.03951 0.0889,0 0.14323,-0.03951 0.0543,-0.04445 0.079,-0.123473 0.0247,-0.08396 0.0247,-0.207433 v -0.237067 h 0.62724 v 0.192617 q 0,0.434622 -0.21731,0.66675 -0.21731,0.232128 -0.66181,0.232128 z m -0.25189,-1.773061 h 0.50377 v -0.271639 q 0,-0.148167 -0.0247,-0.237067 -0.0247,-0.09384 -0.079,-0.13335 -0.0543,-0.04445 -0.1531,-0.04445 -0.0889,0 -0.14323,0.04445 -0.0543,0.04445 -0.079,0.148167 -0.0247,0.103716 -0.0247,0.296333 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4412"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 141.45718,38.98 0.1778,-1.37795 h -0.24201 l 0.005,-0.449439 h 0.30127 l 0.0691,-0.528461 h -0.36054 l 0.005,-0.459317 h 0.42968 l 0.15311,-1.185333 h 0.52352 l -0.15311,1.185333 h 0.40993 l 0.15805,-1.185333 h 0.51858 l -0.15804,1.185333 h 0.23706 l -0.01,0.459317 h -0.29633 l -0.0691,0.528461 h 0.35066 l -0.005,0.449439 h -0.40993 L 142.90921,38.98 h -0.52352 l 0.18274,-1.37795 H 142.1585 L 141.9807,38.98 Z m 0.76059,-1.827389 h 0.41486 l 0.0692,-0.528461 h -0.40993 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4414"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 143.92523,38.98 v -0.484011 l 0.98778,-1.526117 q 0.10866,-0.167922 0.2025,-0.321027 0.0988,-0.153106 0.15804,-0.316089 0.0642,-0.167923 0.0642,-0.365478 0,-0.22225 -0.079,-0.340784 -0.079,-0.118533 -0.24694,-0.118533 -0.15805,0 -0.24695,0.0889 -0.0889,0.0889 -0.12347,0.232128 -0.0296,0.143228 -0.0296,0.316089 V 36.313 h -0.67169 v -0.1778 q 0,-0.3556 0.10372,-0.6223 0.10865,-0.271639 0.34078,-0.424744 0.23213,-0.153106 0.60748,-0.153106 0.51365,0 0.77047,0.276578 0.25682,0.276578 0.25682,0.770466 0,0.246945 -0.0691,0.449439 -0.0691,0.197556 -0.18274,0.380295 -0.1136,0.182739 -0.24695,0.375355 l -0.81985,1.2446 h 1.21497 V 38.98 Z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4416"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 147.49157,39.039267 q -0.35066,0 -0.58278,-0.148167 -0.22719,-0.148167 -0.34573,-0.409928 -0.11359,-0.261761 -0.11359,-0.602544 v -1.773061 q 0,-0.350661 0.10865,-0.612423 0.1136,-0.2667 0.34079,-0.414866 0.23213,-0.148167 0.59266,-0.148167 0.36054,0 0.58773,0.148167 0.23213,0.148166 0.34079,0.414866 0.11359,0.261762 0.11359,0.612423 v 1.773061 q 0,0.340783 -0.11853,0.602544 -0.1136,0.261761 -0.34573,0.409928 -0.22718,0.148167 -0.57785,0.148167 z m 0,-0.587728 q 0.15311,0 0.22719,-0.09384 0.0741,-0.09384 0.0988,-0.227189 0.0247,-0.13335 0.0247,-0.261761 v -1.753305 q 0,-0.138289 -0.0247,-0.271639 -0.0198,-0.138289 -0.0938,-0.232128 -0.0741,-0.09384 -0.23213,-0.09384 -0.15804,0 -0.23212,0.09384 -0.0741,0.09384 -0.0988,0.232128 -0.0198,0.13335 -0.0198,0.271639 v 1.753305 q 0,0.128411 0.0247,0.261761 0.0296,0.13335 0.10371,0.227189 0.0741,0.09384 0.22225,0.09384 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4418"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="ConntrackTable
+#30
+"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4206">
+      <path
+         d="m 133.00642,63.70349 q -0.43956,0 -0.69145,-0.172861 -0.24694,-0.172861 -0.34572,-0.469195 -0.0988,-0.301272 -0.0988,-0.691444 v -1.427339 q 0,-0.409928 0.0988,-0.7112 0.0988,-0.301272 0.34572,-0.464255 0.25189,-0.162984 0.69145,-0.162984 0.41486,0 0.64699,0.143228 0.23707,0.138289 0.33585,0.40005 0.0988,0.261761 0.0988,0.607483 v 0.335845 h -0.70132 v -0.345722 q 0,-0.167923 -0.0197,-0.306212 -0.0148,-0.138288 -0.0938,-0.217311 -0.0741,-0.08396 -0.26176,-0.08396 -0.18768,0 -0.27658,0.0889 -0.084,0.08396 -0.10866,0.232128 -0.0247,0.143228 -0.0247,0.325967 v 1.738489 q 0,0.217311 0.0346,0.360538 0.0346,0.138289 0.12347,0.212373 0.0938,0.06914 0.25189,0.06914 0.18274,0 0.25682,-0.08396 0.079,-0.0889 0.0988,-0.232128 0.0197,-0.143228 0.0197,-0.321028 v -0.360538 h 0.70132 v 0.321027 q 0,0.3556 -0.0938,0.632178 -0.0938,0.271639 -0.33091,0.429684 -0.23213,0.153105 -0.65687,0.153105 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4421"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 135.41197,63.693612 q -0.31115,0 -0.51365,-0.113594 -0.20249,-0.118533 -0.30621,-0.340783 -0.0988,-0.222251 -0.0988,-0.538339 v -0.958145 q 0,-0.316089 0.0988,-0.538339 0.10372,-0.22225 0.30621,-0.335844 0.2025,-0.118534 0.51365,-0.118534 0.31115,0 0.51364,0.118534 0.20743,0.113594 0.30621,0.335844 0.10372,0.22225 0.10372,0.538339 v 0.958145 q 0,0.316088 -0.10372,0.538339 -0.0988,0.22225 -0.30621,0.340783 -0.20249,0.113594 -0.51364,0.113594 z m 0.005,-0.464255 q 0.1136,0 0.16793,-0.06421 0.0543,-0.06421 0.0691,-0.172861 0.0148,-0.113594 0.0148,-0.246944 v -1.047045 q 0,-0.13335 -0.0148,-0.242005 -0.0148,-0.108656 -0.0691,-0.172862 -0.0543,-0.06914 -0.16793,-0.06914 -0.11359,0 -0.16792,0.06914 -0.0543,0.06421 -0.0741,0.172862 -0.0148,0.108655 -0.0148,0.242005 v 1.047045 q 0,0.13335 0.0148,0.246944 0.0197,0.108656 0.0741,0.172861 0.0543,0.06421 0.16792,0.06421 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4423"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 136.79524,63.649162 v -2.854678 h 0.67169 v 0.286456 q 0.1531,-0.148167 0.32103,-0.237067 0.17286,-0.09384 0.37041,-0.09384 0.1778,0 0.28152,0.0889 0.10372,0.08396 0.15311,0.227189 0.0494,0.143228 0.0494,0.31115 v 2.271889 h -0.67168 v -2.138539 q 0,-0.128411 -0.0395,-0.197555 -0.0395,-0.06914 -0.1531,-0.06914 -0.0691,0 -0.15311,0.03951 -0.079,0.03951 -0.15804,0.09878 v 2.26695 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4425"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 139.13928,63.649162 v -2.854678 h 0.67169 v 0.286456 q 0.15311,-0.148167 0.32103,-0.237067 0.17286,-0.09384 0.37042,-0.09384 0.1778,0 0.28151,0.0889 0.10372,0.08396 0.15311,0.227189 0.0494,0.143228 0.0494,0.31115 v 2.271889 h -0.67169 v -2.138539 q 0,-0.128411 -0.0395,-0.197555 -0.0395,-0.06914 -0.15311,-0.06914 -0.0691,0 -0.1531,0.03951 -0.079,0.03951 -0.15805,0.09878 v 2.26695 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4427"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 142.30812,63.683735 q -0.27164,0 -0.42968,-0.0889 -0.15311,-0.0889 -0.21731,-0.256823 -0.0642,-0.167922 -0.0642,-0.40005 v -1.698978 h -0.28646 v -0.4445 h 0.28646 v -0.854427 h 0.67663 v 0.854427 h 0.43462 v 0.4445 h -0.43462 v 1.639712 q 0,0.148166 0.0642,0.212372 0.0642,0.05927 0.19262,0.05927 0.0543,0 0.10372,-0.0049 0.0543,-0.0049 0.10371,-0.0099 v 0.513644 q -0.084,0.0099 -0.19755,0.01976 -0.10866,0.01482 -0.23213,0.01482 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4429"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 143.13801,63.649162 v -2.854678 h 0.67169 v 0.439562 q 0.14816,-0.251884 0.29633,-0.360539 0.14817,-0.113595 0.32597,-0.113595 0.0296,0 0.0494,0.0049 0.0247,0 0.0543,0.0049 v 0.696383 q -0.0593,-0.02469 -0.13335,-0.03951 -0.0691,-0.01976 -0.14322,-0.01976 -0.13335,0 -0.24201,0.06421 -0.10865,0.06421 -0.20743,0.212372 v 1.965678 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4431"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 145.38374,63.693612 q -0.19262,0 -0.33091,-0.09878 -0.13829,-0.103717 -0.21237,-0.256823 -0.0741,-0.158044 -0.0741,-0.325966 0,-0.2667 0.0988,-0.449439 0.0988,-0.182739 0.26176,-0.306211 0.16299,-0.123473 0.37042,-0.212373 0.20743,-0.09384 0.41981,-0.167922 v -0.246944 q 0,-0.123473 -0.0198,-0.207434 -0.0148,-0.08396 -0.0642,-0.128411 -0.0445,-0.04445 -0.14323,-0.04445 -0.084,0 -0.13829,0.03951 -0.0494,0.03951 -0.0741,0.113595 -0.0198,0.06914 -0.0247,0.162983 l -0.01,0.172861 -0.63711,-0.02469 q 0.0148,-0.493889 0.242,-0.726017 0.23213,-0.237067 0.70132,-0.237067 0.42969,0 0.6223,0.237067 0.19756,0.237067 0.19756,0.642056 v 1.318683 q 0,0.158044 0.005,0.286456 0.01,0.128411 0.0198,0.232127 0.0148,0.103717 0.0247,0.182739 h -0.60255 q -0.0148,-0.09878 -0.0395,-0.22225 -0.0198,-0.128411 -0.0296,-0.187677 -0.0494,0.172861 -0.18768,0.316088 -0.13829,0.138289 -0.37535,0.138289 z m 0.24694,-0.498827 q 0.0642,0 0.11853,-0.02963 0.0593,-0.03457 0.10372,-0.07902 0.0445,-0.04445 0.0642,-0.07902 v -0.795161 q -0.10866,0.06421 -0.20744,0.128411 -0.0938,0.06421 -0.16792,0.143227 -0.0691,0.07408 -0.10865,0.162984 -0.0346,0.0889 -0.0346,0.207433 0,0.158045 0.0593,0.251883 0.0642,0.0889 0.17286,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4433"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 147.91824,63.693612 q -0.33091,0 -0.5334,-0.123472 -0.19756,-0.128411 -0.2914,-0.360539 -0.0889,-0.237067 -0.0889,-0.558094 V 61.79214 q 0,-0.330906 0.0889,-0.563033 0.0938,-0.232128 0.29633,-0.3556 0.2025,-0.123473 0.52847,-0.123473 0.30621,0 0.49882,0.09878 0.19756,0.09384 0.28646,0.291395 0.0889,0.192616 0.0889,0.48895 v 0.237066 h -0.63218 V 61.61434 q 0,-0.148167 -0.0247,-0.232128 -0.0198,-0.0889 -0.0741,-0.123472 -0.0543,-0.03951 -0.14322,-0.03951 -0.0889,0 -0.14323,0.04939 -0.0543,0.04445 -0.079,0.148166 -0.0198,0.103717 -0.0198,0.286456 v 1.047044 q 0,0.276578 0.0593,0.375356 0.0593,0.09384 0.18767,0.09384 0.0988,0 0.14817,-0.04445 0.0543,-0.04445 0.0692,-0.128411 0.0197,-0.0889 0.0197,-0.212372 v -0.306212 h 0.63218 v 0.271639 q 0,0.286456 -0.0938,0.48895 -0.0889,0.202495 -0.28646,0.306212 -0.19261,0.09878 -0.49388,0.09878 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4435"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 149.23422,63.649162 v -4.0005 h 0.67169 v 2.296584 l 0.73589,-1.150762 h 0.73096 l -0.71614,1.145823 0.70132,1.708855 h -0.70626 l -0.51858,-1.407583 -0.22719,0.316089 v 1.091494 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4437"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 152.0757,63.649162 v -3.462161 h -0.63712 v -0.538339 h 1.99532 v 0.538339 h -0.62724 v 3.462161 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4439"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 154.0075,63.693612 q -0.19262,0 -0.33091,-0.09878 -0.13829,-0.103717 -0.21237,-0.256823 -0.0741,-0.158044 -0.0741,-0.325966 0,-0.2667 0.0988,-0.449439 0.0988,-0.182739 0.26176,-0.306211 0.16298,-0.123473 0.37041,-0.212373 0.20744,-0.09384 0.41981,-0.167922 v -0.246944 q 0,-0.123473 -0.0198,-0.207434 -0.0148,-0.08396 -0.0642,-0.128411 -0.0445,-0.04445 -0.14323,-0.04445 -0.084,0 -0.13829,0.03951 -0.0494,0.03951 -0.0741,0.113595 -0.0198,0.06914 -0.0247,0.162983 l -0.01,0.172861 -0.63712,-0.02469 q 0.0148,-0.493889 0.242,-0.726017 0.23213,-0.237067 0.70133,-0.237067 0.42968,0 0.6223,0.237067 0.19755,0.237067 0.19755,0.642056 v 1.318683 q 0,0.158044 0.005,0.286456 0.01,0.128411 0.0198,0.232127 0.0148,0.103717 0.0247,0.182739 h -0.60254 q -0.0148,-0.09878 -0.0395,-0.22225 -0.0198,-0.128411 -0.0296,-0.187677 -0.0494,0.172861 -0.18768,0.316088 -0.13828,0.138289 -0.37535,0.138289 z m 0.24694,-0.498827 q 0.0642,0 0.11854,-0.02963 0.0593,-0.03457 0.10371,-0.07902 0.0445,-0.04445 0.0642,-0.07902 v -0.795161 q -0.10866,0.06421 -0.20743,0.128411 -0.0938,0.06421 -0.16793,0.143227 -0.0691,0.07408 -0.10865,0.162984 -0.0346,0.0889 -0.0346,0.207433 0,0.158045 0.0593,0.251883 0.0642,0.0889 0.17286,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4441"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 156.91242,63.693612 q -0.15805,0 -0.29634,-0.07408 -0.13829,-0.07408 -0.25682,-0.182739 v 0.212372 h -0.67169 v -4.0005 h 0.67169 v 1.363134 q 0.12347,-0.118534 0.2667,-0.187678 0.14817,-0.07408 0.31609,-0.07408 0.19262,0 0.31609,0.0889 0.12347,0.0889 0.19261,0.237067 0.0692,0.143228 0.0938,0.31115 0.0296,0.162983 0.0296,0.316089 v 0.968022 q 0,0.281517 -0.0692,0.513645 -0.0642,0.232128 -0.21237,0.370416 -0.14323,0.138289 -0.38029,0.138289 z m -0.25683,-0.469194 q 0.10866,0 0.15805,-0.06914 0.0543,-0.07408 0.0691,-0.192616 0.0198,-0.123473 0.0198,-0.2667 v -1.02235 q 0,-0.13335 -0.0198,-0.237067 -0.0197,-0.108656 -0.0741,-0.172861 -0.0494,-0.06421 -0.15805,-0.06421 -0.079,0 -0.1531,0.03951 -0.0741,0.03457 -0.13829,0.07902 v 1.802694 q 0.0642,0.04445 0.13829,0.07408 0.079,0.02963 0.15804,0.02963 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4443"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 158.08077,63.649162 v -4.0005 h 0.66675 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4445"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 160.145,63.693612 q -0.32103,0 -0.52353,-0.118533 -0.20249,-0.123472 -0.30127,-0.3556 -0.0938,-0.237067 -0.0938,-0.567972 V 61.79214 q 0,-0.340783 0.0938,-0.572911 0.0988,-0.232128 0.30127,-0.350661 0.20744,-0.118534 0.52353,-0.118534 0.34078,0 0.52846,0.128412 0.19261,0.128411 0.27164,0.375355 0.084,0.242006 0.084,0.592667 v 0.404989 h -1.13595 v 0.563033 q 0,0.138289 0.0247,0.227189 0.0296,0.0889 0.0889,0.128411 0.0593,0.03951 0.14323,0.03951 0.0889,0 0.14322,-0.03951 0.0543,-0.04445 0.079,-0.123472 0.0247,-0.08396 0.0247,-0.207434 v -0.237066 h 0.62724 v 0.192616 q 0,0.434623 -0.21731,0.666751 -0.21731,0.232127 -0.66181,0.232127 z m -0.25189,-1.773061 h 0.50377 v -0.271639 q 0,-0.148166 -0.0247,-0.237066 -0.0247,-0.09384 -0.079,-0.13335 -0.0543,-0.04445 -0.1531,-0.04445 -0.0889,0 -0.14323,0.04445 -0.0543,0.04445 -0.079,0.148166 -0.0247,0.103717 -0.0247,0.296334 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4447"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 142.88215,69.822774 0.1778,-1.37795 h -0.242 l 0.005,-0.449439 h 0.30128 l 0.0691,-0.528461 h -0.36054 l 0.005,-0.459317 h 0.42968 l 0.15311,-1.185334 h 0.52352 l -0.1531,1.185334 h 0.40992 l 0.15805,-1.185334 h 0.51858 l -0.15804,1.185334 h 0.23706 l -0.01,0.459317 h -0.29634 l -0.0691,0.528461 h 0.35066 l -0.005,0.449439 h -0.40993 l -0.18274,1.37795 h -0.52352 l 0.18274,-1.37795 h -0.40993 l -0.1778,1.37795 z m 0.76059,-1.827389 h 0.41487 l 0.0691,-0.528461 h -0.40993 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4449"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 146.38243,69.88204 q -0.37535,0 -0.60748,-0.138289 -0.22719,-0.143227 -0.3309,-0.40005 -0.10372,-0.261761 -0.10372,-0.607483 v -0.138289 h 0.67663 q 0,0.01482 0,0.04939 0,0.03457 0,0.06914 0.005,0.187678 0.0346,0.321028 0.0296,0.13335 0.10865,0.202495 0.084,0.06914 0.22719,0.06914 0.15311,0 0.22719,-0.07408 0.079,-0.07408 0.10372,-0.217311 0.0296,-0.143228 0.0296,-0.340784 0,-0.306211 -0.0988,-0.479072 -0.0938,-0.1778 -0.37041,-0.192617 -0.01,0 -0.0494,0 -0.0346,0 -0.0642,0 v -0.548216 q 0.0247,0 0.0494,0 0.0296,0 0.0543,0 0.27164,-0.0049 0.37536,-0.143228 0.10371,-0.143228 0.10371,-0.454378 0,-0.251883 -0.079,-0.395111 -0.0741,-0.143228 -0.29139,-0.143228 -0.21238,0 -0.28646,0.158045 -0.0691,0.158044 -0.0741,0.409927 0,0.03457 0,0.07408 0,0.03457 0,0.07408 h -0.67663 v -0.192617 q 0,-0.340783 0.11853,-0.57785 0.12347,-0.242005 0.3556,-0.365477 0.23213,-0.128411 0.56304,-0.128411 0.34078,0 0.57291,0.123472 0.23212,0.123472 0.35066,0.360539 0.12347,0.232127 0.12347,0.572911 0,0.3556 -0.14817,0.582789 -0.14816,0.227189 -0.38029,0.296333 0.15804,0.04939 0.27658,0.172861 0.11853,0.118534 0.18274,0.316089 0.0691,0.192617 0.0691,0.469195 0,0.360538 -0.10372,0.637116 -0.0988,0.271639 -0.3309,0.424745 -0.22719,0.153105 -0.60749,0.153105 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4451"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 148.91655,69.88204 q -0.35066,0 -0.58279,-0.148166 -0.22719,-0.148167 -0.34572,-0.409928 -0.1136,-0.261761 -0.1136,-0.602545 V 66.94834 q 0,-0.350661 0.10866,-0.612422 0.11359,-0.2667 0.34078,-0.414867 0.23213,-0.148166 0.59267,-0.148166 0.36054,0 0.58773,0.148166 0.23212,0.148167 0.34078,0.414867 0.11359,0.261761 0.11359,0.612422 v 1.773061 q 0,0.340784 -0.11853,0.602545 -0.11359,0.261761 -0.34572,0.409928 -0.22719,0.148166 -0.57785,0.148166 z m 0,-0.587728 q 0.1531,0 0.22719,-0.09384 0.0741,-0.09384 0.0988,-0.227189 0.0247,-0.13335 0.0247,-0.261761 v -1.753306 q 0,-0.138289 -0.0247,-0.271639 -0.0198,-0.138289 -0.0938,-0.232128 -0.0741,-0.09384 -0.23213,-0.09384 -0.15805,0 -0.23213,0.09384 -0.0741,0.09384 -0.0988,0.232128 -0.0198,0.13335 -0.0198,0.271639 v 1.753306 q 0,0.128411 0.0247,0.261761 0.0296,0.13335 0.10372,0.227189 0.0741,0.09384 0.22225,0.09384 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4453"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="ConntrackStateTable
+#31"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4212">
+      <path
+         d="m 184.90358,64.122527 q -0.43956,0 -0.69145,-0.172861 -0.24694,-0.172861 -0.34572,-0.469195 -0.0988,-0.301272 -0.0988,-0.691444 v -1.427339 q 0,-0.409928 0.0988,-0.7112 0.0988,-0.301272 0.34572,-0.464256 0.25189,-0.162983 0.69145,-0.162983 0.41486,0 0.64699,0.143228 0.23707,0.138289 0.33585,0.40005 0.0988,0.261761 0.0988,0.607483 v 0.335845 h -0.70132 v -0.345723 q 0,-0.167922 -0.0198,-0.306211 -0.0148,-0.138289 -0.0938,-0.217311 -0.0741,-0.08396 -0.26176,-0.08396 -0.18768,0 -0.27658,0.0889 -0.084,0.08396 -0.10866,0.232128 -0.0247,0.143228 -0.0247,0.325967 v 1.738488 q 0,0.217312 0.0346,0.360539 0.0346,0.138289 0.12347,0.212373 0.0938,0.06914 0.25189,0.06914 0.18274,0 0.25682,-0.08396 0.079,-0.0889 0.0988,-0.232128 0.0198,-0.143228 0.0198,-0.321028 V 62.58653 h 0.70132 v 0.321028 q 0,0.3556 -0.0938,0.632178 -0.0938,0.271639 -0.33091,0.429683 -0.23213,0.153106 -0.65687,0.153106 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4456"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 187.30913,64.112649 q -0.31115,0 -0.51365,-0.113594 -0.20249,-0.118534 -0.30621,-0.340784 -0.0988,-0.22225 -0.0988,-0.538339 v -0.958144 q 0,-0.316089 0.0988,-0.538339 0.10372,-0.22225 0.30621,-0.335844 0.2025,-0.118534 0.51365,-0.118534 0.31115,0 0.51364,0.118534 0.20743,0.113594 0.30621,0.335844 0.10372,0.22225 0.10372,0.538339 v 0.958144 q 0,0.316089 -0.10372,0.538339 -0.0988,0.22225 -0.30621,0.340784 -0.20249,0.113594 -0.51364,0.113594 z m 0.005,-0.464255 q 0.1136,0 0.16793,-0.06421 0.0543,-0.06421 0.0691,-0.172861 0.0148,-0.113595 0.0148,-0.246945 v -1.047044 q 0,-0.13335 -0.0148,-0.242006 -0.0148,-0.108655 -0.0691,-0.172861 -0.0543,-0.06914 -0.16793,-0.06914 -0.11359,0 -0.16792,0.06914 -0.0543,0.06421 -0.0741,0.172861 -0.0148,0.108656 -0.0148,0.242006 v 1.047044 q 0,0.13335 0.0148,0.246945 0.0198,0.108655 0.0741,0.172861 0.0543,0.06421 0.16792,0.06421 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4458"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 188.6924,64.068199 v -2.854678 h 0.67169 v 0.286456 q 0.15311,-0.148167 0.32103,-0.237067 0.17286,-0.09384 0.37041,-0.09384 0.1778,0 0.28152,0.0889 0.10372,0.08396 0.15311,0.227189 0.0494,0.143228 0.0494,0.31115 v 2.271889 h -0.67169 V 61.92966 q 0,-0.128411 -0.0395,-0.197555 -0.0395,-0.06914 -0.15311,-0.06914 -0.0691,0 -0.15311,0.03951 -0.079,0.03951 -0.15804,0.09878 v 2.26695 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4460"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 191.03644,64.068199 v -2.854678 h 0.67169 v 0.286456 q 0.15311,-0.148167 0.32103,-0.237067 0.17286,-0.09384 0.37042,-0.09384 0.1778,0 0.28151,0.0889 0.10372,0.08396 0.15311,0.227189 0.0494,0.143228 0.0494,0.31115 v 2.271889 h -0.6717 V 61.92966 q 0,-0.128411 -0.0395,-0.197555 -0.0395,-0.06914 -0.15311,-0.06914 -0.0691,0 -0.1531,0.03951 -0.079,0.03951 -0.15805,0.09878 v 2.26695 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4462"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 194.20528,64.102771 q -0.27164,0 -0.42968,-0.0889 -0.15311,-0.0889 -0.21731,-0.256822 -0.0642,-0.167922 -0.0642,-0.40005 v -1.698978 h -0.28645 v -0.4445 h 0.28645 v -0.854428 h 0.67663 v 0.854428 h 0.43462 v 0.4445 h -0.43462 v 1.639711 q 0,0.148167 0.0642,0.212373 0.0642,0.05927 0.19262,0.05927 0.0543,0 0.10372,-0.0049 0.0543,-0.0049 0.10371,-0.0099 v 0.513644 q -0.084,0.0099 -0.19755,0.01976 -0.10866,0.01482 -0.23213,0.01482 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4464"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 195.03517,64.068199 v -2.854678 h 0.67169 v 0.439561 q 0.14816,-0.251883 0.29633,-0.360538 0.14817,-0.113595 0.32597,-0.113595 0.0296,0 0.0494,0.0049 0.0247,0 0.0543,0.0049 v 0.696383 q -0.0593,-0.02469 -0.13335,-0.03951 -0.0691,-0.01976 -0.14322,-0.01976 -0.13335,0 -0.24201,0.06421 -0.10865,0.06421 -0.20743,0.212372 v 1.965678 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4466"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 197.2809,64.112649 q -0.19262,0 -0.33091,-0.09878 -0.13829,-0.103716 -0.21237,-0.256822 -0.0741,-0.158044 -0.0741,-0.325967 0,-0.2667 0.0988,-0.449438 0.0988,-0.182739 0.26177,-0.306212 0.16298,-0.123472 0.37041,-0.212372 0.20744,-0.09384 0.41981,-0.167922 v -0.246944 q 0,-0.123473 -0.0198,-0.207434 -0.0148,-0.08396 -0.0642,-0.128411 -0.0445,-0.04445 -0.14323,-0.04445 -0.084,0 -0.13829,0.03951 -0.0494,0.03951 -0.0741,0.113595 -0.0198,0.06914 -0.0247,0.162983 l -0.01,0.172861 -0.63711,-0.02469 q 0.0148,-0.493889 0.242,-0.726017 0.23213,-0.237067 0.70133,-0.237067 0.42968,0 0.6223,0.237067 0.19755,0.237067 0.19755,0.642056 v 1.318683 q 0,0.158044 0.005,0.286455 0.01,0.128412 0.0198,0.232128 0.0148,0.103717 0.0247,0.182739 h -0.60254 q -0.0148,-0.09878 -0.0395,-0.22225 -0.0197,-0.128411 -0.0296,-0.187678 -0.0494,0.172861 -0.18768,0.316089 -0.13829,0.138289 -0.37535,0.138289 z m 0.24694,-0.498828 q 0.0642,0 0.11854,-0.02963 0.0593,-0.03457 0.10371,-0.07902 0.0445,-0.04445 0.0642,-0.07902 v -0.795162 q -0.10866,0.06421 -0.20744,0.128412 -0.0938,0.06421 -0.16792,0.143227 -0.0691,0.07408 -0.10865,0.162984 -0.0346,0.0889 -0.0346,0.207433 0,0.158044 0.0593,0.251883 0.0642,0.0889 0.17286,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4468"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 199.8154,64.112649 q -0.33091,0 -0.5334,-0.123472 -0.19756,-0.128411 -0.2914,-0.360539 -0.0889,-0.237067 -0.0889,-0.558094 v -0.859367 q 0,-0.330906 0.0889,-0.563033 0.0938,-0.232128 0.29634,-0.3556 0.20249,-0.123473 0.52846,-0.123473 0.30621,0 0.49882,0.09878 0.19756,0.09384 0.28646,0.291395 0.0889,0.192616 0.0889,0.48895 v 0.237066 h -0.63218 v -0.251883 q 0,-0.148167 -0.0247,-0.232128 -0.0198,-0.0889 -0.0741,-0.123472 -0.0543,-0.03951 -0.14322,-0.03951 -0.0889,0 -0.14323,0.04939 -0.0543,0.04445 -0.079,0.148166 -0.0198,0.103717 -0.0198,0.286456 v 1.047044 q 0,0.276578 0.0593,0.375356 0.0593,0.09384 0.18768,0.09384 0.0988,0 0.14816,-0.04445 0.0543,-0.04445 0.0692,-0.128411 0.0197,-0.0889 0.0197,-0.212373 v -0.306211 h 0.63218 v 0.271639 q 0,0.286456 -0.0938,0.48895 -0.0889,0.202495 -0.28645,0.306211 -0.19262,0.09878 -0.49389,0.09878 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4470"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 201.13138,64.068199 v -4.0005 h 0.67169 v 2.296583 l 0.73589,-1.150761 h 0.73096 l -0.71614,1.145823 0.70132,1.708855 h -0.70626 l -0.51858,-1.407583 -0.22719,0.316089 v 1.091494 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4472"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 204.58034,64.122527 q -0.36053,0 -0.60254,-0.138289 -0.24201,-0.143228 -0.36548,-0.414867 -0.12347,-0.271639 -0.13829,-0.66675 l 0.62724,-0.123472 q 0.01,0.232128 0.0543,0.409928 0.0494,0.1778 0.14323,0.276578 0.0988,0.09384 0.25682,0.09384 0.1778,0 0.25188,-0.103717 0.0741,-0.108656 0.0741,-0.271639 0,-0.261761 -0.11854,-0.429683 -0.11853,-0.167923 -0.31609,-0.335845 l -0.50376,-0.4445 q -0.21237,-0.182739 -0.34079,-0.404989 -0.12347,-0.227189 -0.12347,-0.558094 0,-0.474133 0.27658,-0.730956 0.27658,-0.256822 0.75565,-0.256822 0.28152,0 0.46919,0.0889 0.18768,0.08396 0.29634,0.237067 0.11359,0.153105 0.16792,0.350661 0.0543,0.192617 0.0691,0.409928 l -0.6223,0.108655 q -0.01,-0.187678 -0.0445,-0.335844 -0.0296,-0.148167 -0.11359,-0.232128 -0.079,-0.08396 -0.23707,-0.08396 -0.16298,0 -0.25188,0.108655 -0.084,0.103717 -0.084,0.261762 0,0.202494 0.084,0.335844 0.084,0.128411 0.24201,0.2667 l 0.49882,0.439561 q 0.24695,0.207433 0.41981,0.48895 0.1778,0.276578 0.1778,0.671689 0,0.286456 -0.12841,0.508706 -0.12347,0.22225 -0.35066,0.350661 -0.22225,0.123472 -0.52353,0.123472 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4474"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 206.79366,64.102771 q -0.27164,0 -0.42968,-0.0889 -0.15311,-0.0889 -0.21731,-0.256822 -0.0642,-0.167922 -0.0642,-0.40005 V 61.658021 H 205.796 v -0.4445 h 0.28646 v -0.854428 h 0.67663 v 0.854428 h 0.43462 v 0.4445 h -0.43462 v 1.639711 q 0,0.148167 0.0642,0.212373 0.0642,0.05927 0.19262,0.05927 0.0543,0 0.10372,-0.0049 0.0543,-0.0049 0.10371,-0.0099 v 0.513644 q -0.084,0.0099 -0.19755,0.01976 -0.10866,0.01482 -0.23213,0.01482 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4476"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 208.16189,64.112649 q -0.19262,0 -0.33091,-0.09878 -0.13829,-0.103716 -0.21237,-0.256822 -0.0741,-0.158044 -0.0741,-0.325967 0,-0.2667 0.0988,-0.449438 0.0988,-0.182739 0.26176,-0.306212 0.16299,-0.123472 0.37042,-0.212372 0.20743,-0.09384 0.41981,-0.167922 v -0.246944 q 0,-0.123473 -0.0198,-0.207434 -0.0148,-0.08396 -0.0642,-0.128411 -0.0445,-0.04445 -0.14323,-0.04445 -0.084,0 -0.13829,0.03951 -0.0494,0.03951 -0.0741,0.113595 -0.0198,0.06914 -0.0247,0.162983 l -0.01,0.172861 -0.63711,-0.02469 q 0.0148,-0.493889 0.242,-0.726017 0.23213,-0.237067 0.70132,-0.237067 0.42969,0 0.6223,0.237067 0.19756,0.237067 0.19756,0.642056 v 1.318683 q 0,0.158044 0.005,0.286455 0.01,0.128412 0.0198,0.232128 0.0148,0.103717 0.0247,0.182739 H 208.794 q -0.0148,-0.09878 -0.0395,-0.22225 -0.0197,-0.128411 -0.0296,-0.187678 -0.0494,0.172861 -0.18768,0.316089 -0.13829,0.138289 -0.37535,0.138289 z m 0.24694,-0.498828 q 0.0642,0 0.11853,-0.02963 0.0593,-0.03457 0.10372,-0.07902 0.0445,-0.04445 0.0642,-0.07902 v -0.795162 q -0.10866,0.06421 -0.20744,0.128412 -0.0938,0.06421 -0.16792,0.143227 -0.0691,0.07408 -0.10865,0.162984 -0.0346,0.0889 -0.0346,0.207433 0,0.158044 0.0593,0.251883 0.0642,0.0889 0.17286,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4478"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 210.68111,64.102771 q -0.27164,0 -0.42969,-0.0889 -0.1531,-0.0889 -0.21731,-0.256822 -0.0642,-0.167922 -0.0642,-0.40005 v -1.698978 h -0.28646 v -0.4445 h 0.28646 v -0.854428 h 0.67662 v 0.854428 h 0.43463 v 0.4445 h -0.43463 v 1.639711 q 0,0.148167 0.0642,0.212373 0.0642,0.05927 0.19262,0.05927 0.0543,0 0.10371,-0.0049 0.0543,-0.0049 0.10372,-0.0099 v 0.513644 q -0.084,0.0099 -0.19756,0.01976 -0.10865,0.01482 -0.23212,0.01482 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4480"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 212.36048,64.112649 q -0.32103,0 -0.52352,-0.118533 -0.20249,-0.123472 -0.30127,-0.3556 -0.0938,-0.237067 -0.0938,-0.567972 v -0.859367 q 0,-0.340783 0.0938,-0.572911 0.0988,-0.232128 0.30127,-0.350661 0.20743,-0.118534 0.52352,-0.118534 0.34079,0 0.52846,0.128411 0.19262,0.128412 0.27164,0.375356 0.084,0.242006 0.084,0.592667 v 0.404989 h -1.13594 v 0.563033 q 0,0.138289 0.0247,0.227189 0.0296,0.0889 0.0889,0.128411 0.0593,0.03951 0.14323,0.03951 0.0889,0 0.14323,-0.03951 0.0543,-0.04445 0.079,-0.123472 0.0247,-0.08396 0.0247,-0.207434 v -0.237066 h 0.62723 v 0.192616 q 0,0.434623 -0.21731,0.66675 -0.21731,0.232128 -0.66181,0.232128 z m -0.25188,-1.773061 h 0.50377 v -0.271639 q 0,-0.148167 -0.0247,-0.237067 -0.0247,-0.09384 -0.079,-0.13335 -0.0543,-0.04445 -0.15311,-0.04445 -0.0889,0 -0.14322,0.04445 -0.0543,0.04445 -0.079,0.148167 -0.0247,0.103717 -0.0247,0.296333 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4482"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 214.14003,64.068199 v -3.462161 h -0.63712 v -0.538339 h 1.99531 v 0.538339 h -0.62724 v 3.462161 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4484"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 216.07183,64.112649 q -0.19262,0 -0.33091,-0.09878 -0.13829,-0.103716 -0.21237,-0.256822 -0.0741,-0.158044 -0.0741,-0.325967 0,-0.2667 0.0988,-0.449438 0.0988,-0.182739 0.26176,-0.306212 0.16299,-0.123472 0.37042,-0.212372 0.20744,-0.09384 0.41981,-0.167922 v -0.246944 q 0,-0.123473 -0.0198,-0.207434 -0.0148,-0.08396 -0.0642,-0.128411 -0.0444,-0.04445 -0.14323,-0.04445 -0.084,0 -0.13829,0.03951 -0.0494,0.03951 -0.0741,0.113595 -0.0198,0.06914 -0.0247,0.162983 l -0.01,0.172861 -0.63711,-0.02469 q 0.0148,-0.493889 0.242,-0.726017 0.23213,-0.237067 0.70133,-0.237067 0.42968,0 0.6223,0.237067 0.19755,0.237067 0.19755,0.642056 v 1.318683 q 0,0.158044 0.005,0.286455 0.01,0.128412 0.0198,0.232128 0.0148,0.103717 0.0247,0.182739 h -0.60254 q -0.0148,-0.09878 -0.0395,-0.22225 -0.0197,-0.128411 -0.0296,-0.187678 -0.0494,0.172861 -0.18768,0.316089 -0.13829,0.138289 -0.37535,0.138289 z m 0.24694,-0.498828 q 0.0642,0 0.11854,-0.02963 0.0593,-0.03457 0.10371,-0.07902 0.0444,-0.04445 0.0642,-0.07902 v -0.795162 q -0.10866,0.06421 -0.20744,0.128412 -0.0938,0.06421 -0.16792,0.143227 -0.0691,0.07408 -0.10865,0.162984 -0.0346,0.0889 -0.0346,0.207433 0,0.158044 0.0593,0.251883 0.0642,0.0889 0.17286,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4486"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 218.97674,64.112649 q -0.15804,0 -0.29633,-0.07408 -0.13829,-0.07408 -0.25682,-0.182739 v 0.212372 h -0.67169 v -4.0005 h 0.67169 v 1.363133 q 0.12347,-0.118533 0.2667,-0.187677 0.14816,-0.07408 0.31609,-0.07408 0.19261,0 0.31608,0.0889 0.12348,0.0889 0.19262,0.237067 0.0691,0.143228 0.0938,0.31115 0.0296,0.162983 0.0296,0.316089 v 0.968022 q 0,0.281517 -0.0691,0.513645 -0.0642,0.232127 -0.21237,0.370416 -0.14323,0.138289 -0.3803,0.138289 z m -0.25682,-0.469194 q 0.10866,0 0.15804,-0.06915 0.0543,-0.07408 0.0692,-0.192616 0.0197,-0.123473 0.0197,-0.2667 v -1.02235 q 0,-0.13335 -0.0197,-0.237067 -0.0198,-0.108656 -0.0741,-0.172861 -0.0494,-0.06421 -0.15805,-0.06421 -0.079,0 -0.1531,0.03951 -0.0741,0.03457 -0.13829,0.07902 v 1.802694 q 0.0642,0.04445 0.13829,0.07408 0.079,0.02963 0.15804,0.02963 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4488"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 220.1451,64.068199 v -4.0005 h 0.66675 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4490"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 222.20932,64.112649 q -0.32103,0 -0.52352,-0.118533 -0.2025,-0.123472 -0.30127,-0.3556 -0.0938,-0.237067 -0.0938,-0.567972 v -0.859367 q 0,-0.340783 0.0938,-0.572911 0.0988,-0.232128 0.30127,-0.350661 0.20743,-0.118534 0.52352,-0.118534 0.34078,0 0.52846,0.128411 0.19262,0.128412 0.27164,0.375356 0.084,0.242006 0.084,0.592667 v 0.404989 h -1.13594 v 0.563033 q 0,0.138289 0.0247,0.227189 0.0296,0.0889 0.0889,0.128411 0.0593,0.03951 0.14323,0.03951 0.0889,0 0.14323,-0.03951 0.0543,-0.04445 0.079,-0.123472 0.0247,-0.08396 0.0247,-0.207434 v -0.237066 h 0.62724 v 0.192616 q 0,0.434623 -0.21731,0.66675 -0.21731,0.232128 -0.66181,0.232128 z m -0.25188,-1.773061 h 0.50376 v -0.271639 q 0,-0.148167 -0.0247,-0.237067 -0.0247,-0.09384 -0.079,-0.13335 -0.0543,-0.04445 -0.15311,-0.04445 -0.0889,0 -0.14323,0.04445 -0.0543,0.04445 -0.079,0.148167 -0.0247,0.103717 -0.0247,0.296333 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4492"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 200.21016,70.24181 0.1778,-1.37795 h -0.24201 l 0.005,-0.449438 h 0.30128 l 0.0691,-0.528462 h -0.36054 l 0.005,-0.459316 h 0.42968 l 0.15311,-1.185334 h 0.52352 l -0.1531,1.185334 h 0.40992 l 0.15805,-1.185334 h 0.51858 l -0.15804,1.185334 h 0.23706 l -0.01,0.459316 h -0.29634 l -0.0691,0.528462 h 0.35066 l -0.005,0.449438 h -0.40993 l -0.18274,1.37795 h -0.52352 l 0.18274,-1.37795 h -0.40993 l -0.1778,1.37795 z m 0.76059,-1.827388 h 0.41487 l 0.0691,-0.528462 h -0.40993 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4494"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 203.71044,70.301077 q -0.37535,0 -0.60748,-0.138289 -0.22719,-0.143228 -0.33091,-0.40005 -0.10371,-0.261761 -0.10371,-0.607483 v -0.138289 h 0.67663 q 0,0.01482 0,0.04939 0,0.03457 0,0.06914 0.005,0.187678 0.0346,0.321028 0.0296,0.13335 0.10865,0.202495 0.084,0.06914 0.22719,0.06914 0.15311,0 0.22719,-0.07408 0.079,-0.07408 0.10372,-0.217311 0.0296,-0.143228 0.0296,-0.340784 0,-0.306211 -0.0988,-0.479072 -0.0938,-0.1778 -0.37041,-0.192617 -0.01,0 -0.0494,0 -0.0346,0 -0.0642,0 v -0.548216 q 0.0247,0 0.0494,0 0.0296,0 0.0543,0 0.27164,-0.0049 0.37535,-0.143228 0.10372,-0.143228 0.10372,-0.454378 0,-0.251883 -0.079,-0.395111 -0.0741,-0.143228 -0.2914,-0.143228 -0.21237,0 -0.28645,0.158045 -0.0692,0.158044 -0.0741,0.409927 0,0.03457 0,0.07408 0,0.03457 0,0.07408 H 202.6683 V 67.26366 q 0,-0.340783 0.11853,-0.57785 0.12347,-0.242005 0.3556,-0.365477 0.23213,-0.128412 0.56303,-0.128412 0.34079,0 0.57292,0.123473 0.23212,0.123472 0.35066,0.360539 0.12347,0.232127 0.12347,0.572911 0,0.3556 -0.14817,0.582789 -0.14816,0.227188 -0.38029,0.296333 0.15804,0.04939 0.27658,0.172861 0.11853,0.118533 0.18273,0.316089 0.0692,0.192617 0.0692,0.469194 0,0.360539 -0.10372,0.637117 -0.0988,0.271639 -0.3309,0.424745 -0.22719,0.153105 -0.60749,0.153105 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4496"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 205.67165,70.24181 v -3.24485 q -0.0296,0.01482 -0.11854,0.04445 -0.084,0.02963 -0.18768,0.05927 -0.10371,0.02469 -0.19261,0.04939 -0.084,0.02469 -0.11854,0.03951 v -0.508706 q 0.0692,-0.02469 0.17287,-0.06914 0.10371,-0.04445 0.21731,-0.09878 0.11853,-0.05927 0.21731,-0.128411 0.10371,-0.06914 0.16792,-0.143228 h 0.52352 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4498"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="DnatTable
+#40
+"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4220">
+      <path
+         d="m 250.63606,63.85601 v -4.0005 h 0.94333 q 0.48895,0 0.76058,0.13335 0.27658,0.13335 0.39018,0.409928 0.11853,0.276578 0.11853,0.701322 v 1.461912 q 0,0.434622 -0.11853,0.726016 -0.1136,0.286456 -0.38524,0.429684 -0.2667,0.138288 -0.73589,0.138288 z m 0.73095,-0.508705 h 0.22225 q 0.25189,0 0.36054,-0.0889 0.10866,-0.0889 0.13335,-0.256822 0.0247,-0.172861 0.0247,-0.419806 v -1.531056 q 0,-0.242005 -0.0346,-0.390172 -0.0346,-0.148166 -0.14322,-0.217311 -0.10866,-0.06914 -0.35066,-0.06914 h -0.21238 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4501"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 253.34079,63.85601 v -2.854677 h 0.67169 v 0.286455 q 0.15311,-0.148167 0.32103,-0.237067 0.17286,-0.09384 0.37042,-0.09384 0.1778,0 0.28151,0.0889 0.10372,0.08396 0.15311,0.227188 0.0494,0.143228 0.0494,0.31115 v 2.271889 h -0.67169 v -2.138539 q 0,-0.128411 -0.0395,-0.197555 -0.0395,-0.06914 -0.15311,-0.06914 -0.0691,0 -0.1531,0.03951 -0.079,0.03951 -0.15805,0.09878 v 2.26695 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4503"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 256.23799,63.90046 q -0.19261,0 -0.3309,-0.09878 -0.13829,-0.103717 -0.21238,-0.256823 -0.0741,-0.158044 -0.0741,-0.325966 0,-0.2667 0.0988,-0.449439 0.0988,-0.182739 0.26176,-0.306211 0.16298,-0.123472 0.37042,-0.212372 0.20743,-0.09384 0.4198,-0.167923 v -0.246944 q 0,-0.123472 -0.0197,-0.207434 -0.0148,-0.08396 -0.0642,-0.128411 -0.0444,-0.04445 -0.14323,-0.04445 -0.084,0 -0.13829,0.03951 -0.0494,0.03951 -0.0741,0.113595 -0.0198,0.06914 -0.0247,0.162983 l -0.01,0.172861 -0.63712,-0.02469 q 0.0148,-0.493889 0.24201,-0.726017 0.23213,-0.237066 0.70132,-0.237066 0.42968,0 0.6223,0.237066 0.19756,0.237067 0.19756,0.642056 v 1.318683 q 0,0.158045 0.005,0.286456 0.01,0.128411 0.0198,0.232128 0.0148,0.103716 0.0247,0.182738 h -0.60254 q -0.0148,-0.09878 -0.0395,-0.22225 -0.0198,-0.128411 -0.0296,-0.187677 -0.0494,0.172861 -0.18768,0.316089 -0.13829,0.138288 -0.37536,0.138288 z m 0.24695,-0.498827 q 0.0642,0 0.11853,-0.02963 0.0593,-0.03457 0.10372,-0.07902 0.0444,-0.04445 0.0642,-0.07902 v -0.795161 q -0.10865,0.06421 -0.20743,0.128411 -0.0938,0.06421 -0.16792,0.143228 -0.0692,0.07408 -0.10866,0.162983 -0.0346,0.0889 -0.0346,0.207433 0,0.158045 0.0593,0.251884 0.0642,0.0889 0.17286,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4505"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 258.75721,63.890583 q -0.27164,0 -0.42968,-0.0889 -0.15311,-0.0889 -0.21731,-0.256823 -0.0642,-0.167922 -0.0642,-0.40005 v -1.698977 h -0.28645 v -0.4445 h 0.28645 v -0.854428 h 0.67663 v 0.854428 h 0.43462 v 0.4445 h -0.43462 v 1.639711 q 0,0.148166 0.0642,0.212372 0.0642,0.05927 0.19262,0.05927 0.0543,0 0.10372,-0.0049 0.0543,-0.0049 0.10371,-0.0099 v 0.513644 q -0.084,0.0099 -0.19755,0.01976 -0.10866,0.01482 -0.23213,0.01482 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4507"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 260.01678,63.85601 v -3.462161 h -0.63711 V 59.85551 h 1.99531 v 0.538339 h -0.62724 v 3.462161 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4509"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 261.94858,63.90046 q -0.19261,0 -0.3309,-0.09878 -0.13829,-0.103717 -0.21238,-0.256823 -0.0741,-0.158044 -0.0741,-0.325966 0,-0.2667 0.0988,-0.449439 0.0988,-0.182739 0.26176,-0.306211 0.16298,-0.123472 0.37042,-0.212372 0.20743,-0.09384 0.4198,-0.167923 v -0.246944 q 0,-0.123472 -0.0198,-0.207434 -0.0148,-0.08396 -0.0642,-0.128411 -0.0444,-0.04445 -0.14323,-0.04445 -0.084,0 -0.13829,0.03951 -0.0494,0.03951 -0.0741,0.113595 -0.0197,0.06914 -0.0247,0.162983 l -0.01,0.172861 -0.63712,-0.02469 q 0.0148,-0.493889 0.24201,-0.726017 0.23213,-0.237066 0.70132,-0.237066 0.42968,0 0.6223,0.237066 0.19756,0.237067 0.19756,0.642056 v 1.318683 q 0,0.158045 0.005,0.286456 0.01,0.128411 0.0198,0.232128 0.0148,0.103716 0.0247,0.182738 h -0.60254 q -0.0148,-0.09878 -0.0395,-0.22225 -0.0198,-0.128411 -0.0296,-0.187677 -0.0494,0.172861 -0.18768,0.316089 -0.13829,0.138288 -0.37536,0.138288 z m 0.24695,-0.498827 q 0.0642,0 0.11853,-0.02963 0.0593,-0.03457 0.10372,-0.07902 0.0444,-0.04445 0.0642,-0.07902 v -0.795161 q -0.10865,0.06421 -0.20743,0.128411 -0.0938,0.06421 -0.16792,0.143228 -0.0691,0.07408 -0.10866,0.162983 -0.0346,0.0889 -0.0346,0.207433 0,0.158045 0.0593,0.251884 0.0642,0.0889 0.17286,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4511"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 264.8535,63.90046 q -0.15805,0 -0.29634,-0.07408 -0.13828,-0.07408 -0.25682,-0.182739 v 0.212372 h -0.67169 v -4.0005 h 0.67169 v 1.363134 q 0.12347,-0.118534 0.2667,-0.187678 0.14817,-0.07408 0.31609,-0.07408 0.19262,0 0.31609,0.0889 0.12347,0.0889 0.19262,0.237066 0.0691,0.143228 0.0938,0.31115 0.0296,0.162984 0.0296,0.316089 v 0.968022 q 0,0.281517 -0.0691,0.513645 -0.0642,0.232128 -0.21237,0.370417 -0.14323,0.138288 -0.38029,0.138288 z m -0.25682,-0.469194 q 0.10865,0 0.15804,-0.06914 0.0543,-0.07408 0.0691,-0.192617 0.0198,-0.123472 0.0198,-0.2667 v -1.02235 q 0,-0.13335 -0.0198,-0.237067 -0.0198,-0.108655 -0.0741,-0.172861 -0.0494,-0.06421 -0.15804,-0.06421 -0.079,0 -0.15311,0.03951 -0.0741,0.03457 -0.13829,0.07902 v 1.802694 q 0.0642,0.04445 0.13829,0.07408 0.079,0.02963 0.15805,0.02963 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4513"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 266.02185,63.85601 v -4.0005 h 0.66675 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4515"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 268.08608,63.90046 q -0.32103,0 -0.52352,-0.118533 -0.2025,-0.123472 -0.30128,-0.3556 -0.0938,-0.237067 -0.0938,-0.567972 v -0.859367 q 0,-0.340783 0.0938,-0.572911 0.0988,-0.232128 0.30128,-0.350661 0.20743,-0.118533 0.52352,-0.118533 0.34078,0 0.52846,0.128411 0.19262,0.128411 0.27164,0.375355 0.084,0.242006 0.084,0.592667 v 0.404989 h -1.13595 v 0.563033 q 0,0.138289 0.0247,0.227189 0.0296,0.0889 0.0889,0.128411 0.0593,0.03951 0.14323,0.03951 0.0889,0 0.14322,-0.03951 0.0543,-0.04445 0.079,-0.123472 0.0247,-0.08396 0.0247,-0.207433 v -0.237067 h 0.62724 v 0.192617 q 0,0.434622 -0.21731,0.66675 -0.21731,0.232127 -0.66181,0.232127 z m -0.25189,-1.773061 h 0.50377 V 61.85576 q 0,-0.148166 -0.0247,-0.237066 -0.0247,-0.09384 -0.079,-0.13335 -0.0543,-0.04445 -0.1531,-0.04445 -0.0889,0 -0.14323,0.04445 -0.0543,0.04445 -0.079,0.148166 -0.0247,0.103717 -0.0247,0.296334 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4517"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 256.18656,70.029622 0.1778,-1.37795 h -0.24201 l 0.005,-0.449439 h 0.30127 l 0.0691,-0.528461 h -0.36054 l 0.005,-0.459317 h 0.42968 l 0.15311,-1.185333 h 0.52352 l -0.15311,1.185333 h 0.40993 l 0.15805,-1.185333 h 0.51858 l -0.15805,1.185333 h 0.23707 l -0.01,0.459317 h -0.29633 l -0.0691,0.528461 h 0.35066 l -0.005,0.449439 h -0.40993 l -0.18274,1.37795 H 257.115 l 0.18274,-1.37795 h -0.40993 l -0.1778,1.37795 z m 0.76059,-1.827389 h 0.41486 l 0.0691,-0.528461 h -0.40993 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4519"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 259.80537,70.029622 v -0.982839 h -1.19521 v -0.582789 l 1.04211,-2.434872 h 0.79516 v 2.474383 h 0.40993 v 0.543278 h -0.40993 v 0.982839 z m -0.6223,-1.526117 h 0.6223 v -1.738489 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4521"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 262.25954,70.088888 q -0.35066,0 -0.58279,-0.148166 -0.22719,-0.148167 -0.34572,-0.409928 -0.1136,-0.261761 -0.1136,-0.602545 v -1.773061 q 0,-0.350661 0.10866,-0.612422 0.11359,-0.2667 0.34078,-0.414867 0.23213,-0.148166 0.59267,-0.148166 0.36054,0 0.58773,0.148166 0.23212,0.148167 0.34078,0.414867 0.11359,0.261761 0.11359,0.612422 v 1.773061 q 0,0.340784 -0.11853,0.602545 -0.11359,0.261761 -0.34572,0.409928 -0.22719,0.148166 -0.57785,0.148166 z m 0,-0.587727 q 0.1531,0 0.22719,-0.09384 0.0741,-0.09384 0.0988,-0.227189 0.0247,-0.13335 0.0247,-0.261761 v -1.753306 q 0,-0.138289 -0.0247,-0.271639 -0.0198,-0.138289 -0.0938,-0.232128 -0.0741,-0.09384 -0.23213,-0.09384 -0.15805,0 -0.23213,0.09384 -0.0741,0.09384 -0.0988,0.232128 -0.0197,0.13335 -0.0197,0.271639 v 1.753306 q 0,0.128411 0.0247,0.261761 0.0296,0.13335 0.10372,0.227189 0.0741,0.09384 0.22225,0.09384 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4523"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="EgressRuleTable
+#50
+"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4228">
+      <path
+         d="m 201.8384,106.6312 v -4.0005 h 1.67923 v 0.51365 h -0.94827 v 1.15076 h 0.74577 v 0.5087 h -0.74577 v 1.32363 h 0.95814 v 0.50376 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4526"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 204.80398,107.56959 q -0.2914,0 -0.51365,-0.0593 -0.22225,-0.0593 -0.34572,-0.18273 -0.12347,-0.12348 -0.12347,-0.32103 0,-0.13335 0.0543,-0.24201 0.0593,-0.10371 0.15805,-0.18274 0.0988,-0.079 0.21237,-0.13335 -0.16298,-0.0444 -0.25188,-0.14322 -0.084,-0.0988 -0.084,-0.23707 0,-0.16792 0.084,-0.28646 0.084,-0.11853 0.23213,-0.25188 -0.15311,-0.12347 -0.23213,-0.30621 -0.0741,-0.18768 -0.0741,-0.48895 0,-0.32597 0.10372,-0.54822 0.10866,-0.22719 0.31115,-0.34078 0.20743,-0.1136 0.50377,-0.1136 0.22719,0 0.38029,0.0692 0.15311,0.0642 0.25189,0.19755 0.0395,-0.0593 0.13828,-0.14816 0.0988,-0.0889 0.22719,-0.14817 l 0.0889,-0.0395 0.16299,0.36054 q -0.0543,0.0148 -0.14817,0.0494 -0.0889,0.0346 -0.1778,0.0741 -0.0889,0.0395 -0.13829,0.0691 0.0445,0.0988 0.0741,0.24694 0.0296,0.14817 0.0296,0.28152 0,0.30127 -0.0938,0.52352 -0.0938,0.22225 -0.2914,0.34572 -0.19261,0.11853 -0.50376,0.11853 -0.10372,0 -0.2025,-0.0148 -0.0988,-0.0198 -0.18274,-0.0444 -0.0296,0.0444 -0.0593,0.0938 -0.0247,0.0494 -0.0247,0.10371 0,0.0543 0.0593,0.0889 0.0593,0.0346 0.19756,0.0494 l 0.60254,0.0593 q 0.35066,0.0346 0.51858,0.22225 0.16793,0.18274 0.16793,0.49883 0,0.25682 -0.11854,0.42968 -0.11359,0.17286 -0.36054,0.26176 -0.242,0.0889 -0.63217,0.0889 z m 0.0741,-0.50377 q 0.27658,0 0.41487,-0.0543 0.13828,-0.0543 0.13828,-0.19756 0,-0.079 -0.0346,-0.12841 -0.0346,-0.0494 -0.12347,-0.079 -0.0889,-0.0346 -0.25188,-0.0494 l -0.48895,-0.0444 q -0.0543,0.0444 -0.0988,0.0938 -0.0395,0.0444 -0.0642,0.0988 -0.0247,0.0543 -0.0247,0.11359 0,0.12347 0.11853,0.18274 0.11854,0.0642 0.41487,0.0642 z m -0.0395,-1.76318 q 0.0889,0 0.14323,-0.0296 0.0543,-0.0346 0.084,-0.10372 0.0296,-0.0741 0.0395,-0.18274 0.01,-0.10865 0.01,-0.25188 0,-0.14323 -0.01,-0.25188 -0.01,-0.10866 -0.0395,-0.18274 -0.0247,-0.0741 -0.079,-0.10866 -0.0543,-0.0346 -0.14816,-0.0346 -0.0889,0 -0.14817,0.0346 -0.0543,0.0346 -0.084,0.10866 -0.0247,0.0691 -0.0395,0.1778 -0.01,0.10865 -0.01,0.25682 0,0.13829 0.01,0.24694 0.01,0.10372 0.0395,0.1778 0.0296,0.0692 0.084,0.10866 0.0593,0.0346 0.14817,0.0346 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4528"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 206.29429,106.6312 v -2.85468 h 0.67168 v 0.43957 q 0.14817,-0.25189 0.29634,-0.36054 0.14816,-0.1136 0.32596,-0.1136 0.0296,0 0.0494,0.005 0.0247,0 0.0543,0.005 v 0.69638 q -0.0593,-0.0247 -0.13335,-0.0395 -0.0691,-0.0198 -0.14323,-0.0198 -0.13335,0 -0.242,0.0642 -0.10866,0.0642 -0.20744,0.21237 v 1.96568 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4530"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 208.87046,106.67565 q -0.32103,0 -0.52353,-0.11853 -0.20249,-0.12347 -0.30127,-0.3556 -0.0938,-0.23707 -0.0938,-0.56797 v -0.85937 q 0,-0.34078 0.0938,-0.57291 0.0988,-0.23213 0.30127,-0.35066 0.20744,-0.11854 0.52353,-0.11854 0.34078,0 0.52846,0.12842 0.19261,0.12841 0.27164,0.37535 0.084,0.24201 0.084,0.59267 v 0.40499 h -1.13595 v 0.56303 q 0,0.13829 0.0247,0.22719 0.0296,0.0889 0.0889,0.12841 0.0593,0.0395 0.14323,0.0395 0.0889,0 0.14322,-0.0395 0.0543,-0.0444 0.079,-0.12347 0.0247,-0.084 0.0247,-0.20744 v -0.23706 h 0.62724 v 0.19261 q 0,0.43463 -0.21731,0.66675 -0.21731,0.23213 -0.66181,0.23213 z m -0.25189,-1.77306 h 0.50377 v -0.27164 q 0,-0.14816 -0.0247,-0.23706 -0.0247,-0.0938 -0.079,-0.13335 -0.0543,-0.0445 -0.1531,-0.0445 -0.0889,0 -0.14323,0.0445 -0.0543,0.0444 -0.079,0.14816 -0.0247,0.10372 -0.0247,0.29634 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4532"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 210.9809,106.67565 q -0.36053,0 -0.59266,-0.19261 -0.23213,-0.19262 -0.33091,-0.56304 l 0.49883,-0.19261 q 0.0593,0.23212 0.15804,0.3556 0.0988,0.12347 0.25683,0.12347 0.11853,0 0.1778,-0.0593 0.0593,-0.0593 0.0593,-0.16298 0,-0.11854 -0.0741,-0.21237 -0.0691,-0.0988 -0.24201,-0.24201 l -0.34572,-0.29139 q -0.18768,-0.16299 -0.30621,-0.33091 -0.11359,-0.17286 -0.11359,-0.42968 0,-0.23213 0.10371,-0.39511 0.10866,-0.16793 0.2914,-0.25683 0.18768,-0.0938 0.41486,-0.0938 0.34573,0 0.55316,0.20744 0.21237,0.20249 0.27164,0.5334 l -0.43956,0.18768 q -0.0247,-0.11854 -0.0741,-0.21732 -0.0445,-0.10371 -0.11853,-0.16792 -0.0741,-0.0642 -0.17286,-0.0642 -0.10372,0 -0.16792,0.0642 -0.0593,0.0642 -0.0593,0.16299 0,0.084 0.0692,0.17286 0.0741,0.0889 0.20743,0.20249 l 0.35066,0.31609 q 0.11359,0.0988 0.21731,0.21237 0.10372,0.1136 0.17286,0.25682 0.0692,0.13829 0.0692,0.32103 0,0.24695 -0.1136,0.41487 -0.10865,0.16792 -0.30127,0.25682 -0.18768,0.084 -0.41981,0.084 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4534"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 212.95839,106.67565 q -0.36054,0 -0.59267,-0.19261 -0.23212,-0.19262 -0.3309,-0.56304 l 0.49883,-0.19261 q 0.0593,0.23212 0.15804,0.3556 0.0988,0.12347 0.25682,0.12347 0.11854,0 0.1778,-0.0593 0.0593,-0.0593 0.0593,-0.16298 0,-0.11854 -0.0741,-0.21237 -0.0692,-0.0988 -0.24201,-0.24201 l -0.34572,-0.29139 q -0.18768,-0.16299 -0.30621,-0.33091 -0.1136,-0.17286 -0.1136,-0.42968 0,-0.23213 0.10372,-0.39511 0.10866,-0.16793 0.29139,-0.25683 0.18768,-0.0938 0.41487,-0.0938 0.34572,0 0.55316,0.20744 0.21237,0.20249 0.27164,0.5334 l -0.43957,0.18768 q -0.0247,-0.11854 -0.0741,-0.21732 -0.0444,-0.10371 -0.11853,-0.16792 -0.0741,-0.0642 -0.17286,-0.0642 -0.10372,0 -0.16793,0.0642 -0.0593,0.0642 -0.0593,0.16299 0,0.084 0.0691,0.17286 0.0741,0.0889 0.20744,0.20249 l 0.35066,0.31609 q 0.11359,0.0988 0.21731,0.21237 0.10371,0.1136 0.17286,0.25682 0.0691,0.13829 0.0691,0.32103 0,0.24695 -0.11359,0.41487 -0.10866,0.16792 -0.30127,0.25682 -0.18768,0.084 -0.41981,0.084 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4536"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 214.20492,106.6312 v -4.0005 h 0.95814 q 0.40499,0 0.68157,0.0988 0.28152,0.0938 0.42475,0.32597 0.14816,0.23212 0.14816,0.63217 0,0.24201 -0.0445,0.43463 -0.0444,0.19261 -0.1531,0.3309 -0.10372,0.13335 -0.2914,0.20744 l 0.5581,1.97061 h -0.73096 l -0.48401,-1.83233 h -0.33584 v 1.83233 z m 0.73096,-2.29164 h 0.22718 q 0.21238,0 0.33585,-0.0593 0.12841,-0.0642 0.18274,-0.19755 0.0543,-0.13829 0.0543,-0.35067 0,-0.30127 -0.1136,-0.44943 -0.10865,-0.15311 -0.4198,-0.15311 h -0.2667 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4538"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 217.38826,106.67565 q -0.16792,0 -0.27657,-0.084 -0.10866,-0.0889 -0.15805,-0.23213 -0.0494,-0.14816 -0.0494,-0.31115 v -2.27189 h 0.67169 v 2.14842 q 0,0.12841 0.0395,0.2025 0.0444,0.0691 0.15805,0.0691 0.0741,0 0.14816,-0.0395 0.079,-0.0395 0.15311,-0.0938 v -2.28671 h 0.67169 v 2.85468 h -0.67169 v -0.27164 q -0.14323,0.13829 -0.31609,0.22719 -0.17286,0.0889 -0.37042,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4540"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 219.3078,106.6312 v -4.0005 h 0.66675 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4542"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 221.37202,106.67565 q -0.32103,0 -0.52352,-0.11853 -0.2025,-0.12347 -0.30128,-0.3556 -0.0938,-0.23707 -0.0938,-0.56797 v -0.85937 q 0,-0.34078 0.0938,-0.57291 0.0988,-0.23213 0.30128,-0.35066 0.20743,-0.11854 0.52352,-0.11854 0.34078,0 0.52846,0.12842 0.19262,0.12841 0.27164,0.37535 0.084,0.24201 0.084,0.59267 v 0.40499 h -1.13594 v 0.56303 q 0,0.13829 0.0247,0.22719 0.0296,0.0889 0.0889,0.12841 0.0593,0.0395 0.14323,0.0395 0.0889,0 0.14323,-0.0395 0.0543,-0.0444 0.079,-0.12347 0.0247,-0.084 0.0247,-0.20744 v -0.23706 h 0.62724 v 0.19261 q 0,0.43463 -0.21731,0.66675 -0.21731,0.23213 -0.66181,0.23213 z m -0.25188,-1.77306 h 0.50376 v -0.27164 q 0,-0.14816 -0.0247,-0.23706 -0.0247,-0.0938 -0.079,-0.13335 -0.0543,-0.0445 -0.15311,-0.0445 -0.0889,0 -0.14323,0.0445 -0.0543,0.0444 -0.079,0.14816 -0.0247,0.10372 -0.0247,0.29634 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4544"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 223.15156,106.6312 v -3.46216 h -0.63711 v -0.53834 h 1.99531 v 0.53834 h -0.62724 v 3.46216 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4546"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 225.08336,106.67565 q -0.19261,0 -0.3309,-0.0988 -0.13829,-0.10371 -0.21238,-0.25682 -0.0741,-0.15804 -0.0741,-0.32596 0,-0.2667 0.0988,-0.44944 0.0988,-0.18274 0.26176,-0.30621 0.16298,-0.12348 0.37042,-0.21238 0.20743,-0.0938 0.4198,-0.16792 v -0.24694 q 0,-0.12348 -0.0197,-0.20744 -0.0148,-0.084 -0.0642,-0.12841 -0.0445,-0.0444 -0.14323,-0.0444 -0.084,0 -0.13829,0.0395 -0.0494,0.0395 -0.0741,0.1136 -0.0197,0.0691 -0.0247,0.16298 l -0.01,0.17286 -0.63712,-0.0247 q 0.0148,-0.49389 0.24201,-0.72602 0.23213,-0.23707 0.70132,-0.23707 0.42968,0 0.6223,0.23707 0.19756,0.23707 0.19756,0.64206 v 1.31868 q 0,0.15804 0.005,0.28646 0.01,0.12841 0.0198,0.23212 0.0148,0.10372 0.0247,0.18274 h -0.60254 q -0.0148,-0.0988 -0.0395,-0.22225 -0.0198,-0.12841 -0.0296,-0.18768 -0.0494,0.17287 -0.18768,0.31609 -0.13829,0.13829 -0.37536,0.13829 z m 0.24695,-0.49883 q 0.0642,0 0.11853,-0.0296 0.0593,-0.0346 0.10372,-0.079 0.0445,-0.0444 0.0642,-0.079 v -0.79516 q -0.10865,0.0642 -0.20743,0.12841 -0.0938,0.0642 -0.16792,0.14322 -0.0692,0.0741 -0.10866,0.16299 -0.0346,0.0889 -0.0346,0.20743 0,0.15805 0.0593,0.25188 0.0642,0.0889 0.17286,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4548"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 227.98828,106.67565 q -0.15805,0 -0.29633,-0.0741 -0.13829,-0.0741 -0.25683,-0.18274 v 0.21237 h -0.67169 v -4.0005 h 0.67169 v 1.36314 q 0.12348,-0.11854 0.2667,-0.18768 0.14817,-0.0741 0.31609,-0.0741 0.19262,0 0.31609,0.0889 0.12347,0.0889 0.19262,0.23707 0.0691,0.14323 0.0938,0.31115 0.0296,0.16298 0.0296,0.31609 v 0.96802 q 0,0.28152 -0.0691,0.51365 -0.0642,0.23212 -0.21238,0.37041 -0.14322,0.13829 -0.38029,0.13829 z m -0.25682,-0.46919 q 0.10865,0 0.15804,-0.0692 0.0543,-0.0741 0.0692,-0.19261 0.0197,-0.12348 0.0197,-0.2667 v -1.02235 q 0,-0.13335 -0.0197,-0.23707 -0.0198,-0.10866 -0.0741,-0.17286 -0.0494,-0.0642 -0.15804,-0.0642 -0.079,0 -0.15311,0.0395 -0.0741,0.0346 -0.13829,0.079 v 1.80269 q 0.0642,0.0444 0.13829,0.0741 0.079,0.0296 0.15805,0.0296 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4550"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 229.15663,106.6312 v -4.0005 h 0.66675 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4552"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 231.22086,106.67565 q -0.32103,0 -0.52352,-0.11853 -0.2025,-0.12347 -0.30128,-0.3556 -0.0938,-0.23707 -0.0938,-0.56797 v -0.85937 q 0,-0.34078 0.0938,-0.57291 0.0988,-0.23213 0.30128,-0.35066 0.20743,-0.11854 0.52352,-0.11854 0.34078,0 0.52846,0.12842 0.19262,0.12841 0.27164,0.37535 0.084,0.24201 0.084,0.59267 v 0.40499 h -1.13594 v 0.56303 q 0,0.13829 0.0247,0.22719 0.0296,0.0889 0.0889,0.12841 0.0593,0.0395 0.14323,0.0395 0.0889,0 0.14323,-0.0395 0.0543,-0.0444 0.079,-0.12347 0.0247,-0.084 0.0247,-0.20744 v -0.23706 h 0.62724 v 0.19261 q 0,0.43463 -0.21731,0.66675 -0.21731,0.23213 -0.66181,0.23213 z m -0.25188,-1.77306 h 0.50376 v -0.27164 q 0,-0.14816 -0.0247,-0.23706 -0.0247,-0.0938 -0.079,-0.13335 -0.0543,-0.0445 -0.15311,-0.0445 -0.0889,0 -0.14323,0.0445 -0.0543,0.0444 -0.079,0.14816 -0.0247,0.10372 -0.0247,0.29634 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4554"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 213.38406,112.80481 0.1778,-1.37795 h -0.242 l 0.005,-0.44943 h 0.30128 l 0.0691,-0.52847 h -0.36054 l 0.005,-0.45931 h 0.42968 l 0.15311,-1.18534 h 0.52352 l -0.1531,1.18534 h 0.40992 l 0.15805,-1.18534 h 0.51858 l -0.15804,1.18534 h 0.23706 l -0.01,0.45931 h -0.29634 l -0.0691,0.52847 h 0.35066 l -0.005,0.44943 h -0.40993 l -0.18274,1.37795 h -0.52352 l 0.18274,-1.37795 h -0.40993 l -0.1778,1.37795 z m 0.76059,-1.82738 h 0.41487 l 0.0691,-0.52847 h -0.40993 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4556"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 216.87941,112.86408 q -0.40005,0 -0.6223,-0.14817 -0.21732,-0.14816 -0.30128,-0.4198 -0.084,-0.27164 -0.084,-0.63712 h 0.66675 q 0,0.2025 0.0247,0.36054 0.0296,0.15311 0.10865,0.24201 0.084,0.084 0.24201,0.079 0.17286,0 0.242,-0.10866 0.0741,-0.11359 0.0938,-0.31115 0.0198,-0.20249 0.0198,-0.46919 0,-0.23213 -0.0296,-0.40499 -0.0247,-0.17286 -0.10371,-0.2667 -0.079,-0.0988 -0.24695,-0.0988 -0.14322,0 -0.23706,0.0988 -0.0938,0.0938 -0.13829,0.25188 h -0.58773 l 0.0395,-2.22744 h 1.79776 v 0.61243 h -1.22485 l -0.0395,0.96308 q 0.0741,-0.0889 0.21237,-0.14323 0.14323,-0.0543 0.31609,-0.0642 0.31609,-0.0148 0.51365,0.13335 0.19755,0.14816 0.29139,0.42968 0.0938,0.28152 0.0938,0.67169 0,0.31609 -0.0444,0.58279 -0.0395,0.2667 -0.15311,0.46425 -0.11359,0.19262 -0.32102,0.30128 -0.2025,0.10865 -0.52846,0.10865 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4558"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 219.39916,112.86408 q -0.35066,0 -0.58278,-0.14817 -0.22719,-0.14816 -0.34573,-0.40992 -0.11359,-0.26176 -0.11359,-0.60255 v -1.77306 q 0,-0.35066 0.10865,-0.61242 0.1136,-0.2667 0.34079,-0.41487 0.23213,-0.14817 0.59266,-0.14817 0.36054,0 0.58773,0.14817 0.23213,0.14817 0.34079,0.41487 0.11359,0.26176 0.11359,0.61242 v 1.77306 q 0,0.34079 -0.11853,0.60255 -0.1136,0.26176 -0.34573,0.40992 -0.22718,0.14817 -0.57785,0.14817 z m 0,-0.58773 q 0.15311,0 0.22719,-0.0938 0.0741,-0.0938 0.0988,-0.22718 0.0247,-0.13335 0.0247,-0.26177 v -1.7533 q 0,-0.13829 -0.0247,-0.27164 -0.0198,-0.13829 -0.0938,-0.23213 -0.0741,-0.0938 -0.23213,-0.0938 -0.15804,0 -0.23212,0.0938 -0.0741,0.0938 -0.0988,0.23213 -0.0198,0.13335 -0.0198,0.27164 v 1.7533 q 0,0.12842 0.0247,0.26177 0.0296,0.13335 0.10371,0.22718 0.0741,0.0938 0.22225,0.0938 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4560"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="EgressDefaultTable
+#60"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4234">
+      <path
+         d="m 139.14681,121.44521 v -4.0005 h 1.67922 v 0.51365 h -0.94826 v 1.15076 h 0.74577 v 0.5087 h -0.74577 v 1.32363 h 0.95814 v 0.50376 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4563"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 142.11238,122.3836 q -0.29139,0 -0.51364,-0.0593 -0.22225,-0.0593 -0.34573,-0.18274 -0.12347,-0.12348 -0.12347,-0.32103 0,-0.13335 0.0543,-0.24201 0.0593,-0.10371 0.15804,-0.18274 0.0988,-0.079 0.21238,-0.13335 -0.16299,-0.0444 -0.25189,-0.14322 -0.084,-0.0988 -0.084,-0.23707 0,-0.16792 0.084,-0.28646 0.084,-0.11853 0.23213,-0.25188 -0.1531,-0.12347 -0.23213,-0.30621 -0.0741,-0.18768 -0.0741,-0.48895 0,-0.32597 0.10372,-0.54822 0.10865,-0.22719 0.31115,-0.34078 0.20743,-0.11359 0.50376,-0.11359 0.22719,0 0.3803,0.0691 0.1531,0.0642 0.25188,0.19756 0.0395,-0.0593 0.13829,-0.14817 0.0988,-0.0889 0.22719,-0.14817 l 0.0889,-0.0395 0.16298,0.36054 q -0.0543,0.0148 -0.14816,0.0494 -0.0889,0.0346 -0.1778,0.0741 -0.0889,0.0395 -0.13829,0.0692 0.0444,0.0988 0.0741,0.24694 0.0296,0.14817 0.0296,0.28152 0,0.30127 -0.0938,0.52352 -0.0938,0.22225 -0.29139,0.34572 -0.19262,0.11854 -0.50377,0.11854 -0.10371,0 -0.20249,-0.0148 -0.0988,-0.0198 -0.18274,-0.0444 -0.0296,0.0444 -0.0593,0.0938 -0.0247,0.0494 -0.0247,0.10371 0,0.0543 0.0593,0.0889 0.0593,0.0346 0.19755,0.0494 l 0.60255,0.0593 q 0.35066,0.0346 0.51858,0.22225 0.16792,0.18274 0.16792,0.49883 0,0.25682 -0.11853,0.42968 -0.1136,0.17286 -0.36054,0.26176 -0.24201,0.0889 -0.63218,0.0889 z m 0.0741,-0.50376 q 0.27658,0 0.41487,-0.0543 0.13829,-0.0543 0.13829,-0.19756 0,-0.079 -0.0346,-0.12841 -0.0346,-0.0494 -0.12347,-0.079 -0.0889,-0.0346 -0.25189,-0.0494 l -0.48895,-0.0444 q -0.0543,0.0444 -0.0988,0.0938 -0.0395,0.0444 -0.0642,0.0988 -0.0247,0.0543 -0.0247,0.11359 0,0.12347 0.11854,0.18274 0.11853,0.0642 0.41486,0.0642 z m -0.0395,-1.76319 q 0.0889,0 0.14323,-0.0296 0.0543,-0.0346 0.084,-0.10372 0.0296,-0.0741 0.0395,-0.18274 0.01,-0.10865 0.01,-0.25188 0,-0.14323 -0.01,-0.25188 -0.01,-0.10866 -0.0395,-0.18274 -0.0247,-0.0741 -0.079,-0.10866 -0.0543,-0.0346 -0.14817,-0.0346 -0.0889,0 -0.14816,0.0346 -0.0543,0.0346 -0.084,0.10866 -0.0247,0.0691 -0.0395,0.1778 -0.01,0.10865 -0.01,0.25682 0,0.13829 0.01,0.24694 0.01,0.10372 0.0395,0.1778 0.0296,0.0691 0.084,0.10866 0.0593,0.0346 0.14816,0.0346 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4565"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 143.60269,121.44521 v -2.85467 h 0.67169 v 0.43956 q 0.14817,-0.25189 0.29633,-0.36054 0.14817,-0.1136 0.32597,-0.1136 0.0296,0 0.0494,0.005 0.0247,0 0.0543,0.005 v 0.69638 q -0.0593,-0.0247 -0.13335,-0.0395 -0.0692,-0.0198 -0.14323,-0.0198 -0.13335,0 -0.24201,0.0642 -0.10865,0.0642 -0.20743,0.21238 v 1.96567 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4567"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 146.17886,121.48966 q -0.32103,0 -0.52352,-0.11853 -0.20249,-0.12347 -0.30127,-0.3556 -0.0938,-0.23707 -0.0938,-0.56797 v -0.85937 q 0,-0.34078 0.0938,-0.57291 0.0988,-0.23213 0.30127,-0.35066 0.20743,-0.11853 0.52352,-0.11853 0.34079,0 0.52846,0.12841 0.19262,0.12841 0.27164,0.37535 0.084,0.24201 0.084,0.59267 v 0.40499 h -1.13594 v 0.56303 q 0,0.13829 0.0247,0.22719 0.0296,0.0889 0.0889,0.12841 0.0593,0.0395 0.14323,0.0395 0.0889,0 0.14323,-0.0395 0.0543,-0.0444 0.079,-0.12347 0.0247,-0.084 0.0247,-0.20743 v -0.23707 h 0.62723 v 0.19262 q 0,0.43462 -0.21731,0.66675 -0.21731,0.23212 -0.66181,0.23212 z m -0.25188,-1.77306 h 0.50377 v -0.27164 q 0,-0.14816 -0.0247,-0.23706 -0.0247,-0.0938 -0.079,-0.13335 -0.0543,-0.0444 -0.15311,-0.0444 -0.0889,0 -0.14322,0.0444 -0.0543,0.0444 -0.079,0.14816 -0.0247,0.10372 -0.0247,0.29634 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4569"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 148.28931,121.48966 q -0.36054,0 -0.59267,-0.19261 -0.23212,-0.19262 -0.3309,-0.56304 l 0.49883,-0.19261 q 0.0593,0.23212 0.15804,0.3556 0.0988,0.12347 0.25682,0.12347 0.11854,0 0.1778,-0.0593 0.0593,-0.0593 0.0593,-0.16298 0,-0.11853 -0.0741,-0.21237 -0.0692,-0.0988 -0.24201,-0.24201 l -0.34572,-0.29139 q -0.18768,-0.16299 -0.30621,-0.33091 -0.1136,-0.17286 -0.1136,-0.42968 0,-0.23213 0.10372,-0.39511 0.10865,-0.16793 0.29139,-0.25683 0.18768,-0.0938 0.41487,-0.0938 0.34572,0 0.55316,0.20743 0.21237,0.20249 0.27163,0.5334 l -0.43956,0.18768 q -0.0247,-0.11854 -0.0741,-0.21731 -0.0444,-0.10372 -0.11853,-0.16793 -0.0741,-0.0642 -0.17286,-0.0642 -0.10372,0 -0.16793,0.0642 -0.0593,0.0642 -0.0593,0.16299 0,0.084 0.0691,0.17286 0.0741,0.0889 0.20743,0.20249 l 0.35067,0.31609 q 0.11359,0.0988 0.21731,0.21237 0.10371,0.1136 0.17286,0.25683 0.0691,0.13828 0.0691,0.32102 0,0.24695 -0.11359,0.41487 -0.10866,0.16792 -0.30127,0.25682 -0.18768,0.084 -0.41981,0.084 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4571"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 150.2668,121.48966 q -0.36054,0 -0.59267,-0.19261 -0.23213,-0.19262 -0.33091,-0.56304 l 0.49883,-0.19261 q 0.0593,0.23212 0.15805,0.3556 0.0988,0.12347 0.25682,0.12347 0.11853,0 0.1778,-0.0593 0.0593,-0.0593 0.0593,-0.16298 0,-0.11853 -0.0741,-0.21237 -0.0691,-0.0988 -0.242,-0.24201 l -0.34573,-0.29139 q -0.18767,-0.16299 -0.30621,-0.33091 -0.11359,-0.17286 -0.11359,-0.42968 0,-0.23213 0.10371,-0.39511 0.10866,-0.16793 0.2914,-0.25683 0.18768,-0.0938 0.41487,-0.0938 0.34572,0 0.55315,0.20743 0.21237,0.20249 0.27164,0.5334 l -0.43956,0.18768 q -0.0247,-0.11854 -0.0741,-0.21731 -0.0445,-0.10372 -0.11854,-0.16793 -0.0741,-0.0642 -0.17286,-0.0642 -0.10372,0 -0.16792,0.0642 -0.0593,0.0642 -0.0593,0.16299 0,0.084 0.0692,0.17286 0.0741,0.0889 0.20743,0.20249 l 0.35066,0.31609 q 0.1136,0.0988 0.21731,0.21237 0.10372,0.1136 0.17286,0.25683 0.0692,0.13828 0.0692,0.32102 0,0.24695 -0.1136,0.41487 -0.10865,0.16792 -0.30127,0.25682 -0.18768,0.084 -0.4198,0.084 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4573"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 151.51333,121.44521 v -4.0005 h 0.94332 q 0.48895,0 0.76059,0.13335 0.27658,0.13335 0.39017,0.40993 0.11854,0.27658 0.11854,0.70132 v 1.46191 q 0,0.43463 -0.11854,0.72602 -0.11359,0.28646 -0.38523,0.42968 -0.2667,0.13829 -0.73589,0.13829 z m 0.73095,-0.5087 h 0.22225 q 0.25188,0 0.36054,-0.0889 0.10866,-0.0889 0.13335,-0.25682 0.0247,-0.17287 0.0247,-0.41981 v -1.53106 q 0,-0.242 -0.0346,-0.39017 -0.0346,-0.14816 -0.14323,-0.21731 -0.10865,-0.0691 -0.35066,-0.0691 h -0.21237 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4575"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 155.08237,121.48966 q -0.32103,0 -0.52352,-0.11853 -0.2025,-0.12347 -0.30128,-0.3556 -0.0938,-0.23707 -0.0938,-0.56797 v -0.85937 q 0,-0.34078 0.0938,-0.57291 0.0988,-0.23213 0.30128,-0.35066 0.20743,-0.11853 0.52352,-0.11853 0.34078,0 0.52846,0.12841 0.19262,0.12841 0.27164,0.37535 0.084,0.24201 0.084,0.59267 v 0.40499 h -1.13595 v 0.56303 q 0,0.13829 0.0247,0.22719 0.0296,0.0889 0.0889,0.12841 0.0593,0.0395 0.14323,0.0395 0.0889,0 0.14322,-0.0395 0.0543,-0.0444 0.079,-0.12347 0.0247,-0.084 0.0247,-0.20743 v -0.23707 h 0.62724 v 0.19262 q 0,0.43462 -0.21731,0.66675 -0.21731,0.23212 -0.66181,0.23212 z m -0.25189,-1.77306 h 0.50377 v -0.27164 q 0,-0.14816 -0.0247,-0.23706 -0.0247,-0.0938 -0.079,-0.13335 -0.0543,-0.0444 -0.1531,-0.0444 -0.0889,0 -0.14323,0.0444 -0.0543,0.0444 -0.079,0.14816 -0.0247,0.10372 -0.0247,0.29634 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4577"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 156.5557,121.44521 v -2.38548 h -0.30621 v -0.46919 h 0.30621 v -0.18274 q 0,-0.25683 0.0445,-0.4445 0.0494,-0.19262 0.19755,-0.29634 0.15311,-0.10371 0.45932,-0.10371 0.0938,0 0.1778,0.01 0.084,0.005 0.18768,0.0198 v 0.49883 q -0.0395,-0.01 -0.0938,-0.0148 -0.0494,-0.01 -0.0938,-0.01 -0.11853,0 -0.16298,0.0741 -0.0444,0.0741 -0.0444,0.21731 v 0.23213 h 0.39511 v 0.46919 h -0.39511 v 2.38548 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4579"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 158.47538,121.48966 q -0.19261,0 -0.3309,-0.0988 -0.13829,-0.10372 -0.21237,-0.25683 -0.0741,-0.15804 -0.0741,-0.32596 0,-0.2667 0.0988,-0.44944 0.0988,-0.18274 0.26176,-0.30621 0.16298,-0.12348 0.37042,-0.21238 0.20743,-0.0938 0.4198,-0.16792 v -0.24694 q 0,-0.12347 -0.0197,-0.20744 -0.0148,-0.084 -0.0642,-0.12841 -0.0445,-0.0444 -0.14323,-0.0444 -0.084,0 -0.13828,0.0395 -0.0494,0.0395 -0.0741,0.1136 -0.0197,0.0691 -0.0247,0.16298 l -0.01,0.17286 -0.63712,-0.0247 q 0.0148,-0.49389 0.24201,-0.72602 0.23213,-0.23706 0.70132,-0.23706 0.42968,0 0.6223,0.23706 0.19756,0.23707 0.19756,0.64206 v 1.31868 q 0,0.15805 0.005,0.28646 0.01,0.12841 0.0197,0.23212 0.0148,0.10372 0.0247,0.18274 h -0.60255 q -0.0148,-0.0988 -0.0395,-0.22225 -0.0198,-0.12841 -0.0296,-0.18767 -0.0494,0.17286 -0.18768,0.31608 -0.13829,0.13829 -0.37536,0.13829 z m 0.24695,-0.49882 q 0.0642,0 0.11853,-0.0296 0.0593,-0.0346 0.10372,-0.079 0.0445,-0.0445 0.0642,-0.079 V 120.008 q -0.10865,0.0642 -0.20743,0.12841 -0.0938,0.0642 -0.16792,0.14323 -0.0692,0.0741 -0.10866,0.16298 -0.0346,0.0889 -0.0346,0.20743 0,0.15805 0.0593,0.25189 0.0642,0.0889 0.17286,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4581"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 160.60983,121.48966 q -0.16792,0 -0.27657,-0.084 -0.10866,-0.0889 -0.15805,-0.23213 -0.0494,-0.14816 -0.0494,-0.31115 v -2.27188 h 0.67169 v 2.14841 q 0,0.12841 0.0395,0.2025 0.0445,0.0691 0.15805,0.0691 0.0741,0 0.14816,-0.0395 0.079,-0.0395 0.15311,-0.0938 v -2.2867 h 0.67169 v 2.85467 h -0.67169 v -0.27164 q -0.14323,0.13829 -0.31609,0.22719 -0.17286,0.0889 -0.37042,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4583"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 162.52936,121.44521 v -4.0005 h 0.66675 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4585"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 164.55408,121.47979 q -0.27164,0 -0.42969,-0.0889 -0.1531,-0.0889 -0.21731,-0.25683 -0.0642,-0.16792 -0.0642,-0.40005 v -1.69897 h -0.28646 v -0.4445 h 0.28646 v -0.85443 h 0.67662 v 0.85443 h 0.43463 v 0.4445 h -0.43463 v 1.63971 q 0,0.14816 0.0642,0.21237 0.0642,0.0593 0.19262,0.0593 0.0543,0 0.10371,-0.005 0.0543,-0.005 0.10372,-0.01 v 0.51364 q -0.084,0.01 -0.19756,0.0198 -0.10865,0.0148 -0.23212,0.0148 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4587"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 165.81365,121.44521 v -3.46216 h -0.63712 v -0.53834 h 1.99531 v 0.53834 h -0.62724 v 3.46216 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4589"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 167.74545,121.48966 q -0.19262,0 -0.33091,-0.0988 -0.13829,-0.10372 -0.21237,-0.25683 -0.0741,-0.15804 -0.0741,-0.32596 0,-0.2667 0.0988,-0.44944 0.0988,-0.18274 0.26176,-0.30621 0.16299,-0.12348 0.37042,-0.21238 0.20743,-0.0938 0.41981,-0.16792 v -0.24694 q 0,-0.12347 -0.0198,-0.20744 -0.0148,-0.084 -0.0642,-0.12841 -0.0444,-0.0444 -0.14323,-0.0444 -0.084,0 -0.13829,0.0395 -0.0494,0.0395 -0.0741,0.1136 -0.0198,0.0691 -0.0247,0.16298 l -0.01,0.17286 -0.63711,-0.0247 q 0.0148,-0.49389 0.242,-0.72602 0.23213,-0.23706 0.70132,-0.23706 0.42969,0 0.6223,0.23706 0.19756,0.23707 0.19756,0.64206 v 1.31868 q 0,0.15805 0.005,0.28646 0.01,0.12841 0.0197,0.23212 0.0148,0.10372 0.0247,0.18274 h -0.60255 q -0.0148,-0.0988 -0.0395,-0.22225 -0.0197,-0.12841 -0.0296,-0.18767 -0.0494,0.17286 -0.18768,0.31608 -0.13829,0.13829 -0.37535,0.13829 z m 0.24694,-0.49882 q 0.0642,0 0.11853,-0.0296 0.0593,-0.0346 0.10372,-0.079 0.0444,-0.0445 0.0642,-0.079 V 120.008 q -0.10866,0.0642 -0.20744,0.12841 -0.0938,0.0642 -0.16792,0.14323 -0.0691,0.0741 -0.10865,0.16298 -0.0346,0.0889 -0.0346,0.20743 0,0.15805 0.0593,0.25189 0.0642,0.0889 0.17286,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4591"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 170.65036,121.48966 q -0.15804,0 -0.29633,-0.0741 -0.13829,-0.0741 -0.25682,-0.18274 v 0.21237 h -0.67169 v -4.0005 h 0.67169 v 1.36314 q 0.12347,-0.11854 0.2667,-0.18768 0.14816,-0.0741 0.31608,-0.0741 0.19262,0 0.31609,0.0889 0.12348,0.0889 0.19262,0.23706 0.0691,0.14323 0.0938,0.31115 0.0296,0.16299 0.0296,0.31609 v 0.96802 q 0,0.28152 -0.0691,0.51365 -0.0642,0.23213 -0.21237,0.37041 -0.14323,0.13829 -0.3803,0.13829 z m -0.25682,-0.46919 q 0.10865,0 0.15804,-0.0692 0.0543,-0.0741 0.0692,-0.19261 0.0197,-0.12347 0.0197,-0.2667 v -1.02235 q 0,-0.13335 -0.0197,-0.23707 -0.0198,-0.10865 -0.0741,-0.17286 -0.0494,-0.0642 -0.15804,-0.0642 -0.079,0 -0.15311,0.0395 -0.0741,0.0346 -0.13828,0.079 v 1.80269 q 0.0642,0.0445 0.13828,0.0741 0.079,0.0296 0.15805,0.0296 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4593"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 171.81872,121.44521 v -4.0005 h 0.66675 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4595"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 173.88294,121.48966 q -0.32103,0 -0.52352,-0.11853 -0.2025,-0.12347 -0.30127,-0.3556 -0.0938,-0.23707 -0.0938,-0.56797 v -0.85937 q 0,-0.34078 0.0938,-0.57291 0.0988,-0.23213 0.30127,-0.35066 0.20743,-0.11853 0.52352,-0.11853 0.34078,0 0.52846,0.12841 0.19262,0.12841 0.27164,0.37535 0.084,0.24201 0.084,0.59267 v 0.40499 h -1.13594 v 0.56303 q 0,0.13829 0.0247,0.22719 0.0296,0.0889 0.0889,0.12841 0.0593,0.0395 0.14323,0.0395 0.0889,0 0.14323,-0.0395 0.0543,-0.0444 0.079,-0.12347 0.0247,-0.084 0.0247,-0.20743 v -0.23707 h 0.62724 v 0.19262 q 0,0.43462 -0.21731,0.66675 -0.21731,0.23212 -0.66181,0.23212 z m -0.25188,-1.77306 h 0.50376 v -0.27164 q 0,-0.14816 -0.0247,-0.23706 -0.0247,-0.0938 -0.079,-0.13335 -0.0543,-0.0444 -0.15311,-0.0444 -0.0889,0 -0.14323,0.0444 -0.0543,0.0444 -0.079,0.14816 -0.0247,0.10372 -0.0247,0.29634 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4597"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 153.29696,127.61882 0.1778,-1.37795 h -0.24201 l 0.005,-0.44943 h 0.30127 l 0.0692,-0.52847 h -0.36054 l 0.005,-0.45931 h 0.42968 l 0.15311,-1.18534 h 0.52352 l -0.15311,1.18534 h 0.40993 l 0.15805,-1.18534 h 0.51858 l -0.15804,1.18534 h 0.23706 l -0.01,0.45931 h -0.29633 l -0.0691,0.52847 h 0.35066 l -0.005,0.44943 h -0.40993 l -0.18274,1.37795 h -0.52352 l 0.18274,-1.37795 h -0.40993 l -0.1778,1.37795 z m 0.76059,-1.82738 h 0.41486 l 0.0692,-0.52847 h -0.40993 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4599"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 156.8812,127.67315 q -0.37041,0 -0.60254,-0.17286 -0.23213,-0.17286 -0.34078,-0.46919 -0.10372,-0.30128 -0.10372,-0.67169 v -1.40265 q 0,-0.39017 0.0889,-0.70132 0.0889,-0.31609 0.31609,-0.49883 0.22719,-0.18274 0.63711,-0.18274 0.35067,0 0.56798,0.11854 0.22225,0.11359 0.32596,0.33584 0.10372,0.22225 0.10372,0.54822 0,0.0148 0,0.0346 0.005,0.0148 0.005,0.0296 h -0.65687 q 0,-0.2667 -0.0642,-0.40005 -0.0642,-0.13335 -0.27658,-0.13335 -0.12841,0 -0.20743,0.079 -0.079,0.079 -0.11853,0.26176 -0.0346,0.1778 -0.0346,0.47907 v 0.47907 q 0.0692,-0.11359 0.20744,-0.1778 0.14323,-0.0691 0.3309,-0.0691 0.32597,-0.005 0.51365,0.14323 0.18768,0.14816 0.2667,0.40992 0.084,0.26176 0.084,0.59761 0,0.39017 -0.0988,0.70132 -0.0988,0.30621 -0.32597,0.48401 -0.22718,0.1778 -0.61736,0.1778 z m 0.005,-0.52846 q 0.14323,0 0.21731,-0.0889 0.0741,-0.0889 0.10372,-0.24694 0.0296,-0.15805 0.0296,-0.37042 0,-0.21731 -0.0197,-0.38523 -0.0148,-0.17286 -0.0889,-0.27164 -0.0741,-0.10372 -0.24695,-0.10372 -0.084,0 -0.15804,0.0346 -0.0692,0.0296 -0.12347,0.079 -0.0494,0.0494 -0.079,0.0988 v 0.62724 q 0,0.16792 0.0296,0.31115 0.0346,0.14323 0.11359,0.23213 0.084,0.084 0.22225,0.084 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4601"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 159.45676,127.67809 q -0.35066,0 -0.58279,-0.14817 -0.22719,-0.14816 -0.34572,-0.40992 -0.1136,-0.26176 -0.1136,-0.60255 v -1.77306 q 0,-0.35066 0.10866,-0.61242 0.11359,-0.2667 0.34078,-0.41487 0.23213,-0.14816 0.59267,-0.14816 0.36054,0 0.58772,0.14816 0.23213,0.14817 0.34079,0.41487 0.11359,0.26176 0.11359,0.61242 v 1.77306 q 0,0.34079 -0.11853,0.60255 -0.1136,0.26176 -0.34572,0.40992 -0.22719,0.14817 -0.57785,0.14817 z m 0,-0.58773 q 0.1531,0 0.22719,-0.0938 0.0741,-0.0938 0.0988,-0.22718 0.0247,-0.13335 0.0247,-0.26177 v -1.7533 q 0,-0.13829 -0.0247,-0.27164 -0.0198,-0.13829 -0.0938,-0.23213 -0.0741,-0.0938 -0.23212,-0.0938 -0.15805,0 -0.23213,0.0938 -0.0741,0.0938 -0.0988,0.23213 -0.0198,0.13335 -0.0198,0.27164 v 1.7533 q 0,0.12842 0.0247,0.26177 0.0296,0.13335 0.10372,0.22718 0.0741,0.0938 0.22225,0.0938 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4603"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="L3ForwardingTable
+#70
+"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4242">
+      <path
+         d="m 77.980134,106.65405 v -4.0005 h 0.730956 v 3.49674 h 0.968022 v 0.50376 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4606"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 80.958593,106.71332 q -0.375356,0 -0.607484,-0.13829 -0.227188,-0.14323 -0.330905,-0.40005 -0.103717,-0.26176 -0.103717,-0.60748 v -0.13829 h 0.676628 q 0,0.0148 0,0.0494 0,0.0346 0,0.0691 0.0049,0.18768 0.03457,0.32103 0.02963,0.13335 0.108656,0.20249 0.08396,0.0692 0.227189,0.0692 0.153105,0 0.227189,-0.0741 0.07902,-0.0741 0.103716,-0.21731 0.02963,-0.14322 0.02963,-0.34078 0,-0.30621 -0.09878,-0.47907 -0.09384,-0.1778 -0.370417,-0.19262 -0.0099,0 -0.04939,0 -0.03457,0 -0.06421,0 v -0.54822 q 0.02469,0 0.04939,0 0.02963,0 0.05433,0 0.271639,-0.005 0.375356,-0.14322 0.103717,-0.14323 0.103717,-0.45438 0,-0.25188 -0.07902,-0.39511 -0.07408,-0.14323 -0.291394,-0.14323 -0.212372,0 -0.286456,0.15804 -0.06914,0.15805 -0.07408,0.40993 0,0.0346 0,0.0741 0,0.0346 0,0.0741 h -0.676628 v -0.19262 q 0,-0.34078 0.118534,-0.57785 0.123472,-0.242 0.3556,-0.36548 0.232127,-0.12841 0.563033,-0.12841 0.340783,0 0.572911,0.12348 0.232128,0.12347 0.350661,0.36053 0.123472,0.23213 0.123472,0.57292 0,0.3556 -0.148166,0.58278 -0.148167,0.22719 -0.380295,0.29634 0.158045,0.0494 0.276578,0.17286 0.118533,0.11853 0.182739,0.31609 0.06914,0.19261 0.06914,0.46919 0,0.36054 -0.103716,0.63712 -0.09878,0.27164 -0.330906,0.42474 -0.227189,0.15311 -0.607483,0.15311 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4608"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 82.475295,106.65405 v -4.0005 h 1.64465 v 0.50377 H 83.20625 v 1.16558 h 0.745772 v 0.5087 H 83.20625 v 1.82245 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4610"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 85.301574,106.6985 q -0.31115,0 -0.513645,-0.11359 -0.202494,-0.11854 -0.306211,-0.34079 -0.09878,-0.22225 -0.09878,-0.53833 v -0.95815 q 0,-0.31609 0.09878,-0.53834 0.103717,-0.22225 0.306211,-0.33584 0.202495,-0.11854 0.513645,-0.11854 0.31115,0 0.513644,0.11854 0.207434,0.11359 0.306211,0.33584 0.103717,0.22225 0.103717,0.53834 v 0.95815 q 0,0.31608 -0.103717,0.53833 -0.09878,0.22225 -0.306211,0.34079 -0.202494,0.11359 -0.513644,0.11359 z m 0.0049,-0.46425 q 0.113594,0 0.167922,-0.0642 0.05433,-0.0642 0.06914,-0.17286 0.01482,-0.11359 0.01482,-0.24694 v -1.04705 q 0,-0.13335 -0.01482,-0.242 -0.01482,-0.10866 -0.06914,-0.17287 -0.05433,-0.0691 -0.167922,-0.0691 -0.113595,0 -0.167923,0.0691 -0.05433,0.0642 -0.07408,0.17287 -0.01482,0.10865 -0.01482,0.242 v 1.04705 q 0,0.13335 0.01482,0.24694 0.01976,0.10866 0.07408,0.17286 0.05433,0.0642 0.167923,0.0642 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4612"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 86.699665,106.65405 v -2.85468 h 0.671689 v 0.43957 q 0.148167,-0.25189 0.296334,-0.36054 0.148166,-0.1136 0.325966,-0.1136 0.02963,0 0.04939,0.005 0.0247,0 0.05433,0.005 v 0.69638 q -0.05927,-0.0247 -0.13335,-0.0395 -0.06915,-0.0198 -0.143228,-0.0198 -0.13335,0 -0.242005,0.0642 -0.108656,0.0642 -0.207434,0.21237 v 1.96568 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4614"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 88.732095,106.65405 -0.439561,-2.85468 h 0.558095 l 0.251883,1.85209 0.296333,-1.85209 h 0.498828 l 0.281517,1.87184 0.271639,-1.87184 h 0.528461 l -0.449439,2.85468 h -0.567972 l -0.316089,-1.80269 -0.330906,1.80269 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4616"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 91.906798,106.6985 q -0.192617,0 -0.330906,-0.0988 -0.138289,-0.10371 -0.212372,-0.25682 -0.07408,-0.15804 -0.07408,-0.32596 0,-0.2667 0.09878,-0.44944 0.09878,-0.18274 0.261761,-0.30621 0.162983,-0.12348 0.370416,-0.21238 0.207434,-0.0938 0.419806,-0.16792 v -0.24694 q 0,-0.12348 -0.01976,-0.20744 -0.01482,-0.084 -0.06421,-0.12841 -0.04445,-0.0444 -0.143228,-0.0444 -0.08396,0 -0.138289,0.0395 -0.04939,0.0395 -0.07408,0.1136 -0.01976,0.0691 -0.02469,0.16298 l -0.0099,0.17286 -0.637117,-0.0247 q 0.01482,-0.49389 0.242005,-0.72602 0.232128,-0.23707 0.701323,-0.23707 0.429683,0 0.6223,0.23707 0.197555,0.23707 0.197555,0.64206 v 1.31868 q 0,0.15804 0.0049,0.28646 0.0099,0.12841 0.01976,0.23212 0.01482,0.10372 0.02469,0.18274 h -0.602544 q -0.01482,-0.0988 -0.03951,-0.22225 -0.01976,-0.12841 -0.02963,-0.18768 -0.04939,0.17287 -0.187678,0.31609 -0.138288,0.13829 -0.375355,0.13829 z m 0.246944,-0.49883 q 0.06421,0 0.118534,-0.0296 0.05927,-0.0346 0.103716,-0.079 0.04445,-0.0444 0.06421,-0.079 v -0.79516 q -0.108656,0.0642 -0.207433,0.12841 -0.09384,0.0642 -0.167923,0.14322 -0.06914,0.0741 -0.108655,0.16299 -0.03457,0.0889 -0.03457,0.20743 0,0.15805 0.05927,0.25188 0.06421,0.0889 0.172861,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4618"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 93.596747,106.65405 v -2.85468 h 0.671689 v 0.43957 q 0.148166,-0.25189 0.296333,-0.36054 0.148167,-0.1136 0.325967,-0.1136 0.02963,0 0.04939,0.005 0.02469,0 0.05433,0.005 v 0.69638 q -0.05927,-0.0247 -0.13335,-0.0395 -0.06914,-0.0198 -0.143227,-0.0198 -0.13335,0 -0.242006,0.0642 -0.108656,0.0642 -0.207433,0.21237 v 1.96568 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4620"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 95.950668,106.6985 q -0.340783,0 -0.518583,-0.242 -0.172861,-0.24201 -0.172861,-0.77541 v -0.87418 q 0,-0.29634 0.06421,-0.5334 0.06914,-0.23707 0.217311,-0.37536 0.148167,-0.14323 0.40005,-0.14323 0.153106,0 0.281517,0.0642 0.13335,0.0593 0.242006,0.15804 v -1.32362 h 0.671689 v 4.0005 h -0.671689 v -0.20249 q -0.113595,0.11359 -0.242006,0.18274 -0.128411,0.0642 -0.271639,0.0642 z m 0.246945,-0.46425 q 0.05433,0 0.123472,-0.0247 0.06914,-0.0247 0.143228,-0.0691 v -1.83233 q -0.05927,-0.0395 -0.128411,-0.0642 -0.06915,-0.0296 -0.143228,-0.0296 -0.143228,0 -0.202495,0.13335 -0.05433,0.12841 -0.05433,0.31609 v 1.0668 q 0,0.14323 0.01976,0.25682 0.01976,0.1136 0.07408,0.18274 0.05927,0.0642 0.167923,0.0642 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4622"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 97.662765,106.65405 v -2.85468 h 0.671689 v 2.85468 z m 0,-3.30905 v -0.5581 h 0.671689 v 0.5581 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4624"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 98.868086,106.65405 v -2.85468 h 0.671689 v 0.28646 q 0.153105,-0.14817 0.321027,-0.23707 0.172858,-0.0938 0.370418,-0.0938 0.1778,0 0.28152,0.0889 0.10371,0.084 0.1531,0.22719 0.0494,0.14323 0.0494,0.31115 v 2.27189 h -0.67169 v -2.13854 q 0,-0.12841 -0.0395,-0.19755 -0.03951,-0.0691 -0.153105,-0.0691 -0.06915,0 -0.153106,0.0395 -0.07902,0.0395 -0.158044,0.0988 v 2.26695 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4626"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 102.05174,107.59244 q -0.2914,0 -0.51365,-0.0593 -0.22225,-0.0593 -0.34572,-0.18273 -0.12347,-0.12348 -0.12347,-0.32103 0,-0.13335 0.0543,-0.24201 0.0593,-0.10371 0.15804,-0.18274 0.0988,-0.079 0.21237,-0.13335 -0.16298,-0.0444 -0.25188,-0.14322 -0.084,-0.0988 -0.084,-0.23707 0,-0.16792 0.084,-0.28646 0.084,-0.11853 0.23213,-0.25188 -0.15311,-0.12347 -0.23213,-0.30621 -0.0741,-0.18768 -0.0741,-0.48895 0,-0.32597 0.10371,-0.54822 0.10866,-0.22719 0.31115,-0.34078 0.20744,-0.1136 0.50377,-0.1136 0.22719,0 0.3803,0.0692 0.1531,0.0642 0.25188,0.19755 0.0395,-0.0593 0.13829,-0.14816 0.0988,-0.0889 0.22719,-0.14817 l 0.0889,-0.0395 0.16298,0.36054 q -0.0543,0.0148 -0.14817,0.0494 -0.0889,0.0346 -0.1778,0.0741 -0.0889,0.0395 -0.13829,0.0691 0.0444,0.0988 0.0741,0.24694 0.0296,0.14817 0.0296,0.28152 0,0.30127 -0.0938,0.52352 -0.0938,0.22225 -0.29139,0.34572 -0.19262,0.11853 -0.50377,0.11853 -0.10372,0 -0.20249,-0.0148 -0.0988,-0.0198 -0.18274,-0.0444 -0.0296,0.0444 -0.0593,0.0938 -0.0247,0.0494 -0.0247,0.10371 0,0.0543 0.0593,0.0889 0.0593,0.0346 0.19756,0.0494 l 0.60254,0.0593 q 0.35066,0.0346 0.51859,0.22225 0.16792,0.18274 0.16792,0.49883 0,0.25682 -0.11853,0.42968 -0.1136,0.17286 -0.36054,0.26176 -0.24201,0.0889 -0.63218,0.0889 z m 0.0741,-0.50377 q 0.27658,0 0.41487,-0.0543 0.13829,-0.0543 0.13829,-0.19756 0,-0.079 -0.0346,-0.12841 -0.0346,-0.0494 -0.12348,-0.079 -0.0889,-0.0346 -0.25188,-0.0494 l -0.48895,-0.0444 q -0.0543,0.0444 -0.0988,0.0938 -0.0395,0.0444 -0.0642,0.0988 -0.0247,0.0543 -0.0247,0.11359 0,0.12347 0.11854,0.18274 0.11853,0.0642 0.41486,0.0642 z m -0.0395,-1.76318 q 0.0889,0 0.14323,-0.0296 0.0543,-0.0346 0.084,-0.10372 0.0296,-0.0741 0.0395,-0.18274 0.01,-0.10865 0.01,-0.25188 0,-0.14323 -0.01,-0.25188 -0.01,-0.10866 -0.0395,-0.18274 -0.0247,-0.0741 -0.079,-0.10866 -0.0543,-0.0346 -0.14817,-0.0346 -0.0889,0 -0.14817,0.0346 -0.0543,0.0346 -0.084,0.10866 -0.0247,0.0691 -0.0395,0.1778 -0.01,0.10865 -0.01,0.25682 0,0.13829 0.01,0.24694 0.01,0.10372 0.0395,0.1778 0.0296,0.0692 0.084,0.10866 0.0593,0.0346 0.14817,0.0346 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4628"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 103.97173,106.65405 v -3.46216 h -0.63711 v -0.53834 h 1.99531 v 0.53834 h -0.62724 v 3.46216 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4630"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 105.90353,106.6985 q -0.19262,0 -0.3309,-0.0988 -0.13829,-0.10371 -0.21238,-0.25682 -0.0741,-0.15804 -0.0741,-0.32596 0,-0.2667 0.0988,-0.44944 0.0988,-0.18274 0.26176,-0.30621 0.16298,-0.12348 0.37042,-0.21238 0.20743,-0.0938 0.4198,-0.16792 v -0.24694 q 0,-0.12348 -0.0198,-0.20744 -0.0148,-0.084 -0.0642,-0.12841 -0.0444,-0.0444 -0.14323,-0.0444 -0.084,0 -0.13829,0.0395 -0.0494,0.0395 -0.0741,0.1136 -0.0198,0.0691 -0.0247,0.16298 l -0.01,0.17286 -0.63712,-0.0247 q 0.0148,-0.49389 0.24201,-0.72602 0.23212,-0.23707 0.70132,-0.23707 0.42968,0 0.6223,0.23707 0.19755,0.23707 0.19755,0.64206 v 1.31868 q 0,0.15804 0.005,0.28646 0.01,0.12841 0.0198,0.23212 0.0148,0.10372 0.0247,0.18274 h -0.60254 q -0.0148,-0.0988 -0.0395,-0.22225 -0.0198,-0.12841 -0.0296,-0.18768 -0.0494,0.17287 -0.18767,0.31609 -0.13829,0.13829 -0.37536,0.13829 z m 0.24695,-0.49883 q 0.0642,0 0.11853,-0.0296 0.0593,-0.0346 0.10372,-0.079 0.0444,-0.0444 0.0642,-0.079 v -0.79516 q -0.10865,0.0642 -0.20743,0.12841 -0.0938,0.0642 -0.16792,0.14322 -0.0692,0.0741 -0.10866,0.16299 -0.0346,0.0889 -0.0346,0.20743 0,0.15805 0.0593,0.25188 0.0642,0.0889 0.17287,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4632"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 108.80845,106.6985 q -0.15805,0 -0.29634,-0.0741 -0.13828,-0.0741 -0.25682,-0.18274 v 0.21237 h -0.67169 v -4.0005 h 0.67169 v 1.36314 q 0.12347,-0.11854 0.2667,-0.18768 0.14817,-0.0741 0.31609,-0.0741 0.19262,0 0.31609,0.0889 0.12347,0.0889 0.19262,0.23707 0.0691,0.14323 0.0938,0.31115 0.0296,0.16298 0.0296,0.31609 v 0.96802 q 0,0.28152 -0.0691,0.51365 -0.0642,0.23212 -0.21237,0.37041 -0.14323,0.13829 -0.38029,0.13829 z m -0.25682,-0.46919 q 0.10865,0 0.15804,-0.0691 0.0543,-0.0741 0.0691,-0.19261 0.0198,-0.12348 0.0198,-0.2667 v -1.02235 q 0,-0.13335 -0.0198,-0.23707 -0.0197,-0.10866 -0.0741,-0.17286 -0.0494,-0.0642 -0.15804,-0.0642 -0.079,0 -0.15311,0.0395 -0.0741,0.0346 -0.13829,0.079 v 1.80269 q 0.0642,0.0444 0.13829,0.0741 0.079,0.0296 0.15805,0.0296 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4634"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 109.9768,106.65405 v -4.0005 h 0.66675 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4636"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 112.04103,106.6985 q -0.32103,0 -0.52352,-0.11853 -0.2025,-0.12347 -0.30128,-0.3556 -0.0938,-0.23707 -0.0938,-0.56797 v -0.85937 q 0,-0.34078 0.0938,-0.57291 0.0988,-0.23213 0.30128,-0.35066 0.20743,-0.11854 0.52352,-0.11854 0.34078,0 0.52846,0.12842 0.19262,0.12841 0.27164,0.37535 0.084,0.24201 0.084,0.59267 v 0.40499 h -1.13594 v 0.56303 q 0,0.13829 0.0247,0.22719 0.0296,0.0889 0.0889,0.12841 0.0593,0.0395 0.14323,0.0395 0.0889,0 0.14323,-0.0395 0.0543,-0.0445 0.079,-0.12347 0.0247,-0.084 0.0247,-0.20744 v -0.23706 h 0.62724 v 0.19261 q 0,0.43463 -0.21731,0.66675 -0.21731,0.23213 -0.66181,0.23213 z m -0.25188,-1.77306 h 0.50376 v -0.27164 q 0,-0.14816 -0.0247,-0.23706 -0.0247,-0.0938 -0.079,-0.13335 -0.0543,-0.0444 -0.15311,-0.0444 -0.0889,0 -0.14323,0.0444 -0.0543,0.0444 -0.079,0.14816 -0.0247,0.10372 -0.0247,0.29634 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4638"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 92.062759,112.82766 0.1778,-1.37795 h -0.242006 l 0.0049,-0.44943 h 0.301272 l 0.06914,-0.52847 H 92.01337 l 0.0049,-0.45931 h 0.429683 l 0.153106,-1.18534 h 0.523522 l -0.153106,1.18534 h 0.409928 l 0.158045,-1.18534 h 0.518583 l -0.158045,1.18534 h 0.237067 l -0.0099,0.45931 H 93.83082 l -0.06914,0.52847 h 0.350661 l -0.0049,0.44943 h -0.409928 l -0.182739,1.37795 H 92.99127 l 0.182739,-1.37795 h -0.409928 l -0.1778,1.37795 z m 0.760589,-1.82738 h 0.414866 l 0.06915,-0.52847 h -0.409928 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4640"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 94.718492,112.82766 0.795161,-3.47697 h -1.081617 v -0.52353 h 1.753306 v 0.41981 l -0.805039,3.58069 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4642"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 97.682366,112.88693 q -0.350662,0 -0.582789,-0.14817 -0.227189,-0.14816 -0.345723,-0.40992 -0.113594,-0.26176 -0.113594,-0.60255 v -1.77306 q 0,-0.35066 0.108656,-0.61242 0.113594,-0.2667 0.340783,-0.41487 0.232128,-0.14816 0.592667,-0.14816 0.360538,0 0.587727,0.14816 0.232128,0.14817 0.340784,0.41487 0.113594,0.26176 0.113594,0.61242 v 1.77306 q 0,0.34079 -0.118533,0.60255 -0.113595,0.26176 -0.345722,0.40992 -0.227189,0.14817 -0.57785,0.14817 z m 0,-0.58773 q 0.153105,0 0.227188,-0.0938 0.07408,-0.0938 0.09878,-0.22718 0.0247,-0.13335 0.0247,-0.26177 v -1.7533 q 0,-0.13829 -0.0247,-0.27164 -0.01975,-0.13829 -0.09384,-0.23213 -0.07408,-0.0938 -0.232127,-0.0938 -0.158045,0 -0.232128,0.0938 -0.07408,0.0938 -0.09878,0.23213 -0.01976,0.13335 -0.01976,0.27164 v 1.7533 q 0,0.12842 0.02469,0.26177 0.02963,0.13335 0.103717,0.22718 0.07408,0.0938 0.22225,0.0938 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4644"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="L2ForwardingCalcTable
+#80"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4248">
+      <path
+         d="m 6.2350849,106.57745 v -4.0005 h 0.7309556 v 3.49674 h 0.9680223 v 0.50376 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4647"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 8.1813158,106.57745 v -0.48401 l 0.9877778,-1.52611 q 0.1086556,-0.16793 0.2024945,-0.32103 0.098778,-0.15311 0.1580444,-0.31609 0.064206,-0.16792 0.064206,-0.36548 0,-0.22225 -0.079022,-0.34078 -0.079022,-0.11854 -0.2469444,-0.11854 -0.1580445,0 -0.2469445,0.0889 -0.0889,0.0889 -0.1234722,0.23213 -0.029633,0.14323 -0.029633,0.31609 v 0.16792 H 8.1961325 v -0.1778 q 0,-0.3556 0.1037166,-0.6223 0.1086556,-0.27164 0.3407834,-0.42474 0.2321278,-0.15311 0.6074833,-0.15311 0.5136445,0 0.7704672,0.27658 0.256822,0.27658 0.256822,0.77047 0,0.24694 -0.06914,0.44944 -0.06914,0.19755 -0.182739,0.38029 -0.113594,0.18274 -0.246944,0.37536 l -0.8198556,1.2446 h 1.2149666 v 0.54821 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4649"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 10.730246,106.57745 v -4.0005 h 1.64465 v 0.50377 h -0.913695 v 1.16558 h 0.745772 v 0.5087 h -0.745772 v 1.82245 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4651"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 13.556525,106.6219 q -0.31115,0 -0.513645,-0.11359 -0.202494,-0.11853 -0.306211,-0.34078 -0.09878,-0.22225 -0.09878,-0.53834 v -0.95815 q 0,-0.31609 0.09878,-0.53834 0.103717,-0.22225 0.306211,-0.33584 0.202495,-0.11853 0.513645,-0.11853 0.31115,0 0.513644,0.11853 0.207433,0.11359 0.306211,0.33584 0.103717,0.22225 0.103717,0.53834 v 0.95815 q 0,0.31609 -0.103717,0.53834 -0.09878,0.22225 -0.306211,0.34078 -0.202494,0.11359 -0.513644,0.11359 z m 0.0049,-0.46425 q 0.113595,0 0.167923,-0.0642 0.05433,-0.0642 0.06914,-0.17286 0.01482,-0.11359 0.01482,-0.24694 v -1.04705 q 0,-0.13335 -0.01482,-0.242 -0.01482,-0.10866 -0.06914,-0.17286 -0.05433,-0.0692 -0.167923,-0.0692 -0.113594,0 -0.167922,0.0692 -0.05433,0.0642 -0.07408,0.17286 -0.01482,0.10865 -0.01482,0.242 v 1.04705 q 0,0.13335 0.01482,0.24694 0.01976,0.10866 0.07408,0.17286 0.05433,0.0642 0.167922,0.0642 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4653"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 14.954616,106.57745 v -2.85467 h 0.671689 v 0.43956 q 0.148167,-0.25189 0.296333,-0.36054 0.148167,-0.1136 0.325967,-0.1136 0.02963,0 0.04939,0.005 0.02469,0 0.05433,0.005 v 0.69638 q -0.05927,-0.0247 -0.13335,-0.0395 -0.06915,-0.0198 -0.143228,-0.0198 -0.13335,0 -0.242006,0.0642 -0.108655,0.0642 -0.207433,0.21238 v 1.96567 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4655"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 16.987046,106.57745 -0.439561,-2.85467 h 0.558095 l 0.251883,1.85208 0.296333,-1.85208 h 0.498828 l 0.281517,1.87183 0.271639,-1.87183 h 0.528461 l -0.449439,2.85467 H 18.21683 l -0.316089,-1.80269 -0.330906,1.80269 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4657"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 20.161749,106.6219 q -0.192617,0 -0.330906,-0.0988 -0.138289,-0.10372 -0.212372,-0.25683 -0.07408,-0.15804 -0.07408,-0.32596 0,-0.2667 0.09878,-0.44944 0.09878,-0.18274 0.261762,-0.30621 0.162983,-0.12348 0.370416,-0.21238 0.207434,-0.0938 0.419806,-0.16792 v -0.24694 q 0,-0.12347 -0.01976,-0.20744 -0.01482,-0.084 -0.06421,-0.12841 -0.04445,-0.0444 -0.143228,-0.0444 -0.08396,0 -0.138289,0.0395 -0.04939,0.0395 -0.07408,0.1136 -0.01976,0.0691 -0.0247,0.16298 l -0.0099,0.17286 -0.637116,-0.0247 q 0.01482,-0.49389 0.242005,-0.72602 0.232128,-0.23706 0.701323,-0.23706 0.429683,0 0.6223,0.23706 0.197555,0.23707 0.197555,0.64206 v 1.31868 q 0,0.15805 0.0049,0.28646 0.0099,0.12841 0.01976,0.23212 0.01482,0.10372 0.02469,0.18274 h -0.602544 q -0.01482,-0.0988 -0.03951,-0.22225 -0.01975,-0.12841 -0.02963,-0.18767 -0.04939,0.17286 -0.187678,0.31608 -0.138289,0.13829 -0.375355,0.13829 z m 0.246944,-0.49882 q 0.06421,0 0.118534,-0.0296 0.05927,-0.0346 0.103716,-0.079 0.04445,-0.0444 0.06421,-0.079 v -0.79516 q -0.108656,0.0642 -0.207434,0.12841 -0.09384,0.0642 -0.167922,0.14323 -0.06914,0.0741 -0.108655,0.16298 -0.03457,0.0889 -0.03457,0.20743 0,0.15805 0.05927,0.25189 0.06421,0.0889 0.172861,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4659"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 21.851698,106.57745 v -2.85467 h 0.671688 v 0.43956 q 0.148167,-0.25189 0.296334,-0.36054 0.148166,-0.1136 0.325966,-0.1136 0.02963,0 0.04939,0.005 0.0247,0 0.05433,0.005 v 0.69638 q -0.05927,-0.0247 -0.13335,-0.0395 -0.06914,-0.0198 -0.143228,-0.0198 -0.13335,0 -0.242005,0.0642 -0.108656,0.0642 -0.207434,0.21238 v 1.96567 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4661"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 24.205619,106.6219 q -0.340783,0 -0.518583,-0.242 -0.172861,-0.24201 -0.172861,-0.77541 v -0.87418 q 0,-0.29633 0.0642,-0.5334 0.06915,-0.23707 0.217311,-0.37536 0.148167,-0.14322 0.40005,-0.14322 0.153106,0 0.281517,0.0642 0.13335,0.0593 0.242006,0.15805 v -1.32363 h 0.671688 v 4.0005 h -0.671688 v -0.20249 q -0.113595,0.11359 -0.242006,0.18274 -0.128411,0.0642 -0.271639,0.0642 z m 0.246945,-0.46425 q 0.05433,0 0.123472,-0.0247 0.06914,-0.0247 0.143228,-0.0691 v -1.83233 q -0.05927,-0.0395 -0.128412,-0.0642 -0.06914,-0.0296 -0.143227,-0.0296 -0.143228,0 -0.202495,0.13335 -0.05433,0.12841 -0.05433,0.31609 v 1.0668 q 0,0.14323 0.01976,0.25682 0.01976,0.1136 0.07408,0.18274 0.05927,0.0642 0.167923,0.0642 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4663"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 25.917715,106.57745 v -2.85467 h 0.671689 v 2.85467 z m 0,-3.30905 v -0.5581 h 0.671689 v 0.5581 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4665"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 27.123037,106.57745 v -2.85467 h 0.671688 v 0.28645 q 0.153106,-0.14817 0.321028,-0.23707 0.172861,-0.0938 0.370417,-0.0938 0.1778,0 0.281517,0.0889 0.103716,0.084 0.153105,0.22718 0.04939,0.14323 0.04939,0.31115 v 2.27189 h -0.671689 v -2.13854 q 0,-0.12841 -0.03951,-0.19755 -0.03951,-0.0691 -0.153106,-0.0691 -0.06914,0 -0.153105,0.0395 -0.07902,0.0395 -0.158045,0.0988 v 2.26695 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4667"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 30.30669,107.51584 q -0.291395,0 -0.513645,-0.0593 -0.22225,-0.0593 -0.345722,-0.18274 -0.123472,-0.12348 -0.123472,-0.32103 0,-0.13335 0.05433,-0.24201 0.05927,-0.10371 0.158045,-0.18274 0.09878,-0.079 0.212372,-0.13335 -0.162983,-0.0444 -0.251883,-0.14322 -0.08396,-0.0988 -0.08396,-0.23707 0,-0.16792 0.08396,-0.28646 0.08396,-0.11853 0.232128,-0.25188 -0.153106,-0.12347 -0.232128,-0.30621 -0.07408,-0.18768 -0.07408,-0.48895 0,-0.32597 0.103717,-0.54822 0.108656,-0.22719 0.31115,-0.34078 0.207433,-0.11359 0.503767,-0.11359 0.227189,0 0.380294,0.0691 0.153106,0.0642 0.251884,0.19756 0.03951,-0.0593 0.138288,-0.14817 0.09878,-0.0889 0.227189,-0.14817 l 0.0889,-0.0395 0.162984,0.36054 q -0.05433,0.0148 -0.148167,0.0494 -0.0889,0.0346 -0.1778,0.0741 -0.0889,0.0395 -0.138289,0.0691 0.04445,0.0988 0.07408,0.24694 0.02963,0.14817 0.02963,0.28152 0,0.30127 -0.09384,0.52352 -0.09384,0.22225 -0.291395,0.34572 -0.192616,0.11854 -0.503766,0.11854 -0.103717,0 -0.202495,-0.0148 -0.09878,-0.0198 -0.182739,-0.0444 -0.02963,0.0444 -0.05927,0.0938 -0.02469,0.0494 -0.02469,0.10371 0,0.0543 0.05927,0.0889 0.05927,0.0346 0.197556,0.0494 l 0.602544,0.0593 q 0.350661,0.0346 0.518583,0.22225 0.167923,0.18274 0.167923,0.49883 0,0.25682 -0.118534,0.42968 -0.113594,0.17286 -0.360539,0.26176 -0.242005,0.0889 -0.632177,0.0889 z m 0.07408,-0.50376 q 0.276578,0 0.414867,-0.0543 0.138288,-0.0543 0.138288,-0.19756 0,-0.079 -0.03457,-0.12841 -0.03457,-0.0494 -0.123472,-0.079 -0.0889,-0.0346 -0.251883,-0.0494 l -0.48895,-0.0444 q -0.05433,0.0444 -0.09878,0.0938 -0.03951,0.0444 -0.06421,0.0988 -0.02469,0.0543 -0.02469,0.11359 0,0.12347 0.118533,0.18274 0.118534,0.0642 0.414867,0.0642 z m -0.03951,-1.76319 q 0.0889,0 0.143228,-0.0296 0.05433,-0.0346 0.08396,-0.10372 0.02963,-0.0741 0.03951,-0.18274 0.0099,-0.10865 0.0099,-0.25188 0,-0.14323 -0.0099,-0.25188 -0.0099,-0.10866 -0.03951,-0.18274 -0.0247,-0.0741 -0.07902,-0.10866 -0.05433,-0.0346 -0.148166,-0.0346 -0.0889,0 -0.148167,0.0346 -0.05433,0.0346 -0.08396,0.10866 -0.02469,0.0691 -0.03951,0.1778 -0.0099,0.10865 -0.0099,0.25682 0,0.13829 0.0099,0.24694 0.0099,0.10372 0.03951,0.1778 0.02963,0.0691 0.08396,0.10866 0.05927,0.0346 0.148167,0.0346 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4669"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 32.903312,106.63178 q -0.439561,0 -0.691445,-0.17286 -0.246944,-0.17286 -0.345722,-0.46919 -0.09878,-0.30128 -0.09878,-0.69145 v -1.42734 q 0,-0.40993 0.09878,-0.7112 0.09878,-0.30127 0.345722,-0.46425 0.251884,-0.16299 0.691445,-0.16299 0.414866,0 0.646994,0.14323 0.237067,0.13829 0.335845,0.40005 0.09878,0.26176 0.09878,0.60748 v 0.33585 h -0.701322 v -0.34572 q 0,-0.16793 -0.01975,-0.30621 -0.01482,-0.13829 -0.09384,-0.21732 -0.07408,-0.084 -0.261761,-0.084 -0.187678,0 -0.276578,0.0889 -0.08396,0.084 -0.108656,0.23213 -0.02469,0.14323 -0.02469,0.32597 v 1.73849 q 0,0.21731 0.03457,0.36054 0.03457,0.13828 0.123472,0.21237 0.09384,0.0691 0.251884,0.0691 0.182738,0 0.256822,-0.084 0.07902,-0.0889 0.09878,-0.23213 0.01975,-0.14322 0.01975,-0.32102 v -0.36054 h 0.701322 v 0.32102 q 0,0.3556 -0.09384,0.63218 -0.09384,0.27164 -0.330905,0.42969 -0.232128,0.1531 -0.656872,0.1531 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4671"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 34.997708,106.6219 q -0.192616,0 -0.330905,-0.0988 -0.138289,-0.10372 -0.212373,-0.25683 -0.07408,-0.15804 -0.07408,-0.32596 0,-0.2667 0.09878,-0.44944 0.09878,-0.18274 0.261761,-0.30621 0.162983,-0.12348 0.370417,-0.21238 0.207433,-0.0938 0.419805,-0.16792 v -0.24694 q 0,-0.12347 -0.01976,-0.20744 -0.01482,-0.084 -0.06421,-0.12841 -0.04445,-0.0444 -0.143228,-0.0444 -0.08396,0 -0.138289,0.0395 -0.04939,0.0395 -0.07408,0.1136 -0.01975,0.0691 -0.02469,0.16298 l -0.0099,0.17286 -0.637117,-0.0247 q 0.01482,-0.49389 0.242006,-0.72602 0.232128,-0.23706 0.701322,-0.23706 0.429683,0 0.6223,0.23706 0.197556,0.23707 0.197556,0.64206 v 1.31868 q 0,0.15805 0.0049,0.28646 0.0099,0.12841 0.01976,0.23212 0.01482,0.10372 0.02469,0.18274 h -0.602544 q -0.01482,-0.0988 -0.03951,-0.22225 -0.01976,-0.12841 -0.02963,-0.18767 -0.04939,0.17286 -0.187678,0.31608 -0.138289,0.13829 -0.375356,0.13829 z m 0.246945,-0.49882 q 0.06421,0 0.118533,-0.0296 0.05927,-0.0346 0.103717,-0.079 0.04445,-0.0444 0.06421,-0.079 v -0.79516 q -0.108655,0.0642 -0.207433,0.12841 -0.09384,0.0642 -0.167922,0.14323 -0.06914,0.0741 -0.108656,0.16298 -0.03457,0.0889 -0.03457,0.20743 0,0.15805 0.05927,0.25189 0.06421,0.0889 0.172861,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4673"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 36.717291,106.57745 v -4.0005 h 0.66675 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4675"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 38.776576,106.6219 q -0.330906,0 -0.5334,-0.12347 -0.197556,-0.12841 -0.291395,-0.36054 -0.0889,-0.23706 -0.0889,-0.55809 v -0.85937 q 0,-0.3309 0.0889,-0.56303 0.09384,-0.23213 0.296333,-0.3556 0.202495,-0.12347 0.528462,-0.12347 0.306211,0 0.498827,0.0988 0.197556,0.0938 0.286456,0.2914 0.0889,0.19261 0.0889,0.48895 v 0.23706 h -0.632178 v -0.25188 q 0,-0.14817 -0.02469,-0.23213 -0.01976,-0.0889 -0.07408,-0.12347 -0.05433,-0.0395 -0.143227,-0.0395 -0.0889,0 -0.143228,0.0494 -0.05433,0.0444 -0.07902,0.14817 -0.01976,0.10371 -0.01976,0.28645 v 1.04705 q 0,0.27657 0.05927,0.37535 0.05927,0.0938 0.187677,0.0938 0.09878,0 0.148167,-0.0444 0.05433,-0.0444 0.06914,-0.12841 0.01975,-0.0889 0.01975,-0.21237 v -0.30621 h 0.632178 v 0.27163 q 0,0.28646 -0.09384,0.48895 -0.0889,0.2025 -0.286456,0.30622 -0.192616,0.0988 -0.493888,0.0988 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4677"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 40.532119,106.57745 v -3.46216 h -0.637117 v -0.53834 h 1.995312 v 0.53834 h -0.627239 v 3.46216 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4679"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 42.463921,106.6219 q -0.192616,0 -0.330905,-0.0988 -0.138289,-0.10372 -0.212372,-0.25683 -0.07408,-0.15804 -0.07408,-0.32596 0,-0.2667 0.09878,-0.44944 0.09878,-0.18274 0.261761,-0.30621 0.162984,-0.12348 0.370417,-0.21238 0.207433,-0.0938 0.419805,-0.16792 v -0.24694 q 0,-0.12347 -0.01975,-0.20744 -0.01482,-0.084 -0.06421,-0.12841 -0.04445,-0.0444 -0.143227,-0.0444 -0.08396,0 -0.138289,0.0395 -0.04939,0.0395 -0.07408,0.1136 -0.01976,0.0691 -0.02469,0.16298 l -0.0099,0.17286 -0.637117,-0.0247 q 0.01482,-0.49389 0.242006,-0.72602 0.232128,-0.23706 0.701322,-0.23706 0.429684,0 0.6223,0.23706 0.197556,0.23707 0.197556,0.64206 v 1.31868 q 0,0.15805 0.0049,0.28646 0.0099,0.12841 0.01976,0.23212 0.01482,0.10372 0.0247,0.18274 h -0.602545 q -0.01482,-0.0988 -0.03951,-0.22225 -0.01975,-0.12841 -0.02963,-0.18767 -0.04939,0.17286 -0.187678,0.31608 -0.138289,0.13829 -0.375356,0.13829 z m 0.246945,-0.49882 q 0.0642,0 0.118533,-0.0296 0.05927,-0.0346 0.103717,-0.079 0.04445,-0.0444 0.06421,-0.079 v -0.79516 q -0.108655,0.0642 -0.207433,0.12841 -0.09384,0.0642 -0.167922,0.14323 -0.06914,0.0741 -0.108656,0.16298 -0.03457,0.0889 -0.03457,0.20743 0,0.15805 0.05927,0.25189 0.06421,0.0889 0.172861,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4681"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 45.368836,106.6219 q -0.158044,0 -0.296333,-0.0741 -0.138289,-0.0741 -0.256823,-0.18274 v 0.21237 h -0.671689 v -4.0005 h 0.671689 v 1.36314 q 0.123473,-0.11854 0.2667,-0.18768 0.148167,-0.0741 0.316089,-0.0741 0.192617,0 0.316089,0.0889 0.123472,0.0889 0.192617,0.23706 0.06914,0.14323 0.09384,0.31115 0.02963,0.16299 0.02963,0.31609 v 0.96802 q 0,0.28152 -0.06914,0.51365 -0.06421,0.23213 -0.212373,0.37041 -0.143227,0.13829 -0.380294,0.13829 z m -0.256822,-0.46919 q 0.108655,0 0.158044,-0.0691 0.05433,-0.0741 0.06914,-0.19261 0.01976,-0.12347 0.01976,-0.2667 v -1.02235 q 0,-0.13335 -0.01976,-0.23707 -0.01976,-0.10865 -0.07408,-0.17286 -0.04939,-0.0642 -0.158044,-0.0642 -0.07902,0 -0.153106,0.0395 -0.07408,0.0346 -0.138289,0.079 v 1.80269 q 0.06421,0.0444 0.138289,0.0741 0.07902,0.0296 0.158045,0.0296 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4683"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 46.53719,106.57745 v -4.0005 h 0.66675 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4685"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 48.601415,106.6219 q -0.321028,0 -0.523522,-0.11853 -0.202495,-0.12347 -0.301273,-0.3556 -0.09384,-0.23707 -0.09384,-0.56797 v -0.85937 q 0,-0.34078 0.09384,-0.57291 0.09878,-0.23213 0.301273,-0.35066 0.207433,-0.11853 0.523522,-0.11853 0.340783,0 0.528461,0.12841 0.192617,0.12841 0.271639,0.37535 0.08396,0.24201 0.08396,0.59267 v 0.40499 h -1.135944 v 0.56303 q 0,0.13829 0.02469,0.22719 0.02963,0.0889 0.0889,0.12841 0.05927,0.0395 0.143228,0.0395 0.0889,0 0.143228,-0.0395 0.05433,-0.0445 0.07902,-0.12347 0.02469,-0.084 0.02469,-0.20743 v -0.23707 h 0.627239 v 0.19262 q 0,0.43462 -0.217311,0.66675 -0.217311,0.23212 -0.661811,0.23212 z m -0.251883,-1.77306 h 0.503766 v -0.27164 q 0,-0.14816 -0.02469,-0.23706 -0.0247,-0.0938 -0.07902,-0.13335 -0.05433,-0.0444 -0.153106,-0.0444 -0.0889,0 -0.143228,0.0444 -0.05433,0.0444 -0.07902,0.14816 -0.02469,0.10372 -0.02469,0.29634 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4687"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 24.229271,112.75106 0.1778,-1.37795 h -0.242005 l 0.0049,-0.44943 h 0.301273 l 0.06914,-0.52847 H 24.17984 l 0.0049,-0.45931 h 0.429683 l 0.153106,-1.18534 h 0.523522 l -0.153105,1.18534 h 0.409928 l 0.158044,-1.18534 h 0.518583 l -0.158044,1.18534 h 0.237067 l -0.0099,0.45931 H 25.99729 l -0.06914,0.52847 h 0.350661 l -0.0049,0.44943 h -0.409928 l -0.182738,1.37795 h -0.523523 l 0.182739,-1.37795 h -0.409928 l -0.1778,1.37795 z m 0.760589,-1.82738 h 0.414867 l 0.06914,-0.52847 h -0.409928 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4689"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 27.754249,112.80539 q -0.380295,0 -0.612422,-0.1531 -0.232128,-0.15311 -0.330906,-0.42475 -0.09878,-0.27658 -0.09878,-0.63711 0,-0.17287 0.02963,-0.31609 0.03457,-0.14817 0.09384,-0.2667 0.06421,-0.11854 0.153106,-0.20744 0.0889,-0.0938 0.202494,-0.1531 -0.1778,-0.12347 -0.301272,-0.33585 -0.118533,-0.21731 -0.123472,-0.54821 0,-0.32597 0.103717,-0.56304 0.108655,-0.242 0.330905,-0.36547 0.22225,-0.12842 0.553156,-0.12842 0.335844,0 0.553155,0.12842 0.217311,0.12841 0.321028,0.36547 0.108656,0.23707 0.103717,0.56304 -0.0049,0.33584 -0.123472,0.54821 -0.113595,0.21238 -0.291395,0.33585 0.113595,0.0593 0.202495,0.1531 0.0889,0.0889 0.148166,0.20744 0.06421,0.11853 0.09384,0.2667 0.03457,0.14322 0.03457,0.31609 0.0049,0.36053 -0.09878,0.63711 -0.09878,0.27164 -0.330906,0.42475 -0.227189,0.1531 -0.612422,0.1531 z m 0,-0.51858 q 0.162983,0 0.242005,-0.0988 0.08396,-0.0988 0.108656,-0.24694 0.02469,-0.15311 0.02469,-0.31115 0.0049,-0.16793 -0.02469,-0.32103 -0.02963,-0.15805 -0.113595,-0.25682 -0.07902,-0.0988 -0.237066,-0.0988 -0.153106,0 -0.237067,0.0988 -0.07902,0.0988 -0.113594,0.25188 -0.02963,0.15311 -0.02963,0.32597 0,0.15804 0.02469,0.31115 0.02963,0.1531 0.113594,0.25188 0.08396,0.0938 0.242006,0.0938 z m 0,-1.91135 q 0.123472,-0.005 0.192616,-0.084 0.07408,-0.084 0.103717,-0.22719 0.02963,-0.14323 0.02963,-0.32597 0,-0.22719 -0.07408,-0.37041 -0.07408,-0.14323 -0.251883,-0.14323 -0.172861,0 -0.256822,0.14323 -0.07902,0.14322 -0.07902,0.36547 0,0.18274 0.02963,0.33091 0.03457,0.14323 0.108655,0.22719 0.07408,0.079 0.197557,0.084 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4691"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 30.331192,112.81033 q -0.350662,0 -0.582789,-0.14817 -0.227189,-0.14816 -0.345723,-0.40992 -0.113594,-0.26176 -0.113594,-0.60255 v -1.77306 q 0,-0.35066 0.108656,-0.61242 0.113594,-0.2667 0.340783,-0.41487 0.232128,-0.14816 0.592667,-0.14816 0.360538,0 0.587727,0.14816 0.232128,0.14817 0.340784,0.41487 0.113594,0.26176 0.113594,0.61242 v 1.77306 q 0,0.34079 -0.118533,0.60255 -0.113595,0.26176 -0.345722,0.40992 -0.227189,0.14817 -0.57785,0.14817 z m 0,-0.58773 q 0.153105,0 0.227188,-0.0938 0.07408,-0.0938 0.09878,-0.22718 0.0247,-0.13335 0.0247,-0.26177 v -1.7533 q 0,-0.13829 -0.0247,-0.27164 -0.01975,-0.13829 -0.09384,-0.23213 -0.07408,-0.0938 -0.232127,-0.0938 -0.158045,0 -0.232128,0.0938 -0.07408,0.0938 -0.09878,0.23213 -0.01976,0.13335 -0.01976,0.27164 v 1.7533 q 0,0.12842 0.02469,0.26177 0.02963,0.13335 0.103717,0.22718 0.07408,0.0938 0.22225,0.0938 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4693"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="IngressRuleTable
+#90"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4254">
+      <path
+         d="m 12.088711,190.43074 v -4.0005 h 0.721078 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4696"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 13.384629,190.43074 v -2.85468 h 0.671689 v 0.28646 q 0.153105,-0.14817 0.321028,-0.23707 0.172861,-0.0938 0.370416,-0.0938 0.1778,0 0.281517,0.0889 0.103717,0.084 0.153106,0.22719 0.04939,0.14323 0.04939,0.31115 v 2.27189 h -0.671688 v -2.13854 q 0,-0.12841 -0.03951,-0.19755 -0.03951,-0.0692 -0.153105,-0.0692 -0.06915,0 -0.153106,0.0395 -0.07902,0.0395 -0.158044,0.0988 v 2.26695 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4698"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 16.568283,191.36913 q -0.291394,0 -0.513644,-0.0593 -0.22225,-0.0593 -0.345722,-0.18274 -0.123473,-0.12347 -0.123473,-0.32102 0,-0.13335 0.05433,-0.24201 0.05927,-0.10372 0.158045,-0.18274 0.09878,-0.079 0.212372,-0.13335 -0.162984,-0.0444 -0.251884,-0.14323 -0.08396,-0.0988 -0.08396,-0.23706 0,-0.16793 0.08396,-0.28646 0.08396,-0.11853 0.232128,-0.25188 -0.153105,-0.12347 -0.232128,-0.30621 -0.07408,-0.18768 -0.07408,-0.48895 0,-0.32597 0.103717,-0.54822 0.108655,-0.22719 0.31115,-0.34078 0.207433,-0.1136 0.503766,-0.1136 0.227189,0 0.380295,0.0692 0.153105,0.0642 0.251883,0.19755 0.03951,-0.0593 0.138289,-0.14816 0.09878,-0.0889 0.227189,-0.14817 l 0.0889,-0.0395 0.162983,0.36054 q -0.05433,0.0148 -0.148166,0.0494 -0.0889,0.0346 -0.1778,0.0741 -0.0889,0.0395 -0.138289,0.0691 0.04445,0.0988 0.07408,0.24695 0.02963,0.14816 0.02963,0.28151 0,0.30128 -0.09384,0.52353 -0.09384,0.22225 -0.291395,0.34572 -0.192617,0.11853 -0.503767,0.11853 -0.103716,0 -0.202494,-0.0148 -0.09878,-0.0198 -0.182739,-0.0445 -0.02963,0.0445 -0.05927,0.0938 -0.02469,0.0494 -0.02469,0.10372 0,0.0543 0.05927,0.0889 0.05927,0.0346 0.197555,0.0494 l 0.602545,0.0593 q 0.350661,0.0346 0.518583,0.22225 0.167922,0.18274 0.167922,0.49882 0,0.25683 -0.118533,0.42969 -0.113595,0.17286 -0.360539,0.26176 -0.242006,0.0889 -0.632178,0.0889 z m 0.07408,-0.50377 q 0.276577,0 0.414866,-0.0543 0.138289,-0.0543 0.138289,-0.19755 0,-0.079 -0.03457,-0.12841 -0.03457,-0.0494 -0.123472,-0.079 -0.0889,-0.0346 -0.251884,-0.0494 l -0.48895,-0.0445 q -0.05433,0.0445 -0.09878,0.0938 -0.03951,0.0445 -0.06421,0.0988 -0.02469,0.0543 -0.02469,0.1136 0,0.12347 0.118533,0.18274 0.118533,0.0642 0.414867,0.0642 z m -0.03951,-1.76318 q 0.0889,0 0.143228,-0.0296 0.05433,-0.0346 0.08396,-0.10372 0.02963,-0.0741 0.03951,-0.18274 0.0099,-0.10866 0.0099,-0.25188 0,-0.14323 -0.0099,-0.25189 -0.0099,-0.10865 -0.03951,-0.18274 -0.02469,-0.0741 -0.07902,-0.10865 -0.05433,-0.0346 -0.148167,-0.0346 -0.0889,0 -0.148166,0.0346 -0.05433,0.0346 -0.08396,0.10865 -0.0247,0.0692 -0.03951,0.1778 -0.0099,0.10866 -0.0099,0.25683 0,0.13829 0.0099,0.24694 0.0099,0.10372 0.03951,0.1778 0.02963,0.0692 0.08396,0.10866 0.05927,0.0346 0.148166,0.0346 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4700"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 18.058593,190.43074 v -2.85468 h 0.671689 v 0.43956 q 0.148166,-0.25188 0.296333,-0.36054 0.148167,-0.11359 0.325967,-0.11359 0.02963,0 0.04939,0.005 0.02469,0 0.05433,0.005 v 0.69638 q -0.05927,-0.0247 -0.13335,-0.0395 -0.06914,-0.0198 -0.143227,-0.0198 -0.13335,0 -0.242006,0.0642 -0.108656,0.0642 -0.207433,0.21237 v 1.96568 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4702"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 20.634764,190.47519 q -0.321028,0 -0.523522,-0.11853 -0.202495,-0.12348 -0.301273,-0.3556 -0.09384,-0.23707 -0.09384,-0.56798 v -0.85936 q 0,-0.34079 0.09384,-0.57291 0.09878,-0.23213 0.301273,-0.35066 0.207433,-0.11854 0.523522,-0.11854 0.340783,0 0.528461,0.12841 0.192617,0.12841 0.271639,0.37536 0.08396,0.242 0.08396,0.59267 v 0.40498 H 20.38288 v 0.56304 q 0,0.13829 0.02469,0.22719 0.02963,0.0889 0.0889,0.12841 0.05927,0.0395 0.143228,0.0395 0.0889,0 0.143228,-0.0395 0.05433,-0.0445 0.07902,-0.12347 0.02469,-0.084 0.02469,-0.20744 v -0.23706 h 0.627239 v 0.19261 q 0,0.43462 -0.217311,0.66675 -0.217311,0.23213 -0.661811,0.23213 z m -0.251883,-1.77306 h 0.503766 v -0.27164 q 0,-0.14817 -0.02469,-0.23707 -0.0247,-0.0938 -0.07902,-0.13335 -0.05433,-0.0444 -0.153106,-0.0444 -0.0889,0 -0.143228,0.0444 -0.05433,0.0445 -0.07902,0.14817 -0.02469,0.10372 -0.02469,0.29633 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4704"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 22.745213,190.47519 q -0.360539,0 -0.592667,-0.19262 -0.232128,-0.19261 -0.330905,-0.56303 l 0.498827,-0.19262 q 0.05927,0.23213 0.158045,0.3556 0.09878,0.12348 0.256822,0.12348 0.118533,0 0.1778,-0.0593 0.05927,-0.0593 0.05927,-0.16298 0,-0.11854 -0.07408,-0.21238 -0.06914,-0.0988 -0.242005,-0.242 l -0.345722,-0.2914 q -0.187678,-0.16298 -0.306212,-0.3309 -0.113594,-0.17286 -0.113594,-0.42969 0,-0.23212 0.103717,-0.39511 0.108655,-0.16792 0.291394,-0.25682 0.187678,-0.0938 0.414867,-0.0938 0.345722,0 0.553155,0.20744 0.212373,0.20249 0.271639,0.5334 l -0.439561,0.18767 q -0.02469,-0.11853 -0.07408,-0.21731 -0.04445,-0.10371 -0.118534,-0.16792 -0.07408,-0.0642 -0.172861,-0.0642 -0.103716,0 -0.167922,0.0642 -0.05927,0.0642 -0.05927,0.16298 0,0.084 0.06915,0.17286 0.07408,0.0889 0.207433,0.2025 l 0.350661,0.31609 q 0.113595,0.0988 0.217311,0.21237 0.103717,0.11359 0.172862,0.25682 0.06914,0.13829 0.06914,0.32103 0,0.24694 -0.113594,0.41487 -0.108656,0.16792 -0.301273,0.25682 -0.187677,0.084 -0.419805,0.084 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4706"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 24.722697,190.47519 q -0.360538,0 -0.592666,-0.19262 -0.232128,-0.19261 -0.330906,-0.56303 l 0.498828,-0.19262 q 0.05927,0.23213 0.158044,0.3556 0.09878,0.12348 0.256823,0.12348 0.118533,0 0.1778,-0.0593 0.05927,-0.0593 0.05927,-0.16298 0,-0.11854 -0.07408,-0.21238 -0.06914,-0.0988 -0.242006,-0.242 l -0.345722,-0.2914 q -0.187678,-0.16298 -0.306211,-0.3309 -0.113594,-0.17286 -0.113594,-0.42969 0,-0.23212 0.103716,-0.39511 0.108656,-0.16792 0.291395,-0.25682 0.187678,-0.0938 0.414866,-0.0938 0.345723,0 0.553156,0.20744 0.212372,0.20249 0.271639,0.5334 l -0.439561,0.18767 q -0.02469,-0.11853 -0.07408,-0.21731 -0.04445,-0.10371 -0.118533,-0.16792 -0.07408,-0.0642 -0.172861,-0.0642 -0.103717,0 -0.167922,0.0642 -0.05927,0.0642 -0.05927,0.16298 0,0.084 0.06914,0.17286 0.07408,0.0889 0.207433,0.2025 l 0.350661,0.31609 q 0.113594,0.0988 0.217311,0.21237 0.103717,0.11359 0.172861,0.25682 0.06914,0.13829 0.06914,0.32103 0,0.24694 -0.113595,0.41487 -0.108655,0.16792 -0.301272,0.25682 -0.187678,0.084 -0.419806,0.084 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4708"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 25.969227,190.43074 v -4.0005 h 0.958144 q 0.404989,0 0.681567,0.0988 0.281516,0.0938 0.424744,0.32596 0.148167,0.23213 0.148167,0.63218 0,0.24201 -0.04445,0.43462 -0.04445,0.19262 -0.153106,0.33091 -0.103716,0.13335 -0.291394,0.20743 l 0.558094,1.97062 h -0.730955 l -0.484011,-1.83233 h -0.335845 v 1.83233 z m 0.730955,-2.29164 h 0.227189 q 0.212372,0 0.335845,-0.0593 0.128411,-0.0642 0.182738,-0.19756 0.05433,-0.13829 0.05433,-0.35066 0,-0.30127 -0.113594,-0.44944 -0.108656,-0.1531 -0.419806,-0.1531 h -0.2667 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4710"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 29.152573,190.47519 q -0.167923,0 -0.276578,-0.084 -0.108656,-0.0889 -0.158045,-0.23213 -0.04939,-0.14817 -0.04939,-0.31115 v -2.27189 h 0.671688 v 2.14842 q 0,0.12841 0.03951,0.20249 0.04445,0.0691 0.158044,0.0691 0.07408,0 0.148167,-0.0395 0.07902,-0.0395 0.153105,-0.0938 v -2.28671 h 0.671689 v 2.85468 h -0.671689 v -0.27164 q -0.143228,0.13829 -0.316089,0.22719 -0.172861,0.0889 -0.370416,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4712"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 31.072102,190.43074 v -4.0005 h 0.66675 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4714"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 33.136327,190.47519 q -0.321027,0 -0.523522,-0.11853 -0.202494,-0.12348 -0.301272,-0.3556 -0.09384,-0.23707 -0.09384,-0.56798 v -0.85936 q 0,-0.34079 0.09384,-0.57291 0.09878,-0.23213 0.301272,-0.35066 0.207434,-0.11854 0.523522,-0.11854 0.340784,0 0.528462,0.12841 0.192616,0.12841 0.271638,0.37536 0.08396,0.242 0.08396,0.59267 v 0.40498 h -1.135945 v 0.56304 q 0,0.13829 0.0247,0.22719 0.02963,0.0889 0.0889,0.12841 0.05927,0.0395 0.143227,0.0395 0.0889,0 0.143228,-0.0395 0.05433,-0.0445 0.07902,-0.12347 0.0247,-0.084 0.0247,-0.20744 v -0.23706 h 0.627239 v 0.19261 q 0,0.43462 -0.217311,0.66675 -0.217312,0.23213 -0.661812,0.23213 z m -0.251883,-1.77306 h 0.503767 v -0.27164 q 0,-0.14817 -0.0247,-0.23707 -0.02469,-0.0938 -0.07902,-0.13335 -0.05433,-0.0444 -0.153105,-0.0444 -0.0889,0 -0.143228,0.0444 -0.05433,0.0445 -0.07902,0.14817 -0.0247,0.10372 -0.0247,0.29633 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4716"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 34.91587,190.43074 v -3.46216 h -0.637116 v -0.53834 h 1.995311 v 0.53834 h -0.627239 v 3.46216 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4718"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 36.847671,190.47519 q -0.192617,0 -0.330906,-0.0988 -0.138289,-0.10371 -0.212372,-0.25682 -0.07408,-0.15804 -0.07408,-0.32597 0,-0.2667 0.09878,-0.44944 0.09878,-0.18273 0.261762,-0.30621 0.162983,-0.12347 0.370416,-0.21237 0.207434,-0.0938 0.419806,-0.16792 v -0.24695 q 0,-0.12347 -0.01976,-0.20743 -0.01482,-0.084 -0.0642,-0.12841 -0.04445,-0.0445 -0.143228,-0.0445 -0.08396,0 -0.138289,0.0395 -0.04939,0.0395 -0.07408,0.1136 -0.01976,0.0691 -0.0247,0.16298 l -0.0099,0.17286 -0.637116,-0.0247 q 0.01482,-0.49389 0.242005,-0.72602 0.232128,-0.23707 0.701323,-0.23707 0.429683,0 0.6223,0.23707 0.197555,0.23707 0.197555,0.64205 v 1.31869 q 0,0.15804 0.0049,0.28645 0.0099,0.12841 0.01976,0.23213 0.01482,0.10372 0.02469,0.18274 h -0.602544 q -0.01482,-0.0988 -0.03951,-0.22225 -0.01975,-0.12841 -0.02963,-0.18768 -0.04939,0.17286 -0.187678,0.31609 -0.138289,0.13829 -0.375355,0.13829 z m 0.246944,-0.49883 q 0.06421,0 0.118534,-0.0296 0.05927,-0.0346 0.103716,-0.079 0.04445,-0.0444 0.06421,-0.079 v -0.79516 q -0.108656,0.0642 -0.207434,0.12841 -0.09384,0.0642 -0.167922,0.14323 -0.06914,0.0741 -0.108655,0.16299 -0.03457,0.0889 -0.03457,0.20743 0,0.15804 0.05927,0.25188 0.06421,0.0889 0.172861,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4720"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 39.752585,190.47519 q -0.158044,0 -0.296333,-0.0741 -0.138289,-0.0741 -0.256822,-0.18274 v 0.21237 h -0.671689 v -4.0005 h 0.671689 v 1.36313 q 0.123472,-0.11853 0.2667,-0.18767 0.148166,-0.0741 0.316089,-0.0741 0.192616,0 0.316089,0.0889 0.123472,0.0889 0.192616,0.23707 0.06915,0.14323 0.09384,0.31115 0.02963,0.16298 0.02963,0.31609 v 0.96802 q 0,0.28152 -0.06914,0.51364 -0.06421,0.23213 -0.212372,0.37042 -0.143228,0.13829 -0.380295,0.13829 z M 39.495763,190.006 q 0.108656,0 0.158045,-0.0692 0.05433,-0.0741 0.06914,-0.19262 0.01976,-0.12347 0.01976,-0.2667 v -1.02235 q 0,-0.13335 -0.01976,-0.23706 -0.01976,-0.10866 -0.07408,-0.17286 -0.04939,-0.0642 -0.158045,-0.0642 -0.07902,0 -0.153105,0.0395 -0.07408,0.0346 -0.138289,0.079 v 1.8027 q 0.06421,0.0445 0.138289,0.0741 0.07902,0.0296 0.158044,0.0296 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4722"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 40.920941,190.43074 v -4.0005 h 0.66675 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4724"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 42.985166,190.47519 q -0.321028,0 -0.523522,-0.11853 -0.202494,-0.12348 -0.301272,-0.3556 -0.09384,-0.23707 -0.09384,-0.56798 v -0.85936 q 0,-0.34079 0.09384,-0.57291 0.09878,-0.23213 0.301272,-0.35066 0.207433,-0.11854 0.523522,-0.11854 0.340784,0 0.528461,0.12841 0.192617,0.12841 0.271639,0.37536 0.08396,0.242 0.08396,0.59267 v 0.40498 h -1.135944 v 0.56304 q 0,0.13829 0.02469,0.22719 0.02963,0.0889 0.0889,0.12841 0.05927,0.0395 0.143228,0.0395 0.0889,0 0.143228,-0.0395 0.05433,-0.0445 0.07902,-0.12347 0.0247,-0.084 0.0247,-0.20744 v -0.23706 h 0.627238 v 0.19261 q 0,0.43462 -0.217311,0.66675 -0.217311,0.23213 -0.661811,0.23213 z m -0.251883,-1.77306 h 0.503767 v -0.27164 q 0,-0.14817 -0.0247,-0.23707 -0.02469,-0.0938 -0.07902,-0.13335 -0.05433,-0.0444 -0.153106,-0.0444 -0.0889,0 -0.143227,0.0444 -0.05433,0.0445 -0.07902,0.14817 -0.02469,0.10372 -0.02469,0.29633 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4726"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 24.309143,196.60435 0.1778,-1.37795 h -0.242006 l 0.0049,-0.44944 h 0.301272 l 0.06914,-0.52846 H 24.25971 l 0.0049,-0.45932 h 0.429683 l 0.153106,-1.18533 h 0.523522 l -0.153106,1.18533 h 0.409928 l 0.158045,-1.18533 h 0.518583 l -0.158045,1.18533 h 0.237067 l -0.0099,0.45932 H 26.07716 l -0.06914,0.52846 h 0.350661 l -0.0049,0.44944 h -0.409928 l -0.182739,1.37795 h -0.523522 l 0.182739,-1.37795 h -0.409928 l -0.1778,1.37795 z m 0.760589,-1.82739 h 0.414866 l 0.06915,-0.52846 H 25.14382 Z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4728"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 27.824243,196.65868 q -0.345723,0 -0.567973,-0.11853 -0.22225,-0.11854 -0.325966,-0.34573 -0.103717,-0.22719 -0.103717,-0.55315 0,-0.01 0,-0.0247 0,-0.0148 0,-0.0296 h 0.651933 q 0,0.2667 0.06421,0.40005 0.06914,0.13335 0.286456,0.13335 0.13335,0 0.207433,-0.079 0.07408,-0.079 0.108655,-0.26176 0.03457,-0.18274 0.03457,-0.47908 v -0.47907 q -0.06915,0.1136 -0.207434,0.1778 -0.138289,0.0642 -0.330905,0.0692 -0.321028,0.005 -0.513645,-0.14817 -0.187678,-0.15804 -0.271639,-0.42474 -0.07902,-0.2667 -0.07902,-0.60255 0,-0.39511 0.103717,-0.69144 0.103716,-0.30128 0.335844,-0.4692 0.232128,-0.17286 0.607484,-0.17286 0.370416,0 0.602544,0.16792 0.232128,0.16299 0.335845,0.45438 0.108655,0.2914 0.108655,0.66675 v 1.41746 q 0,0.39017 -0.09384,0.70626 -0.0889,0.31609 -0.316089,0.50377 -0.22225,0.18274 -0.637116,0.18274 z m 0.0049,-2.10891 q 0.138288,0 0.217311,-0.0691 0.08396,-0.0691 0.13335,-0.14817 v -0.6223 q 0,-0.17286 -0.02963,-0.31115 -0.02963,-0.14323 -0.108655,-0.22719 -0.07408,-0.0889 -0.217311,-0.0889 -0.138289,0 -0.217311,0.0889 -0.07408,0.0889 -0.103717,0.24695 -0.02963,0.15804 -0.02963,0.37041 0,0.21238 0.01482,0.38524 0.01976,0.17286 0.09384,0.27658 0.07408,0.0988 0.246945,0.0988 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4730"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 30.468941,196.66362 q -0.350661,0 -0.582789,-0.14817 -0.227189,-0.14817 -0.345722,-0.40993 -0.113595,-0.26176 -0.113595,-0.60254 v -1.77306 q 0,-0.35066 0.108656,-0.61242 0.113594,-0.2667 0.340783,-0.41487 0.232128,-0.14817 0.592667,-0.14817 0.360539,0 0.587728,0.14817 0.232127,0.14817 0.340783,0.41487 0.113594,0.26176 0.113594,0.61242 v 1.77306 q 0,0.34078 -0.118533,0.60254 -0.113594,0.26176 -0.345722,0.40993 -0.227189,0.14817 -0.57785,0.14817 z m 0,-0.58773 q 0.153105,0 0.227189,-0.0938 0.07408,-0.0938 0.09878,-0.22719 0.0247,-0.13335 0.0247,-0.26176 v -1.7533 q 0,-0.13829 -0.0247,-0.27164 -0.01975,-0.13829 -0.09384,-0.23213 -0.07408,-0.0938 -0.232128,-0.0938 -0.158045,0 -0.232128,0.0938 -0.07408,0.0938 -0.09878,0.23213 -0.01975,0.13335 -0.01975,0.27164 v 1.7533 q 0,0.12841 0.02469,0.26176 0.02963,0.13335 0.103717,0.22719 0.07408,0.0938 0.22225,0.0938 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4732"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="IngressDefaultTable
+#100"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4260">
+      <path
+         d="m 76.734282,174.84334 v -4.0005 h 0.721078 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4735"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 78.0302,174.84334 v -2.85468 h 0.671689 v 0.28646 q 0.153106,-0.14817 0.321028,-0.23707 0.172861,-0.0938 0.370417,-0.0938 0.1778,0 0.281516,0.0889 0.103717,0.084 0.153106,0.22719 0.04939,0.14323 0.04939,0.31115 v 2.27189 h -0.671689 v -2.13854 q 0,-0.12841 -0.03951,-0.19756 -0.03951,-0.0691 -0.153106,-0.0691 -0.06914,0 -0.153105,0.0395 -0.07902,0.0395 -0.158045,0.0988 v 2.26695 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4737"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 81.213855,175.78173 q -0.291395,0 -0.513645,-0.0593 -0.22225,-0.0593 -0.345722,-0.18274 -0.123472,-0.12347 -0.123472,-0.32103 0,-0.13335 0.05433,-0.242 0.05927,-0.10372 0.158045,-0.18274 0.09878,-0.079 0.212372,-0.13335 -0.162983,-0.0444 -0.251883,-0.14323 -0.08396,-0.0988 -0.08396,-0.23707 0,-0.16792 0.08396,-0.28645 0.08396,-0.11853 0.232128,-0.25188 -0.153106,-0.12348 -0.232128,-0.30622 -0.07408,-0.18767 -0.07408,-0.48895 0,-0.32596 0.103717,-0.54821 0.108656,-0.22719 0.31115,-0.34079 0.207433,-0.11359 0.503767,-0.11359 0.227189,0 0.380294,0.0691 0.153106,0.0642 0.251884,0.19756 0.03951,-0.0593 0.138288,-0.14817 0.09878,-0.0889 0.227189,-0.14816 l 0.0889,-0.0395 0.162984,0.36053 q -0.05433,0.0148 -0.148167,0.0494 -0.0889,0.0346 -0.1778,0.0741 -0.0889,0.0395 -0.138289,0.0691 0.04445,0.0988 0.07408,0.24695 0.02963,0.14816 0.02963,0.28151 0,0.30127 -0.09384,0.52352 -0.09384,0.22225 -0.291395,0.34573 -0.192616,0.11853 -0.503766,0.11853 -0.103717,0 -0.202495,-0.0148 -0.09878,-0.0198 -0.182739,-0.0445 -0.02963,0.0445 -0.05927,0.0938 -0.0247,0.0494 -0.0247,0.10372 0,0.0543 0.05927,0.0889 0.05927,0.0346 0.197556,0.0494 l 0.602544,0.0593 q 0.350661,0.0346 0.518583,0.22225 0.167923,0.18274 0.167923,0.49883 0,0.25682 -0.118534,0.42969 -0.113594,0.17286 -0.360539,0.26176 -0.242005,0.0889 -0.632177,0.0889 z m 0.07408,-0.50377 q 0.276578,0 0.414867,-0.0543 0.138288,-0.0543 0.138288,-0.19755 0,-0.079 -0.03457,-0.12841 -0.03457,-0.0494 -0.123472,-0.079 -0.0889,-0.0346 -0.251883,-0.0494 l -0.48895,-0.0445 q -0.05433,0.0445 -0.09878,0.0938 -0.03951,0.0445 -0.06421,0.0988 -0.02469,0.0543 -0.02469,0.1136 0,0.12347 0.118533,0.18273 0.118534,0.0642 0.414867,0.0642 z m -0.03951,-1.76318 q 0.0889,0 0.143228,-0.0296 0.05433,-0.0346 0.08396,-0.10371 0.02963,-0.0741 0.03951,-0.18274 0.0099,-0.10866 0.0099,-0.25189 0,-0.14322 -0.0099,-0.25188 -0.0099,-0.10865 -0.03951,-0.18274 -0.0247,-0.0741 -0.07902,-0.10865 -0.05433,-0.0346 -0.148166,-0.0346 -0.0889,0 -0.148167,0.0346 -0.05433,0.0346 -0.08396,0.10865 -0.02469,0.0692 -0.03951,0.1778 -0.0099,0.10866 -0.0099,0.25682 0,0.13829 0.0099,0.24695 0.0099,0.10372 0.03951,0.1778 0.02963,0.0691 0.08396,0.10865 0.05927,0.0346 0.148167,0.0346 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4739"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 82.704164,174.84334 v -2.85468 h 0.671689 v 0.43956 q 0.148167,-0.25188 0.296333,-0.36054 0.148167,-0.11359 0.325967,-0.11359 0.02963,0 0.04939,0.005 0.02469,0 0.05433,0.005 v 0.69638 q -0.05927,-0.0247 -0.13335,-0.0395 -0.06914,-0.0198 -0.143228,-0.0198 -0.13335,0 -0.242006,0.0642 -0.108655,0.0642 -0.207433,0.21237 v 1.96568 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4741"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 85.280335,174.88779 q -0.321028,0 -0.523522,-0.11854 -0.202495,-0.12347 -0.301272,-0.3556 -0.09384,-0.23706 -0.09384,-0.56797 v -0.85936 q 0,-0.34079 0.09384,-0.57292 0.09878,-0.23212 0.301272,-0.35066 0.207433,-0.11853 0.523522,-0.11853 0.340784,0 0.528461,0.12841 0.192617,0.12841 0.271639,0.37536 0.08396,0.242 0.08396,0.59266 v 0.40499 h -1.135944 v 0.56304 q 0,0.13828 0.02469,0.22718 0.02963,0.0889 0.0889,0.12842 0.05927,0.0395 0.143228,0.0395 0.0889,0 0.143228,-0.0395 0.05433,-0.0445 0.07902,-0.12348 0.02469,-0.084 0.02469,-0.20743 v -0.23707 h 0.627238 v 0.19262 q 0,0.43462 -0.217311,0.66675 -0.217311,0.23213 -0.661811,0.23213 z m -0.251883,-1.77306 h 0.503767 v -0.27164 q 0,-0.14817 -0.02469,-0.23707 -0.02469,-0.0938 -0.07902,-0.13335 -0.05433,-0.0444 -0.153106,-0.0444 -0.0889,0 -0.143228,0.0444 -0.05433,0.0445 -0.07902,0.14817 -0.02469,0.10371 -0.02469,0.29633 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4743"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 87.390784,174.88779 q -0.360539,0 -0.592667,-0.19262 -0.232127,-0.19262 -0.330905,-0.56303 l 0.498828,-0.19262 q 0.05927,0.23213 0.158044,0.3556 0.09878,0.12347 0.256822,0.12347 0.118534,0 0.1778,-0.0593 0.05927,-0.0593 0.05927,-0.16299 0,-0.11853 -0.07408,-0.21237 -0.06915,-0.0988 -0.242006,-0.242 l -0.345722,-0.2914 q -0.187678,-0.16298 -0.306211,-0.3309 -0.113595,-0.17287 -0.113595,-0.42969 0,-0.23213 0.103717,-0.39511 0.108656,-0.16792 0.291394,-0.25682 0.187678,-0.0938 0.414867,-0.0938 0.345722,0 0.553156,0.20743 0.212372,0.2025 0.271639,0.5334 l -0.439562,0.18768 q -0.02469,-0.11853 -0.07408,-0.21731 -0.04445,-0.10372 -0.118533,-0.16792 -0.07408,-0.0642 -0.172861,-0.0642 -0.103717,0 -0.167923,0.0642 -0.05927,0.0642 -0.05927,0.16298 0,0.084 0.06914,0.17286 0.07408,0.0889 0.207434,0.2025 l 0.350661,0.31609 q 0.113594,0.0988 0.217311,0.21237 0.103716,0.11359 0.172861,0.25682 0.06914,0.13829 0.06914,0.32103 0,0.24694 -0.113594,0.41486 -0.108656,0.16793 -0.301272,0.25683 -0.187678,0.084 -0.419806,0.084 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4745"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 89.368269,174.88779 q -0.360539,0 -0.592667,-0.19262 -0.232128,-0.19262 -0.330905,-0.56303 l 0.498827,-0.19262 q 0.05927,0.23213 0.158045,0.3556 0.09878,0.12347 0.256822,0.12347 0.118533,0 0.1778,-0.0593 0.05927,-0.0593 0.05927,-0.16299 0,-0.11853 -0.07408,-0.21237 -0.06914,-0.0988 -0.242005,-0.242 l -0.345722,-0.2914 q -0.187678,-0.16298 -0.306212,-0.3309 -0.113594,-0.17287 -0.113594,-0.42969 0,-0.23213 0.103717,-0.39511 0.108655,-0.16792 0.291394,-0.25682 0.187678,-0.0938 0.414867,-0.0938 0.345722,0 0.553155,0.20743 0.212373,0.2025 0.271639,0.5334 l -0.439561,0.18768 q -0.02469,-0.11853 -0.07408,-0.21731 -0.04445,-0.10372 -0.118534,-0.16792 -0.07408,-0.0642 -0.172861,-0.0642 -0.103716,0 -0.167922,0.0642 -0.05927,0.0642 -0.05927,0.16298 0,0.084 0.06915,0.17286 0.07408,0.0889 0.207433,0.2025 l 0.350661,0.31609 q 0.113595,0.0988 0.217311,0.21237 0.103717,0.11359 0.172862,0.25682 0.06914,0.13829 0.06914,0.32103 0,0.24694 -0.113594,0.41486 -0.108656,0.16793 -0.301273,0.25683 -0.187677,0.084 -0.419805,0.084 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4747"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 90.614798,174.84334 v -4.0005 h 0.943328 q 0.48895,0 0.760589,0.13335 0.276577,0.13335 0.390172,0.40993 0.118533,0.27657 0.118533,0.70132 v 1.46191 q 0,0.43462 -0.118533,0.72602 -0.113595,0.28645 -0.385233,0.42968 -0.2667,0.13829 -0.735895,0.13829 z m 0.730955,-0.50871 h 0.222251 q 0.251883,0 0.360538,-0.0889 0.108656,-0.0889 0.13335,-0.25682 0.02469,-0.17286 0.02469,-0.41981 v -1.53105 q 0,-0.24201 -0.03457,-0.39017 -0.03457,-0.14817 -0.143228,-0.21731 -0.108656,-0.0691 -0.350661,-0.0691 H 91.34575 Z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4749"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 94.18384,174.88779 q -0.321028,0 -0.523522,-0.11854 -0.202495,-0.12347 -0.301272,-0.3556 -0.09384,-0.23706 -0.09384,-0.56797 v -0.85936 q 0,-0.34079 0.09384,-0.57292 0.09878,-0.23212 0.301272,-0.35066 0.207433,-0.11853 0.523522,-0.11853 0.340783,0 0.528461,0.12841 0.192617,0.12841 0.271639,0.37536 0.08396,0.242 0.08396,0.59266 v 0.40499 h -1.135944 v 0.56304 q 0,0.13828 0.02469,0.22718 0.02963,0.0889 0.0889,0.12842 0.05927,0.0395 0.143228,0.0395 0.0889,0 0.143228,-0.0395 0.05433,-0.0445 0.07902,-0.12348 0.02469,-0.084 0.02469,-0.20743 v -0.23707 h 0.627239 v 0.19262 q 0,0.43462 -0.217311,0.66675 -0.217311,0.23213 -0.661811,0.23213 z m -0.251883,-1.77306 h 0.503766 v -0.27164 q 0,-0.14817 -0.02469,-0.23707 -0.02469,-0.0938 -0.07902,-0.13335 -0.05433,-0.0444 -0.153106,-0.0444 -0.0889,0 -0.143228,0.0444 -0.05433,0.0445 -0.07902,0.14817 -0.02469,0.10371 -0.02469,0.29633 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4751"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 95.657172,174.84334 v -2.38549 h -0.306211 v -0.46919 h 0.306211 v -0.18274 q 0,-0.25682 0.04445,-0.4445 0.04939,-0.19262 0.197555,-0.29633 0.153106,-0.10372 0.459317,-0.10372 0.09384,0 0.1778,0.01 0.08396,0.005 0.187678,0.0198 V 171.49 q -0.03951,-0.01 -0.09384,-0.0148 -0.04939,-0.01 -0.09384,-0.01 -0.118533,0 -0.162983,0.0741 -0.04445,0.0741 -0.04445,0.21731 v 0.23213 h 0.395111 v 0.46919 h -0.395111 v 2.38549 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4753"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 97.576856,174.88779 q -0.192616,0 -0.330905,-0.0988 -0.138289,-0.10372 -0.212372,-0.25682 -0.07408,-0.15805 -0.07408,-0.32597 0,-0.2667 0.09878,-0.44944 0.09878,-0.18274 0.261761,-0.30621 0.162984,-0.12347 0.370417,-0.21237 0.207433,-0.0938 0.419805,-0.16792 v -0.24695 q 0,-0.12347 -0.01976,-0.20743 -0.01482,-0.084 -0.06421,-0.12841 -0.04445,-0.0445 -0.143227,-0.0445 -0.08396,0 -0.138289,0.0395 -0.04939,0.0395 -0.07408,0.11359 -0.01975,0.0692 -0.02469,0.16299 l -0.0099,0.17286 -0.637117,-0.0247 q 0.01482,-0.49389 0.242006,-0.72601 0.232128,-0.23707 0.701322,-0.23707 0.429684,0 0.6223,0.23707 0.197556,0.23706 0.197556,0.64205 v 1.31869 q 0,0.15804 0.0049,0.28645 0.0099,0.12841 0.01976,0.23213 0.01482,0.10372 0.02469,0.18274 h -0.602545 q -0.01482,-0.0988 -0.03951,-0.22225 -0.01976,-0.12841 -0.02963,-0.18768 -0.04939,0.17286 -0.187678,0.31609 -0.138289,0.13829 -0.375356,0.13829 z m 0.246945,-0.49883 q 0.06421,0 0.118533,-0.0296 0.05927,-0.0346 0.103717,-0.079 0.04445,-0.0445 0.06421,-0.079 v -0.79516 q -0.108655,0.0642 -0.207433,0.12841 -0.09384,0.0642 -0.167922,0.14323 -0.06914,0.0741 -0.108656,0.16298 -0.03457,0.0889 -0.03457,0.20744 0,0.15804 0.05927,0.25188 0.06421,0.0889 0.172861,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4755"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 99.711306,174.88779 q -0.167922,0 -0.276578,-0.084 -0.108655,-0.0889 -0.158044,-0.23213 -0.04939,-0.14817 -0.04939,-0.31115 v -2.27189 h 0.671689 v 2.14842 q 0,0.12841 0.03951,0.20249 0.04445,0.0691 0.158047,0.0691 0.0741,0 0.14817,-0.0395 0.079,-0.0395 0.1531,-0.0938 v -2.28671 h 0.67169 v 2.85468 h -0.67169 v -0.27164 q -0.14323,0.13829 -0.31609,0.22719 -0.17286,0.0889 -0.370416,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4757"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 101.63084,174.84334 v -4.0005 h 0.66675 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4759"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 103.65555,174.87791 q -0.27164,0 -0.42969,-0.0889 -0.1531,-0.0889 -0.21731,-0.25682 -0.0642,-0.16792 -0.0642,-0.40005 v -1.69898 h -0.28646 v -0.4445 h 0.28646 v -0.85443 h 0.67663 v 0.85443 h 0.43462 v 0.4445 h -0.43462 v 1.63971 q 0,0.14817 0.0642,0.21237 0.0642,0.0593 0.19262,0.0593 0.0543,0 0.10371,-0.005 0.0543,-0.005 0.10372,-0.01 v 0.51365 q -0.084,0.01 -0.19755,0.0197 -0.10866,0.0148 -0.23213,0.0148 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4761"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 104.91512,174.84334 v -3.46216 H 104.278 v -0.53834 h 1.99531 v 0.53834 h -0.62724 v 3.46216 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4763"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 106.84692,174.88779 q -0.19262,0 -0.33091,-0.0988 -0.13828,-0.10372 -0.21237,-0.25682 -0.0741,-0.15805 -0.0741,-0.32597 0,-0.2667 0.0988,-0.44944 0.0988,-0.18274 0.26176,-0.30621 0.16298,-0.12347 0.37041,-0.21237 0.20744,-0.0938 0.41981,-0.16792 v -0.24695 q 0,-0.12347 -0.0198,-0.20743 -0.0148,-0.084 -0.0642,-0.12841 -0.0445,-0.0445 -0.14323,-0.0445 -0.084,0 -0.13829,0.0395 -0.0494,0.0395 -0.0741,0.11359 -0.0198,0.0692 -0.0247,0.16299 l -0.01,0.17286 -0.63712,-0.0247 q 0.0148,-0.49389 0.24201,-0.72601 0.23212,-0.23707 0.70132,-0.23707 0.42968,0 0.6223,0.23707 0.19755,0.23706 0.19755,0.64205 v 1.31869 q 0,0.15804 0.005,0.28645 0.01,0.12841 0.0198,0.23213 0.0148,0.10372 0.0247,0.18274 h -0.60254 q -0.0148,-0.0988 -0.0395,-0.22225 -0.0198,-0.12841 -0.0296,-0.18768 -0.0494,0.17286 -0.18767,0.31609 -0.13829,0.13829 -0.37536,0.13829 z m 0.24694,-0.49883 q 0.0642,0 0.11854,-0.0296 0.0593,-0.0346 0.10371,-0.079 0.0445,-0.0445 0.0642,-0.079 v -0.79516 q -0.10866,0.0642 -0.20743,0.12841 -0.0938,0.0642 -0.16793,0.14323 -0.0691,0.0741 -0.10865,0.16298 -0.0346,0.0889 -0.0346,0.20744 0,0.15804 0.0593,0.25188 0.0642,0.0889 0.17286,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4765"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 109.75184,174.88779 q -0.15805,0 -0.29634,-0.0741 -0.13829,-0.0741 -0.25682,-0.18273 v 0.21237 h -0.67169 v -4.0005 h 0.67169 v 1.36313 q 0.12347,-0.11853 0.2667,-0.18768 0.14817,-0.0741 0.31609,-0.0741 0.19262,0 0.31609,0.0889 0.12347,0.0889 0.19262,0.23707 0.0691,0.14322 0.0938,0.31115 0.0296,0.16298 0.0296,0.31609 v 0.96802 q 0,0.28151 -0.0692,0.51364 -0.0642,0.23213 -0.21237,0.37042 -0.14323,0.13829 -0.38029,0.13829 z m -0.25683,-0.4692 q 0.10866,0 0.15805,-0.0691 0.0543,-0.0741 0.0691,-0.19262 0.0198,-0.12347 0.0198,-0.2667 v -1.02235 q 0,-0.13335 -0.0198,-0.23706 -0.0198,-0.10866 -0.0741,-0.17287 -0.0494,-0.0642 -0.15804,-0.0642 -0.079,0 -0.15311,0.0395 -0.0741,0.0346 -0.13829,0.079 v 1.8027 q 0.0642,0.0445 0.13829,0.0741 0.079,0.0296 0.15804,0.0296 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4767"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 110.92019,174.84334 v -4.0005 h 0.66675 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4769"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 112.98442,174.88779 q -0.32103,0 -0.52353,-0.11854 -0.20249,-0.12347 -0.30127,-0.3556 -0.0938,-0.23706 -0.0938,-0.56797 v -0.85936 q 0,-0.34079 0.0938,-0.57292 0.0988,-0.23212 0.30127,-0.35066 0.20744,-0.11853 0.52353,-0.11853 0.34078,0 0.52846,0.12841 0.19261,0.12841 0.27164,0.37536 0.084,0.242 0.084,0.59266 v 0.40499 h -1.13595 v 0.56304 q 0,0.13828 0.0247,0.22718 0.0296,0.0889 0.0889,0.12842 0.0593,0.0395 0.14323,0.0395 0.0889,0 0.14322,-0.0395 0.0543,-0.0445 0.079,-0.12348 0.0247,-0.084 0.0247,-0.20743 v -0.23707 h 0.62724 v 0.19262 q 0,0.43462 -0.21731,0.66675 -0.21731,0.23213 -0.66181,0.23213 z m -0.25189,-1.77306 h 0.50377 v -0.27164 q 0,-0.14817 -0.0247,-0.23707 -0.0247,-0.0938 -0.079,-0.13335 -0.0543,-0.0444 -0.1531,-0.0444 -0.0889,0 -0.14323,0.0444 -0.0543,0.0445 -0.079,0.14817 -0.0247,0.10371 -0.0247,0.29633 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4771"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 90.633165,181.01695 0.1778,-1.37795 h -0.242006 l 0.0049,-0.44944 h 0.301272 l 0.06915,-0.52846 h -0.360539 l 0.0049,-0.45932 h 0.429683 l 0.153106,-1.18533 h 0.523522 l -0.153106,1.18533 h 0.409928 l 0.158044,-1.18533 h 0.518584 l -0.158045,1.18533 h 0.237067 l -0.0099,0.45932 h -0.296333 l -0.06914,0.52846 h 0.350662 l -0.0049,0.44944 h -0.409928 l -0.182739,1.37795 h -0.523522 l 0.182739,-1.37795 h -0.409928 l -0.1778,1.37795 z m 0.760589,-1.82739 h 0.414866 l 0.06914,-0.52846 h -0.409928 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4773"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 93.644498,181.01695 v -3.24485 q -0.02963,0.0148 -0.118534,0.0445 -0.08396,0.0296 -0.187677,0.0593 -0.103717,0.0247 -0.192617,0.0494 -0.08396,0.0247 -0.118533,0.0395 v -0.50871 q 0.06914,-0.0247 0.172861,-0.0691 0.103716,-0.0444 0.217311,-0.0988 0.118533,-0.0593 0.217311,-0.12841 0.103717,-0.0692 0.167922,-0.14323 h 0.523523 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4775"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 96.156309,181.07622 q -0.350661,0 -0.582789,-0.14817 -0.227189,-0.14817 -0.345722,-0.40993 -0.113595,-0.26176 -0.113595,-0.60254 v -1.77306 q 0,-0.35067 0.108656,-0.61243 0.113594,-0.2667 0.340783,-0.41486 0.232128,-0.14817 0.592667,-0.14817 0.360539,0 0.587728,0.14817 0.232127,0.14816 0.340783,0.41486 0.113594,0.26176 0.113594,0.61243 v 1.77306 q 0,0.34078 -0.118533,0.60254 -0.113594,0.26176 -0.345722,0.40993 -0.227189,0.14817 -0.57785,0.14817 z m 0,-0.58773 q 0.153105,0 0.227189,-0.0938 0.07408,-0.0938 0.09878,-0.22719 0.02469,-0.13335 0.02469,-0.26176 v -1.75331 q 0,-0.13829 -0.02469,-0.27164 -0.01976,-0.13828 -0.09384,-0.23212 -0.07408,-0.0938 -0.232128,-0.0938 -0.158045,0 -0.232128,0.0938 -0.07408,0.0938 -0.09878,0.23212 -0.01975,0.13335 -0.01975,0.27164 v 1.75331 q 0,0.12841 0.02469,0.26176 0.02963,0.13335 0.103717,0.22719 0.07408,0.0938 0.22225,0.0938 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4777"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 98.78974,181.07622 q -0.350661,0 -0.582789,-0.14817 -0.227189,-0.14817 -0.345722,-0.40993 -0.113595,-0.26176 -0.113595,-0.60254 v -1.77306 q 0,-0.35067 0.108656,-0.61243 0.113594,-0.2667 0.340783,-0.41486 0.232128,-0.14817 0.592667,-0.14817 0.360539,0 0.587727,0.14817 0.232128,0.14816 0.340784,0.41486 0.113594,0.26176 0.113594,0.61243 v 1.77306 q 0,0.34078 -0.118533,0.60254 -0.113595,0.26176 -0.345722,0.40993 -0.227189,0.14817 -0.57785,0.14817 z m 0,-0.58773 q 0.153105,0 0.227189,-0.0938 0.07408,-0.0938 0.09878,-0.22719 0.02469,-0.13335 0.02469,-0.26176 v -1.75331 q 0,-0.13829 -0.02469,-0.27164 -0.01976,-0.13828 -0.09384,-0.23212 -0.07408,-0.0938 -0.232127,-0.0938 -0.158045,0 -0.232128,0.0938 -0.07408,0.0938 -0.09878,0.23212 -0.01975,0.13335 -0.01975,0.27164 v 1.75331 q 0,0.12841 0.02469,0.26176 0.02963,0.13335 0.103717,0.22719 0.07408,0.0938 0.222249,0.0938 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4779"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="ConntrackCommitTable
+#105"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4266">
+      <path
+         d="m 140.15388,191.0451 q -0.43956,0 -0.69145,-0.17286 -0.24694,-0.17287 -0.34572,-0.4692 -0.0988,-0.30127 -0.0988,-0.69144 v -1.42734 q 0,-0.40993 0.0988,-0.7112 0.0988,-0.30128 0.34572,-0.46426 0.25189,-0.16298 0.69145,-0.16298 0.41486,0 0.64699,0.14323 0.23707,0.13828 0.33585,0.40005 0.0988,0.26176 0.0988,0.60748 v 0.33584 h -0.70132 v -0.34572 q 0,-0.16792 -0.0197,-0.30621 -0.0148,-0.13829 -0.0938,-0.21731 -0.0741,-0.084 -0.26176,-0.084 -0.18768,0 -0.27658,0.0889 -0.084,0.084 -0.10866,0.23213 -0.0247,0.14322 -0.0247,0.32596 v 1.73849 q 0,0.21731 0.0346,0.36054 0.0346,0.13829 0.12347,0.21237 0.0938,0.0692 0.25189,0.0692 0.18274,0 0.25682,-0.084 0.079,-0.0889 0.0988,-0.23213 0.0197,-0.14323 0.0197,-0.32103 v -0.36054 h 0.70132 v 0.32103 q 0,0.3556 -0.0938,0.63218 -0.0938,0.27164 -0.33091,0.42968 -0.23213,0.15311 -0.65687,0.15311 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4782"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 142.55943,191.03522 q -0.31115,0 -0.51365,-0.1136 -0.20249,-0.11853 -0.30621,-0.34078 -0.0988,-0.22225 -0.0988,-0.53834 v -0.95814 q 0,-0.31609 0.0988,-0.53834 0.10372,-0.22225 0.30621,-0.33585 0.2025,-0.11853 0.51365,-0.11853 0.31115,0 0.51364,0.11853 0.20743,0.1136 0.30621,0.33585 0.10372,0.22225 0.10372,0.53834 v 0.95814 q 0,0.31609 -0.10372,0.53834 -0.0988,0.22225 -0.30621,0.34078 -0.20249,0.1136 -0.51364,0.1136 z m 0.005,-0.46426 q 0.1136,0 0.16793,-0.0642 0.0543,-0.0642 0.0691,-0.17286 0.0148,-0.1136 0.0148,-0.24695 v -1.04704 q 0,-0.13335 -0.0148,-0.24201 -0.0148,-0.10865 -0.0691,-0.17286 -0.0543,-0.0691 -0.16793,-0.0691 -0.11359,0 -0.16792,0.0691 -0.0543,0.0642 -0.0741,0.17286 -0.0148,0.10866 -0.0148,0.24201 v 1.04704 q 0,0.13335 0.0148,0.24695 0.0197,0.10865 0.0741,0.17286 0.0543,0.0642 0.16792,0.0642 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4784"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 143.9427,190.99077 v -2.85468 h 0.67169 v 0.28646 q 0.1531,-0.14817 0.32103,-0.23707 0.17286,-0.0938 0.37041,-0.0938 0.1778,0 0.28152,0.0889 0.10372,0.084 0.15311,0.22719 0.0494,0.14323 0.0494,0.31115 v 2.27189 h -0.67168 v -2.13854 q 0,-0.12841 -0.0395,-0.19756 -0.0395,-0.0691 -0.1531,-0.0691 -0.0692,0 -0.15311,0.0395 -0.079,0.0395 -0.15804,0.0988 v 2.26695 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4786"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 146.28674,190.99077 v -2.85468 h 0.67169 v 0.28646 q 0.15311,-0.14817 0.32103,-0.23707 0.17286,-0.0938 0.37042,-0.0938 0.1778,0 0.28151,0.0889 0.10372,0.084 0.15311,0.22719 0.0494,0.14323 0.0494,0.31115 v 2.27189 h -0.67169 v -2.13854 q 0,-0.12841 -0.0395,-0.19756 -0.0395,-0.0691 -0.15311,-0.0691 -0.0691,0 -0.1531,0.0395 -0.079,0.0395 -0.15805,0.0988 v 2.26695 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4788"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 149.45558,191.02534 q -0.27164,0 -0.42968,-0.0889 -0.15311,-0.0889 -0.21731,-0.25682 -0.0642,-0.16792 -0.0642,-0.40005 v -1.69898 h -0.28646 v -0.4445 h 0.28646 v -0.85443 h 0.67663 v 0.85443 h 0.43462 v 0.4445 h -0.43462 v 1.63971 q 0,0.14817 0.0642,0.21237 0.0642,0.0593 0.19262,0.0593 0.0543,0 0.10372,-0.005 0.0543,-0.005 0.10371,-0.01 v 0.51365 q -0.084,0.01 -0.19755,0.0198 -0.10866,0.0148 -0.23213,0.0148 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4790"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 150.28547,190.99077 v -2.85468 h 0.67169 v 0.43956 q 0.14816,-0.25188 0.29633,-0.36054 0.14817,-0.11359 0.32597,-0.11359 0.0296,0 0.0494,0.005 0.0247,0 0.0543,0.005 v 0.69638 q -0.0593,-0.0247 -0.13335,-0.0395 -0.0691,-0.0198 -0.14322,-0.0198 -0.13335,0 -0.24201,0.0642 -0.10866,0.0642 -0.20743,0.21237 v 1.96568 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4792"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 152.5312,191.03522 q -0.19262,0 -0.33091,-0.0988 -0.13829,-0.10372 -0.21237,-0.25682 -0.0741,-0.15805 -0.0741,-0.32597 0,-0.2667 0.0988,-0.44944 0.0988,-0.18274 0.26176,-0.30621 0.16299,-0.12347 0.37042,-0.21237 0.20743,-0.0938 0.41981,-0.16792 v -0.24695 q 0,-0.12347 -0.0198,-0.20743 -0.0148,-0.084 -0.0642,-0.12841 -0.0444,-0.0444 -0.14323,-0.0444 -0.084,0 -0.13829,0.0395 -0.0494,0.0395 -0.0741,0.11359 -0.0198,0.0692 -0.0247,0.16299 l -0.01,0.17286 -0.63711,-0.0247 q 0.0148,-0.49388 0.242,-0.72601 0.23213,-0.23707 0.70132,-0.23707 0.42969,0 0.6223,0.23707 0.19756,0.23706 0.19756,0.64205 v 1.31869 q 0,0.15804 0.005,0.28645 0.01,0.12841 0.0197,0.23213 0.0148,0.10372 0.0247,0.18274 h -0.60255 q -0.0148,-0.0988 -0.0395,-0.22225 -0.0198,-0.12841 -0.0296,-0.18768 -0.0494,0.17286 -0.18768,0.31609 -0.13829,0.13829 -0.37535,0.13829 z m 0.24694,-0.49883 q 0.0642,0 0.11853,-0.0296 0.0593,-0.0346 0.10372,-0.079 0.0444,-0.0445 0.0642,-0.079 v -0.79516 q -0.10866,0.0642 -0.20744,0.12841 -0.0938,0.0642 -0.16792,0.14323 -0.0691,0.0741 -0.10865,0.16298 -0.0346,0.0889 -0.0346,0.20744 0,0.15804 0.0593,0.25188 0.0642,0.0889 0.17286,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4794"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 155.0657,191.03522 q -0.33091,0 -0.5334,-0.12347 -0.19756,-0.12841 -0.2914,-0.36054 -0.0889,-0.23707 -0.0889,-0.5581 v -0.85936 q 0,-0.33091 0.0889,-0.56304 0.0938,-0.23212 0.29633,-0.3556 0.2025,-0.12347 0.52847,-0.12347 0.30621,0 0.49882,0.0988 0.19756,0.0938 0.28646,0.29139 0.0889,0.19262 0.0889,0.48895 v 0.23707 h -0.63218 v -0.25188 q 0,-0.14817 -0.0247,-0.23213 -0.0198,-0.0889 -0.0741,-0.12347 -0.0543,-0.0395 -0.14322,-0.0395 -0.0889,0 -0.14323,0.0494 -0.0543,0.0445 -0.079,0.14817 -0.0198,0.10372 -0.0198,0.28646 v 1.04704 q 0,0.27658 0.0593,0.37536 0.0593,0.0938 0.18767,0.0938 0.0988,0 0.14817,-0.0445 0.0543,-0.0444 0.0692,-0.12842 0.0198,-0.0889 0.0198,-0.21237 v -0.30621 h 0.63218 v 0.27164 q 0,0.28646 -0.0938,0.48895 -0.0889,0.20249 -0.28646,0.30621 -0.19261,0.0988 -0.49388,0.0988 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4796"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 156.38168,190.99077 v -4.0005 h 0.67169 v 2.29658 l 0.73589,-1.15076 h 0.73096 l -0.71614,1.14582 0.70132,1.70886 h -0.70626 l -0.51859,-1.40758 -0.22718,0.31608 v 1.0915 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4798"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 159.89979,191.0451 q -0.43956,0 -0.69145,-0.17286 -0.24694,-0.17287 -0.34572,-0.4692 -0.0988,-0.30127 -0.0988,-0.69144 v -1.42734 q 0,-0.40993 0.0988,-0.7112 0.0988,-0.30128 0.34572,-0.46426 0.25189,-0.16298 0.69145,-0.16298 0.41486,0 0.64699,0.14323 0.23707,0.13828 0.33585,0.40005 0.0988,0.26176 0.0988,0.60748 v 0.33584 h -0.70132 v -0.34572 q 0,-0.16792 -0.0197,-0.30621 -0.0148,-0.13829 -0.0938,-0.21731 -0.0741,-0.084 -0.26176,-0.084 -0.18768,0 -0.27658,0.0889 -0.084,0.084 -0.10866,0.23213 -0.0247,0.14322 -0.0247,0.32596 v 1.73849 q 0,0.21731 0.0346,0.36054 0.0346,0.13829 0.12347,0.21237 0.0938,0.0692 0.25189,0.0692 0.18274,0 0.25682,-0.084 0.079,-0.0889 0.0988,-0.23213 0.0197,-0.14323 0.0197,-0.32103 v -0.36054 h 0.70132 v 0.32103 q 0,0.3556 -0.0938,0.63218 -0.0938,0.27164 -0.33091,0.42968 -0.23213,0.15311 -0.65687,0.15311 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4800"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 162.30533,191.03522 q -0.31115,0 -0.51364,-0.1136 -0.20249,-0.11853 -0.30621,-0.34078 -0.0988,-0.22225 -0.0988,-0.53834 v -0.95814 q 0,-0.31609 0.0988,-0.53834 0.10372,-0.22225 0.30621,-0.33585 0.20249,-0.11853 0.51364,-0.11853 0.31115,0 0.51365,0.11853 0.20743,0.1136 0.30621,0.33585 0.10372,0.22225 0.10372,0.53834 v 0.95814 q 0,0.31609 -0.10372,0.53834 -0.0988,0.22225 -0.30621,0.34078 -0.2025,0.1136 -0.51365,0.1136 z m 0.005,-0.46426 q 0.1136,0 0.16793,-0.0642 0.0543,-0.0642 0.0691,-0.17286 0.0148,-0.1136 0.0148,-0.24695 v -1.04704 q 0,-0.13335 -0.0148,-0.24201 -0.0148,-0.10865 -0.0691,-0.17286 -0.0543,-0.0691 -0.16793,-0.0691 -0.11359,0 -0.16792,0.0691 -0.0543,0.0642 -0.0741,0.17286 -0.0148,0.10866 -0.0148,0.24201 v 1.04704 q 0,0.13335 0.0148,0.24695 0.0197,0.10865 0.0741,0.17286 0.0543,0.0642 0.16792,0.0642 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4802"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 163.68861,190.99077 v -2.85468 h 0.647 v 0.24695 q 0.14816,-0.15805 0.32102,-0.22719 0.17286,-0.0741 0.35066,-0.0741 0.16793,0 0.2914,0.084 0.12841,0.084 0.18768,0.2667 0.16298,-0.18767 0.34572,-0.2667 0.18274,-0.084 0.37535,-0.084 0.15311,0 0.27164,0.079 0.11854,0.0741 0.18768,0.22718 0.0691,0.14817 0.0691,0.37536 v 2.22744 h -0.64206 v -2.16817 q 0,-0.16299 -0.0543,-0.22225 -0.0543,-0.0642 -0.1531,-0.0642 -0.079,0 -0.1778,0.0445 -0.0938,0.0445 -0.17286,0.12347 0,0.0148 0,0.0296 0,0.01 0,0.0296 v 2.22744 h -0.63712 v -2.16817 q 0,-0.16299 -0.0593,-0.22225 -0.0543,-0.0642 -0.1531,-0.0642 -0.079,0 -0.17286,0.0445 -0.0938,0.0445 -0.1778,0.12347 v 2.28671 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4804"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 167.23844,190.99077 v -2.85468 h 0.64699 v 0.24695 q 0.14817,-0.15805 0.32103,-0.22719 0.17286,-0.0741 0.35066,-0.0741 0.16792,0 0.29139,0.084 0.12842,0.084 0.18768,0.2667 0.16299,-0.18767 0.34572,-0.2667 0.18274,-0.084 0.37536,-0.084 0.15311,0 0.27164,0.079 0.11853,0.0741 0.18768,0.22718 0.0691,0.14817 0.0691,0.37536 v 2.22744 h -0.64205 v -2.16817 q 0,-0.16299 -0.0543,-0.22225 -0.0543,-0.0642 -0.15311,-0.0642 -0.079,0 -0.1778,0.0445 -0.0938,0.0445 -0.17286,0.12347 0,0.0148 0,0.0296 0,0.01 0,0.0296 v 2.22744 h -0.63712 v -2.16817 q 0,-0.16299 -0.0593,-0.22225 -0.0543,-0.0642 -0.15311,-0.0642 -0.079,0 -0.17286,0.0445 -0.0938,0.0445 -0.1778,0.12347 v 2.28671 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4806"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 170.80802,190.99077 v -2.85468 h 0.67169 v 2.85468 z m 0,-3.30906 v -0.55809 h 0.67169 v 0.55809 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4808"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 172.83813,191.02534 q -0.27164,0 -0.42968,-0.0889 -0.15311,-0.0889 -0.21731,-0.25682 -0.0642,-0.16792 -0.0642,-0.40005 v -1.69898 h -0.28645 v -0.4445 h 0.28645 v -0.85443 h 0.67663 v 0.85443 h 0.43462 v 0.4445 h -0.43462 v 1.63971 q 0,0.14817 0.0642,0.21237 0.0642,0.0593 0.19262,0.0593 0.0543,0 0.10372,-0.005 0.0543,-0.005 0.10371,-0.01 v 0.51365 q -0.084,0.01 -0.19755,0.0198 -0.10866,0.0148 -0.23213,0.0148 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4810"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 174.0977,190.99077 v -3.46216 h -0.63711 v -0.53834 h 1.99531 v 0.53834 h -0.62724 v 3.46216 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4812"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 176.0295,191.03522 q -0.19261,0 -0.3309,-0.0988 -0.13829,-0.10372 -0.21237,-0.25682 -0.0741,-0.15805 -0.0741,-0.32597 0,-0.2667 0.0988,-0.44944 0.0988,-0.18274 0.26176,-0.30621 0.16299,-0.12347 0.37042,-0.21237 0.20743,-0.0938 0.4198,-0.16792 v -0.24695 q 0,-0.12347 -0.0198,-0.20743 -0.0148,-0.084 -0.0642,-0.12841 -0.0444,-0.0444 -0.14322,-0.0444 -0.084,0 -0.13829,0.0395 -0.0494,0.0395 -0.0741,0.11359 -0.0198,0.0692 -0.0247,0.16299 l -0.01,0.17286 -0.63712,-0.0247 q 0.0148,-0.49388 0.24201,-0.72601 0.23213,-0.23707 0.70132,-0.23707 0.42969,0 0.6223,0.23707 0.19756,0.23706 0.19756,0.64205 v 1.31869 q 0,0.15804 0.005,0.28645 0.01,0.12841 0.0198,0.23213 0.0148,0.10372 0.0247,0.18274 h -0.60255 q -0.0148,-0.0988 -0.0395,-0.22225 -0.0198,-0.12841 -0.0296,-0.18768 -0.0494,0.17286 -0.18768,0.31609 -0.13829,0.13829 -0.37536,0.13829 z m 0.24695,-0.49883 q 0.0642,0 0.11853,-0.0296 0.0593,-0.0346 0.10372,-0.079 0.0444,-0.0445 0.0642,-0.079 v -0.79516 q -0.10865,0.0642 -0.20743,0.12841 -0.0938,0.0642 -0.16792,0.14323 -0.0691,0.0741 -0.10866,0.16298 -0.0346,0.0889 -0.0346,0.20744 0,0.15804 0.0593,0.25188 0.0642,0.0889 0.17286,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4814"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 178.93442,191.03522 q -0.15804,0 -0.29633,-0.0741 -0.13829,-0.0741 -0.25683,-0.18274 v 0.21237 h -0.67168 v -4.0005 h 0.67168 v 1.36313 q 0.12348,-0.11853 0.2667,-0.18768 0.14817,-0.0741 0.31609,-0.0741 0.19262,0 0.31609,0.0889 0.12347,0.0889 0.19262,0.23707 0.0691,0.14323 0.0938,0.31115 0.0296,0.16298 0.0296,0.31609 v 0.96802 q 0,0.28152 -0.0691,0.51364 -0.0642,0.23213 -0.21238,0.37042 -0.14322,0.13829 -0.38029,0.13829 z m -0.25682,-0.4692 q 0.10865,0 0.15804,-0.0691 0.0543,-0.0741 0.0691,-0.19262 0.0198,-0.12347 0.0198,-0.2667 v -1.02235 q 0,-0.13335 -0.0198,-0.23706 -0.0198,-0.10866 -0.0741,-0.17286 -0.0494,-0.0642 -0.15804,-0.0642 -0.079,0 -0.15311,0.0395 -0.0741,0.0346 -0.13829,0.079 v 1.8027 q 0.0642,0.0445 0.13829,0.0741 0.079,0.0296 0.15805,0.0296 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4816"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 180.10278,190.99077 v -4.0005 h 0.66675 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4818"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 182.167,191.03522 q -0.32103,0 -0.52352,-0.11853 -0.2025,-0.12348 -0.30128,-0.3556 -0.0938,-0.23707 -0.0938,-0.56798 v -0.85936 q 0,-0.34079 0.0938,-0.57291 0.0988,-0.23213 0.30128,-0.35067 0.20743,-0.11853 0.52352,-0.11853 0.34078,0 0.52846,0.12841 0.19262,0.12841 0.27164,0.37536 0.084,0.242 0.084,0.59266 v 0.40499 h -1.13594 v 0.56304 q 0,0.13829 0.0247,0.22719 0.0296,0.0889 0.0889,0.12841 0.0593,0.0395 0.14323,0.0395 0.0889,0 0.14323,-0.0395 0.0543,-0.0444 0.079,-0.12348 0.0247,-0.084 0.0247,-0.20743 v -0.23707 h 0.62724 v 0.19262 q 0,0.43462 -0.21731,0.66675 -0.21731,0.23213 -0.66181,0.23213 z m -0.25188,-1.77306 h 0.50376 v -0.27164 q 0,-0.14817 -0.0247,-0.23707 -0.0247,-0.0938 -0.079,-0.13335 -0.0543,-0.0445 -0.15311,-0.0445 -0.0889,0 -0.14323,0.0445 -0.0543,0.0444 -0.079,0.14817 -0.0247,0.10372 -0.0247,0.29633 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4820"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 156.50708,197.16438 0.1778,-1.37795 h -0.24201 l 0.005,-0.44944 h 0.30127 l 0.0692,-0.52846 h -0.36054 l 0.005,-0.45932 h 0.42968 l 0.15311,-1.18533 h 0.52352 l -0.15311,1.18533 h 0.40993 l 0.15805,-1.18533 h 0.51858 l -0.15804,1.18533 h 0.23706 l -0.01,0.45932 h -0.29633 l -0.0691,0.52846 h 0.35066 l -0.005,0.44944 h -0.40993 l -0.18274,1.37795 h -0.52352 l 0.18274,-1.37795 h -0.40993 l -0.1778,1.37795 z m 0.76059,-1.82739 h 0.41486 l 0.0691,-0.52846 h -0.40993 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4822"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 159.51841,197.16438 v -3.24485 q -0.0296,0.0148 -0.11853,0.0444 -0.084,0.0296 -0.18768,0.0593 -0.10372,0.0247 -0.19262,0.0494 -0.084,0.0247 -0.11853,0.0395 v -0.50871 q 0.0692,-0.0247 0.17286,-0.0691 0.10372,-0.0445 0.21731,-0.0988 0.11854,-0.0593 0.21731,-0.12841 0.10372,-0.0692 0.16793,-0.14323 h 0.52352 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4824"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 162.03022,197.22365 q -0.35066,0 -0.58279,-0.14817 -0.22718,-0.14817 -0.34572,-0.40993 -0.11359,-0.26176 -0.11359,-0.60254 v -1.77306 q 0,-0.35066 0.10865,-0.61243 0.1136,-0.2667 0.34079,-0.41486 0.23212,-0.14817 0.59266,-0.14817 0.36054,0 0.58773,0.14817 0.23213,0.14816 0.34078,0.41486 0.1136,0.26177 0.1136,0.61243 v 1.77306 q 0,0.34078 -0.11853,0.60254 -0.1136,0.26176 -0.34573,0.40993 -0.22719,0.14817 -0.57785,0.14817 z m 0,-0.58773 q 0.15311,0 0.22719,-0.0938 0.0741,-0.0938 0.0988,-0.22719 0.0247,-0.13335 0.0247,-0.26176 v -1.75331 q 0,-0.13828 -0.0247,-0.27163 -0.0198,-0.13829 -0.0938,-0.23213 -0.0741,-0.0938 -0.23213,-0.0938 -0.15804,0 -0.23212,0.0938 -0.0741,0.0938 -0.0988,0.23213 -0.0198,0.13335 -0.0198,0.27163 v 1.75331 q 0,0.12841 0.0247,0.26176 0.0296,0.13335 0.10371,0.22719 0.0741,0.0938 0.22225,0.0938 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4826"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 164.57475,197.22365 q -0.40005,0 -0.6223,-0.14817 -0.21731,-0.14817 -0.30127,-0.41981 -0.084,-0.27163 -0.084,-0.63711 h 0.66675 q 0,0.20249 0.0247,0.36054 0.0296,0.1531 0.10865,0.242 0.084,0.084 0.24201,0.079 0.17286,0 0.242,-0.10865 0.0741,-0.1136 0.0938,-0.31115 0.0198,-0.2025 0.0198,-0.4692 0,-0.23212 -0.0296,-0.40498 -0.0247,-0.17287 -0.10371,-0.2667 -0.079,-0.0988 -0.24695,-0.0988 -0.14323,0 -0.23706,0.0988 -0.0938,0.0938 -0.13829,0.25188 h -0.58773 l 0.0395,-2.22744 h 1.79776 v 0.61242 h -1.22485 l -0.0395,0.96309 q 0.0741,-0.0889 0.21237,-0.14323 0.14323,-0.0543 0.31609,-0.0642 0.31609,-0.0148 0.51365,0.13335 0.19755,0.14817 0.29139,0.42969 0.0938,0.28151 0.0938,0.67168 0,0.31609 -0.0445,0.58279 -0.0395,0.2667 -0.15311,0.46426 -0.11359,0.19262 -0.32102,0.30127 -0.2025,0.10866 -0.52847,0.10866 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4828"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="drop"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4270">
+      <path
+         d="m 84.392662,17.80042 q -0.340783,0 -0.518583,-0.242006 -0.172861,-0.242005 -0.172861,-0.775405 v -0.874183 q 0,-0.296334 0.06421,-0.533401 0.06914,-0.237066 0.217311,-0.375355 0.148166,-0.143228 0.40005,-0.143228 0.153105,0 0.281516,0.06421 0.13335,0.05927 0.242006,0.158044 V 13.75547 H 85.578 v 4.0005 h -0.671689 v -0.202494 q -0.113595,0.113594 -0.242006,0.182738 -0.128411,0.06421 -0.271639,0.06421 z m 0.246945,-0.464256 q 0.05433,0 0.123472,-0.02469 0.06914,-0.02469 0.143228,-0.06914 v -1.832328 q -0.05927,-0.03951 -0.128411,-0.06421 -0.06914,-0.02963 -0.143228,-0.02963 -0.143228,0 -0.202494,0.13335 -0.05433,0.128411 -0.05433,0.316089 v 1.0668 q 0,0.143228 0.01975,0.256822 0.01976,0.113594 0.07408,0.182739 0.05927,0.06421 0.167922,0.06421 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4831"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 86.09982,17.75597 v -2.854678 h 0.671689 v 0.439561 q 0.148167,-0.251883 0.296334,-0.360539 0.148166,-0.113594 0.325966,-0.113594 0.02963,0 0.04939,0.0049 0.0247,0 0.05433,0.0049 v 0.696383 q -0.05927,-0.02469 -0.13335,-0.03951 -0.06914,-0.01976 -0.143228,-0.01976 -0.13335,0 -0.242005,0.06421 -0.108656,0.0642 -0.207434,0.212372 v 1.965678 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4833"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 88.675991,17.80042 q -0.31115,0 -0.513644,-0.113594 -0.202494,-0.118534 -0.306211,-0.340784 -0.09878,-0.22225 -0.09878,-0.538339 v -0.958144 q 0,-0.316089 0.09878,-0.538339 0.103717,-0.22225 0.306211,-0.335845 0.202494,-0.118533 0.513644,-0.118533 0.31115,0 0.513645,0.118533 0.207433,0.113595 0.306211,0.335845 0.103717,0.22225 0.103717,0.538339 v 0.958144 q 0,0.316089 -0.103717,0.538339 -0.09878,0.22225 -0.306211,0.340784 -0.202495,0.113594 -0.513645,0.113594 z m 0.0049,-0.464256 q 0.113595,0 0.167923,-0.06421 0.05433,-0.06421 0.06914,-0.172861 0.01482,-0.113595 0.01482,-0.246945 v -1.047044 q 0,-0.13335 -0.01482,-0.242006 -0.01482,-0.108655 -0.06914,-0.172861 -0.05433,-0.06914 -0.167923,-0.06914 -0.113594,0 -0.167922,0.06914 -0.05433,0.06421 -0.07408,0.172861 -0.01482,0.108656 -0.01482,0.242006 v 1.047044 q 0,0.13335 0.01482,0.246945 0.01976,0.108655 0.07408,0.172861 0.05433,0.06421 0.167922,0.06421 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4835"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 90.059266,18.694359 v -3.793067 h 0.671689 v 0.217311 q 0.123472,-0.118533 0.271639,-0.187678 0.148166,-0.07408 0.31115,-0.07408 0.192616,0 0.316089,0.0889 0.123472,0.0889 0.192616,0.237067 0.06914,0.143228 0.09384,0.31115 0.02963,0.162983 0.02963,0.316089 v 0.968022 q 0,0.281517 -0.06914,0.513644 -0.06421,0.232128 -0.212372,0.370417 -0.143228,0.138289 -0.385233,0.138289 -0.153106,0 -0.291395,-0.07408 -0.13335,-0.07408 -0.256822,-0.187678 v 1.1557 z m 0.968022,-1.363133 q 0.108656,0 0.158045,-0.06915 0.05433,-0.07408 0.06914,-0.192617 0.01976,-0.123472 0.01976,-0.2667 v -1.02235 q 0,-0.13335 -0.01976,-0.237066 -0.01975,-0.108656 -0.07408,-0.172861 -0.05433,-0.06421 -0.158045,-0.06421 -0.07902,0 -0.158044,0.03951 -0.07408,0.03457 -0.13335,0.08396 v 1.802695 q 0.06421,0.04445 0.138289,0.07408 0.07408,0.0247 0.158044,0.0247 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4837"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="drop"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4274">
+      <path
+         d="m 199.6754,34.053395 q -0.34078,0 -0.51858,-0.242005 -0.17286,-0.242006 -0.17286,-0.775406 v -0.874183 q 0,-0.296333 0.0642,-0.5334 0.0692,-0.237067 0.21731,-0.375356 0.14817,-0.143227 0.40005,-0.143227 0.15311,0 0.28152,0.0642 0.13335,0.05927 0.242,0.158045 V 30.00844 h 0.67169 v 4.0005 h -0.67169 v -0.202494 q -0.11359,0.113594 -0.242,0.182739 -0.12841,0.06421 -0.27164,0.06421 z m 0.24694,-0.464255 q 0.0543,0 0.12348,-0.0247 0.0691,-0.02469 0.14322,-0.06914 v -1.832328 q -0.0593,-0.03951 -0.12841,-0.06421 -0.0691,-0.02963 -0.14322,-0.02963 -0.14323,0 -0.2025,0.13335 -0.0543,0.128411 -0.0543,0.316089 v 1.0668 q 0,0.143228 0.0198,0.256822 0.0197,0.113595 0.0741,0.182739 0.0593,0.06421 0.16792,0.06421 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4840"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 201.38256,34.008945 v -2.854677 h 0.67169 v 0.439561 q 0.14816,-0.251884 0.29633,-0.360539 0.14817,-0.113595 0.32597,-0.113595 0.0296,0 0.0494,0.0049 0.0247,0 0.0543,0.0049 v 0.696384 q -0.0593,-0.02469 -0.13335,-0.03951 -0.0691,-0.01975 -0.14322,-0.01975 -0.13335,0 -0.24201,0.06421 -0.10866,0.06421 -0.20743,0.212373 v 1.965677 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4842"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 203.95873,34.053395 q -0.31115,0 -0.51365,-0.113594 -0.20249,-0.118533 -0.30621,-0.340783 -0.0988,-0.22225 -0.0988,-0.538339 v -0.958145 q 0,-0.316089 0.0988,-0.538339 0.10372,-0.22225 0.30621,-0.335844 0.2025,-0.118533 0.51365,-0.118533 0.31115,0 0.51364,0.118533 0.20744,0.113594 0.30621,0.335844 0.10372,0.22225 0.10372,0.538339 v 0.958145 q 0,0.316089 -0.10372,0.538339 -0.0988,0.22225 -0.30621,0.340783 -0.20249,0.113594 -0.51364,0.113594 z m 0.005,-0.464255 q 0.11359,0 0.16792,-0.06421 0.0543,-0.06421 0.0691,-0.172861 0.0148,-0.113594 0.0148,-0.246944 V 32.05808 q 0,-0.13335 -0.0148,-0.242005 -0.0148,-0.108656 -0.0691,-0.172861 -0.0543,-0.06915 -0.16792,-0.06915 -0.1136,0 -0.16792,0.06915 -0.0543,0.0642 -0.0741,0.172861 -0.0148,0.108655 -0.0148,0.242005 v 1.047045 q 0,0.13335 0.0148,0.246944 0.0198,0.108656 0.0741,0.172861 0.0543,0.06421 0.16792,0.06421 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4844"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 205.342,34.947334 v -3.793066 h 0.67169 v 0.217311 q 0.12347,-0.118534 0.27164,-0.187678 0.14817,-0.07408 0.31115,-0.07408 0.19262,0 0.31609,0.0889 0.12347,0.0889 0.19262,0.237066 0.0691,0.143228 0.0938,0.31115 0.0296,0.162984 0.0296,0.316089 v 0.968022 q 0,0.281517 -0.0691,0.513645 -0.0642,0.232128 -0.21237,0.370417 -0.14323,0.138288 -0.38523,0.138288 -0.15311,0 -0.2914,-0.07408 -0.13335,-0.07408 -0.25682,-0.187678 v 1.1557 z m 0.96803,-1.363133 q 0.10865,0 0.15804,-0.06914 0.0543,-0.07408 0.0691,-0.192617 0.0198,-0.123472 0.0198,-0.2667 v -1.02235 q 0,-0.13335 -0.0198,-0.237067 -0.0197,-0.108655 -0.0741,-0.172861 -0.0543,-0.06421 -0.15804,-0.06421 -0.079,0 -0.15805,0.03951 -0.0741,0.03457 -0.13335,0.08396 v 1.802694 q 0.0642,0.04445 0.13829,0.07408 0.0741,0.02469 0.15805,0.02469 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4846"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="drop"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4278">
+      <path
+         d="m 90.893868,147.2195 q -0.340783,0 -0.518583,-0.24201 -0.172862,-0.242 -0.172862,-0.7754 v -0.87419 q 0,-0.29633 0.06421,-0.5334 0.06914,-0.23706 0.217311,-0.37535 0.148167,-0.14323 0.40005,-0.14323 0.153106,0 0.281517,0.0642 0.13335,0.0593 0.242005,0.15804 v -1.32362 h 0.671689 v 4.0005 h -0.671689 v -0.2025 q -0.113594,0.1136 -0.242005,0.18274 -0.128411,0.0642 -0.271639,0.0642 z m 0.246944,-0.46426 q 0.05433,0 0.123473,-0.0247 0.06914,-0.0247 0.143227,-0.0692 v -1.83232 q -0.05927,-0.0395 -0.128411,-0.0642 -0.06914,-0.0296 -0.143228,-0.0296 -0.143227,0 -0.202494,0.13335 -0.05433,0.12841 -0.05433,0.31609 v 1.0668 q 0,0.14322 0.01976,0.25682 0.01975,0.11359 0.07408,0.18274 0.05927,0.0642 0.167922,0.0642 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4849"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 92.601026,147.17505 v -2.85468 h 0.671689 v 0.43956 q 0.148166,-0.25188 0.296333,-0.36054 0.148167,-0.11359 0.325967,-0.11359 0.02963,0 0.04939,0.005 0.02469,0 0.05433,0.005 v 0.69638 q -0.05927,-0.0247 -0.13335,-0.0395 -0.06914,-0.0198 -0.143227,-0.0198 -0.13335,0 -0.242006,0.0642 -0.108655,0.0642 -0.207433,0.21237 v 1.96568 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4851"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 95.177197,147.2195 q -0.31115,0 -0.513645,-0.1136 -0.202494,-0.11853 -0.306211,-0.34078 -0.09878,-0.22225 -0.09878,-0.53834 v -0.95814 q 0,-0.31609 0.09878,-0.53834 0.103717,-0.22225 0.306211,-0.33585 0.202495,-0.11853 0.513645,-0.11853 0.31115,0 0.513644,0.11853 0.207434,0.1136 0.306211,0.33585 0.103717,0.22225 0.103717,0.53834 v 0.95814 q 0,0.31609 -0.103717,0.53834 -0.09878,0.22225 -0.306211,0.34078 -0.202494,0.1136 -0.513644,0.1136 z m 0.0049,-0.46426 q 0.113594,0 0.167922,-0.0642 0.05433,-0.0642 0.06914,-0.17286 0.01482,-0.1136 0.01482,-0.24695 v -1.04704 q 0,-0.13335 -0.01482,-0.24201 -0.01482,-0.10865 -0.06914,-0.17286 -0.05433,-0.0691 -0.167922,-0.0691 -0.113595,0 -0.167922,0.0691 -0.05433,0.0642 -0.07408,0.17286 -0.01482,0.10866 -0.01482,0.24201 v 1.04704 q 0,0.13335 0.01482,0.24695 0.01976,0.10865 0.07408,0.17286 0.05433,0.0642 0.167922,0.0642 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4853"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 96.560471,148.11344 v -3.79307 h 0.671689 v 0.21731 q 0.123473,-0.11853 0.271639,-0.18768 0.148167,-0.0741 0.31115,-0.0741 0.192617,0 0.316089,0.0889 0.123472,0.0889 0.192617,0.23707 0.06914,0.14323 0.09384,0.31115 0.02963,0.16298 0.02963,0.31609 v 0.96802 q 0,0.28152 -0.06914,0.51364 -0.06421,0.23213 -0.212373,0.37042 -0.143227,0.13829 -0.385233,0.13829 -0.153106,0 -0.291394,-0.0741 -0.13335,-0.0741 -0.256823,-0.18768 v 1.1557 z m 0.968023,-1.36314 q 0.108655,0 0.158044,-0.0691 0.05433,-0.0741 0.06915,-0.19262 0.01975,-0.12347 0.01975,-0.2667 v -1.02235 q 0,-0.13335 -0.01975,-0.23706 -0.01976,-0.10866 -0.07408,-0.17286 -0.05433,-0.0642 -0.158044,-0.0642 -0.07902,0 -0.158045,0.0395 -0.07408,0.0346 -0.13335,0.084 v 1.8027 q 0.06421,0.0444 0.138289,0.0741 0.07408,0.0247 0.158045,0.0247 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4855"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="drop"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4282">
+      <path
+         d="m 270.13014,201.49686 q -0.34078,0 -0.51858,-0.24201 -0.17286,-0.242 -0.17286,-0.7754 v -0.87419 q 0,-0.29633 0.0642,-0.5334 0.0691,-0.23706 0.21731,-0.37535 0.14817,-0.14323 0.40005,-0.14323 0.15311,0 0.28152,0.0642 0.13335,0.0593 0.24201,0.15804 v -1.32362 h 0.67169 v 4.0005 h -0.67169 v -0.2025 q -0.1136,0.1136 -0.24201,0.18274 -0.12841,0.0642 -0.27164,0.0642 z m 0.24695,-0.46426 q 0.0543,0 0.12347,-0.0247 0.0691,-0.0247 0.14323,-0.0692 v -1.83232 q -0.0593,-0.0395 -0.12841,-0.0642 -0.0691,-0.0296 -0.14323,-0.0296 -0.14323,0 -0.2025,0.13335 -0.0543,0.12841 -0.0543,0.31609 v 1.0668 q 0,0.14322 0.0198,0.25682 0.0198,0.11359 0.0741,0.18274 0.0593,0.0642 0.16793,0.0642 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4858"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 271.8373,201.45241 v -2.85468 h 0.67169 v 0.43956 q 0.14817,-0.25188 0.29633,-0.36054 0.14817,-0.11359 0.32597,-0.11359 0.0296,0 0.0494,0.005 0.0247,0 0.0543,0.005 v 0.69638 q -0.0593,-0.0247 -0.13335,-0.0395 -0.0691,-0.0198 -0.14323,-0.0198 -0.13335,0 -0.24201,0.0642 -0.10865,0.0642 -0.20743,0.21237 v 1.96568 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4860"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 274.41347,201.49686 q -0.31115,0 -0.51364,-0.1136 -0.2025,-0.11853 -0.30621,-0.34078 -0.0988,-0.22225 -0.0988,-0.53834 V 199.546 q 0,-0.31609 0.0988,-0.53834 0.10371,-0.22225 0.30621,-0.33585 0.20249,-0.11853 0.51364,-0.11853 0.31115,0 0.51365,0.11853 0.20743,0.1136 0.30621,0.33585 0.10371,0.22225 0.10371,0.53834 v 0.95814 q 0,0.31609 -0.10371,0.53834 -0.0988,0.22225 -0.30621,0.34078 -0.2025,0.1136 -0.51365,0.1136 z m 0.005,-0.46426 q 0.11359,0 0.16792,-0.0642 0.0543,-0.0642 0.0692,-0.17286 0.0148,-0.1136 0.0148,-0.24695 v -1.04704 q 0,-0.13335 -0.0148,-0.24201 -0.0148,-0.10865 -0.0692,-0.17286 -0.0543,-0.0691 -0.16792,-0.0691 -0.11359,0 -0.16792,0.0691 -0.0543,0.0642 -0.0741,0.17286 -0.0148,0.10866 -0.0148,0.24201 v 1.04704 q 0,0.13335 0.0148,0.24695 0.0198,0.10865 0.0741,0.17286 0.0543,0.0642 0.16792,0.0642 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4862"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 275.79675,202.3908 v -3.79307 h 0.67169 v 0.21731 q 0.12347,-0.11853 0.27163,-0.18768 0.14817,-0.0741 0.31115,-0.0741 0.19262,0 0.31609,0.0889 0.12348,0.0889 0.19262,0.23707 0.0691,0.14322 0.0938,0.31115 0.0296,0.16298 0.0296,0.31609 v 0.96802 q 0,0.28151 -0.0691,0.51364 -0.0642,0.23213 -0.21237,0.37042 -0.14323,0.13829 -0.38524,0.13829 -0.1531,0 -0.29139,-0.0741 -0.13335,-0.0741 -0.25682,-0.18767 v 1.1557 z m 0.96802,-1.36314 q 0.10865,0 0.15804,-0.0691 0.0543,-0.0741 0.0691,-0.19262 0.0197,-0.12347 0.0197,-0.2667 v -1.02235 q 0,-0.13335 -0.0197,-0.23706 -0.0198,-0.10866 -0.0741,-0.17287 -0.0543,-0.0642 -0.15804,-0.0642 -0.079,0 -0.15804,0.0395 -0.0741,0.0346 -0.13335,0.084 v 1.8027 q 0.0642,0.0445 0.13828,0.0741 0.0741,0.0247 0.15805,0.0247 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4864"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="ct"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4286">
+      <path
+         d="m 144.73185,94.156945 q -0.33091,0 -0.5334,-0.123472 -0.19756,-0.128411 -0.2914,-0.360539 -0.0889,-0.237066 -0.0889,-0.558094 v -0.859367 q 0,-0.330905 0.0889,-0.563033 0.0938,-0.232128 0.29634,-0.3556 0.20249,-0.123472 0.52846,-0.123472 0.30621,0 0.49883,0.09878 0.19755,0.09384 0.28645,0.291395 0.0889,0.192616 0.0889,0.48895 v 0.237066 h -0.63218 v -0.251883 q 0,-0.148167 -0.0247,-0.232128 -0.0198,-0.0889 -0.0741,-0.123472 -0.0543,-0.03951 -0.14323,-0.03951 -0.0889,0 -0.14323,0.04939 -0.0543,0.04445 -0.079,0.148167 -0.0198,0.103716 -0.0198,0.286455 v 1.047045 q 0,0.276577 0.0593,0.375355 0.0593,0.09384 0.18768,0.09384 0.0988,0 0.14816,-0.04445 0.0543,-0.04445 0.0692,-0.128411 0.0197,-0.0889 0.0197,-0.212372 v -0.306211 h 0.63218 v 0.271639 q 0,0.286455 -0.0938,0.48895 -0.0889,0.202494 -0.28645,0.306211 -0.19262,0.09878 -0.49389,0.09878 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4867"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 146.86769,94.147068 q -0.27164,0 -0.42969,-0.0889 -0.1531,-0.0889 -0.21731,-0.256823 -0.0642,-0.167922 -0.0642,-0.40005 v -1.698977 h -0.28646 v -0.4445 h 0.28646 V 90.40339 h 0.67662 v 0.854428 h 0.43463 v 0.4445 h -0.43463 v 1.639711 q 0,0.148166 0.0642,0.212372 0.0642,0.05927 0.19262,0.05927 0.0543,0 0.10371,-0.0049 0.0543,-0.0049 0.10372,-0.0099 v 0.513644 q -0.084,0.0099 -0.19756,0.01976 -0.10865,0.01482 -0.23212,0.01482 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4869"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="output"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4290">
+      <path
+         d="m 269.48362,177.23607 q -0.31115,0 -0.51364,-0.11359 -0.2025,-0.11854 -0.30621,-0.34079 -0.0988,-0.22225 -0.0988,-0.53834 v -0.95814 q 0,-0.31609 0.0988,-0.53834 0.10371,-0.22225 0.30621,-0.33584 0.20249,-0.11854 0.51364,-0.11854 0.31115,0 0.51365,0.11854 0.20743,0.11359 0.30621,0.33584 0.10371,0.22225 0.10371,0.53834 v 0.95814 q 0,0.31609 -0.10371,0.53834 -0.0988,0.22225 -0.30621,0.34079 -0.2025,0.11359 -0.51365,0.11359 z m 0.005,-0.46426 q 0.11359,0 0.16792,-0.0642 0.0543,-0.0642 0.0692,-0.17286 0.0148,-0.1136 0.0148,-0.24695 v -1.04704 q 0,-0.13335 -0.0148,-0.24201 -0.0148,-0.10865 -0.0692,-0.17286 -0.0543,-0.0691 -0.16792,-0.0691 -0.11359,0 -0.16792,0.0691 -0.0543,0.0642 -0.0741,0.17286 -0.0148,0.10866 -0.0148,0.24201 v 1.04704 q 0,0.13335 0.0148,0.24695 0.0198,0.10865 0.0741,0.17286 0.0543,0.0642 0.16792,0.0642 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4872"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 271.32621,177.23607 q -0.16792,0 -0.27658,-0.084 -0.10865,-0.0889 -0.15804,-0.23213 -0.0494,-0.14817 -0.0494,-0.31115 v -2.27189 h 0.67169 v 2.14842 q 0,0.12841 0.0395,0.20249 0.0444,0.0692 0.15805,0.0692 0.0741,0 0.14816,-0.0395 0.079,-0.0395 0.15311,-0.0938 V 174.337 h 0.67169 v 2.85468 h -0.67169 v -0.27164 q -0.14323,0.13829 -0.31609,0.22719 -0.17286,0.0889 -0.37042,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4874"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 274.02609,177.22619 q -0.27164,0 -0.42969,-0.0889 -0.1531,-0.0889 -0.21731,-0.25682 -0.0642,-0.16792 -0.0642,-0.40005 v -1.69898 h -0.28646 v -0.4445 h 0.28646 v -0.85443 h 0.67662 v 0.85443 h 0.43463 v 0.4445 h -0.43463 v 1.63971 q 0,0.14817 0.0642,0.21238 0.0642,0.0593 0.19262,0.0593 0.0543,0 0.10371,-0.005 0.0543,-0.005 0.10372,-0.01 v 0.51364 q -0.084,0.01 -0.19756,0.0198 -0.10865,0.0148 -0.23212,0.0148 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4876"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 274.84116,178.13001 v -3.79307 h 0.67169 v 0.21731 q 0.12347,-0.11853 0.27164,-0.18767 0.14816,-0.0741 0.31115,-0.0741 0.19261,0 0.31608,0.0889 0.12348,0.0889 0.19262,0.23707 0.0692,0.14323 0.0938,0.31115 0.0296,0.16298 0.0296,0.31609 v 0.96802 q 0,0.28152 -0.0691,0.51364 -0.0642,0.23213 -0.21237,0.37042 -0.14323,0.13829 -0.38524,0.13829 -0.1531,0 -0.29139,-0.0741 -0.13335,-0.0741 -0.25682,-0.18768 v 1.1557 z m 0.96802,-1.36313 q 0.10866,0 0.15804,-0.0691 0.0543,-0.0741 0.0691,-0.19262 0.0198,-0.12347 0.0198,-0.2667 v -1.02235 q 0,-0.13335 -0.0198,-0.23706 -0.0198,-0.10866 -0.0741,-0.17286 -0.0543,-0.0642 -0.15805,-0.0642 -0.079,0 -0.15804,0.0395 -0.0741,0.0346 -0.13335,0.084 v 1.8027 q 0.0642,0.0444 0.13829,0.0741 0.0741,0.0247 0.15804,0.0247 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4878"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 277.65416,177.23607 q -0.16792,0 -0.27657,-0.084 -0.10866,-0.0889 -0.15805,-0.23213 -0.0494,-0.14817 -0.0494,-0.31115 v -2.27189 h 0.67169 v 2.14842 q 0,0.12841 0.0395,0.20249 0.0444,0.0692 0.15805,0.0692 0.0741,0 0.14816,-0.0395 0.079,-0.0395 0.15311,-0.0938 V 174.337 h 0.67169 v 2.85468 h -0.67169 v -0.27164 q -0.14323,0.13829 -0.31609,0.22719 -0.17286,0.0889 -0.37042,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4880"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 280.35404,177.22619 q -0.27164,0 -0.42969,-0.0889 -0.1531,-0.0889 -0.21731,-0.25682 -0.0642,-0.16792 -0.0642,-0.40005 v -1.69898 h -0.28646 v -0.4445 h 0.28646 v -0.85443 h 0.67663 v 0.85443 h 0.43462 v 0.4445 h -0.43462 v 1.63971 q 0,0.14817 0.0642,0.21238 0.0642,0.0593 0.19262,0.0593 0.0543,0 0.10371,-0.005 0.0543,-0.005 0.10372,-0.01 v 0.51364 q -0.084,0.01 -0.19755,0.0198 -0.10866,0.0148 -0.23213,0.0148 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4882"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="output: gw"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4294">
+      <path
+         d="m 265.14435,125.37778 q -0.31115,0 -0.51364,-0.1136 -0.2025,-0.11853 -0.30621,-0.34078 -0.0988,-0.22225 -0.0988,-0.53834 v -0.95814 q 0,-0.31609 0.0988,-0.53834 0.10371,-0.22225 0.30621,-0.33585 0.20249,-0.11853 0.51364,-0.11853 0.31115,0 0.51365,0.11853 0.20743,0.1136 0.30621,0.33585 0.10372,0.22225 0.10372,0.53834 v 0.95814 q 0,0.31609 -0.10372,0.53834 -0.0988,0.22225 -0.30621,0.34078 -0.2025,0.1136 -0.51365,0.1136 z m 0.005,-0.46426 q 0.1136,0 0.16792,-0.0642 0.0543,-0.0642 0.0692,-0.17286 0.0148,-0.1136 0.0148,-0.24695 v -1.04704 q 0,-0.13335 -0.0148,-0.24201 -0.0148,-0.10865 -0.0692,-0.17286 -0.0543,-0.0691 -0.16792,-0.0691 -0.11359,0 -0.16792,0.0691 -0.0543,0.0642 -0.0741,0.17286 -0.0148,0.10866 -0.0148,0.24201 v 1.04704 q 0,0.13335 0.0148,0.24695 0.0197,0.10865 0.0741,0.17286 0.0543,0.0642 0.16792,0.0642 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4885"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 266.98694,125.37778 q -0.16792,0 -0.27657,-0.084 -0.10866,-0.0889 -0.15805,-0.23213 -0.0494,-0.14817 -0.0494,-0.31115 v -2.27189 h 0.67169 v 2.14842 q 0,0.12841 0.0395,0.20249 0.0444,0.0691 0.15805,0.0691 0.0741,0 0.14816,-0.0395 0.079,-0.0395 0.15311,-0.0938 v -2.28671 h 0.67169 v 2.85468 h -0.67169 v -0.27164 q -0.14323,0.13829 -0.31609,0.22719 -0.17286,0.0889 -0.37042,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4887"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 269.68682,125.3679 q -0.27164,0 -0.42968,-0.0889 -0.15311,-0.0889 -0.21732,-0.25682 -0.0642,-0.16792 -0.0642,-0.40005 v -1.69898 h -0.28646 v -0.4445 h 0.28646 v -0.85443 h 0.67663 v 0.85443 h 0.43462 v 0.4445 h -0.43462 v 1.63971 q 0,0.14817 0.0642,0.21237 0.0642,0.0593 0.19262,0.0593 0.0543,0 0.10372,-0.005 0.0543,-0.005 0.10371,-0.01 v 0.51365 q -0.084,0.01 -0.19755,0.0198 -0.10866,0.0148 -0.23213,0.0148 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4889"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 270.50189,126.27172 v -3.79307 h 0.67169 v 0.21731 q 0.12347,-0.11853 0.27164,-0.18768 0.14817,-0.0741 0.31115,-0.0741 0.19262,0 0.31609,0.0889 0.12347,0.0889 0.19261,0.23707 0.0692,0.14322 0.0938,0.31115 0.0296,0.16298 0.0296,0.31609 v 0.96802 q 0,0.28151 -0.0692,0.51364 -0.0642,0.23213 -0.21237,0.37042 -0.14323,0.13829 -0.38523,0.13829 -0.15311,0 -0.2914,-0.0741 -0.13335,-0.0741 -0.25682,-0.18767 v 1.1557 z m 0.96802,-1.36314 q 0.10866,0 0.15805,-0.0691 0.0543,-0.0741 0.0691,-0.19262 0.0198,-0.12347 0.0198,-0.2667 v -1.02235 q 0,-0.13335 -0.0198,-0.23706 -0.0197,-0.10866 -0.0741,-0.17287 -0.0543,-0.0642 -0.15805,-0.0642 -0.079,0 -0.15804,0.0395 -0.0741,0.0346 -0.13335,0.084 v 1.8027 q 0.0642,0.0444 0.13829,0.0741 0.0741,0.0247 0.15804,0.0247 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4891"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 273.3149,125.37778 q -0.16793,0 -0.27658,-0.084 -0.10866,-0.0889 -0.15805,-0.23213 -0.0494,-0.14817 -0.0494,-0.31115 v -2.27189 h 0.67168 v 2.14842 q 0,0.12841 0.0395,0.20249 0.0445,0.0691 0.15804,0.0691 0.0741,0 0.14817,-0.0395 0.079,-0.0395 0.1531,-0.0938 v -2.28671 h 0.67169 v 2.85468 h -0.67169 v -0.27164 q -0.14323,0.13829 -0.31609,0.22719 -0.17286,0.0889 -0.37041,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4893"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 276.01477,125.3679 q -0.27164,0 -0.42968,-0.0889 -0.15311,-0.0889 -0.21731,-0.25682 -0.0642,-0.16792 -0.0642,-0.40005 v -1.69898 h -0.28645 v -0.4445 h 0.28645 v -0.85443 h 0.67663 v 0.85443 h 0.43462 v 0.4445 h -0.43462 v 1.63971 q 0,0.14817 0.0642,0.21237 0.0642,0.0593 0.19262,0.0593 0.0543,0 0.10372,-0.005 0.0543,-0.005 0.10371,-0.01 v 0.51365 q -0.084,0.01 -0.19755,0.0198 -0.10866,0.0148 -0.23213,0.0148 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4895"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 276.88911,123.29357 v -0.66181 h 0.64205 v 0.66181 z m 0,1.66934 v -0.66181 h 0.64205 v 0.66181 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4897"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 280.04244,126.27172 q -0.2914,0 -0.51365,-0.0593 -0.22225,-0.0593 -0.34572,-0.18274 -0.12347,-0.12347 -0.12347,-0.32103 0,-0.13335 0.0543,-0.242 0.0593,-0.10372 0.15805,-0.18274 0.0988,-0.079 0.21237,-0.13335 -0.16298,-0.0444 -0.25188,-0.14323 -0.084,-0.0988 -0.084,-0.23707 0,-0.16792 0.084,-0.28645 0.084,-0.11853 0.23213,-0.25188 -0.15311,-0.12348 -0.23213,-0.30622 -0.0741,-0.18767 -0.0741,-0.48895 0,-0.32596 0.10372,-0.54821 0.10866,-0.22719 0.31115,-0.34079 0.20743,-0.11359 0.50377,-0.11359 0.22719,0 0.38029,0.0691 0.15311,0.0642 0.25189,0.19756 0.0395,-0.0593 0.13828,-0.14817 0.0988,-0.0889 0.22719,-0.14816 l 0.0889,-0.0395 0.16299,0.36053 q -0.0543,0.0148 -0.14817,0.0494 -0.0889,0.0346 -0.1778,0.0741 -0.0889,0.0395 -0.13829,0.0691 0.0445,0.0988 0.0741,0.24695 0.0296,0.14816 0.0296,0.28151 0,0.30127 -0.0938,0.52352 -0.0938,0.22225 -0.2914,0.34573 -0.19261,0.11853 -0.50376,0.11853 -0.10372,0 -0.2025,-0.0148 -0.0988,-0.0198 -0.18274,-0.0444 -0.0296,0.0444 -0.0593,0.0938 -0.0247,0.0494 -0.0247,0.10372 0,0.0543 0.0593,0.0889 0.0593,0.0346 0.19756,0.0494 l 0.60254,0.0593 q 0.35066,0.0346 0.51858,0.22225 0.16793,0.18274 0.16793,0.49883 0,0.25682 -0.11854,0.42969 -0.11359,0.17286 -0.36054,0.26176 -0.242,0.0889 -0.63217,0.0889 z m 0.0741,-0.50377 q 0.27658,0 0.41487,-0.0543 0.13828,-0.0543 0.13828,-0.19755 0,-0.079 -0.0346,-0.12841 -0.0346,-0.0494 -0.12347,-0.079 -0.0889,-0.0346 -0.25188,-0.0494 l -0.48895,-0.0445 q -0.0543,0.0445 -0.0988,0.0938 -0.0395,0.0445 -0.0642,0.0988 -0.0247,0.0543 -0.0247,0.1136 0,0.12347 0.11853,0.18273 0.11854,0.0642 0.41487,0.0642 z m -0.0395,-1.76318 q 0.0889,0 0.14323,-0.0296 0.0543,-0.0346 0.084,-0.10371 0.0296,-0.0741 0.0395,-0.18274 0.01,-0.10866 0.01,-0.25189 0,-0.14322 -0.01,-0.25188 -0.01,-0.10865 -0.0395,-0.18274 -0.0247,-0.0741 -0.079,-0.10865 -0.0543,-0.0346 -0.14816,-0.0346 -0.0889,0 -0.14817,0.0346 -0.0543,0.0346 -0.084,0.10865 -0.0247,0.0691 -0.0395,0.1778 -0.01,0.10866 -0.01,0.25682 0,0.13829 0.01,0.24695 0.01,0.10372 0.0395,0.1778 0.0296,0.0691 0.084,0.10865 0.0593,0.0346 0.14817,0.0346 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4899"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 281.8192,125.33333 -0.43956,-2.85468 h 0.55809 l 0.25189,1.85208 0.29633,-1.85208 h 0.49883 l 0.28152,1.87184 0.27163,-1.87184 h 0.52847 l -0.44944,2.85468 h -0.56798 l -0.31608,-1.8027 -0.33091,1.8027 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4901"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="kube-proxy"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4298">
+      <path
+         d="m 264.6681,150.43094 v -4.0005 h 0.67169 v 2.29658 l 0.73589,-1.15076 h 0.73096 l -0.71614,1.14582 0.70132,1.70886 h -0.70626 l -0.51858,-1.40758 -0.22719,0.31608 v 1.0915 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4904"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 267.5244,150.47539 q -0.16793,0 -0.27658,-0.084 -0.10866,-0.0889 -0.15805,-0.23213 -0.0494,-0.14817 -0.0494,-0.31115 v -2.27189 h 0.67169 v 2.14842 q 0,0.12841 0.0395,0.20249 0.0444,0.0692 0.15805,0.0692 0.0741,0 0.14817,-0.0395 0.079,-0.0395 0.1531,-0.0938 v -2.28671 h 0.67169 v 2.85468 h -0.67169 v -0.27164 q -0.14323,0.13829 -0.31609,0.22719 -0.17286,0.0889 -0.37041,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4906"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 270.62926,150.47539 q -0.15804,0 -0.29633,-0.0741 -0.13829,-0.0741 -0.25683,-0.18274 v 0.21237 h -0.67168 v -4.0005 h 0.67168 v 1.36313 q 0.12348,-0.11853 0.2667,-0.18768 0.14817,-0.0741 0.31609,-0.0741 0.19262,0 0.31609,0.0889 0.12347,0.0889 0.19262,0.23707 0.0691,0.14323 0.0938,0.31115 0.0296,0.16298 0.0296,0.31609 v 0.96802 q 0,0.28152 -0.0691,0.51364 -0.0642,0.23213 -0.21238,0.37042 -0.14322,0.13829 -0.38029,0.13829 z m -0.25682,-0.4692 q 0.10865,0 0.15804,-0.0691 0.0543,-0.0741 0.0691,-0.19262 0.0197,-0.12347 0.0197,-0.2667 v -1.02235 q 0,-0.13335 -0.0197,-0.23706 -0.0198,-0.10866 -0.0741,-0.17286 -0.0494,-0.0642 -0.15804,-0.0642 -0.079,0 -0.15311,0.0395 -0.0741,0.0346 -0.13829,0.079 v 1.8027 q 0.0642,0.0445 0.13829,0.0741 0.079,0.0296 0.15805,0.0296 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4908"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 272.61747,150.47539 q -0.32103,0 -0.52352,-0.11853 -0.2025,-0.12348 -0.30127,-0.3556 -0.0938,-0.23707 -0.0938,-0.56798 v -0.85936 q 0,-0.34079 0.0938,-0.57291 0.0988,-0.23213 0.30127,-0.35067 0.20743,-0.11853 0.52352,-0.11853 0.34078,0 0.52846,0.12841 0.19262,0.12841 0.27164,0.37536 0.084,0.242 0.084,0.59266 v 0.40499 h -1.13594 v 0.56304 q 0,0.13829 0.0247,0.22719 0.0296,0.0889 0.0889,0.12841 0.0593,0.0395 0.14323,0.0395 0.0889,0 0.14323,-0.0395 0.0543,-0.0445 0.079,-0.12348 0.0247,-0.084 0.0247,-0.20743 v -0.23707 h 0.62724 v 0.19262 q 0,0.43462 -0.21731,0.66675 -0.21731,0.23213 -0.66181,0.23213 z m -0.25188,-1.77306 h 0.50376 v -0.27164 q 0,-0.14817 -0.0247,-0.23707 -0.0247,-0.0938 -0.079,-0.13335 -0.0543,-0.0445 -0.15311,-0.0445 -0.0889,0 -0.14323,0.0445 -0.0543,0.0444 -0.079,0.14817 -0.0247,0.10372 -0.0247,0.29633 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4910"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 273.97721,149.04311 v -0.45438 h 1.19027 v 0.45438 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4912"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 275.70813,151.36933 v -3.79307 h 0.67169 v 0.21731 q 0.12348,-0.11853 0.27164,-0.18768 0.14817,-0.0741 0.31115,-0.0741 0.19262,0 0.31609,0.0889 0.12347,0.0889 0.19262,0.23707 0.0691,0.14323 0.0938,0.31115 0.0296,0.16298 0.0296,0.31609 v 0.96802 q 0,0.28152 -0.0691,0.51364 -0.0642,0.23213 -0.21238,0.37042 -0.14322,0.13829 -0.38523,0.13829 -0.15311,0 -0.29139,-0.0741 -0.13335,-0.0741 -0.25683,-0.18768 v 1.1557 z m 0.96803,-1.36314 q 0.10865,0 0.15804,-0.0691 0.0543,-0.0741 0.0691,-0.19262 0.0197,-0.12347 0.0197,-0.2667 v -1.02235 q 0,-0.13335 -0.0197,-0.23706 -0.0198,-0.10866 -0.0741,-0.17286 -0.0543,-0.0642 -0.15804,-0.0642 -0.079,0 -0.15805,0.0395 -0.0741,0.0346 -0.13335,0.084 v 1.8027 q 0.0642,0.0445 0.13829,0.0741 0.0741,0.0247 0.15805,0.0247 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4914"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 278.07664,150.43094 v -2.85468 h 0.67169 v 0.43956 q 0.14817,-0.25188 0.29633,-0.36054 0.14817,-0.11359 0.32597,-0.11359 0.0296,0 0.0494,0.005 0.0247,0 0.0543,0.005 v 0.69638 q -0.0593,-0.0247 -0.13335,-0.0395 -0.0692,-0.0198 -0.14323,-0.0198 -0.13335,0 -0.24201,0.0642 -0.10865,0.0642 -0.20743,0.21237 v 1.96568 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4916"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 280.65281,150.47539 q -0.31115,0 -0.51364,-0.1136 -0.2025,-0.11853 -0.30621,-0.34078 -0.0988,-0.22225 -0.0988,-0.53834 v -0.95814 q 0,-0.31609 0.0988,-0.53834 0.10371,-0.22225 0.30621,-0.33585 0.20249,-0.11853 0.51364,-0.11853 0.31115,0 0.51365,0.11853 0.20743,0.1136 0.30621,0.33585 0.10371,0.22225 0.10371,0.53834 v 0.95814 q 0,0.31609 -0.10371,0.53834 -0.0988,0.22225 -0.30621,0.34078 -0.2025,0.1136 -0.51365,0.1136 z m 0.005,-0.46426 q 0.11359,0 0.16792,-0.0642 0.0543,-0.0642 0.0691,-0.17286 0.0148,-0.1136 0.0148,-0.24695 v -1.04704 q 0,-0.13335 -0.0148,-0.24201 -0.0148,-0.10865 -0.0691,-0.17286 -0.0543,-0.0691 -0.16792,-0.0691 -0.11359,0 -0.16792,0.0691 -0.0543,0.0642 -0.0741,0.17286 -0.0148,0.10866 -0.0148,0.24201 v 1.04704 q 0,0.13335 0.0148,0.24695 0.0198,0.10865 0.0741,0.17286 0.0543,0.0642 0.16792,0.0642 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4918"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 281.8383,150.43094 0.6223,-1.536 -0.59761,-1.31868 h 0.66182 l 0.36053,0.79022 0.31609,-0.79022 h 0.57291 l -0.60748,1.41252 0.65193,1.44216 h -0.66675 l -0.39511,-0.87418 -0.3309,0.87418 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4920"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 284.12014,151.20634 v -0.48401 q 0.17286,0 0.28152,-0.0197 0.10866,-0.0198 0.15804,-0.0692 0.0494,-0.0494 0.0494,-0.13829 0,-0.0642 -0.0346,-0.20249 -0.0296,-0.13829 -0.0691,-0.30127 l -0.62724,-2.41512 h 0.65193 l 0.37042,1.88172 0.32103,-1.88172 h 0.64699 l -0.66675,2.96827 q -0.0543,0.25189 -0.18274,0.39511 -0.12841,0.14323 -0.32103,0.2025 -0.19261,0.0642 -0.44944,0.0642 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4922"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="L2ForwardingOutTable
+#110"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4304">
+      <path
+         d="m 198.95217,190.99077 v -4.0005 h 0.73095 v 3.49673 h 0.96803 v 0.50377 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4925"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 200.8984,190.99077 v -0.48401 l 0.98778,-1.52612 q 0.10865,-0.16792 0.20249,-0.32103 0.0988,-0.1531 0.15805,-0.31609 0.0642,-0.16792 0.0642,-0.36547 0,-0.22225 -0.079,-0.34079 -0.079,-0.11853 -0.24694,-0.11853 -0.15805,0 -0.24695,0.0889 -0.0889,0.0889 -0.12347,0.23213 -0.0296,0.14323 -0.0296,0.31609 v 0.16792 h -0.67169 v -0.1778 q 0,-0.3556 0.10371,-0.6223 0.10866,-0.27164 0.34079,-0.42475 0.23212,-0.1531 0.60748,-0.1531 0.51364,0 0.77047,0.27658 0.25682,0.27657 0.25682,0.77046 0,0.24695 -0.0692,0.44944 -0.0691,0.19756 -0.18273,0.3803 -0.1136,0.18274 -0.24695,0.37535 l -0.81985,1.2446 h 1.21496 v 0.54822 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4927"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 203.44733,190.99077 v -4.0005 h 1.64465 v 0.50377 h -0.91369 v 1.16557 h 0.74577 v 0.50871 h -0.74577 v 1.82245 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4929"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 206.27361,191.03522 q -0.31115,0 -0.51365,-0.1136 -0.20249,-0.11853 -0.30621,-0.34078 -0.0988,-0.22225 -0.0988,-0.53834 v -0.95814 q 0,-0.31609 0.0988,-0.53834 0.10372,-0.22225 0.30621,-0.33585 0.2025,-0.11853 0.51365,-0.11853 0.31115,0 0.51364,0.11853 0.20744,0.1136 0.30621,0.33585 0.10372,0.22225 0.10372,0.53834 v 0.95814 q 0,0.31609 -0.10372,0.53834 -0.0988,0.22225 -0.30621,0.34078 -0.20249,0.1136 -0.51364,0.1136 z m 0.005,-0.46426 q 0.11359,0 0.16792,-0.0642 0.0543,-0.0642 0.0691,-0.17286 0.0148,-0.1136 0.0148,-0.24695 v -1.04704 q 0,-0.13335 -0.0148,-0.24201 -0.0148,-0.10865 -0.0691,-0.17286 -0.0543,-0.0691 -0.16792,-0.0691 -0.1136,0 -0.16792,0.0691 -0.0543,0.0642 -0.0741,0.17286 -0.0148,0.10866 -0.0148,0.24201 v 1.04704 q 0,0.13335 0.0148,0.24695 0.0198,0.10865 0.0741,0.17286 0.0543,0.0642 0.16792,0.0642 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4931"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 207.6717,190.99077 v -2.85468 h 0.67169 v 0.43956 q 0.14817,-0.25188 0.29633,-0.36054 0.14817,-0.11359 0.32597,-0.11359 0.0296,0 0.0494,0.005 0.0247,0 0.0543,0.005 v 0.69638 q -0.0593,-0.0247 -0.13335,-0.0395 -0.0692,-0.0198 -0.14323,-0.0198 -0.13335,0 -0.24201,0.0642 -0.10865,0.0642 -0.20743,0.21237 v 1.96568 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4933"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 209.70413,190.99077 -0.43956,-2.85468 h 0.55809 l 0.25189,1.85208 0.29633,-1.85208 h 0.49883 l 0.28151,1.87184 0.27164,-1.87184 h 0.52846 l -0.44943,2.85468 h -0.56798 l -0.31609,-1.8027 -0.3309,1.8027 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4935"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 212.87883,191.03522 q -0.19261,0 -0.3309,-0.0988 -0.13829,-0.10372 -0.21238,-0.25682 -0.0741,-0.15805 -0.0741,-0.32597 0,-0.2667 0.0988,-0.44944 0.0988,-0.18274 0.26176,-0.30621 0.16298,-0.12347 0.37042,-0.21237 0.20743,-0.0938 0.4198,-0.16792 v -0.24695 q 0,-0.12347 -0.0197,-0.20743 -0.0148,-0.084 -0.0642,-0.12841 -0.0445,-0.0444 -0.14323,-0.0444 -0.084,0 -0.13829,0.0395 -0.0494,0.0395 -0.0741,0.11359 -0.0197,0.0692 -0.0247,0.16299 l -0.01,0.17286 -0.63712,-0.0247 q 0.0148,-0.49388 0.24201,-0.72601 0.23213,-0.23707 0.70132,-0.23707 0.42968,0 0.6223,0.23707 0.19756,0.23706 0.19756,0.64205 v 1.31869 q 0,0.15804 0.005,0.28645 0.01,0.12841 0.0198,0.23213 0.0148,0.10372 0.0247,0.18274 h -0.60254 q -0.0148,-0.0988 -0.0395,-0.22225 -0.0198,-0.12841 -0.0296,-0.18768 -0.0494,0.17286 -0.18768,0.31609 -0.13829,0.13829 -0.37536,0.13829 z m 0.24695,-0.49883 q 0.0642,0 0.11853,-0.0296 0.0593,-0.0346 0.10372,-0.079 0.0445,-0.0445 0.0642,-0.079 v -0.79516 q -0.10865,0.0642 -0.20743,0.12841 -0.0938,0.0642 -0.16792,0.14323 -0.0692,0.0741 -0.10866,0.16298 -0.0346,0.0889 -0.0346,0.20744 0,0.15804 0.0593,0.25188 0.0642,0.0889 0.17286,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4937"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 214.56878,190.99077 v -2.85468 h 0.67169 v 0.43956 q 0.14817,-0.25188 0.29633,-0.36054 0.14817,-0.11359 0.32597,-0.11359 0.0296,0 0.0494,0.005 0.0247,0 0.0543,0.005 v 0.69638 q -0.0593,-0.0247 -0.13335,-0.0395 -0.0691,-0.0198 -0.14323,-0.0198 -0.13335,0 -0.24201,0.0642 -0.10865,0.0642 -0.20743,0.21237 v 1.96568 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4939"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 216.9227,191.03522 q -0.34078,0 -0.51858,-0.24201 -0.17286,-0.242 -0.17286,-0.7754 v -0.87419 q 0,-0.29633 0.0642,-0.5334 0.0692,-0.23706 0.21732,-0.37535 0.14816,-0.14323 0.40005,-0.14323 0.1531,0 0.28151,0.0642 0.13335,0.0593 0.24201,0.15804 v -1.32362 h 0.67169 v 4.0005 h -0.67169 v -0.2025 q -0.1136,0.1136 -0.24201,0.18274 -0.12841,0.0642 -0.27164,0.0642 z m 0.24695,-0.46426 q 0.0543,0 0.12347,-0.0247 0.0691,-0.0247 0.14323,-0.0691 v -1.83232 q -0.0593,-0.0395 -0.12841,-0.0642 -0.0692,-0.0296 -0.14323,-0.0296 -0.14323,0 -0.2025,0.13335 -0.0543,0.12841 -0.0543,0.31609 v 1.0668 q 0,0.14322 0.0197,0.25682 0.0198,0.11359 0.0741,0.18274 0.0593,0.0642 0.16792,0.0642 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4941"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 218.6348,190.99077 v -2.85468 h 0.67169 v 2.85468 z m 0,-3.30906 v -0.55809 h 0.67169 v 0.55809 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4943"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 219.84012,190.99077 v -2.85468 h 0.67169 v 0.28646 q 0.1531,-0.14817 0.32103,-0.23707 0.17286,-0.0938 0.37041,-0.0938 0.1778,0 0.28152,0.0889 0.10372,0.084 0.15311,0.22719 0.0494,0.14323 0.0494,0.31115 v 2.27189 h -0.67169 v -2.13854 q 0,-0.12841 -0.0395,-0.19756 -0.0395,-0.0691 -0.1531,-0.0691 -0.0692,0 -0.15311,0.0395 -0.079,0.0395 -0.15804,0.0988 v 2.26695 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4945"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 223.02377,191.92916 q -0.29139,0 -0.51364,-0.0593 -0.22225,-0.0593 -0.34572,-0.18274 -0.12348,-0.12347 -0.12348,-0.32103 0,-0.13335 0.0543,-0.242 0.0593,-0.10372 0.15805,-0.18274 0.0988,-0.079 0.21237,-0.13335 -0.16298,-0.0445 -0.25188,-0.14323 -0.084,-0.0988 -0.084,-0.23706 0,-0.16793 0.084,-0.28646 0.084,-0.11853 0.23212,-0.25188 -0.1531,-0.12348 -0.23212,-0.30621 -0.0741,-0.18768 -0.0741,-0.48895 0,-0.32597 0.10372,-0.54822 0.10865,-0.22719 0.31115,-0.34078 0.20743,-0.1136 0.50377,-0.1136 0.22718,0 0.38029,0.0691 0.15311,0.0642 0.25188,0.19755 0.0395,-0.0593 0.13829,-0.14817 0.0988,-0.0889 0.22719,-0.14816 l 0.0889,-0.0395 0.16298,0.36054 q -0.0543,0.0148 -0.14816,0.0494 -0.0889,0.0346 -0.1778,0.0741 -0.0889,0.0395 -0.13829,0.0691 0.0445,0.0988 0.0741,0.24695 0.0296,0.14816 0.0296,0.28151 0,0.30128 -0.0938,0.52353 -0.0938,0.22225 -0.2914,0.34572 -0.19261,0.11853 -0.50376,0.11853 -0.10372,0 -0.2025,-0.0148 -0.0988,-0.0197 -0.18274,-0.0444 -0.0296,0.0444 -0.0593,0.0938 -0.0247,0.0494 -0.0247,0.10372 0,0.0543 0.0593,0.0889 0.0593,0.0346 0.19755,0.0494 l 0.60255,0.0593 q 0.35066,0.0346 0.51858,0.22225 0.16792,0.18273 0.16792,0.49882 0,0.25683 -0.11853,0.42969 -0.11359,0.17286 -0.36054,0.26176 -0.242,0.0889 -0.63218,0.0889 z m 0.0741,-0.50377 q 0.27657,0 0.41486,-0.0543 0.13829,-0.0543 0.13829,-0.19755 0,-0.079 -0.0346,-0.12841 -0.0346,-0.0494 -0.12347,-0.079 -0.0889,-0.0346 -0.25189,-0.0494 l -0.48895,-0.0444 q -0.0543,0.0444 -0.0988,0.0938 -0.0395,0.0445 -0.0642,0.0988 -0.0247,0.0543 -0.0247,0.1136 0,0.12347 0.11853,0.18274 0.11853,0.0642 0.41487,0.0642 z m -0.0395,-1.76318 q 0.0889,0 0.14322,-0.0296 0.0543,-0.0346 0.084,-0.10371 0.0296,-0.0741 0.0395,-0.18274 0.01,-0.10866 0.01,-0.25188 0,-0.14323 -0.01,-0.25189 -0.01,-0.10865 -0.0395,-0.18274 -0.0247,-0.0741 -0.079,-0.10865 -0.0543,-0.0346 -0.14816,-0.0346 -0.0889,0 -0.14817,0.0346 -0.0543,0.0346 -0.084,0.10865 -0.0247,0.0692 -0.0395,0.1778 -0.01,0.10866 -0.01,0.25683 0,0.13828 0.01,0.24694 0.01,0.10372 0.0395,0.1778 0.0296,0.0691 0.084,0.10866 0.0593,0.0346 0.14817,0.0346 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4947"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 225.63027,191.0451 q -0.42474,0 -0.67662,-0.15805 -0.25189,-0.15804 -0.36054,-0.45438 -0.10866,-0.29633 -0.10866,-0.70132 v -1.49648 q 0,-0.40499 0.10866,-0.69145 0.10865,-0.29139 0.36054,-0.4445 0.25188,-0.1531 0.67662,-0.1531 0.43463,0 0.68157,0.1531 0.25188,0.15311 0.36054,0.4445 0.11359,0.28646 0.11359,0.69145 v 1.50142 q 0,0.40005 -0.11359,0.69638 -0.10866,0.2914 -0.36054,0.45438 -0.24694,0.15805 -0.68157,0.15805 z m 0,-0.53834 q 0.18274,0 0.2667,-0.079 0.0889,-0.079 0.11854,-0.21732 0.0296,-0.13828 0.0296,-0.30127 v -1.8422 q 0,-0.16793 -0.0296,-0.30128 -0.0296,-0.13335 -0.11854,-0.20743 -0.084,-0.079 -0.2667,-0.079 -0.17286,0 -0.26176,0.079 -0.0889,0.0741 -0.11853,0.20743 -0.0296,0.13335 -0.0296,0.30128 v 1.8422 q 0,0.16299 0.0247,0.30127 0.0296,0.13829 0.11853,0.21732 0.0889,0.079 0.2667,0.079 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4949"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 227.73671,191.03522 q -0.16792,0 -0.27658,-0.084 -0.10866,-0.0889 -0.15804,-0.23213 -0.0494,-0.14817 -0.0494,-0.31115 v -2.27189 h 0.67169 v 2.14842 q 0,0.12841 0.0395,0.20249 0.0445,0.0692 0.15804,0.0692 0.0741,0 0.14817,-0.0395 0.079,-0.0395 0.1531,-0.0938 v -2.28671 h 0.67169 v 2.85468 h -0.67169 v -0.27164 q -0.14322,0.13829 -0.31609,0.22719 -0.17286,0.0889 -0.37041,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4951"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 230.43658,191.02534 q -0.27164,0 -0.42968,-0.0889 -0.15311,-0.0889 -0.21731,-0.25682 -0.0642,-0.16792 -0.0642,-0.40005 v -1.69898 h -0.28645 v -0.4445 h 0.28645 v -0.85443 h 0.67663 v 0.85443 h 0.43462 v 0.4445 h -0.43462 v 1.63971 q 0,0.14817 0.0642,0.21237 0.0642,0.0593 0.19261,0.0593 0.0543,0 0.10372,-0.005 0.0543,-0.005 0.10372,-0.01 v 0.51365 q -0.084,0.01 -0.19756,0.0198 -0.10866,0.0148 -0.23213,0.0148 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4953"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 231.69616,190.99077 v -3.46216 h -0.63712 v -0.53834 h 1.99531 v 0.53834 h -0.62724 v 3.46216 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4955"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 233.62795,191.03522 q -0.19261,0 -0.3309,-0.0988 -0.13829,-0.10372 -0.21237,-0.25682 -0.0741,-0.15805 -0.0741,-0.32597 0,-0.2667 0.0988,-0.44944 0.0988,-0.18274 0.26176,-0.30621 0.16299,-0.12347 0.37042,-0.21237 0.20743,-0.0938 0.4198,-0.16792 v -0.24695 q 0,-0.12347 -0.0197,-0.20743 -0.0148,-0.084 -0.0642,-0.12841 -0.0445,-0.0444 -0.14322,-0.0444 -0.084,0 -0.13829,0.0395 -0.0494,0.0395 -0.0741,0.11359 -0.0197,0.0692 -0.0247,0.16299 l -0.01,0.17286 -0.63712,-0.0247 q 0.0148,-0.49388 0.24201,-0.72601 0.23213,-0.23707 0.70132,-0.23707 0.42969,0 0.6223,0.23707 0.19756,0.23706 0.19756,0.64205 v 1.31869 q 0,0.15804 0.005,0.28645 0.01,0.12841 0.0197,0.23213 0.0148,0.10372 0.0247,0.18274 h -0.60255 q -0.0148,-0.0988 -0.0395,-0.22225 -0.0197,-0.12841 -0.0296,-0.18768 -0.0494,0.17286 -0.18768,0.31609 -0.13829,0.13829 -0.37536,0.13829 z m 0.24695,-0.49883 q 0.0642,0 0.11853,-0.0296 0.0593,-0.0346 0.10372,-0.079 0.0445,-0.0445 0.0642,-0.079 v -0.79516 q -0.10865,0.0642 -0.20743,0.12841 -0.0938,0.0642 -0.16792,0.14323 -0.0692,0.0741 -0.10866,0.16298 -0.0346,0.0889 -0.0346,0.20744 0,0.15804 0.0593,0.25188 0.0642,0.0889 0.17286,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4957"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 236.53287,191.03522 q -0.15805,0 -0.29633,-0.0741 -0.13829,-0.0741 -0.25683,-0.18274 v 0.21237 h -0.67169 v -4.0005 h 0.67169 v 1.36313 q 0.12348,-0.11853 0.2667,-0.18768 0.14817,-0.0741 0.31609,-0.0741 0.19262,0 0.31609,0.0889 0.12347,0.0889 0.19262,0.23707 0.0691,0.14323 0.0938,0.31115 0.0296,0.16298 0.0296,0.31609 v 0.96802 q 0,0.28152 -0.0691,0.51364 -0.0642,0.23213 -0.21238,0.37042 -0.14322,0.13829 -0.38029,0.13829 z m -0.25682,-0.4692 q 0.10865,0 0.15804,-0.0691 0.0543,-0.0741 0.0692,-0.19262 0.0197,-0.12347 0.0197,-0.2667 v -1.02235 q 0,-0.13335 -0.0197,-0.23706 -0.0198,-0.10866 -0.0741,-0.17286 -0.0494,-0.0642 -0.15804,-0.0642 -0.079,0 -0.15311,0.0395 -0.0741,0.0346 -0.13829,0.079 v 1.8027 q 0.0642,0.0445 0.13829,0.0741 0.079,0.0296 0.15805,0.0296 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4959"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 237.70123,190.99077 v -4.0005 h 0.66675 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4961"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 239.76545,191.03522 q -0.32103,0 -0.52352,-0.11853 -0.20249,-0.12348 -0.30127,-0.3556 -0.0938,-0.23707 -0.0938,-0.56798 v -0.85936 q 0,-0.34079 0.0938,-0.57291 0.0988,-0.23213 0.30127,-0.35067 0.20743,-0.11853 0.52352,-0.11853 0.34079,0 0.52846,0.12841 0.19262,0.12841 0.27164,0.37536 0.084,0.242 0.084,0.59266 v 0.40499 h -1.13594 v 0.56304 q 0,0.13829 0.0247,0.22719 0.0296,0.0889 0.0889,0.12841 0.0593,0.0395 0.14323,0.0395 0.0889,0 0.14323,-0.0395 0.0543,-0.0444 0.079,-0.12348 0.0247,-0.084 0.0247,-0.20743 v -0.23707 h 0.62723 v 0.19262 q 0,0.43462 -0.21731,0.66675 -0.21731,0.23213 -0.66181,0.23213 z m -0.25188,-1.77306 h 0.50377 v -0.27164 q 0,-0.14817 -0.0247,-0.23707 -0.0247,-0.0938 -0.079,-0.13335 -0.0543,-0.0445 -0.15311,-0.0445 -0.0889,0 -0.14322,0.0445 -0.0543,0.0444 -0.079,0.14817 -0.0247,0.10372 -0.0247,0.29633 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4963"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 215.48977,197.16438 0.1778,-1.37795 h -0.24201 l 0.005,-0.44944 h 0.30127 l 0.0691,-0.52846 h -0.36054 l 0.005,-0.45932 h 0.42968 l 0.15311,-1.18533 h 0.52352 l -0.15311,1.18533 h 0.40993 l 0.15805,-1.18533 h 0.51858 l -0.15804,1.18533 h 0.23706 l -0.01,0.45932 h -0.29633 l -0.0691,0.52846 h 0.35066 l -0.005,0.44944 h -0.40993 l -0.18274,1.37795 h -0.52352 l 0.18274,-1.37795 h -0.40993 l -0.1778,1.37795 z m 0.76059,-1.82739 h 0.41486 l 0.0692,-0.52846 h -0.40993 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4965"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 218.5011,197.16438 v -3.24485 q -0.0296,0.0148 -0.11853,0.0444 -0.084,0.0296 -0.18768,0.0593 -0.10372,0.0247 -0.19262,0.0494 -0.084,0.0247 -0.11853,0.0395 v -0.50871 q 0.0692,-0.0247 0.17286,-0.0691 0.10372,-0.0445 0.21731,-0.0988 0.11854,-0.0593 0.21731,-0.12841 0.10372,-0.0692 0.16793,-0.14323 h 0.52352 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4967"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 220.44,197.16438 v -3.24485 q -0.0296,0.0148 -0.11853,0.0444 -0.084,0.0296 -0.18768,0.0593 -0.10372,0.0247 -0.19262,0.0494 -0.084,0.0247 -0.11853,0.0395 v -0.50871 q 0.0691,-0.0247 0.17286,-0.0691 0.10372,-0.0445 0.21731,-0.0988 0.11854,-0.0593 0.21731,-0.12841 0.10372,-0.0692 0.16793,-0.14323 h 0.52352 v 4.0005 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4969"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 222.95181,197.22365 q -0.35066,0 -0.58279,-0.14817 -0.22719,-0.14817 -0.34572,-0.40993 -0.11359,-0.26176 -0.11359,-0.60254 v -1.77306 q 0,-0.35066 0.10865,-0.61243 0.1136,-0.2667 0.34079,-0.41486 0.23212,-0.14817 0.59266,-0.14817 0.36054,0 0.58773,0.14817 0.23213,0.14816 0.34078,0.41486 0.1136,0.26177 0.1136,0.61243 v 1.77306 q 0,0.34078 -0.11854,0.60254 -0.11359,0.26176 -0.34572,0.40993 -0.22719,0.14817 -0.57785,0.14817 z m 0,-0.58773 q 0.15311,0 0.22719,-0.0938 0.0741,-0.0938 0.0988,-0.22719 0.0247,-0.13335 0.0247,-0.26176 v -1.75331 q 0,-0.13828 -0.0247,-0.27163 -0.0198,-0.13829 -0.0938,-0.23213 -0.0741,-0.0938 -0.23213,-0.0938 -0.15804,0 -0.23213,0.0938 -0.0741,0.0938 -0.0988,0.23213 -0.0198,0.13335 -0.0198,0.27163 v 1.75331 q 0,0.12841 0.0247,0.26176 0.0296,0.13335 0.10371,0.22719 0.0741,0.0938 0.22225,0.0938 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4971"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="drop"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text4308">
+      <path
+         d="m 152.50398,150.99925 q -0.34078,0 -0.51858,-0.242 -0.17286,-0.24201 -0.17286,-0.77541 v -0.87418 q 0,-0.29633 0.0642,-0.5334 0.0691,-0.23707 0.21732,-0.37536 0.14816,-0.14322 0.40005,-0.14322 0.1531,0 0.28151,0.0642 0.13335,0.0593 0.24201,0.15805 v -1.32363 h 0.67169 v 4.0005 h -0.67169 v -0.20249 q -0.1136,0.11359 -0.24201,0.18274 -0.12841,0.0642 -0.27164,0.0642 z m 0.24695,-0.46425 q 0.0543,0 0.12347,-0.0247 0.0691,-0.0247 0.14323,-0.0691 v -1.83233 q -0.0593,-0.0395 -0.12841,-0.0642 -0.0692,-0.0296 -0.14323,-0.0296 -0.14323,0 -0.2025,0.13335 -0.0543,0.12841 -0.0543,0.31609 v 1.0668 q 0,0.14323 0.0197,0.25682 0.0198,0.1136 0.0741,0.18274 0.0593,0.0642 0.16792,0.0642 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4974"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 154.21114,150.9548 v -2.85467 h 0.67169 v 0.43956 q 0.14817,-0.25189 0.29633,-0.36054 0.14817,-0.1136 0.32597,-0.1136 0.0296,0 0.0494,0.005 0.0247,0 0.0543,0.005 v 0.69638 q -0.0593,-0.0247 -0.13335,-0.0395 -0.0692,-0.0198 -0.14323,-0.0198 -0.13335,0 -0.24201,0.0642 -0.10865,0.0642 -0.20743,0.21238 v 1.96567 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4976"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 156.78731,150.99925 q -0.31115,0 -0.51364,-0.11359 -0.2025,-0.11853 -0.30621,-0.34078 -0.0988,-0.22225 -0.0988,-0.53834 v -0.95815 q 0,-0.31609 0.0988,-0.53834 0.10371,-0.22225 0.30621,-0.33584 0.20249,-0.11853 0.51364,-0.11853 0.31115,0 0.51365,0.11853 0.20743,0.11359 0.30621,0.33584 0.10371,0.22225 0.10371,0.53834 v 0.95815 q 0,0.31609 -0.10371,0.53834 -0.0988,0.22225 -0.30621,0.34078 -0.2025,0.11359 -0.51365,0.11359 z m 0.005,-0.46425 q 0.1136,0 0.16792,-0.0642 0.0543,-0.0642 0.0692,-0.17286 0.0148,-0.11359 0.0148,-0.24694 v -1.04705 q 0,-0.13335 -0.0148,-0.242 -0.0148,-0.10866 -0.0692,-0.17286 -0.0543,-0.0692 -0.16792,-0.0692 -0.11359,0 -0.16792,0.0692 -0.0543,0.0642 -0.0741,0.17286 -0.0148,0.10865 -0.0148,0.242 v 1.04705 q 0,0.13335 0.0148,0.24694 0.0197,0.10866 0.0741,0.17286 0.0543,0.0642 0.16792,0.0642 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4978"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 158.17059,151.89319 v -3.79306 h 0.67169 v 0.21731 q 0.12347,-0.11854 0.27163,-0.18768 0.14817,-0.0741 0.31115,-0.0741 0.19262,0 0.31609,0.0889 0.12348,0.0889 0.19262,0.23706 0.0691,0.14323 0.0938,0.31115 0.0296,0.16299 0.0296,0.31609 v 0.96802 q 0,0.28152 -0.0691,0.51365 -0.0642,0.23213 -0.21237,0.37041 -0.14323,0.13829 -0.38524,0.13829 -0.1531,0 -0.29139,-0.0741 -0.13335,-0.0741 -0.25682,-0.18768 v 1.1557 z m 0.96802,-1.36313 q 0.10865,0 0.15804,-0.0691 0.0543,-0.0741 0.0692,-0.19261 0.0197,-0.12347 0.0197,-0.2667 v -1.02235 q 0,-0.13335 -0.0197,-0.23707 -0.0198,-0.10865 -0.0741,-0.17286 -0.0543,-0.0642 -0.15804,-0.0642 -0.079,0 -0.15804,0.0395 -0.0741,0.0346 -0.13335,0.084 v 1.80269 q 0.0642,0.0445 0.13828,0.0741 0.0741,0.0247 0.15805,0.0247 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.93888903px;font-family:Oswald;-inkscape-font-specification:'Oswald, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         id="path4980"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="TextConnectors"
+     style="display:none"
+     sodipodi:insensitive="true">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="47.851784"
+       y="70.753571"
+       id="text923"><tspan
+         sodipodi:role="line"
+         id="tspan921"
+         x="47.851784"
+         y="70.753571"
+         style="stroke-width:0.26458332">from tunnel</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="48.380951"
+       y="46.714283"
+       id="text919"><tspan
+         sodipodi:role="line"
+         id="tspan917"
+         x="48.380951"
+         y="46.714283"
+         style="stroke-width:0.26458332">from local</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="111.125"
+       y="38.020832"
+       id="text927"><tspan
+         sodipodi:role="line"
+         id="tspan925"
+         x="111.125"
+         y="38.020832"
+         style="stroke-width:0.26458332">ARP</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="113.01487"
+       y="54.198215"
+       id="text931"><tspan
+         sodipodi:role="line"
+         id="tspan929"
+         x="113.01487"
+         y="54.198215"
+         style="stroke-width:0.26458332">IP</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="78.46785"
+       y="38.398811"
+       id="text948"><tspan
+         sodipodi:role="line"
+         id="tspan946"
+         x="78.46785"
+         y="38.398811"
+         style="stroke-width:0.26458332">&amp; spoof traffic</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="76.351189"
+       y="32.653576"
+       id="text952"><tspan
+         sodipodi:role="line"
+         id="tspan950"
+         x="76.351189"
+         y="32.653576"
+         style="stroke-width:0.26458332">non-IP, non-ARP</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="142.49702"
+       y="105.67856"
+       id="text960"><tspan
+         sodipodi:role="line"
+         id="tspan958"
+         x="142.49702"
+         y="105.67856"
+         style="stroke-width:0.26458332">whitelisted traffic</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="184.15001"
+       y="120.04166"
+       id="text964"><tspan
+         sodipodi:role="line"
+         id="tspan962"
+         x="184.15001"
+         y="120.04166"
+         style="stroke-width:0.26458332">miss</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="160.86668"
+       y="138.18452"
+       id="text968"><tspan
+         sodipodi:role="line"
+         id="tspan966"
+         x="160.86668"
+         y="138.18452"
+         style="stroke-width:0.26458332">from isolated Pod</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="66.901764"
+       y="162.97977"
+       id="text972"><tspan
+         sodipodi:role="line"
+         id="tspan970"
+         x="66.901764"
+         y="162.97977"
+         style="stroke-width:0.26458332">to isolated Pod</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="224.59279"
+       y="178.55234"
+       id="text976"><tspan
+         sodipodi:role="line"
+         id="tspan974"
+         x="224.59279"
+         y="178.55234"
+         style="stroke-width:0.26458332">output port known</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="242.28218"
+       y="205.08627"
+       id="text980"><tspan
+         sodipodi:role="line"
+         id="tspan978"
+         x="242.28218"
+         y="205.08627"
+         style="stroke-width:0.26458332">miss</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="81.189278"
+       y="197.90475"
+       id="text960-4"><tspan
+         sodipodi:role="line"
+         id="tspan958-7"
+         x="81.189278"
+         y="197.90475"
+         style="stroke-width:0.26458332">whitelisted traffic</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="56.696434"
+       y="181.2738"
+       id="text964-7"><tspan
+         sodipodi:role="line"
+         id="tspan962-3"
+         x="56.696434"
+         y="181.2738"
+         style="stroke-width:0.26458332">miss</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="205.24107"
+       y="49.738094"
+       id="text1020"><tspan
+         sodipodi:role="line"
+         id="tspan1018"
+         x="205.24107"
+         y="49.738094"
+         style="stroke-width:0.26458332">conntrack invalid</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="268.3631"
+       y="96.229164"
+       id="text1068"><tspan
+         sodipodi:role="line"
+         id="tspan1066"
+         x="268.3631"
+         y="96.229164"
+         style="stroke-width:0.26458332">service traffic</tspan></text>
+    <text
+       id="text3157"
+       y="123.27631"
+       x="88.501503"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.26458332"
+         y="123.27631"
+         x="88.501503"
+         id="tspan3155"
+         sodipodi:role="line">to tunnel</tspan></text>
+  </g>
+  <g
+     style="display:inline"
+     inkscape:label="TextConnectorsPath"
+     id="g1791"
+     inkscape:groupmode="layer"
+     sodipodi:insensitive="true">
+    <g
+       aria-label="from tunnel"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text5333">
+      <path
+         d="m 48.306161,70.753571 v -2.592917 h -0.365477 v -0.261761 h 0.365477 V 67.60256 q 0,-0.212373 0.03457,-0.375356 0.03457,-0.162983 0.143227,-0.256822 0.113595,-0.09384 0.345723,-0.09384 0.07902,0 0.148166,0.0099 0.07408,0.0049 0.143228,0.02469 v 0.2667 q -0.04445,-0.0099 -0.103717,-0.01482 -0.05433,-0.0099 -0.09878,-0.0099 -0.162984,0 -0.207434,0.103716 -0.03951,0.09878 -0.03951,0.31115 v 0.330906 h 0.459317 v 0.261761 h -0.459317 v 2.592917 z"
+         style="stroke-width:0.26458332"
+         id="path5399"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 49.474595,70.753571 v -2.854678 h 0.365477 v 0.390172 q 0.138289,-0.227189 0.316089,-0.321028 0.1778,-0.09878 0.340783,-0.09878 0.01482,0 0.02963,0 0.01482,0 0.03457,0.0049 v 0.385233 q -0.03457,-0.01482 -0.08396,-0.01976 -0.04939,-0.0099 -0.09384,-0.0099 -0.167922,0 -0.306211,0.07902 -0.13335,0.07902 -0.237067,0.251883 V 70.7535 Z"
+         style="stroke-width:0.26458332"
+         id="path5401"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 51.603101,70.798021 q -0.291394,0 -0.459317,-0.123473 -0.167922,-0.128411 -0.237066,-0.365477 -0.06421,-0.242006 -0.06421,-0.587728 v -0.790222 q 0,-0.345723 0.06421,-0.582789 0.06914,-0.242006 0.237066,-0.365478 0.167923,-0.128411 0.459317,-0.128411 0.296333,0 0.459317,0.128411 0.167922,0.123472 0.232127,0.365478 0.06914,0.237066 0.06914,0.582789 v 0.790222 q 0,0.345722 -0.06914,0.587728 -0.06421,0.237066 -0.232127,0.365477 -0.162984,0.123473 -0.459317,0.123473 z m 0,-0.271639 q 0.187678,0 0.271639,-0.09878 0.0889,-0.09878 0.108655,-0.276578 0.01976,-0.1778 0.01976,-0.409928 v -0.829733 q 0,-0.232128 -0.01976,-0.404989 -0.01976,-0.1778 -0.108655,-0.276577 -0.08396,-0.103717 -0.271639,-0.103717 -0.187678,0 -0.271639,0.103717 -0.08396,0.09878 -0.108655,0.276577 -0.01976,0.172861 -0.01976,0.404989 v 0.829733 q 0,0.232128 0.01976,0.409928 0.02469,0.1778 0.108655,0.276578 0.08396,0.09878 0.271639,0.09878 z"
+         style="stroke-width:0.26458332"
+         id="path5403"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 52.864678,70.753571 v -2.854678 h 0.335845 v 0.291394 q 0.143227,-0.167922 0.316088,-0.251883 0.172862,-0.0889 0.3556,-0.0889 0.148167,0 0.271639,0.07902 0.128411,0.07902 0.182739,0.296334 0.143228,-0.187678 0.321028,-0.281517 0.182739,-0.09384 0.380294,-0.09384 0.123473,0 0.232128,0.05927 0.113595,0.05927 0.182739,0.202494 0.06914,0.143228 0.06914,0.390172 v 2.252134 h -0.340783 v -2.242256 q 0,-0.251883 -0.07902,-0.330905 -0.07902,-0.08396 -0.202495,-0.08396 -0.138288,0 -0.276577,0.07902 -0.138289,0.07902 -0.261761,0.217311 0.0049,0.02469 0.0049,0.05433 0,0.02469 0,0.05433 v 2.252134 h -0.335845 v -2.242256 q 0,-0.251883 -0.08396,-0.330905 -0.07902,-0.08396 -0.202494,-0.08396 -0.13335,0 -0.271639,0.07902 -0.138289,0.07902 -0.261761,0.212372 v 2.365728 z"
+         style="stroke-width:0.26458332"
+         id="path5405"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 57.727785,70.788143 q -0.207433,0 -0.321027,-0.07902 -0.113595,-0.08396 -0.153106,-0.22225 -0.03951,-0.143228 -0.03951,-0.325967 V 68.13596 H 56.86348 v -0.237067 h 0.350661 v -0.884061 h 0.360539 v 0.884061 h 0.474133 V 68.13596 H 57.57468 v 1.990372 q 0,0.207433 0.04445,0.296333 0.04939,0.08396 0.207433,0.08396 0.04445,0 0.09878,-0.0049 0.05433,-0.0099 0.103717,-0.01482 v 0.271638 q -0.07408,0.01482 -0.153106,0.01976 -0.07408,0.0099 -0.148167,0.0099 z"
+         style="stroke-width:0.26458332"
+         id="path5407"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 58.85038,70.798021 q -0.143228,0 -0.242006,-0.06915 -0.09878,-0.07408 -0.153105,-0.207433 -0.04939,-0.138289 -0.04939,-0.330906 v -2.291644 h 0.360539 v 2.212622 q 0,0.22225 0.06914,0.316089 0.06914,0.0889 0.207433,0.0889 0.128412,0 0.256823,-0.07902 0.13335,-0.08396 0.246944,-0.207434 V 67.89889 h 0.360539 v 2.854678 h -0.360539 v -0.316089 q -0.138289,0.158044 -0.316089,0.261761 -0.1778,0.09878 -0.380294,0.09878 z"
+         style="stroke-width:0.26458332"
+         id="path5409"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 60.465936,70.753571 v -2.854678 h 0.360539 v 0.296333 q 0.138289,-0.148166 0.31115,-0.242005 0.172861,-0.09878 0.375356,-0.09878 0.143228,0 0.237066,0.07408 0.09878,0.06914 0.148167,0.207434 0.05433,0.13335 0.05433,0.325966 v 2.291645 h -0.360539 v -2.212623 q 0,-0.222249 -0.06914,-0.311149 -0.06914,-0.09384 -0.207434,-0.09384 -0.118533,0 -0.246944,0.07408 -0.128411,0.07408 -0.242006,0.192617 v 2.350911 z"
+         style="stroke-width:0.26458332"
+         id="path5411"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 62.482006,70.753571 v -2.854678 h 0.360539 v 0.296333 q 0.138289,-0.148166 0.31115,-0.242005 0.172861,-0.09878 0.375355,-0.09878 0.143228,0 0.237067,0.07408 0.09878,0.06914 0.148167,0.207434 0.05433,0.13335 0.05433,0.325966 v 2.291645 h -0.360539 v -2.212623 q 0,-0.222249 -0.06914,-0.311149 -0.06914,-0.09384 -0.207433,-0.09384 -0.118534,0 -0.246945,0.07408 -0.128411,0.07408 -0.242005,0.192617 v 2.350911 z"
+         style="stroke-width:0.26458332"
+         id="path5413"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 65.214215,70.798021 q -0.2667,0 -0.439561,-0.103717 -0.167922,-0.108656 -0.251883,-0.3556 -0.07902,-0.246945 -0.07902,-0.656872 v -0.721078 q 0,-0.424744 0.08396,-0.661811 0.08396,-0.242006 0.256822,-0.340783 0.172861,-0.103717 0.429683,-0.103717 0.306211,0 0.464256,0.128411 0.158044,0.128411 0.217311,0.390172 0.06421,0.256822 0.06421,0.661811 v 0.256823 h -1.1557 v 0.498827 q 0,0.276578 0.03951,0.439561 0.04445,0.158045 0.13335,0.227189 0.09384,0.06914 0.237067,0.06914 0.108656,0 0.197556,-0.03951 0.0889,-0.04445 0.138289,-0.162984 0.05433,-0.123472 0.05433,-0.345722 V 69.78061 h 0.350661 v 0.158044 q 0,0.390172 -0.162983,0.627239 -0.162983,0.232128 -0.57785,0.232128 z m -0.409928,-1.713795 h 0.8001 V 68.84716 q 0,-0.227189 -0.02469,-0.385234 -0.0247,-0.162983 -0.108656,-0.246944 -0.07902,-0.0889 -0.256822,-0.0889 -0.148167,0 -0.242005,0.06421 -0.0889,0.06421 -0.128412,0.232128 -0.03951,0.162983 -0.03951,0.469195 z"
+         style="stroke-width:0.26458332"
+         id="path5415"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 66.496011,70.753571 v -4.0005 h 0.360538 v 4.0005 z"
+         style="stroke-width:0.26458332"
+         id="path5417"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="from local"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text5337">
+      <path
+         d="m 48.835329,46.714283 v -2.592916 h -0.365478 v -0.261762 h 0.365478 v -0.296333 q 0,-0.212372 0.03457,-0.375355 0.03457,-0.162984 0.143228,-0.256823 0.113594,-0.09384 0.345722,-0.09384 0.07902,0 0.148167,0.0099 0.07408,0.0049 0.143227,0.0247 v 0.2667 q -0.04445,-0.0099 -0.103716,-0.01482 -0.05433,-0.0099 -0.09878,-0.0099 -0.162983,0 -0.207433,0.103717 -0.03951,0.09878 -0.03951,0.31115 v 0.330905 h 0.459317 v 0.261762 h -0.459317 v 2.592916 z"
+         style="stroke-width:0.26458332"
+         id="path5420"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 50.003762,46.714283 v -2.854678 h 0.365477 v 0.390173 q 0.138289,-0.227189 0.316089,-0.321028 0.1778,-0.09878 0.340784,-0.09878 0.01482,0 0.02963,0 0.01482,0 0.03457,0.0049 v 0.385233 q -0.03457,-0.01482 -0.08396,-0.01975 -0.04939,-0.0099 -0.09384,-0.0099 -0.167922,0 -0.306211,0.07902 -0.13335,0.07902 -0.237067,0.251883 v 2.192867 z"
+         style="stroke-width:0.26458332"
+         id="path5422"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 52.132268,46.758733 q -0.291394,0 -0.459316,-0.123472 -0.167923,-0.128411 -0.237067,-0.365478 -0.06421,-0.242006 -0.06421,-0.587728 v -0.790222 q 0,-0.345722 0.06421,-0.582789 0.06914,-0.242005 0.237067,-0.365477 0.167922,-0.128412 0.459316,-0.128412 0.296333,0 0.459317,0.128412 0.167922,0.123472 0.232128,0.365477 0.06914,0.237067 0.06914,0.582789 v 0.790222 q 0,0.345722 -0.06914,0.587728 -0.06421,0.237067 -0.232128,0.365478 -0.162984,0.123472 -0.459317,0.123472 z m 0,-0.271639 q 0.187678,0 0.271639,-0.09878 0.0889,-0.09878 0.108656,-0.276577 0.01975,-0.1778 0.01975,-0.409928 v -0.829733 q 0,-0.232128 -0.01975,-0.404989 -0.01976,-0.1778 -0.108656,-0.276578 -0.08396,-0.103717 -0.271639,-0.103717 -0.187678,0 -0.271639,0.103717 -0.08396,0.09878 -0.108655,0.276578 -0.01976,0.172861 -0.01976,0.404989 v 0.829733 q 0,0.232128 0.01976,0.409928 0.02469,0.1778 0.108655,0.276577 0.08396,0.09878 0.271639,0.09878 z"
+         style="stroke-width:0.26458332"
+         id="path5424"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 53.393845,46.714283 V 43.859605 H 53.72969 V 44.151 q 0.143228,-0.167922 0.316089,-0.251883 0.172861,-0.0889 0.3556,-0.0889 0.148166,0 0.271639,0.07902 0.128411,0.07902 0.182738,0.296333 0.143228,-0.187678 0.321028,-0.281517 0.182739,-0.09384 0.380295,-0.09384 0.123472,0 0.232127,0.05927 0.113595,0.05927 0.182739,0.202495 0.06914,0.143227 0.06914,0.390172 v 2.252133 h -0.340784 v -2.242255 q 0,-0.251884 -0.07902,-0.330906 -0.07902,-0.08396 -0.202494,-0.08396 -0.138289,0 -0.276578,0.07902 -0.138289,0.07902 -0.261761,0.217311 0.0049,0.0247 0.0049,0.05433 0,0.02469 0,0.05433 v 2.252133 h -0.335845 v -2.242255 q 0,-0.251884 -0.08396,-0.330906 -0.07902,-0.08396 -0.202494,-0.08396 -0.13335,0 -0.271639,0.07902 -0.138289,0.07902 -0.261761,0.212372 v 2.365728 z"
+         style="stroke-width:0.26458332"
+         id="path5426"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 57.629714,46.714283 v -4.0005 h 0.360539 v 4.0005 z"
+         style="stroke-width:0.26458332"
+         id="path5428"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 59.280152,46.758733 q -0.291395,0 -0.459317,-0.123472 -0.167922,-0.128411 -0.237067,-0.365478 -0.06421,-0.242006 -0.06421,-0.587728 v -0.790222 q 0,-0.345722 0.06421,-0.582789 0.06914,-0.242005 0.237067,-0.365477 0.167922,-0.128412 0.459317,-0.128412 0.296333,0 0.459316,0.128412 0.167922,0.123472 0.232128,0.365477 0.06914,0.237067 0.06914,0.582789 v 0.790222 q 0,0.345722 -0.06914,0.587728 -0.06421,0.237067 -0.232128,0.365478 -0.162983,0.123472 -0.459316,0.123472 z m 0,-0.271639 q 0.187677,0 0.271638,-0.09878 0.0889,-0.09878 0.108656,-0.276577 0.01976,-0.1778 0.01976,-0.409928 v -0.829733 q 0,-0.232128 -0.01976,-0.404989 -0.01976,-0.1778 -0.108656,-0.276578 -0.08396,-0.103717 -0.271638,-0.103717 -0.187678,0 -0.271639,0.103717 -0.08396,0.09878 -0.108656,0.276578 -0.01975,0.172861 -0.01975,0.404989 v 0.829733 q 0,0.232128 0.01975,0.409928 0.0247,0.1778 0.108656,0.276577 0.08396,0.09878 0.271639,0.09878 z"
+         style="stroke-width:0.26458332"
+         id="path5430"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 61.247991,46.758733 q -0.330906,0 -0.493889,-0.148167 -0.162983,-0.148166 -0.217311,-0.40005 -0.04939,-0.256822 -0.04939,-0.57785 v -0.66675 q 0,-0.395111 0.06421,-0.646994 0.06421,-0.256822 0.227188,-0.380294 0.167923,-0.123473 0.469195,-0.123473 0.306211,0 0.464255,0.113595 0.158045,0.113594 0.212373,0.321028 0.05433,0.207433 0.05433,0.484011 v 0.13335 h -0.33585 V 44.72885 q 0,-0.251884 -0.03951,-0.390172 -0.03457,-0.138289 -0.123472,-0.192617 -0.08396,-0.05927 -0.227189,-0.05927 -0.167923,0 -0.256823,0.07902 -0.0889,0.07902 -0.118533,0.261762 -0.02963,0.1778 -0.02963,0.479072 v 0.8001 q 0,0.429683 0.08396,0.607483 0.08396,0.172861 0.325967,0.172861 0.167922,0 0.251883,-0.07408 0.08396,-0.07902 0.108655,-0.232128 0.0247,-0.153106 0.0247,-0.380294 v -0.158045 h 0.335844 v 0.138289 q 0,0.286456 -0.05433,0.508706 -0.05433,0.217311 -0.212373,0.345722 -0.153105,0.123472 -0.464255,0.123472 z"
+         style="stroke-width:0.26458332"
+         id="path5432"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 62.950286,46.758733 q -0.167922,0 -0.296333,-0.08396 -0.128412,-0.0889 -0.202495,-0.232128 -0.07408,-0.143228 -0.07408,-0.321028 0,-0.217311 0.06421,-0.370416 0.06421,-0.153106 0.197556,-0.271639 0.138289,-0.123472 0.3556,-0.237067 0.22225,-0.118533 0.538339,-0.261761 V 44.77824 q 0,-0.261761 -0.03457,-0.409928 -0.02963,-0.153106 -0.108656,-0.217311 -0.07408,-0.06421 -0.212372,-0.06421 -0.113595,0 -0.202495,0.04445 -0.0889,0.04445 -0.143227,0.153106 -0.05433,0.103716 -0.05433,0.291394 v 0.09878 l -0.3556,-0.0049 q 0.0049,-0.434622 0.182739,-0.642055 0.182739,-0.212373 0.592666,-0.212373 0.380295,0 0.538339,0.232128 0.158045,0.227189 0.158045,0.7112 v 1.387828 q 0,0.07408 0,0.192616 0.0049,0.113595 0.0099,0.217312 0.0099,0.103716 0.01482,0.158044 H 63.59728 q -0.01482,-0.09384 -0.03457,-0.207433 -0.01482,-0.118534 -0.01976,-0.187678 -0.05927,0.172861 -0.212373,0.306211 -0.148166,0.13335 -0.380294,0.13335 z m 0.118533,-0.306211 q 0.108656,0 0.192617,-0.04939 0.0889,-0.05433 0.158044,-0.13335 0.07408,-0.07902 0.113595,-0.158044 v -0.889 q -0.212372,0.113594 -0.365478,0.202494 -0.148167,0.08396 -0.242006,0.167922 -0.09384,0.08396 -0.138288,0.192617 -0.04445,0.103717 -0.04445,0.246944 0,0.227189 0.09384,0.325967 0.09878,0.09384 0.232128,0.09384 z"
+         style="stroke-width:0.26458332"
+         id="path5434"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 64.468918,46.714283 v -4.0005 h 0.360539 v 4.0005 z"
+         style="stroke-width:0.26458332"
+         id="path5436"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="ARP"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text5341">
+      <path
+         d="m 111.25835,38.020832 0.84455,-4.0005 h 0.39511 l 0.84949,4.0005 h -0.37042 l -0.19755,-1.071739 h -0.95321 l -0.20249,1.071739 z m 0.6223,-1.343378 h 0.84949 l -0.42968,-2.158294 z"
+         style="stroke-width:0.26458332"
+         id="path5439"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 113.79077,38.020832 v -4.0005 h 0.90381 q 0.37536,0 0.58773,0.123473 0.21731,0.118533 0.31115,0.350661 0.0938,0.227189 0.0938,0.543277 0,0.22225 -0.0494,0.419806 -0.0494,0.197555 -0.16792,0.335844 -0.11854,0.138289 -0.33585,0.182739 l 0.61242,2.0447 h -0.36547 l -0.58773,-1.965678 h -0.62724 v 1.965678 z m 0.37535,-2.242255 h 0.50871 q 0.25188,0 0.39017,-0.08396 0.13829,-0.08396 0.19755,-0.246945 0.0593,-0.162983 0.0593,-0.409928 0,-0.370416 -0.12841,-0.553155 -0.12841,-0.182739 -0.50871,-0.182739 h -0.51858 z"
+         style="stroke-width:0.26458332"
+         id="path5441"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 116.29879,38.020832 v -4.0005 h 0.95815 q 0.36054,0 0.56303,0.13335 0.20744,0.13335 0.29634,0.370417 0.0889,0.237067 0.0889,0.558094 0,0.281517 -0.0938,0.523523 -0.0889,0.237066 -0.30128,0.380294 -0.20743,0.143228 -0.54821,0.143228 h -0.58773 v 1.891594 z m 0.37536,-2.173111 h 0.47907 q 0.24201,0 0.39017,-0.06914 0.15311,-0.07408 0.22225,-0.242006 0.0691,-0.167922 0.0691,-0.454378 0,-0.306211 -0.0593,-0.474133 -0.0593,-0.172861 -0.20743,-0.237067 -0.14323,-0.06914 -0.40993,-0.06914 h -0.48401 z"
+         style="stroke-width:0.26458332"
+         id="path5443"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="IP"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text5345">
+      <path
+         d="m 113.37541,54.198215 v -4.000499 h 0.37535 v 4.000499 z"
+         style="stroke-width:0.26458332"
+         id="path5446"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 114.46521,54.198215 v -4.000499 h 0.95814 q 0.36054,0 0.56303,0.13335 0.20744,0.13335 0.29634,0.370416 0.0889,0.237067 0.0889,0.558095 0,0.281516 -0.0938,0.523522 -0.0889,0.237067 -0.30127,0.380294 -0.20744,0.143228 -0.54822,0.143228 h -0.58773 v 1.891594 z m 0.37535,-2.17311 h 0.47907 q 0.24201,0 0.39018,-0.06915 0.1531,-0.07408 0.22225,-0.242005 0.0691,-0.167923 0.0691,-0.454378 0,-0.306211 -0.0593,-0.474134 -0.0593,-0.172861 -0.20743,-0.237066 -0.14323,-0.06914 -0.40993,-0.06914 h -0.48401 z"
+         style="stroke-width:0.26458332"
+         id="path5448"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="&amp; spoof traffic"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text5349">
+      <path
+         d="m 79.672939,38.4482 q -0.306212,0 -0.513645,-0.123472 -0.202494,-0.123472 -0.306211,-0.330906 -0.103717,-0.207433 -0.103717,-0.454377 0,-0.31115 0.153106,-0.592667 0.153105,-0.281517 0.48895,-0.597605 -0.138289,-0.237067 -0.246945,-0.424745 -0.103716,-0.187678 -0.162983,-0.360539 -0.05927,-0.172861 -0.05927,-0.360539 0,-0.2667 0.103717,-0.454377 0.103717,-0.192617 0.291395,-0.291395 0.192616,-0.09878 0.454377,-0.09878 0.246945,0 0.429684,0.08396 0.182738,0.08396 0.281516,0.246944 0.103717,0.158044 0.103717,0.380294 0,0.227189 -0.113595,0.4445 -0.113594,0.217312 -0.301272,0.434623 -0.187677,0.217311 -0.419805,0.424744 l 0.770466,1.214967 q 0.0889,-0.123473 0.153106,-0.291395 0.06914,-0.172861 0.108655,-0.350661 0.04445,-0.1778 0.04939,-0.321028 h 0.350661 q 0,0.1778 -0.05927,0.40005 -0.05433,0.217311 -0.158045,0.429684 -0.09878,0.207433 -0.227189,0.365477 0.108656,0.138289 0.217312,0.197556 0.113594,0.05927 0.237066,0.05927 v 0.3556 q -0.02469,0 -0.04939,-0.0049 -0.02469,0 -0.04445,-0.0049 -0.118533,-0.0099 -0.22225,-0.05927 -0.103716,-0.05433 -0.192616,-0.13335 -0.08396,-0.08396 -0.162984,-0.172861 -0.138289,0.158044 -0.3556,0.276578 -0.212372,0.113594 -0.493888,0.113594 z m 0,-0.301272 q 0.197555,0 0.350661,-0.08396 0.153105,-0.0889 0.291394,-0.242006 L 79.53465,36.605995 q -0.227189,0.256822 -0.325967,0.484011 -0.09384,0.22225 -0.09384,0.449439 0,0.143228 0.04939,0.286455 0.05433,0.138289 0.172861,0.232128 0.123472,0.0889 0.335845,0.0889 z m -0.04939,-1.980494 q 0.158044,-0.158045 0.296333,-0.335845 0.138289,-0.182739 0.22225,-0.375355 0.0889,-0.197556 0.0889,-0.390172 0,-0.197556 -0.128411,-0.301273 -0.128411,-0.103716 -0.340783,-0.103716 -0.251884,0 -0.370417,0.162983 -0.113595,0.158044 -0.113595,0.375356 0,0.227188 0.0889,0.454377 0.09384,0.22225 0.256823,0.513645 z"
+         style="stroke-width:0.26458332"
+         id="path5451"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 83.380269,38.443261 q -0.340783,0 -0.543278,-0.217311 -0.202494,-0.22225 -0.232128,-0.592666 l 0.301273,-0.0889 q 0.02963,0.325966 0.153105,0.479072 0.123472,0.148166 0.345722,0.148166 0.187678,0 0.286456,-0.103716 0.103717,-0.108656 0.103717,-0.301272 0,-0.138289 -0.08396,-0.276578 -0.08396,-0.143228 -0.266699,-0.296333 l -0.385234,-0.335845 q -0.192616,-0.162983 -0.291394,-0.325967 -0.09878,-0.162983 -0.09878,-0.390172 0,-0.207433 0.08396,-0.345722 0.0889,-0.143228 0.237067,-0.217311 0.153105,-0.07902 0.360539,-0.07902 0.325966,0 0.493888,0.212372 0.167923,0.207433 0.182739,0.538339 l -0.256822,0.08396 q -0.0099,-0.192617 -0.05927,-0.316089 -0.04939,-0.128411 -0.138288,-0.187678 -0.08396,-0.05927 -0.207434,-0.05927 -0.162983,0 -0.2667,0.09384 -0.09878,0.0889 -0.09878,0.251883 0,0.128411 0.04939,0.227189 0.04939,0.09878 0.182739,0.22225 l 0.404989,0.360539 q 0.118533,0.103716 0.227189,0.22225 0.108656,0.118533 0.1778,0.2667 0.06914,0.143227 0.06914,0.340783 0,0.22225 -0.09384,0.375355 -0.0889,0.148167 -0.251884,0.232128 -0.162983,0.07902 -0.385233,0.07902 z"
+         style="stroke-width:0.26458332"
+         id="path5453"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 84.522541,39.3372 V 35.544134 H 84.88308 V 35.7812 q 0.0889,-0.103716 0.22225,-0.192616 0.13335,-0.0889 0.325967,-0.0889 0.207433,0 0.330905,0.09878 0.128411,0.09384 0.197556,0.256822 0.06914,0.162983 0.09384,0.365477 0.02469,0.202495 0.02469,0.419806 v 0.597606 q 0,0.365477 -0.0642,0.637116 -0.05927,0.271639 -0.207434,0.419806 -0.148166,0.148166 -0.414866,0.148166 -0.172861,0 -0.301272,-0.0889 -0.123473,-0.0889 -0.207434,-0.182739 V 39.3372 Z m 0.809978,-1.175455 q 0.162983,0 0.246944,-0.103717 0.08396,-0.108656 0.108656,-0.31115 0.02963,-0.207433 0.02963,-0.498828 v -0.607483 q 0,-0.281517 -0.02963,-0.469194 -0.02469,-0.192617 -0.108656,-0.291395 -0.08396,-0.09878 -0.251883,-0.09878 -0.138289,0 -0.256822,0.07408 -0.113594,0.07408 -0.187678,0.148166 v 1.945922 q 0.07902,0.08396 0.192617,0.148167 0.118533,0.06421 0.256822,0.06421 z"
+         style="stroke-width:0.26458332"
+         id="path5455"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 87.293103,38.443261 q -0.291394,0 -0.459316,-0.123472 -0.167922,-0.128411 -0.237067,-0.365478 -0.06421,-0.242005 -0.06421,-0.587727 v -0.790223 q 0,-0.345722 0.06421,-0.582788 0.06914,-0.242006 0.237067,-0.365478 0.167922,-0.128411 0.459316,-0.128411 0.296334,0 0.459317,0.128411 0.167922,0.123472 0.232128,0.365478 0.06914,0.237066 0.06914,0.582788 v 0.790223 q 0,0.345722 -0.06914,0.587727 -0.06421,0.237067 -0.232128,0.365478 -0.162983,0.123472 -0.459317,0.123472 z m 0,-0.271639 q 0.187678,0 0.271639,-0.09878 0.0889,-0.09878 0.108656,-0.276578 0.01975,-0.1778 0.01975,-0.409928 v -0.829733 q 0,-0.232128 -0.01975,-0.404989 -0.01976,-0.1778 -0.108656,-0.276578 -0.08396,-0.103716 -0.271639,-0.103716 -0.187677,0 -0.271638,0.103716 -0.08396,0.09878 -0.108656,0.276578 -0.01976,0.172861 -0.01976,0.404989 v 0.829733 q 0,0.232128 0.01976,0.409928 0.02469,0.1778 0.108656,0.276578 0.08396,0.09878 0.271638,0.09878 z"
+         style="stroke-width:0.26458332"
+         id="path5457"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 89.260942,38.443261 q -0.291395,0 -0.459317,-0.123472 -0.167922,-0.128411 -0.237067,-0.365478 -0.06421,-0.242005 -0.06421,-0.587727 v -0.790223 q 0,-0.345722 0.06421,-0.582788 0.06914,-0.242006 0.237067,-0.365478 0.167922,-0.128411 0.459317,-0.128411 0.296333,0 0.459316,0.128411 0.167923,0.123472 0.232128,0.365478 0.06914,0.237066 0.06914,0.582788 v 0.790223 q 0,0.345722 -0.06914,0.587727 -0.06421,0.237067 -0.232128,0.365478 -0.162983,0.123472 -0.459316,0.123472 z m 0,-0.271639 q 0.187677,0 0.271639,-0.09878 0.0889,-0.09878 0.108655,-0.276578 0.01976,-0.1778 0.01976,-0.409928 v -0.829733 q 0,-0.232128 -0.01976,-0.404989 -0.01976,-0.1778 -0.108655,-0.276578 -0.08396,-0.103716 -0.271639,-0.103716 -0.187678,0 -0.271639,0.103716 -0.08396,0.09878 -0.108656,0.276578 -0.01975,0.172861 -0.01975,0.404989 v 0.829733 q 0,0.232128 0.01975,0.409928 0.0247,0.1778 0.108656,0.276578 0.08396,0.09878 0.271639,0.09878 z"
+         style="stroke-width:0.26458332"
+         id="path5459"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 90.700319,38.398811 v -2.592916 h -0.365478 v -0.261761 h 0.365478 V 35.2478 q 0,-0.212372 0.03457,-0.375355 0.03457,-0.162983 0.143228,-0.256822 0.113594,-0.09384 0.345722,-0.09384 0.07902,0 0.148167,0.0099 0.07408,0.0049 0.143228,0.02469 v 0.2667 q -0.04445,-0.0099 -0.103717,-0.01482 -0.05433,-0.0099 -0.09878,-0.0099 -0.162983,0 -0.207433,0.103716 -0.03951,0.09878 -0.03951,0.31115 v 0.330906 h 0.459316 v 0.261761 h -0.459316 v 2.592916 z"
+         style="stroke-width:0.26458332"
+         id="path5461"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 93.523898,38.433384 q -0.207434,0 -0.321028,-0.07902 -0.113595,-0.08396 -0.153106,-0.22225 -0.03951,-0.143227 -0.03951,-0.325966 V 35.7812 h -0.350661 v -0.237066 h 0.350661 v -0.884061 h 0.360539 v 0.884061 h 0.474133 V 35.7812 h -0.474133 v 1.990372 q 0,0.207434 0.04445,0.296334 0.04939,0.08396 0.207433,0.08396 0.04445,0 0.09878,-0.0049 0.05433,-0.0099 0.103717,-0.01482 v 0.271639 q -0.07408,0.01482 -0.153106,0.01976 -0.07408,0.0099 -0.148166,0.0099 z"
+         style="stroke-width:0.26458332"
+         id="path5463"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 94.25138,38.398811 v -2.854677 h 0.365478 v 0.390172 q 0.138288,-0.227189 0.316088,-0.321028 0.1778,-0.09878 0.340784,-0.09878 0.01482,0 0.02963,0 0.01482,0 0.03457,0.0049 v 0.385234 q -0.03457,-0.01482 -0.08396,-0.01976 -0.04939,-0.0099 -0.09384,-0.0099 -0.167922,0 -0.306211,0.07902 -0.13335,0.07902 -0.237066,0.251883 v 2.192866 z"
+         style="stroke-width:0.26458332"
+         id="path5465"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 96.143284,38.443261 q -0.167922,0 -0.296333,-0.08396 -0.128412,-0.0889 -0.202495,-0.232128 -0.07408,-0.143227 -0.07408,-0.321027 0,-0.217311 0.06421,-0.370417 0.06421,-0.153105 0.197556,-0.271639 0.138289,-0.123472 0.3556,-0.237066 0.22225,-0.118534 0.538339,-0.261762 v -0.202494 q 0,-0.261761 -0.03457,-0.409928 -0.02963,-0.153105 -0.108655,-0.217311 -0.07408,-0.0642 -0.212372,-0.0642 -0.113595,0 -0.202495,0.04445 -0.0889,0.04445 -0.143227,0.153105 -0.05433,0.103717 -0.05433,0.291395 v 0.09878 l -0.3556,-0.0049 q 0.0049,-0.434622 0.182739,-0.642055 0.182739,-0.212372 0.592666,-0.212372 0.380295,0 0.538339,0.232128 0.158045,0.227188 0.158045,0.711199 v 1.387828 q 0,0.07408 0,0.192617 0.0049,0.113594 0.0099,0.217311 0.0099,0.103717 0.01482,0.158044 h -0.321028 q -0.01482,-0.09384 -0.03457,-0.207433 -0.01482,-0.118533 -0.01976,-0.187678 -0.05927,0.172861 -0.212372,0.306211 -0.148166,0.13335 -0.380294,0.13335 z m 0.118533,-0.306211 q 0.108656,0 0.192617,-0.04939 0.0889,-0.05433 0.158044,-0.13335 0.07408,-0.07902 0.113595,-0.158044 v -0.889 q -0.212373,0.113594 -0.365478,0.202494 -0.148167,0.08396 -0.242006,0.167923 -0.09384,0.08396 -0.138288,0.192616 -0.04445,0.103717 -0.04445,0.246945 0,0.227189 0.09384,0.325966 0.09878,0.09384 0.232128,0.09384 z"
+         style="stroke-width:0.26458332"
+         id="path5467"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 97.790325,38.398811 v -2.592916 h -0.365478 v -0.261761 h 0.365478 V 35.2478 q 0,-0.212372 0.03457,-0.375355 0.03457,-0.162983 0.143228,-0.256822 0.113594,-0.09384 0.345722,-0.09384 0.07902,0 0.153106,0.0099 0.07408,0.0049 0.138288,0.02469 v 0.2667 q -0.04445,-0.0099 -0.103716,-0.01482 -0.05433,-0.0099 -0.09878,-0.0099 -0.162983,0 -0.207433,0.103716 -0.03951,0.09878 -0.03951,0.31115 v 0.330906 h 0.800099 V 35.2478 q 0,-0.212372 0.02963,-0.375355 0.03457,-0.162983 0.143228,-0.256822 0.113594,-0.09384 0.350661,-0.09384 0.07902,0 0.148166,0.0099 0.07408,0.0049 0.143228,0.02469 v 0.2667 q -0.04939,-0.0099 -0.103717,-0.01482 -0.05433,-0.0099 -0.09878,-0.0099 -0.162984,0 -0.207434,0.103716 -0.04445,0.09878 -0.04445,0.31115 v 0.330906 h 1.155699 v 2.854677 h -0.36054 v -2.592916 h -0.795159 v 2.592916 h -0.360539 v -2.592916 h -0.800099 v 2.592916 z m 2.321275,-3.249788 v -0.48895 h 0.36054 v 0.48895 z"
+         style="stroke-width:0.26458332"
+         id="path5469"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 101.7818,38.443261 q -0.33091,0 -0.49389,-0.148166 -0.16299,-0.148167 -0.21731,-0.40005 -0.0494,-0.256822 -0.0494,-0.57785 v -0.66675 q 0,-0.395111 0.0642,-0.646995 0.0642,-0.256822 0.22719,-0.380294 0.16792,-0.123472 0.4692,-0.123472 0.30621,0 0.46425,0.113594 0.15805,0.113595 0.21237,0.321028 0.0543,0.207433 0.0543,0.484011 v 0.13335 h -0.33584 v -0.138289 q 0,-0.251883 -0.0395,-0.390172 -0.0346,-0.138289 -0.12348,-0.192617 -0.084,-0.05927 -0.22718,-0.05927 -0.16793,0 -0.25683,0.07902 -0.0889,0.07902 -0.11853,0.261761 -0.0296,0.1778 -0.0296,0.479072 v 0.8001 q 0,0.429683 0.084,0.607483 0.084,0.172861 0.32596,0.172861 0.16793,0 0.25189,-0.07408 0.084,-0.07902 0.10865,-0.232128 0.0247,-0.153105 0.0247,-0.380294 V 37.32707 h 0.33584 v 0.138288 q 0,0.286456 -0.0543,0.508706 -0.0543,0.217311 -0.21237,0.345722 -0.1531,0.123472 -0.46425,0.123472 z"
+         style="stroke-width:0.26458332"
+         id="path5471"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="non-IP, non-ARP"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text5353">
+      <path
+         d="m 76.627766,32.653576 v -2.854678 h 0.360539 v 0.296334 q 0.138289,-0.148167 0.31115,-0.242006 0.172861,-0.09878 0.375356,-0.09878 0.143228,0 0.237066,0.07408 0.09878,0.06914 0.148167,0.207433 0.05433,0.13335 0.05433,0.325967 v 2.291644 h -0.360539 v -2.212622 q 0,-0.22225 -0.06914,-0.31115 -0.06915,-0.09384 -0.207434,-0.09384 -0.118533,0 -0.246944,0.07408 -0.128411,0.07408 -0.242006,0.192617 v 2.350911 z"
+         style="stroke-width:0.26458332"
+         id="path5474"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 79.350097,32.698026 q -0.291394,0 -0.459317,-0.123472 -0.167922,-0.128411 -0.237066,-0.365478 -0.06421,-0.242006 -0.06421,-0.587728 v -0.790222 q 0,-0.345722 0.06421,-0.582789 0.06914,-0.242005 0.237066,-0.365478 0.167923,-0.128411 0.459317,-0.128411 0.296333,0 0.459317,0.128411 0.167922,0.123473 0.232128,0.365478 0.06914,0.237067 0.06914,0.582789 v 0.790222 q 0,0.345722 -0.06914,0.587728 -0.06421,0.237067 -0.232128,0.365478 -0.162984,0.123472 -0.459317,0.123472 z m 0,-0.271639 q 0.187678,0 0.271639,-0.09878 0.0889,-0.09878 0.108656,-0.276578 0.01976,-0.177799 0.01976,-0.409927 V 30.81137 q 0,-0.232127 -0.01976,-0.404988 -0.01976,-0.1778 -0.108656,-0.276578 -0.08396,-0.103717 -0.271639,-0.103717 -0.187678,0 -0.271639,0.103717 -0.08396,0.09878 -0.108655,0.276578 -0.01976,0.172861 -0.01976,0.404988 v 0.829734 q 0,0.232128 0.01976,0.409927 0.02469,0.1778 0.108655,0.276578 0.08396,0.09878 0.271639,0.09878 z"
+         style="stroke-width:0.26458332"
+         id="path5476"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 80.611675,32.653576 v -2.854678 h 0.360538 v 0.296334 q 0.138289,-0.148167 0.31115,-0.242006 0.172862,-0.09878 0.375356,-0.09878 0.143228,0 0.237067,0.07408 0.09878,0.06914 0.148166,0.207433 0.05433,0.13335 0.05433,0.325967 v 2.291644 h -0.360539 v -2.212622 q 0,-0.22225 -0.06914,-0.31115 -0.06915,-0.09384 -0.207434,-0.09384 -0.118533,0 -0.246944,0.07408 -0.128411,0.07408 -0.242006,0.192617 v 2.350911 z"
+         style="stroke-width:0.26458332"
+         id="path5478"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 82.563538,31.186726 V 30.90027 h 1.047045 v 0.286456 z"
+         style="stroke-width:0.26458332"
+         id="path5480"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 84.177938,32.653576 v -4.0005 h 0.375355 v 4.0005 z"
+         style="stroke-width:0.26458332"
+         id="path5482"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 85.267734,32.653576 v -4.0005 h 0.958145 q 0.360539,0 0.563033,0.13335 0.207433,0.13335 0.296333,0.370417 0.0889,0.237066 0.0889,0.558094 0,0.281517 -0.09384,0.523522 -0.0889,0.237067 -0.301272,0.380295 -0.207433,0.143228 -0.548216,0.143228 H 85.64309 v 1.891594 z m 0.375356,-2.173111 h 0.479072 q 0.242006,0 0.390172,-0.06914 0.153106,-0.07408 0.22225,-0.242005 0.06915,-0.167922 0.06915,-0.454378 0,-0.306211 -0.05927,-0.474133 -0.05927,-0.172861 -0.207433,-0.237067 -0.143228,-0.06914 -0.409928,-0.06914 H 85.64309 Z"
+         style="stroke-width:0.26458332"
+         id="path5484"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 87.070891,33.226487 -0.07902,-0.158044 q 0.13335,-0.07408 0.182739,-0.172862 0.05433,-0.09384 0.05433,-0.242005 h -0.212372 v -0.538339 h 0.40005 v 0.498828 q 0,0.242005 -0.08396,0.380294 -0.07902,0.138289 -0.261761,0.232128 z"
+         style="stroke-width:0.26458332"
+         id="path5486"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 88.926757,32.653576 v -2.854678 h 0.360539 v 0.296334 q 0.138288,-0.148167 0.31115,-0.242006 0.172861,-0.09878 0.375355,-0.09878 0.143228,0 0.237067,0.07408 0.09878,0.06914 0.148166,0.207433 0.05433,0.13335 0.05433,0.325967 v 2.291644 h -0.360539 v -2.212622 q 0,-0.22225 -0.06914,-0.31115 -0.06914,-0.09384 -0.207434,-0.09384 -0.118533,0 -0.246944,0.07408 -0.128411,0.07408 -0.242005,0.192617 v 2.350911 z"
+         style="stroke-width:0.26458332"
+         id="path5488"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 91.649087,32.698026 q -0.291394,0 -0.459316,-0.123472 -0.167923,-0.128411 -0.237067,-0.365478 -0.06421,-0.242006 -0.06421,-0.587728 v -0.790222 q 0,-0.345722 0.06421,-0.582789 0.06914,-0.242005 0.237067,-0.365478 0.167922,-0.128411 0.459316,-0.128411 0.296333,0 0.459317,0.128411 0.167922,0.123473 0.232128,0.365478 0.06914,0.237067 0.06914,0.582789 v 0.790222 q 0,0.345722 -0.06914,0.587728 -0.06421,0.237067 -0.232128,0.365478 -0.162984,0.123472 -0.459317,0.123472 z m 0,-0.271639 q 0.187678,0 0.271639,-0.09878 0.0889,-0.09878 0.108656,-0.276578 0.01976,-0.177799 0.01976,-0.409927 V 30.81137 q 0,-0.232127 -0.01976,-0.404988 -0.01976,-0.1778 -0.108656,-0.276578 -0.08396,-0.103717 -0.271639,-0.103717 -0.187678,0 -0.271639,0.103717 -0.08396,0.09878 -0.108655,0.276578 -0.01976,0.172861 -0.01976,0.404988 v 0.829734 q 0,0.232128 0.01976,0.409927 0.02469,0.1778 0.108655,0.276578 0.08396,0.09878 0.271639,0.09878 z"
+         style="stroke-width:0.26458332"
+         id="path5490"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 92.910664,32.653576 v -2.854678 h 0.360539 v 0.296334 q 0.138289,-0.148167 0.31115,-0.242006 0.172861,-0.09878 0.375356,-0.09878 0.143228,0 0.237066,0.07408 0.09878,0.06914 0.148167,0.207433 0.05433,0.13335 0.05433,0.325967 v 2.291644 h -0.360539 v -2.212622 q 0,-0.22225 -0.06914,-0.31115 -0.06914,-0.09384 -0.207434,-0.09384 -0.118533,0 -0.246944,0.07408 -0.128411,0.07408 -0.242006,0.192617 v 2.350911 z"
+         style="stroke-width:0.26458332"
+         id="path5492"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 94.862528,31.186726 V 30.90027 h 1.047045 v 0.286456 z"
+         style="stroke-width:0.26458332"
+         id="path5494"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 96.249738,32.653576 0.84455,-4.0005 h 0.395111 l 0.849489,4.0005 H 97.968472 L 97.770916,31.581837 H 96.81771 l -0.202494,1.071739 z m 0.6223,-1.343378 h 0.849489 l -0.429683,-2.158294 z"
+         style="stroke-width:0.26458332"
+         id="path5496"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 98.782153,32.653576 v -4.0005 h 0.903817 q 0.37536,0 0.58773,0.123472 0.21731,0.118534 0.31115,0.350661 0.0938,0.227189 0.0938,0.543278 0,0.22225 -0.0494,0.419806 -0.0494,0.197555 -0.16792,0.335844 -0.11854,0.138289 -0.33585,0.182739 l 0.61242,2.0447 h -0.36547 l -0.587733,-1.965678 h -0.627239 v 1.965678 z m 0.375355,-2.242256 h 0.508706 q 0.251883,0 0.390176,-0.08396 0.13829,-0.08396 0.19755,-0.246944 0.0593,-0.162983 0.0593,-0.409928 0,-0.370416 -0.12841,-0.553155 -0.12841,-0.182739 -0.508708,-0.182739 h -0.518584 z"
+         style="stroke-width:0.26458332"
+         id="path5498"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 101.29018,32.653576 v -4.0005 h 0.95815 q 0.36054,0 0.56303,0.13335 0.20743,0.13335 0.29633,0.370417 0.0889,0.237066 0.0889,0.558094 0,0.281517 -0.0938,0.523522 -0.0889,0.237067 -0.30127,0.380295 -0.20743,0.143228 -0.54821,0.143228 h -0.58773 v 1.891594 z m 0.37536,-2.173111 h 0.47907 q 0.24201,0 0.39017,-0.06914 0.15311,-0.07408 0.22225,-0.242005 0.0691,-0.167922 0.0691,-0.454378 0,-0.306211 -0.0593,-0.474133 -0.0593,-0.172861 -0.20743,-0.237067 -0.14323,-0.06914 -0.40993,-0.06914 h -0.48401 z"
+         style="stroke-width:0.26458332"
+         id="path5500"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="whitelisted traffic"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text5357">
+      <path
+         d="m 143.11439,105.67856 -0.46426,-2.85468 h 0.30621 l 0.36054,2.38548 0.44944,-2.38548 h 0.31115 l 0.45438,2.37561 0.34078,-2.37561 h 0.31115 l -0.46426,2.85468 h -0.33584 l -0.45932,-2.32128 -0.4445,2.32128 z"
+         style="stroke-width:0.26458332"
+         id="path5503"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 145.61454,105.67856 v -4.0005 h 0.36054 v 1.44709 q 0.14323,-0.1531 0.31609,-0.24694 0.17286,-0.0988 0.3803,-0.0988 0.14322,0 0.23706,0.0741 0.0988,0.0691 0.14817,0.20744 0.0543,0.13335 0.0543,0.32596 v 2.29165 h -0.36548 v -2.21262 q 0,-0.22225 -0.0692,-0.31115 -0.0642,-0.0938 -0.20249,-0.0938 -0.12347,0 -0.25682,0.079 -0.12841,0.0741 -0.24201,0.19262 v 2.34597 z"
+         style="stroke-width:0.26458332"
+         id="path5505"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 147.68448,105.67856 v -2.85468 h 0.36054 v 2.85468 z m 0,-3.24979 v -0.48895 h 0.36054 v 0.48895 z"
+         style="stroke-width:0.26458332"
+         id="path5507"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 149.32481,105.71313 q -0.20744,0 -0.32103,-0.079 -0.1136,-0.084 -0.15311,-0.22225 -0.0395,-0.14323 -0.0395,-0.32597 v -2.02494 h -0.35066 v -0.23707 h 0.35066 v -0.88406 h 0.36054 v 0.88406 h 0.47413 v 0.23707 h -0.47413 v 1.99037 q 0,0.20743 0.0445,0.29633 0.0494,0.084 0.20743,0.084 0.0445,0 0.0988,-0.005 0.0543,-0.01 0.10372,-0.0148 v 0.27164 q -0.0741,0.0148 -0.15311,0.0198 -0.0741,0.01 -0.14816,0.01 z"
+         style="stroke-width:0.26458332"
+         id="path5509"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 150.74373,105.72301 q -0.2667,0 -0.43956,-0.10372 -0.16792,-0.10865 -0.25188,-0.3556 -0.079,-0.24694 -0.079,-0.65687 v -0.72108 q 0,-0.42474 0.084,-0.66181 0.084,-0.242 0.25682,-0.34078 0.17286,-0.10372 0.42968,-0.10372 0.30621,0 0.46426,0.12841 0.15804,0.12841 0.21731,0.39017 0.0642,0.25683 0.0642,0.66182 v 0.25682 h -1.1557 v 0.49883 q 0,0.27657 0.0395,0.43956 0.0444,0.15804 0.13335,0.22719 0.0938,0.0691 0.23706,0.0691 0.10866,0 0.19756,-0.0395 0.0889,-0.0444 0.13829,-0.16298 0.0543,-0.12348 0.0543,-0.34573 v -0.19755 h 0.35066 v 0.15804 q 0,0.39017 -0.16299,0.62724 -0.16298,0.23213 -0.57785,0.23213 z m -0.40992,-1.7138 h 0.8001 v -0.23706 q 0,-0.22719 -0.0247,-0.38524 -0.0247,-0.16298 -0.10865,-0.24694 -0.079,-0.0889 -0.25683,-0.0889 -0.14816,0 -0.242,0.0642 -0.0889,0.0642 -0.12841,0.23212 -0.0395,0.16299 -0.0395,0.4692 z"
+         style="stroke-width:0.26458332"
+         id="path5511"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 152.02553,105.67856 v -4.0005 h 0.36054 v 4.0005 z"
+         style="stroke-width:0.26458332"
+         id="path5513"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 153.00922,105.67856 v -2.85468 h 0.36054 v 2.85468 z m 0,-3.24979 v -0.48895 h 0.36054 v 0.48895 z"
+         style="stroke-width:0.26458332"
+         id="path5515"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 154.62485,105.72301 q -0.34078,0 -0.54328,-0.21731 -0.20249,-0.22225 -0.23212,-0.59267 l 0.30127,-0.0889 q 0.0296,0.32597 0.1531,0.47907 0.12348,0.14817 0.34573,0.14817 0.18767,0 0.28645,-0.10372 0.10372,-0.10865 0.10372,-0.30127 0,-0.13829 -0.084,-0.27658 -0.084,-0.14322 -0.2667,-0.29633 l -0.38524,-0.33584 q -0.19261,-0.16299 -0.29139,-0.32597 -0.0988,-0.16298 -0.0988,-0.39017 0,-0.20744 0.084,-0.34573 0.0889,-0.14322 0.23707,-0.21731 0.1531,-0.079 0.36054,-0.079 0.32596,0 0.49389,0.21237 0.16792,0.20744 0.18274,0.53834 l -0.25683,0.084 q -0.01,-0.19261 -0.0593,-0.31609 -0.0494,-0.12841 -0.13829,-0.18767 -0.084,-0.0593 -0.20744,-0.0593 -0.16298,0 -0.2667,0.0938 -0.0988,0.0889 -0.0988,0.25188 0,0.12841 0.0494,0.22719 0.0494,0.0988 0.18273,0.22225 l 0.40499,0.36054 q 0.11854,0.10372 0.22719,0.22225 0.10866,0.11853 0.1778,0.2667 0.0691,0.14323 0.0691,0.34078 0,0.22225 -0.0938,0.37536 -0.0889,0.14817 -0.25189,0.23213 -0.16298,0.079 -0.38523,0.079 z"
+         style="stroke-width:0.26458332"
+         id="path5517"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 156.44375,105.71313 q -0.20743,0 -0.32103,-0.079 -0.11359,-0.084 -0.1531,-0.22225 -0.0395,-0.14323 -0.0395,-0.32597 v -2.02494 h -0.35066 v -0.23707 h 0.35066 v -0.88406 h 0.36054 v 0.88406 h 0.47413 v 0.23707 h -0.47413 v 1.99037 q 0,0.20743 0.0445,0.29633 0.0494,0.084 0.20743,0.084 0.0445,0 0.0988,-0.005 0.0543,-0.01 0.10371,-0.0148 v 0.27164 q -0.0741,0.0148 -0.1531,0.0198 -0.0741,0.01 -0.14817,0.01 z"
+         style="stroke-width:0.26458332"
+         id="path5519"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 157.86268,105.72301 q -0.2667,0 -0.43956,-0.10372 -0.16792,-0.10865 -0.25189,-0.3556 -0.079,-0.24694 -0.079,-0.65687 v -0.72108 q 0,-0.42474 0.084,-0.66181 0.084,-0.242 0.25683,-0.34078 0.17286,-0.10372 0.42968,-0.10372 0.30621,0 0.46425,0.12841 0.15805,0.12841 0.21731,0.39017 0.0642,0.25683 0.0642,0.66182 v 0.25682 h -1.1557 v 0.49883 q 0,0.27657 0.0395,0.43956 0.0445,0.15804 0.13335,0.22719 0.0938,0.0691 0.23707,0.0691 0.10865,0 0.19755,-0.0395 0.0889,-0.0444 0.13829,-0.16298 0.0543,-0.12348 0.0543,-0.34573 v -0.19755 h 0.35066 v 0.15804 q 0,0.39017 -0.16298,0.62724 -0.16299,0.23213 -0.57785,0.23213 z m -0.40993,-1.7138 h 0.8001 v -0.23706 q 0,-0.22719 -0.0247,-0.38524 -0.0247,-0.16298 -0.10866,-0.24694 -0.079,-0.0889 -0.25682,-0.0889 -0.14817,0 -0.24201,0.0642 -0.0889,0.0642 -0.12841,0.23212 -0.0395,0.16299 -0.0395,0.4692 z"
+         style="stroke-width:0.26458332"
+         id="path5521"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 159.72726,105.72301 q -0.36547,0 -0.52846,-0.27658 -0.15804,-0.27658 -0.15804,-0.91863 v -0.52846 q 0,-0.37536 0.0543,-0.647 0.0543,-0.27164 0.19755,-0.4198 0.14817,-0.15311 0.41981,-0.15311 0.16792,0 0.29139,0.079 0.12841,0.0741 0.21237,0.16793 v -1.34832 h 0.36054 v 4.0005 h -0.36054 v -0.2025 q -0.084,0.0938 -0.20743,0.17287 -0.11853,0.0741 -0.28152,0.0741 z m 0.0741,-0.28152 q 0.11359,0 0.22225,-0.0543 0.10865,-0.0593 0.19261,-0.13828 v -1.98544 q -0.0741,-0.0691 -0.18274,-0.13335 -0.10865,-0.0691 -0.242,-0.0691 -0.23707,0 -0.31609,0.21237 -0.0741,0.20743 -0.0741,0.61242 v 0.67169 q 0,0.28646 0.0296,0.48401 0.0346,0.19756 0.11853,0.30127 0.0889,0.0988 0.25189,0.0988 z"
+         style="stroke-width:0.26458332"
+         id="path5523"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 162.81029,105.71313 q -0.20744,0 -0.32103,-0.079 -0.11359,-0.084 -0.15311,-0.22225 -0.0395,-0.14323 -0.0395,-0.32597 v -2.02494 h -0.35066 v -0.23707 h 0.35066 v -0.88406 h 0.36054 v 0.88406 h 0.47414 v 0.23707 h -0.47414 v 1.99037 q 0,0.20743 0.0444,0.29633 0.0494,0.084 0.20744,0.084 0.0444,0 0.0988,-0.005 0.0543,-0.01 0.10372,-0.0148 v 0.27164 q -0.0741,0.0148 -0.15311,0.0198 -0.0741,0.01 -0.14816,0.01 z"
+         style="stroke-width:0.26458332"
+         id="path5525"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 163.53777,105.67856 v -2.85468 h 0.36548 v 0.39017 q 0.13829,-0.22719 0.31609,-0.32102 0.1778,-0.0988 0.34078,-0.0988 0.0148,0 0.0296,0 0.0148,0 0.0346,0.005 v 0.38523 q -0.0346,-0.0148 -0.084,-0.0198 -0.0494,-0.01 -0.0938,-0.01 -0.16793,0 -0.30622,0.079 -0.13335,0.079 -0.23706,0.25188 v 2.19287 z"
+         style="stroke-width:0.26458332"
+         id="path5527"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 165.42967,105.72301 q -0.16792,0 -0.29633,-0.084 -0.12841,-0.0889 -0.2025,-0.23213 -0.0741,-0.14323 -0.0741,-0.32103 0,-0.21731 0.0642,-0.37041 0.0642,-0.15311 0.19755,-0.27164 0.13829,-0.12348 0.3556,-0.23707 0.22225,-0.11853 0.53834,-0.26176 v -0.2025 q 0,-0.26176 -0.0346,-0.40992 -0.0296,-0.15311 -0.10866,-0.21731 -0.0741,-0.0642 -0.21237,-0.0642 -0.11359,0 -0.20249,0.0444 -0.0889,0.0445 -0.14323,0.15311 -0.0543,0.10371 -0.0543,0.29139 v 0.0988 l -0.3556,-0.005 q 0.005,-0.43462 0.18274,-0.64206 0.18274,-0.21237 0.59267,-0.21237 0.38029,0 0.53834,0.23213 0.15804,0.22719 0.15804,0.7112 v 1.38783 q 0,0.0741 0,0.19261 0.005,0.1136 0.01,0.21731 0.01,0.10372 0.0148,0.15805 h -0.32102 q -0.0148,-0.0938 -0.0346,-0.20743 -0.0148,-0.11854 -0.0197,-0.18768 -0.0593,0.17286 -0.21237,0.30621 -0.14817,0.13335 -0.3803,0.13335 z m 0.11854,-0.30621 q 0.10865,0 0.19261,-0.0494 0.0889,-0.0543 0.15805,-0.13335 0.0741,-0.079 0.11359,-0.15805 v -0.889 q -0.21237,0.1136 -0.36548,0.2025 -0.14816,0.084 -0.242,0.16792 -0.0938,0.084 -0.13829,0.19262 -0.0445,0.10371 -0.0445,0.24694 0,0.22719 0.0938,0.32597 0.0988,0.0938 0.23213,0.0938 z"
+         style="stroke-width:0.26458332"
+         id="path5529"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 167.07672,105.67856 v -2.59292 h -0.36548 v -0.26176 h 0.36548 v -0.29633 q 0,-0.21237 0.0346,-0.37536 0.0346,-0.16298 0.14323,-0.25682 0.11359,-0.0938 0.34572,-0.0938 0.079,0 0.1531,0.01 0.0741,0.005 0.13829,0.0247 v 0.2667 q -0.0444,-0.01 -0.10371,-0.0148 -0.0543,-0.01 -0.0988,-0.01 -0.16299,0 -0.20744,0.10372 -0.0395,0.0988 -0.0395,0.31115 v 0.3309 h 0.8001 v -0.29633 q 0,-0.21237 0.0296,-0.37536 0.0346,-0.16298 0.14322,-0.25682 0.1136,-0.0938 0.35066,-0.0938 0.079,0 0.14817,0.01 0.0741,0.005 0.14323,0.0247 v 0.2667 q -0.0494,-0.01 -0.10372,-0.0148 -0.0543,-0.01 -0.0988,-0.01 -0.16298,0 -0.20743,0.10372 -0.0444,0.0988 -0.0444,0.31115 v 0.3309 h 1.1557 v 2.85468 H 169.398 v -2.59292 h -0.79516 v 2.59292 h -0.36054 v -2.59292 h -0.8001 v 2.59292 z m 2.32127,-3.24979 v -0.48895 h 0.36054 v 0.48895 z"
+         style="stroke-width:0.26458332"
+         id="path5531"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 171.06819,105.72301 q -0.33091,0 -0.49389,-0.14817 -0.16299,-0.14816 -0.21731,-0.40005 -0.0494,-0.25682 -0.0494,-0.57785 v -0.66675 q 0,-0.39511 0.0642,-0.64699 0.0642,-0.25682 0.22719,-0.3803 0.16792,-0.12347 0.4692,-0.12347 0.30621,0 0.46425,0.1136 0.15805,0.11359 0.21237,0.32102 0.0543,0.20744 0.0543,0.48401 v 0.13335 h -0.33584 v -0.13828 q 0,-0.25189 -0.0395,-0.39018 -0.0346,-0.13829 -0.12348,-0.19261 -0.084,-0.0593 -0.22718,-0.0593 -0.16793,0 -0.25683,0.079 -0.0889,0.079 -0.11853,0.26176 -0.0296,0.1778 -0.0296,0.47908 v 0.8001 q 0,0.42968 0.084,0.60748 0.084,0.17286 0.32596,0.17286 0.16793,0 0.25189,-0.0741 0.084,-0.079 0.10865,-0.23213 0.0247,-0.15311 0.0247,-0.3803 v -0.15804 h 0.33584 v 0.13829 q 0,0.28645 -0.0543,0.5087 -0.0543,0.21732 -0.21237,0.34573 -0.1531,0.12347 -0.46425,0.12347 z"
+         style="stroke-width:0.26458332"
+         id="path5533"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="miss"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text5361">
+      <path
+         d="m 184.42659,120.04166 v -2.85468 h 0.33584 v 0.29139 q 0.14323,-0.16792 0.31609,-0.25188 0.17286,-0.0889 0.3556,-0.0889 0.14817,0 0.27164,0.079 0.12841,0.079 0.18274,0.29634 0.14323,-0.18768 0.32103,-0.28152 0.18273,-0.0938 0.38029,-0.0938 0.12347,0 0.23213,0.0593 0.11359,0.0593 0.18274,0.20249 0.0691,0.14323 0.0691,0.39017 v 2.25214 h -0.34078 v -2.24226 q 0,-0.25188 -0.079,-0.3309 -0.079,-0.084 -0.2025,-0.084 -0.13829,0 -0.27658,0.079 -0.13829,0.079 -0.26176,0.21731 0.005,0.0247 0.005,0.0543 0,0.0247 0,0.0543 v 2.25214 h -0.33584 v -2.24226 q 0,-0.25188 -0.084,-0.3309 -0.079,-0.084 -0.2025,-0.084 -0.13335,0 -0.27164,0.079 -0.13829,0.079 -0.26176,0.21237 v 2.36573 z"
+         style="stroke-width:0.26458332"
+         id="path5536"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 187.64937,120.04166 v -2.85468 h 0.36053 v 2.85468 z m 0,-3.24979 v -0.48895 h 0.36053 v 0.48895 z"
+         style="stroke-width:0.26458332"
+         id="path5538"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 189.265,120.08611 q -0.34078,0 -0.54328,-0.21731 -0.20249,-0.22225 -0.23213,-0.59267 l 0.30128,-0.0889 q 0.0296,0.32597 0.1531,0.47907 0.12347,0.14817 0.34572,0.14817 0.18768,0 0.28646,-0.10372 0.10372,-0.10865 0.10372,-0.30127 0,-0.13829 -0.084,-0.27658 -0.084,-0.14323 -0.2667,-0.29633 l -0.38524,-0.33585 q -0.19261,-0.16298 -0.29139,-0.32596 -0.0988,-0.16299 -0.0988,-0.39018 0,-0.20743 0.084,-0.34572 0.0889,-0.14323 0.23707,-0.21731 0.1531,-0.079 0.36054,-0.079 0.32596,0 0.49389,0.21237 0.16792,0.20743 0.18273,0.53834 l -0.25682,0.084 q -0.01,-0.19262 -0.0593,-0.31609 -0.0494,-0.12841 -0.13829,-0.18768 -0.084,-0.0593 -0.20744,-0.0593 -0.16298,0 -0.2667,0.0938 -0.0988,0.0889 -0.0988,0.25188 0,0.12841 0.0494,0.22719 0.0494,0.0988 0.18274,0.22225 l 0.40499,0.36054 q 0.11854,0.10371 0.22719,0.22225 0.10866,0.11853 0.1778,0.2667 0.0692,0.14323 0.0692,0.34078 0,0.22225 -0.0938,0.37536 -0.0889,0.14816 -0.25189,0.23212 -0.16298,0.079 -0.38523,0.079 z"
+         style="stroke-width:0.26458332"
+         id="path5540"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 191.05921,120.08611 q -0.34079,0 -0.54328,-0.21731 -0.2025,-0.22225 -0.23213,-0.59267 l 0.30127,-0.0889 q 0.0296,0.32597 0.15311,0.47907 0.12347,0.14817 0.34572,0.14817 0.18768,0 0.28646,-0.10372 0.10371,-0.10865 0.10371,-0.30127 0,-0.13829 -0.084,-0.27658 -0.084,-0.14323 -0.2667,-0.29633 l -0.38523,-0.33585 q -0.19262,-0.16298 -0.2914,-0.32596 -0.0988,-0.16299 -0.0988,-0.39018 0,-0.20743 0.084,-0.34572 0.0889,-0.14323 0.23706,-0.21731 0.15311,-0.079 0.36054,-0.079 0.32597,0 0.49389,0.21237 0.16792,0.20743 0.18274,0.53834 l -0.25682,0.084 q -0.01,-0.19262 -0.0593,-0.31609 -0.0494,-0.12841 -0.13829,-0.18768 -0.084,-0.0593 -0.20743,-0.0593 -0.16298,0 -0.2667,0.0938 -0.0988,0.0889 -0.0988,0.25188 0,0.12841 0.0494,0.22719 0.0494,0.0988 0.18274,0.22225 l 0.40499,0.36054 q 0.11853,0.10371 0.22719,0.22225 0.10865,0.11853 0.1778,0.2667 0.0691,0.14323 0.0691,0.34078 0,0.22225 -0.0938,0.37536 -0.0889,0.14816 -0.25188,0.23212 -0.16298,0.079 -0.38523,0.079 z"
+         style="stroke-width:0.26458332"
+         id="path5542"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="from isolated Pod"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text5365">
+      <path
+         d="m 161.32106,138.18452 v -2.59291 h -0.36548 v -0.26176 h 0.36548 v -0.29634 q 0,-0.21237 0.0346,-0.37535 0.0346,-0.16299 0.14323,-0.25682 0.1136,-0.0938 0.34572,-0.0938 0.079,0 0.14817,0.01 0.0741,0.005 0.14323,0.0247 v 0.2667 q -0.0444,-0.01 -0.10372,-0.0148 -0.0543,-0.01 -0.0988,-0.01 -0.16298,0 -0.20743,0.10372 -0.0395,0.0988 -0.0395,0.31115 v 0.33091 h 0.45932 v 0.26176 h -0.45932 v 2.59291 z"
+         style="stroke-width:0.26458332"
+         id="path5545"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 162.48949,138.18452 v -2.85467 h 0.36548 v 0.39017 q 0.13829,-0.22719 0.31609,-0.32103 0.1778,-0.0988 0.34078,-0.0988 0.0148,0 0.0296,0 0.0148,0 0.0346,0.005 v 0.38524 q -0.0346,-0.0148 -0.084,-0.0198 -0.0494,-0.01 -0.0938,-0.01 -0.16792,0 -0.30621,0.079 -0.13335,0.079 -0.23707,0.25189 v 2.19286 z"
+         style="stroke-width:0.26458332"
+         id="path5547"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 164.618,138.22897 q -0.29139,0 -0.45932,-0.12347 -0.16792,-0.12841 -0.23706,-0.36548 -0.0642,-0.242 -0.0642,-0.58772 v -0.79023 q 0,-0.34572 0.0642,-0.58278 0.0691,-0.24201 0.23706,-0.36548 0.16793,-0.12841 0.45932,-0.12841 0.29633,0 0.45932,0.12841 0.16792,0.12347 0.23213,0.36548 0.0691,0.23706 0.0691,0.58278 v 0.79023 q 0,0.34572 -0.0691,0.58772 -0.0642,0.23707 -0.23213,0.36548 -0.16299,0.12347 -0.45932,0.12347 z m 0,-0.27163 q 0.18768,0 0.27164,-0.0988 0.0889,-0.0988 0.10866,-0.27658 0.0197,-0.1778 0.0197,-0.40993 v -0.82973 q 0,-0.23213 -0.0197,-0.40499 -0.0198,-0.1778 -0.10866,-0.27658 -0.084,-0.10371 -0.27164,-0.10371 -0.18768,0 -0.27164,0.10371 -0.084,0.0988 -0.10865,0.27658 -0.0198,0.17286 -0.0198,0.40499 v 0.82973 q 0,0.23213 0.0198,0.40993 0.0247,0.1778 0.10865,0.27658 0.084,0.0988 0.27164,0.0988 z"
+         style="stroke-width:0.26458332"
+         id="path5549"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 165.87958,138.18452 v -2.85467 h 0.33584 v 0.29139 q 0.14323,-0.16792 0.31609,-0.25188 0.17286,-0.0889 0.3556,-0.0889 0.14817,0 0.27164,0.079 0.12841,0.079 0.18274,0.29633 0.14323,-0.18767 0.32103,-0.28151 0.18274,-0.0938 0.38029,-0.0938 0.12347,0 0.23213,0.0593 0.11359,0.0593 0.18274,0.2025 0.0691,0.14323 0.0691,0.39017 v 2.25213 H 168.186 v -2.24225 q 0,-0.25188 -0.079,-0.33091 -0.079,-0.084 -0.2025,-0.084 -0.13829,0 -0.27658,0.079 -0.13828,0.079 -0.26176,0.21732 0.005,0.0247 0.005,0.0543 0,0.0247 0,0.0543 v 2.25213 h -0.33584 v -2.24225 q 0,-0.25188 -0.084,-0.33091 -0.079,-0.084 -0.2025,-0.084 -0.13335,0 -0.27164,0.079 -0.13828,0.079 -0.26176,0.21238 v 2.36572 z"
+         style="stroke-width:0.26458332"
+         id="path5551"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 170.10557,138.18452 v -2.85467 h 0.36054 v 2.85467 z m 0,-3.24978 v -0.48895 h 0.36054 v 0.48895 z"
+         style="stroke-width:0.26458332"
+         id="path5553"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 171.7212,138.22897 q -0.34078,0 -0.54327,-0.21731 -0.2025,-0.22225 -0.23213,-0.59266 l 0.30127,-0.0889 q 0.0296,0.32596 0.15311,0.47907 0.12347,0.14817 0.34572,0.14817 0.18768,0 0.28645,-0.10372 0.10372,-0.10866 0.10372,-0.30127 0,-0.13829 -0.084,-0.27658 -0.084,-0.14323 -0.2667,-0.29633 l -0.38523,-0.33585 q -0.19262,-0.16298 -0.2914,-0.32597 -0.0988,-0.16298 -0.0988,-0.39017 0,-0.20743 0.084,-0.34572 0.0889,-0.14323 0.23707,-0.21731 0.15311,-0.079 0.36054,-0.079 0.32597,0 0.49389,0.21237 0.16792,0.20743 0.18274,0.53834 l -0.25682,0.084 q -0.01,-0.19262 -0.0593,-0.31609 -0.0494,-0.12841 -0.13829,-0.18768 -0.084,-0.0593 -0.20743,-0.0593 -0.16299,0 -0.2667,0.0938 -0.0988,0.0889 -0.0988,0.25189 0,0.12841 0.0494,0.22719 0.0494,0.0988 0.18274,0.22225 l 0.40499,0.36054 q 0.11853,0.10371 0.22718,0.22225 0.10866,0.11853 0.1778,0.2667 0.0691,0.14322 0.0691,0.34078 0,0.22225 -0.0938,0.37535 -0.0889,0.14817 -0.25188,0.23213 -0.16299,0.079 -0.38524,0.079 z"
+         style="stroke-width:0.26458332"
+         id="path5555"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 173.56974,138.22897 q -0.2914,0 -0.45932,-0.12347 -0.16792,-0.12841 -0.23707,-0.36548 -0.0642,-0.242 -0.0642,-0.58772 v -0.79023 q 0,-0.34572 0.0642,-0.58278 0.0692,-0.24201 0.23707,-0.36548 0.16792,-0.12841 0.45932,-0.12841 0.29633,0 0.45931,0.12841 0.16793,0.12347 0.23213,0.36548 0.0692,0.23706 0.0692,0.58278 v 0.79023 q 0,0.34572 -0.0692,0.58772 -0.0642,0.23707 -0.23213,0.36548 -0.16298,0.12347 -0.45931,0.12347 z m 0,-0.27163 q 0.18767,0 0.27164,-0.0988 0.0889,-0.0988 0.10865,-0.27658 0.0198,-0.1778 0.0198,-0.40993 v -0.82973 q 0,-0.23213 -0.0198,-0.40499 -0.0197,-0.1778 -0.10865,-0.27658 -0.084,-0.10371 -0.27164,-0.10371 -0.18768,0 -0.27164,0.10371 -0.084,0.0988 -0.10866,0.27658 -0.0197,0.17286 -0.0197,0.40499 v 0.82973 q 0,0.23213 0.0197,0.40993 0.0247,0.1778 0.10866,0.27658 0.084,0.0988 0.27164,0.0988 z"
+         style="stroke-width:0.26458332"
+         id="path5557"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 174.8807,138.18452 v -4.0005 h 0.36054 v 4.0005 z"
+         style="stroke-width:0.26458332"
+         id="path5559"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 176.31383,138.22897 q -0.16792,0 -0.29633,-0.084 -0.12841,-0.0889 -0.2025,-0.23212 -0.0741,-0.14323 -0.0741,-0.32103 0,-0.21731 0.0642,-0.37042 0.0642,-0.1531 0.19756,-0.27164 0.13829,-0.12347 0.3556,-0.23706 0.22225,-0.11854 0.53834,-0.26177 v -0.20249 q 0,-0.26176 -0.0346,-0.40993 -0.0296,-0.1531 -0.10866,-0.21731 -0.0741,-0.0642 -0.21237,-0.0642 -0.1136,0 -0.2025,0.0445 -0.0889,0.0444 -0.14322,0.1531 -0.0543,0.10372 -0.0543,0.2914 v 0.0988 l -0.3556,-0.005 q 0.005,-0.43462 0.18274,-0.64205 0.18274,-0.21237 0.59266,-0.21237 0.3803,0 0.53834,0.23212 0.15805,0.22719 0.15805,0.7112 v 1.38783 q 0,0.0741 0,0.19262 0.005,0.11359 0.01,0.21731 0.01,0.10372 0.0148,0.15804 h -0.32103 q -0.0148,-0.0938 -0.0346,-0.20743 -0.0148,-0.11853 -0.0198,-0.18768 -0.0593,0.17286 -0.21238,0.30621 -0.14816,0.13335 -0.38029,0.13335 z m 0.11853,-0.30621 q 0.10866,0 0.19262,-0.0494 0.0889,-0.0543 0.15804,-0.13335 0.0741,-0.079 0.1136,-0.15804 v -0.889 q -0.21237,0.11359 -0.36548,0.20249 -0.14817,0.084 -0.24201,0.16793 -0.0938,0.084 -0.13828,0.19261 -0.0444,0.10372 -0.0444,0.24695 0,0.22719 0.0938,0.32596 0.0988,0.0938 0.23213,0.0938 z"
+         style="stroke-width:0.26458332"
+         id="path5561"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 178.47899,138.2191 q -0.20743,0 -0.32102,-0.079 -0.1136,-0.084 -0.15311,-0.22225 -0.0395,-0.14322 -0.0395,-0.32596 v -2.02495 h -0.35066 v -0.23706 h 0.35066 v -0.88406 h 0.36054 v 0.88406 h 0.47413 v 0.23706 h -0.47413 v 1.99038 q 0,0.20743 0.0445,0.29633 0.0494,0.084 0.20743,0.084 0.0445,0 0.0988,-0.005 0.0543,-0.01 0.10372,-0.0148 v 0.27164 q -0.0741,0.0148 -0.15311,0.0198 -0.0741,0.01 -0.14817,0.01 z"
+         style="stroke-width:0.26458332"
+         id="path5563"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 179.89792,138.22897 q -0.2667,0 -0.43956,-0.10371 -0.16792,-0.10866 -0.25188,-0.3556 -0.079,-0.24695 -0.079,-0.65687 v -0.72108 q 0,-0.42475 0.084,-0.66181 0.084,-0.24201 0.25683,-0.34079 0.17286,-0.10371 0.42968,-0.10371 0.30621,0 0.46425,0.12841 0.15805,0.12841 0.21732,0.39017 0.0642,0.25682 0.0642,0.66181 v 0.25682 h -1.1557 v 0.49883 q 0,0.27658 0.0395,0.43956 0.0444,0.15805 0.13335,0.22719 0.0938,0.0691 0.23707,0.0691 0.10866,0 0.19756,-0.0395 0.0889,-0.0445 0.13828,-0.16298 0.0543,-0.12347 0.0543,-0.34572 v -0.19756 h 0.35066 v 0.15805 q 0,0.39017 -0.16298,0.62724 -0.16298,0.23212 -0.57785,0.23212 z m -0.40993,-1.71379 h 0.8001 v -0.23707 q 0,-0.22719 -0.0247,-0.38523 -0.0247,-0.16298 -0.10866,-0.24694 -0.079,-0.0889 -0.25682,-0.0889 -0.14817,0 -0.24201,0.0642 -0.0889,0.0642 -0.12841,0.23213 -0.0395,0.16298 -0.0395,0.46919 z"
+         style="stroke-width:0.26458332"
+         id="path5565"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 181.7625,138.22897 q -0.36547,0 -0.52846,-0.27657 -0.15804,-0.27658 -0.15804,-0.91864 v -0.52846 q 0,-0.37535 0.0543,-0.64699 0.0543,-0.27164 0.19755,-0.41981 0.14817,-0.1531 0.41981,-0.1531 0.16792,0 0.29139,0.079 0.12841,0.0741 0.21237,0.16792 V 134.184 h 0.36054 v 4.0005 h -0.36054 v -0.20249 q -0.084,0.0938 -0.20743,0.17286 -0.11853,0.0741 -0.28152,0.0741 z m 0.0741,-0.28151 q 0.11359,0 0.22225,-0.0543 0.10865,-0.0593 0.19261,-0.13829 v -1.98543 q -0.0741,-0.0692 -0.18274,-0.13335 -0.10865,-0.0691 -0.242,-0.0691 -0.23707,0 -0.31609,0.21238 -0.0741,0.20743 -0.0741,0.61242 v 0.67169 q 0,0.28645 0.0296,0.48401 0.0346,0.19755 0.11853,0.30127 0.0889,0.0988 0.25189,0.0988 z"
+         style="stroke-width:0.26458332"
+         id="path5567"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 184.24298,138.18452 v -4.0005 h 0.95815 q 0.36054,0 0.56303,0.13335 0.20743,0.13335 0.29633,0.37042 0.0889,0.23707 0.0889,0.5581 0,0.28151 -0.0938,0.52352 -0.0889,0.23706 -0.30128,0.38029 -0.20743,0.14323 -0.54821,0.14323 h -0.58773 v 1.89159 z m 0.37536,-2.17311 h 0.47907 q 0.24201,0 0.39017,-0.0691 0.15311,-0.0741 0.22225,-0.24201 0.0691,-0.16792 0.0691,-0.45437 0,-0.30622 -0.0593,-0.47414 -0.0593,-0.17286 -0.20743,-0.23706 -0.14323,-0.0692 -0.40993,-0.0692 h -0.48401 z"
+         style="stroke-width:0.26458332"
+         id="path5569"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 187.2385,138.22897 q -0.2914,0 -0.45932,-0.12347 -0.16792,-0.12841 -0.23707,-0.36548 -0.0642,-0.242 -0.0642,-0.58772 v -0.79023 q 0,-0.34572 0.0642,-0.58278 0.0691,-0.24201 0.23707,-0.36548 0.16792,-0.12841 0.45932,-0.12841 0.29633,0 0.45931,0.12841 0.16792,0.12347 0.23213,0.36548 0.0691,0.23706 0.0691,0.58278 v 0.79023 q 0,0.34572 -0.0691,0.58772 -0.0642,0.23707 -0.23213,0.36548 -0.16298,0.12347 -0.45931,0.12347 z m 0,-0.27163 q 0.18767,0 0.27163,-0.0988 0.0889,-0.0988 0.10866,-0.27658 0.0198,-0.1778 0.0198,-0.40993 v -0.82973 q 0,-0.23213 -0.0198,-0.40499 -0.0198,-0.1778 -0.10866,-0.27658 -0.084,-0.10371 -0.27163,-0.10371 -0.18768,0 -0.27164,0.10371 -0.084,0.0988 -0.10866,0.27658 -0.0198,0.17286 -0.0198,0.40499 v 0.82973 q 0,0.23213 0.0198,0.40993 0.0247,0.1778 0.10866,0.27658 0.084,0.0988 0.27164,0.0988 z"
+         style="stroke-width:0.26458332"
+         id="path5571"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 189.13225,138.22897 q -0.36548,0 -0.52846,-0.27657 -0.15804,-0.27658 -0.15804,-0.91864 v -0.52846 q 0,-0.37535 0.0543,-0.64699 0.0543,-0.27164 0.19756,-0.41981 0.14817,-0.1531 0.4198,-0.1531 0.16793,0 0.2914,0.079 0.12841,0.0741 0.21237,0.16792 V 134.184 h 0.36054 v 4.0005 h -0.36054 v -0.20249 q -0.084,0.0938 -0.20743,0.17286 -0.11854,0.0741 -0.28152,0.0741 z m 0.0741,-0.28151 q 0.1136,0 0.22225,-0.0543 0.10866,-0.0593 0.19262,-0.13829 v -1.98543 q -0.0741,-0.0692 -0.18274,-0.13335 -0.10865,-0.0691 -0.242,-0.0691 -0.23707,0 -0.31609,0.21238 -0.0741,0.20743 -0.0741,0.61242 v 0.67169 q 0,0.28645 0.0296,0.48401 0.0346,0.19755 0.11853,0.30127 0.0889,0.0988 0.25188,0.0988 z"
+         style="stroke-width:0.26458332"
+         id="path5573"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="to isolated Pod"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text5369">
+      <path
+         d="m 67.854969,163.01434 q -0.207433,0 -0.321027,-0.079 -0.113595,-0.084 -0.153106,-0.22225 -0.03951,-0.14323 -0.03951,-0.32597 v -2.02494 h -0.350661 v -0.23707 h 0.350661 v -0.88406 h 0.360539 v 0.88406 h 0.474133 v 0.23707 h -0.474133 v 1.99037 q 0,0.20743 0.04445,0.29633 0.04939,0.084 0.207433,0.084 0.04445,0 0.09878,-0.005 0.05433,-0.01 0.103717,-0.0148 v 0.27164 q -0.07408,0.0148 -0.153106,0.0197 -0.07408,0.01 -0.148167,0.01 z"
+         style="stroke-width:0.26458332"
+         id="path5576"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 69.264019,163.02422 q -0.291395,0 -0.459317,-0.12348 -0.167922,-0.12841 -0.237066,-0.36547 -0.06421,-0.24201 -0.06421,-0.58773 v -0.79022 q 0,-0.34573 0.06421,-0.58279 0.06914,-0.24201 0.237066,-0.36548 0.167922,-0.12841 0.459317,-0.12841 0.296333,0 0.459316,0.12841 0.167923,0.12347 0.232128,0.36548 0.06915,0.23706 0.06915,0.58279 v 0.79022 q 0,0.34572 -0.06915,0.58773 -0.06421,0.23706 -0.232128,0.36547 -0.162983,0.12348 -0.459316,0.12348 z m 0,-0.27164 q 0.187678,0 0.271639,-0.0988 0.0889,-0.0988 0.108655,-0.27658 0.01976,-0.1778 0.01976,-0.40993 v -0.82973 q 0,-0.23213 -0.01976,-0.40499 -0.01976,-0.1778 -0.108655,-0.27658 -0.08396,-0.10371 -0.271639,-0.10371 -0.187678,0 -0.271639,0.10371 -0.08396,0.0988 -0.108656,0.27658 -0.01976,0.17286 -0.01976,0.40499 v 0.82973 q 0,0.23213 0.01976,0.40993 0.02469,0.1778 0.108656,0.27658 0.08396,0.0988 0.271639,0.0988 z"
+         style="stroke-width:0.26458332"
+         id="path5578"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 71.568319,162.97977 v -2.85468 h 0.360539 v 2.85468 z m 0,-3.24979 v -0.48895 h 0.360539 v 0.48895 z"
+         style="stroke-width:0.26458332"
+         id="path5580"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 73.183953,163.02422 q -0.340784,0 -0.543278,-0.21731 -0.202494,-0.22225 -0.232128,-0.59267 l 0.301272,-0.0889 q 0.02963,0.32597 0.153106,0.47907 0.123472,0.14817 0.345722,0.14817 0.187678,0 0.286456,-0.10372 0.103716,-0.10865 0.103716,-0.30127 0,-0.13829 -0.08396,-0.27658 -0.08396,-0.14323 -0.2667,-0.29633 l -0.385233,-0.33585 q -0.192617,-0.16298 -0.291394,-0.32596 -0.09878,-0.16299 -0.09878,-0.39018 0,-0.20743 0.08396,-0.34572 0.0889,-0.14323 0.237067,-0.21731 0.153105,-0.079 0.360538,-0.079 0.325967,0 0.493889,0.21237 0.167922,0.20743 0.182739,0.53834 l -0.256822,0.084 q -0.0099,-0.19262 -0.05927,-0.31609 -0.04939,-0.12841 -0.138289,-0.18768 -0.08396,-0.0593 -0.207433,-0.0593 -0.162983,0 -0.2667,0.0938 -0.09878,0.0889 -0.09878,0.25188 0,0.12841 0.04939,0.22719 0.04939,0.0988 0.182739,0.22225 l 0.404989,0.36054 q 0.118533,0.10371 0.227189,0.22225 0.108655,0.11853 0.1778,0.2667 0.06914,0.14323 0.06914,0.34078 0,0.22225 -0.09384,0.37536 -0.0889,0.14816 -0.251883,0.23212 -0.162983,0.079 -0.385233,0.079 z"
+         style="stroke-width:0.26458332"
+         id="path5582"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 75.032486,163.02422 q -0.291394,0 -0.459316,-0.12348 -0.167923,-0.12841 -0.237067,-0.36547 -0.06421,-0.24201 -0.06421,-0.58773 v -0.79022 q 0,-0.34573 0.06421,-0.58279 0.06914,-0.24201 0.237067,-0.36548 0.167922,-0.12841 0.459316,-0.12841 0.296333,0 0.459317,0.12841 0.167922,0.12347 0.232128,0.36548 0.06914,0.23706 0.06914,0.58279 v 0.79022 q 0,0.34572 -0.06914,0.58773 -0.06421,0.23706 -0.232128,0.36547 -0.162984,0.12348 -0.459317,0.12348 z m 0,-0.27164 q 0.187678,0 0.271639,-0.0988 0.0889,-0.0988 0.108656,-0.27658 0.01976,-0.1778 0.01976,-0.40993 v -0.82973 q 0,-0.23213 -0.01976,-0.40499 -0.01976,-0.1778 -0.108656,-0.27658 -0.08396,-0.10371 -0.271639,-0.10371 -0.187678,0 -0.271639,0.10371 -0.08396,0.0988 -0.108655,0.27658 -0.01976,0.17286 -0.01976,0.40499 v 0.82973 q 0,0.23213 0.01976,0.40993 0.02469,0.1778 0.108655,0.27658 0.08396,0.0988 0.271639,0.0988 z"
+         style="stroke-width:0.26458332"
+         id="path5584"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 76.343452,162.97977 v -4.0005 h 0.360539 v 4.0005 z"
+         style="stroke-width:0.26458332"
+         id="path5586"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 77.776579,163.02422 q -0.167922,0 -0.296333,-0.084 -0.128412,-0.0889 -0.202495,-0.23213 -0.07408,-0.14323 -0.07408,-0.32103 0,-0.21731 0.06421,-0.37042 0.06421,-0.1531 0.197556,-0.27164 0.138289,-0.12347 0.3556,-0.23706 0.22225,-0.11854 0.538339,-0.26176 v -0.2025 q 0,-0.26176 -0.03457,-0.40993 -0.02963,-0.1531 -0.108656,-0.21731 -0.07408,-0.0642 -0.212372,-0.0642 -0.113595,0 -0.202495,0.0444 -0.0889,0.0445 -0.143227,0.1531 -0.05433,0.10372 -0.05433,0.2914 v 0.0988 l -0.3556,-0.005 q 0.0049,-0.43463 0.182739,-0.64206 0.182739,-0.21237 0.592666,-0.21237 0.380295,0 0.538339,0.23213 0.158045,0.22719 0.158045,0.7112 v 1.38782 q 0,0.0741 0,0.19262 0.0049,0.1136 0.0099,0.21731 0.0099,0.10372 0.01482,0.15805 h -0.321028 q -0.01482,-0.0938 -0.03457,-0.20744 -0.01482,-0.11853 -0.01975,-0.18767 -0.05927,0.17286 -0.212373,0.30621 -0.148166,0.13335 -0.380294,0.13335 z m 0.118533,-0.30621 q 0.108656,0 0.192617,-0.0494 0.0889,-0.0543 0.158044,-0.13335 0.07408,-0.079 0.113595,-0.15805 v -0.889 q -0.212372,0.1136 -0.365478,0.2025 -0.148167,0.084 -0.242006,0.16792 -0.09384,0.084 -0.138288,0.19262 -0.04445,0.10371 -0.04445,0.24694 0,0.22719 0.09384,0.32597 0.09878,0.0938 0.232128,0.0938 z"
+         style="stroke-width:0.26458332"
+         id="path5588"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 79.941741,163.01434 q -0.207433,0 -0.321027,-0.079 -0.113595,-0.084 -0.153106,-0.22225 -0.03951,-0.14323 -0.03951,-0.32597 v -2.02494 h -0.350661 v -0.23707 h 0.350661 v -0.88406 h 0.360539 v 0.88406 h 0.474133 v 0.23707 h -0.474133 v 1.99037 q 0,0.20743 0.04445,0.29633 0.04939,0.084 0.207433,0.084 0.04445,0 0.09878,-0.005 0.05433,-0.01 0.103717,-0.0148 v 0.27164 q -0.07408,0.0148 -0.153106,0.0197 -0.07408,0.01 -0.148167,0.01 z"
+         style="stroke-width:0.26458332"
+         id="path5590"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 81.360669,163.02422 q -0.2667,0 -0.439561,-0.10372 -0.167922,-0.10866 -0.251883,-0.3556 -0.07902,-0.24694 -0.07902,-0.65687 v -0.72108 q 0,-0.42474 0.08396,-0.66181 0.08396,-0.24201 0.256823,-0.34078 0.172861,-0.10372 0.429683,-0.10372 0.306211,0 0.464255,0.12841 0.158045,0.12841 0.217312,0.39017 0.06421,0.25682 0.06421,0.66181 v 0.25683 h -1.1557 v 0.49882 q 0,0.27658 0.03951,0.43956 0.04445,0.15805 0.13335,0.22719 0.09384,0.0692 0.237067,0.0692 0.108655,0 0.197555,-0.0395 0.0889,-0.0444 0.138289,-0.16299 0.05433,-0.12347 0.05433,-0.34572 v -0.19755 h 0.350661 v 0.15804 q 0,0.39017 -0.162983,0.62724 -0.162983,0.23213 -0.57785,0.23213 z m -0.409928,-1.7138 h 0.8001 v -0.23706 q 0,-0.22719 -0.02469,-0.38524 -0.02469,-0.16298 -0.108656,-0.24694 -0.07902,-0.0889 -0.256822,-0.0889 -0.148167,0 -0.242006,0.0642 -0.0889,0.0642 -0.128411,0.23213 -0.03951,0.16298 -0.03951,0.4692 z"
+         style="stroke-width:0.26458332"
+         id="path5592"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 83.225253,163.02422 q -0.365477,0 -0.528461,-0.27658 -0.158044,-0.27658 -0.158044,-0.91863 v -0.52847 q 0,-0.37535 0.05433,-0.64699 0.05433,-0.27164 0.197555,-0.41981 0.148167,-0.1531 0.419806,-0.1531 0.167922,0 0.291394,0.079 0.128411,0.0741 0.212372,0.16792 v -1.34831 h 0.360539 v 4.0005 h -0.360539 v -0.2025 q -0.08396,0.0938 -0.207433,0.17286 -0.118533,0.0741 -0.281517,0.0741 z m 0.07408,-0.28152 q 0.113594,0 0.22225,-0.0543 0.108655,-0.0593 0.192616,-0.13829 v -1.98543 q -0.07408,-0.0691 -0.182739,-0.13335 -0.108655,-0.0691 -0.242005,-0.0691 -0.237067,0 -0.316089,0.21237 -0.07408,0.20743 -0.07408,0.61242 v 0.67169 q 0,0.28645 0.02963,0.48401 0.03457,0.19756 0.118533,0.30127 0.0889,0.0988 0.251884,0.0988 z"
+         style="stroke-width:0.26458332"
+         id="path5594"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 85.705733,162.97977 v -4.0005 h 0.958144 q 0.360539,0 0.563034,0.13335 0.207433,0.13335 0.296333,0.37041 0.0889,0.23707 0.0889,0.5581 0,0.28151 -0.09384,0.52352 -0.0889,0.23707 -0.301272,0.38029 -0.207433,0.14323 -0.548217,0.14323 h -0.587727 v 1.8916 z m 0.375356,-2.17311 h 0.479072 q 0.242005,0 0.390172,-0.0692 0.153106,-0.0741 0.22225,-0.242 0.06914,-0.16793 0.06914,-0.45438 0,-0.30621 -0.05927,-0.47414 -0.05927,-0.17286 -0.207434,-0.23706 -0.143227,-0.0691 -0.409927,-0.0691 h -0.484011 z"
+         style="stroke-width:0.26458332"
+         id="path5596"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 88.701245,163.02422 q -0.291394,0 -0.459316,-0.12348 -0.167922,-0.12841 -0.237067,-0.36547 -0.06421,-0.24201 -0.06421,-0.58773 v -0.79022 q 0,-0.34573 0.06421,-0.58279 0.06914,-0.24201 0.237067,-0.36548 0.167922,-0.12841 0.459316,-0.12841 0.296334,0 0.459317,0.12841 0.167922,0.12347 0.232128,0.36548 0.06914,0.23706 0.06914,0.58279 v 0.79022 q 0,0.34572 -0.06914,0.58773 -0.06421,0.23706 -0.232128,0.36547 -0.162983,0.12348 -0.459317,0.12348 z m 0,-0.27164 q 0.187678,0 0.271639,-0.0988 0.0889,-0.0988 0.108656,-0.27658 0.01975,-0.1778 0.01975,-0.40993 v -0.82973 q 0,-0.23213 -0.01975,-0.40499 -0.01976,-0.1778 -0.108656,-0.27658 -0.08396,-0.10371 -0.271639,-0.10371 -0.187677,0 -0.271638,0.10371 -0.08396,0.0988 -0.108656,0.27658 -0.01975,0.17286 -0.01975,0.40499 v 0.82973 q 0,0.23213 0.01975,0.40993 0.0247,0.1778 0.108656,0.27658 0.08396,0.0988 0.271638,0.0988 z"
+         style="stroke-width:0.26458332"
+         id="path5598"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 90.595,163.02422 q -0.365477,0 -0.528461,-0.27658 -0.158044,-0.27658 -0.158044,-0.91863 v -0.52847 q 0,-0.37535 0.05433,-0.64699 0.05433,-0.27164 0.197555,-0.41981 0.148167,-0.1531 0.419806,-0.1531 0.167922,0 0.291394,0.079 0.128411,0.0741 0.212372,0.16792 v -1.34831 h 0.360539 v 4.0005 H 91.08395 v -0.2025 q -0.08396,0.0938 -0.207433,0.17286 -0.118533,0.0741 -0.281517,0.0741 z m 0.07408,-0.28152 q 0.113594,0 0.22225,-0.0543 0.108655,-0.0593 0.192616,-0.13829 v -1.98543 q -0.07408,-0.0691 -0.182738,-0.13335 -0.108656,-0.0691 -0.242006,-0.0691 -0.237067,0 -0.316089,0.21237 -0.07408,0.20743 -0.07408,0.61242 v 0.67169 q 0,0.28645 0.02963,0.48401 0.03457,0.19756 0.118533,0.30127 0.0889,0.0988 0.251884,0.0988 z"
+         style="stroke-width:0.26458332"
+         id="path5600"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="output port known"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text5373">
+      <path
+         d="m 225.57563,178.59679 q -0.2914,0 -0.45932,-0.12347 -0.16792,-0.12842 -0.23707,-0.36548 -0.0642,-0.24201 -0.0642,-0.58773 v -0.79022 q 0,-0.34572 0.0642,-0.58279 0.0691,-0.24201 0.23707,-0.36548 0.16792,-0.12841 0.45932,-0.12841 0.29633,0 0.45931,0.12841 0.16793,0.12347 0.23213,0.36548 0.0692,0.23707 0.0692,0.58279 v 0.79022 q 0,0.34572 -0.0692,0.58773 -0.0642,0.23706 -0.23213,0.36548 -0.16298,0.12347 -0.45931,0.12347 z m 0,-0.27164 q 0.18768,0 0.27164,-0.0988 0.0889,-0.0988 0.10865,-0.27658 0.0198,-0.1778 0.0198,-0.40992 v -0.82974 q 0,-0.23213 -0.0198,-0.40499 -0.0197,-0.1778 -0.10865,-0.27657 -0.084,-0.10372 -0.27164,-0.10372 -0.18768,0 -0.27164,0.10372 -0.084,0.0988 -0.10866,0.27657 -0.0198,0.17286 -0.0198,0.40499 v 0.82974 q 0,0.23212 0.0198,0.40992 0.0247,0.1778 0.10866,0.27658 0.084,0.0988 0.27164,0.0988 z"
+         style="stroke-width:0.26458332"
+         id="path5603"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 227.25701,178.59679 q -0.14323,0 -0.24201,-0.0692 -0.0988,-0.0741 -0.1531,-0.20743 -0.0494,-0.13829 -0.0494,-0.33091 v -2.29164 h 0.36054 v 2.21262 q 0,0.22225 0.0691,0.31609 0.0692,0.0889 0.20744,0.0889 0.12841,0 0.25682,-0.079 0.13335,-0.084 0.24694,-0.20743 v -2.33116 h 0.36054 v 2.85468 h -0.36054 v -0.31609 q -0.13829,0.15804 -0.31609,0.26176 -0.1778,0.0988 -0.38029,0.0988 z"
+         style="stroke-width:0.26458332"
+         id="path5605"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 229.54919,178.58691 q -0.20743,0 -0.32102,-0.079 -0.1136,-0.084 -0.15311,-0.22225 -0.0395,-0.14323 -0.0395,-0.32597 v -2.02494 h -0.35066 v -0.23707 h 0.35066 v -0.88406 h 0.36054 v 0.88406 h 0.47413 v 0.23707 h -0.47413 v 1.99037 q 0,0.20743 0.0445,0.29633 0.0494,0.084 0.20743,0.084 0.0445,0 0.0988,-0.005 0.0543,-0.01 0.10372,-0.0148 v 0.27164 q -0.0741,0.0148 -0.15311,0.0198 -0.0741,0.01 -0.14817,0.01 z"
+         style="stroke-width:0.26458332"
+         id="path5607"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 230.25198,179.49073 v -3.79307 h 0.36054 v 0.23707 q 0.0889,-0.10372 0.22225,-0.19262 0.13335,-0.0889 0.32597,-0.0889 0.20743,0 0.3309,0.0988 0.12842,0.0938 0.19756,0.25682 0.0691,0.16298 0.0938,0.36548 0.0247,0.20249 0.0247,0.4198 v 0.59761 q 0,0.36548 -0.0642,0.63712 -0.0593,0.27163 -0.20744,0.4198 -0.14816,0.14817 -0.41486,0.14817 -0.17286,0 -0.30127,-0.0889 -0.12348,-0.0889 -0.20744,-0.18274 v 1.16558 z m 0.80998,-1.17546 q 0.16298,0 0.24695,-0.10372 0.084,-0.10865 0.10865,-0.31115 0.0296,-0.20743 0.0296,-0.49882 v -0.60749 q 0,-0.28151 -0.0296,-0.46919 -0.0247,-0.19262 -0.10865,-0.2914 -0.084,-0.0988 -0.25189,-0.0988 -0.13829,0 -0.25682,0.0741 -0.11359,0.0741 -0.18768,0.14817 v 1.94592 q 0.079,0.084 0.19262,0.14817 0.11853,0.0642 0.25682,0.0642 z"
+         style="stroke-width:0.26458332"
+         id="path5609"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 232.73609,178.59679 q -0.14323,0 -0.24201,-0.0692 -0.0988,-0.0741 -0.1531,-0.20743 -0.0494,-0.13829 -0.0494,-0.33091 v -2.29164 h 0.36054 v 2.21262 q 0,0.22225 0.0691,0.31609 0.0692,0.0889 0.20744,0.0889 0.12841,0 0.25682,-0.079 0.13335,-0.084 0.24694,-0.20743 v -2.33116 h 0.36054 v 2.85468 h -0.36054 v -0.31609 q -0.13829,0.15804 -0.31609,0.26176 -0.1778,0.0988 -0.38029,0.0988 z"
+         style="stroke-width:0.26458332"
+         id="path5611"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 235.02827,178.58691 q -0.20743,0 -0.32102,-0.079 -0.1136,-0.084 -0.15311,-0.22225 -0.0395,-0.14323 -0.0395,-0.32597 v -2.02494 h -0.35066 v -0.23707 h 0.35066 v -0.88406 h 0.36054 v 0.88406 h 0.47413 v 0.23707 h -0.47413 v 1.99037 q 0,0.20743 0.0445,0.29633 0.0494,0.084 0.20743,0.084 0.0445,0 0.0988,-0.005 0.0543,-0.01 0.10372,-0.0148 v 0.27164 q -0.0741,0.0148 -0.15311,0.0198 -0.0741,0.01 -0.14817,0.01 z"
+         style="stroke-width:0.26458332"
+         id="path5613"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 236.73427,179.49073 v -3.79307 h 0.36054 v 0.23707 q 0.0889,-0.10372 0.22225,-0.19262 0.13335,-0.0889 0.32597,-0.0889 0.20743,0 0.33091,0.0988 0.12841,0.0938 0.19755,0.25682 0.0692,0.16298 0.0938,0.36548 0.0247,0.20249 0.0247,0.4198 v 0.59761 q 0,0.36548 -0.0642,0.63712 -0.0593,0.27163 -0.20743,0.4198 -0.14817,0.14817 -0.41487,0.14817 -0.17286,0 -0.30127,-0.0889 -0.12348,-0.0889 -0.20744,-0.18274 v 1.16558 z m 0.80998,-1.17546 q 0.16299,0 0.24695,-0.10372 0.084,-0.10865 0.10865,-0.31115 0.0296,-0.20743 0.0296,-0.49882 v -0.60749 q 0,-0.28151 -0.0296,-0.46919 -0.0247,-0.19262 -0.10865,-0.2914 -0.084,-0.0988 -0.25189,-0.0988 -0.13829,0 -0.25682,0.0741 -0.11359,0.0741 -0.18768,0.14817 v 1.94592 q 0.079,0.084 0.19262,0.14817 0.11853,0.0642 0.25682,0.0642 z"
+         style="stroke-width:0.26458332"
+         id="path5615"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 239.50484,178.59679 q -0.2914,0 -0.45932,-0.12347 -0.16792,-0.12842 -0.23707,-0.36548 -0.0642,-0.24201 -0.0642,-0.58773 v -0.79022 q 0,-0.34572 0.0642,-0.58279 0.0692,-0.24201 0.23707,-0.36548 0.16792,-0.12841 0.45932,-0.12841 0.29633,0 0.45931,0.12841 0.16793,0.12347 0.23213,0.36548 0.0692,0.23707 0.0692,0.58279 v 0.79022 q 0,0.34572 -0.0692,0.58773 -0.0642,0.23706 -0.23213,0.36548 -0.16298,0.12347 -0.45931,0.12347 z m 0,-0.27164 q 0.18767,0 0.27164,-0.0988 0.0889,-0.0988 0.10865,-0.27658 0.0198,-0.1778 0.0198,-0.40992 v -0.82974 q 0,-0.23213 -0.0198,-0.40499 -0.0198,-0.1778 -0.10865,-0.27657 -0.084,-0.10372 -0.27164,-0.10372 -0.18768,0 -0.27164,0.10372 -0.084,0.0988 -0.10866,0.27657 -0.0197,0.17286 -0.0197,0.40499 v 0.82974 q 0,0.23212 0.0197,0.40992 0.0247,0.1778 0.10866,0.27658 0.084,0.0988 0.27164,0.0988 z"
+         style="stroke-width:0.26458332"
+         id="path5617"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 240.79111,178.55234 v -2.85468 h 0.36548 v 0.39017 q 0.13828,-0.22719 0.31608,-0.32103 0.1778,-0.0988 0.34079,-0.0988 0.0148,0 0.0296,0 0.0148,0 0.0346,0.005 v 0.38523 q -0.0346,-0.0148 -0.084,-0.0198 -0.0494,-0.01 -0.0938,-0.01 -0.16792,0 -0.30621,0.079 -0.13335,0.079 -0.23706,0.25188 v 2.19287 z"
+         style="stroke-width:0.26458332"
+         id="path5619"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 242.90927,178.58691 q -0.20743,0 -0.32102,-0.079 -0.1136,-0.084 -0.15311,-0.22225 -0.0395,-0.14323 -0.0395,-0.32597 v -2.02494 h -0.35066 v -0.23707 h 0.35066 v -0.88406 h 0.36054 v 0.88406 h 0.47413 v 0.23707 h -0.47413 v 1.99037 q 0,0.20743 0.0445,0.29633 0.0494,0.084 0.20743,0.084 0.0445,0 0.0988,-0.005 0.0543,-0.01 0.10372,-0.0148 v 0.27164 q -0.0741,0.0148 -0.15311,0.0198 -0.0741,0.01 -0.14817,0.01 z"
+         style="stroke-width:0.26458332"
+         id="path5621"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 244.62021,178.55234 v -4.0005 h 0.36054 v 2.54353 l 0.95321,-1.39771 h 0.38029 l -0.72108,1.10137 0.69145,1.75331 h -0.36548 l -0.60254,-1.55081 -0.33585,0.46919 v 1.08162 z"
+         style="stroke-width:0.26458332"
+         id="path5623"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 246.59276,178.55234 v -2.85468 h 0.36054 v 0.29633 q 0.13829,-0.14816 0.31115,-0.242 0.17286,-0.0988 0.37535,-0.0988 0.14323,0 0.23707,0.0741 0.0988,0.0691 0.14817,0.20744 0.0543,0.13335 0.0543,0.32596 v 2.29165 h -0.36053 v -2.21262 q 0,-0.22225 -0.0692,-0.31115 -0.0691,-0.0938 -0.20743,-0.0938 -0.11854,0 -0.24695,0.0741 -0.12841,0.0741 -0.242,0.19262 v 2.35091 z"
+         style="stroke-width:0.26458332"
+         id="path5625"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 249.31509,178.59679 q -0.2914,0 -0.45932,-0.12347 -0.16792,-0.12842 -0.23706,-0.36548 -0.0642,-0.24201 -0.0642,-0.58773 v -0.79022 q 0,-0.34572 0.0642,-0.58279 0.0691,-0.24201 0.23706,-0.36548 0.16792,-0.12841 0.45932,-0.12841 0.29633,0 0.45932,0.12841 0.16792,0.12347 0.23212,0.36548 0.0692,0.23707 0.0692,0.58279 v 0.79022 q 0,0.34572 -0.0692,0.58773 -0.0642,0.23706 -0.23212,0.36548 -0.16299,0.12347 -0.45932,0.12347 z m 0,-0.27164 q 0.18768,0 0.27164,-0.0988 0.0889,-0.0988 0.10865,-0.27658 0.0198,-0.1778 0.0198,-0.40992 v -0.82974 q 0,-0.23213 -0.0198,-0.40499 -0.0197,-0.1778 -0.10865,-0.27657 -0.084,-0.10372 -0.27164,-0.10372 -0.18768,0 -0.27164,0.10372 -0.084,0.0988 -0.10866,0.27657 -0.0197,0.17286 -0.0197,0.40499 v 0.82974 q 0,0.23212 0.0197,0.40992 0.0247,0.1778 0.10866,0.27658 0.084,0.0988 0.27164,0.0988 z"
+         style="stroke-width:0.26458332"
+         id="path5627"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 250.93674,178.55234 -0.46425,-2.85468 h 0.30621 l 0.36054,2.38548 0.44944,-2.38548 h 0.31115 l 0.45437,2.37561 0.34079,-2.37561 h 0.31115 l -0.46426,2.85468 h -0.33584 l -0.45932,-2.32128 -0.4445,2.32128 z"
+         style="stroke-width:0.26458332"
+         id="path5629"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 253.43196,178.55234 v -2.85468 h 0.36054 v 0.29633 q 0.13829,-0.14816 0.31115,-0.242 0.17286,-0.0988 0.37536,-0.0988 0.14322,0 0.23706,0.0741 0.0988,0.0691 0.14817,0.20744 0.0543,0.13335 0.0543,0.32596 v 2.29165 H 254.558 v -2.21262 q 0,-0.22225 -0.0692,-0.31115 -0.0691,-0.0938 -0.20743,-0.0938 -0.11853,0 -0.24694,0.0741 -0.12841,0.0741 -0.24201,0.19262 v 2.35091 z"
+         style="stroke-width:0.26458332"
+         id="path5631"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="miss"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text5377">
+      <path
+         d="m 242.55876,205.08627 v -2.85467 h 0.33584 v 0.29139 q 0.14323,-0.16792 0.31609,-0.25188 0.17286,-0.0889 0.3556,-0.0889 0.14817,0 0.27164,0.079 0.12841,0.079 0.18274,0.29633 0.14323,-0.18768 0.32103,-0.28151 0.18274,-0.0938 0.38029,-0.0938 0.12347,0 0.23213,0.0593 0.11359,0.0593 0.18274,0.2025 0.0691,0.14323 0.0691,0.39017 v 2.25213 h -0.34078 v -2.24225 q 0,-0.25189 -0.079,-0.33091 -0.079,-0.084 -0.2025,-0.084 -0.13829,0 -0.27657,0.079 -0.13829,0.079 -0.26177,0.21731 0.005,0.0247 0.005,0.0543 0,0.0247 0,0.0543 v 2.25213 h -0.33584 v -2.24225 q 0,-0.25189 -0.084,-0.33091 -0.079,-0.084 -0.2025,-0.084 -0.13335,0 -0.27164,0.079 -0.13828,0.079 -0.26176,0.21238 v 2.36572 z"
+         style="stroke-width:0.26458332"
+         id="path5634"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 245.78154,205.08627 v -2.85467 h 0.36054 v 2.85467 z m 0,-3.24979 v -0.48895 h 0.36054 v 0.48895 z"
+         style="stroke-width:0.26458332"
+         id="path5636"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 247.39717,205.13072 q -0.34078,0 -0.54328,-0.21731 -0.20249,-0.22225 -0.23212,-0.59266 l 0.30127,-0.0889 q 0.0296,0.32596 0.1531,0.47907 0.12348,0.14816 0.34573,0.14816 0.18767,0 0.28645,-0.10371 0.10372,-0.10866 0.10372,-0.30127 0,-0.13829 -0.084,-0.27658 -0.084,-0.14323 -0.2667,-0.29634 l -0.38524,-0.33584 q -0.19261,-0.16298 -0.29139,-0.32597 -0.0988,-0.16298 -0.0988,-0.39017 0,-0.20743 0.084,-0.34572 0.0889,-0.14323 0.23707,-0.21731 0.1531,-0.079 0.36054,-0.079 0.32596,0 0.49389,0.21237 0.16792,0.20743 0.18274,0.53834 l -0.25683,0.084 q -0.01,-0.19262 -0.0593,-0.31609 -0.0494,-0.12841 -0.13829,-0.18768 -0.084,-0.0593 -0.20744,-0.0593 -0.16298,0 -0.2667,0.0938 -0.0988,0.0889 -0.0988,0.25189 0,0.12841 0.0494,0.22719 0.0494,0.0988 0.18273,0.22225 l 0.40499,0.36053 q 0.11854,0.10372 0.22719,0.22225 0.10866,0.11854 0.1778,0.2667 0.0692,0.14323 0.0692,0.34079 0,0.22225 -0.0938,0.37535 -0.0889,0.14817 -0.25189,0.23213 -0.16298,0.079 -0.38523,0.079 z"
+         style="stroke-width:0.26458332"
+         id="path5638"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 249.19138,205.13072 q -0.34079,0 -0.54328,-0.21731 -0.2025,-0.22225 -0.23213,-0.59266 l 0.30127,-0.0889 q 0.0296,0.32596 0.15311,0.47907 0.12347,0.14816 0.34572,0.14816 0.18768,0 0.28646,-0.10371 0.10371,-0.10866 0.10371,-0.30127 0,-0.13829 -0.084,-0.27658 -0.084,-0.14323 -0.2667,-0.29634 l -0.38523,-0.33584 q -0.19262,-0.16298 -0.2914,-0.32597 -0.0988,-0.16298 -0.0988,-0.39017 0,-0.20743 0.084,-0.34572 0.0889,-0.14323 0.23706,-0.21731 0.15311,-0.079 0.36054,-0.079 0.32597,0 0.49389,0.21237 0.16792,0.20743 0.18274,0.53834 l -0.25682,0.084 q -0.01,-0.19262 -0.0593,-0.31609 -0.0494,-0.12841 -0.13829,-0.18768 -0.084,-0.0593 -0.20743,-0.0593 -0.16298,0 -0.2667,0.0938 -0.0988,0.0889 -0.0988,0.25189 0,0.12841 0.0494,0.22719 0.0494,0.0988 0.18274,0.22225 l 0.40499,0.36053 q 0.11853,0.10372 0.22719,0.22225 0.10865,0.11854 0.1778,0.2667 0.0691,0.14323 0.0691,0.34079 0,0.22225 -0.0938,0.37535 -0.0889,0.14817 -0.25188,0.23213 -0.16298,0.079 -0.38523,0.079 z"
+         style="stroke-width:0.26458332"
+         id="path5640"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="whitelisted traffic"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text5381">
+      <path
+         d="m 81.806639,197.90475 -0.464256,-2.85467 h 0.306211 l 0.360539,2.38548 0.449439,-2.38548 h 0.31115 l 0.454378,2.3756 0.340783,-2.3756 h 0.31115 l -0.464256,2.85467 h -0.335844 l -0.459317,-2.32127 -0.4445,2.32127 z"
+         style="stroke-width:0.26458332"
+         id="path5643"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 84.306797,197.90475 v -4.0005 h 0.360539 v 1.4471 q 0.143227,-0.15311 0.316088,-0.24695 0.172861,-0.0988 0.380295,-0.0988 0.143228,0 0.237066,0.0741 0.09878,0.0691 0.148167,0.20743 0.05433,0.13335 0.05433,0.32597 v 2.29164 h -0.365478 v -2.21262 q 0,-0.22225 -0.06914,-0.31115 -0.06421,-0.0938 -0.202495,-0.0938 -0.123472,0 -0.256822,0.079 -0.128411,0.0741 -0.242005,0.19261 v 2.34597 z"
+         style="stroke-width:0.26458332"
+         id="path5645"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 86.376731,197.90475 v -2.85467 h 0.360539 v 2.85467 z m 0,-3.24978 v -0.48895 h 0.360539 v 0.48895 z"
+         style="stroke-width:0.26458332"
+         id="path5647"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 88.01706,197.93933 q -0.207434,0 -0.321028,-0.079 -0.113594,-0.084 -0.153106,-0.22225 -0.03951,-0.14322 -0.03951,-0.32596 v -2.02495 h -0.350661 v -0.23706 h 0.350661 v -0.88406 h 0.360539 v 0.88406 h 0.474133 v 0.23706 h -0.474133 v 1.99038 q 0,0.20743 0.04445,0.29633 0.04939,0.084 0.207433,0.084 0.04445,0 0.09878,-0.005 0.05433,-0.01 0.103717,-0.0148 v 0.27164 q -0.07408,0.0148 -0.153106,0.0198 -0.07408,0.01 -0.148166,0.01 z"
+         style="stroke-width:0.26458332"
+         id="path5649"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 89.435987,197.9492 q -0.2667,0 -0.439561,-0.10371 -0.167922,-0.10866 -0.251884,-0.3556 -0.07902,-0.24695 -0.07902,-0.65687 v -0.72108 q 0,-0.42475 0.08396,-0.66181 0.08396,-0.24201 0.256823,-0.34079 0.172861,-0.10371 0.429683,-0.10371 0.306211,0 0.464255,0.12841 0.158045,0.12841 0.217311,0.39017 0.06421,0.25682 0.06421,0.66181 v 0.25682 h -1.1557 v 0.49883 q 0,0.27658 0.03951,0.43956 0.04445,0.15805 0.13335,0.22719 0.09384,0.0692 0.237067,0.0692 0.108655,0 0.197555,-0.0395 0.0889,-0.0444 0.138289,-0.16298 0.05433,-0.12347 0.05433,-0.34572 v -0.19756 h 0.350661 v 0.15805 q 0,0.39017 -0.162983,0.62724 -0.162984,0.23212 -0.57785,0.23212 z m -0.409928,-1.71379 h 0.8001 v -0.23707 q 0,-0.22719 -0.02469,-0.38523 -0.02469,-0.16298 -0.108656,-0.24694 -0.07902,-0.0889 -0.256822,-0.0889 -0.148167,0 -0.242006,0.0642 -0.0889,0.0642 -0.128411,0.23213 -0.03951,0.16298 -0.03951,0.46919 z"
+         style="stroke-width:0.26458332"
+         id="path5651"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 90.717783,197.90475 v -4.0005 h 0.360539 v 4.0005 z"
+         style="stroke-width:0.26458332"
+         id="path5653"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 91.701471,197.90475 v -2.85467 h 0.360538 v 2.85467 z m 0,-3.24978 v -0.48895 h 0.360538 v 0.48895 z"
+         style="stroke-width:0.26458332"
+         id="path5655"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 93.317105,197.9492 q -0.340784,0 -0.543278,-0.21731 -0.202494,-0.22225 -0.232128,-0.59266 l 0.301272,-0.0889 q 0.02963,0.32596 0.153106,0.47907 0.123472,0.14817 0.345722,0.14817 0.187678,0 0.286456,-0.10372 0.103716,-0.10866 0.103716,-0.30127 0,-0.13829 -0.08396,-0.27658 -0.08396,-0.14323 -0.2667,-0.29633 l -0.385233,-0.33585 q -0.192617,-0.16298 -0.291394,-0.32597 -0.09878,-0.16298 -0.09878,-0.39017 0,-0.20743 0.08396,-0.34572 0.0889,-0.14323 0.237067,-0.21731 0.153105,-0.079 0.360538,-0.079 0.325967,0 0.493889,0.21237 0.167922,0.20743 0.182739,0.53834 l -0.256822,0.084 q -0.0099,-0.19262 -0.05927,-0.31609 -0.04939,-0.12841 -0.138289,-0.18768 -0.08396,-0.0593 -0.207433,-0.0593 -0.162983,0 -0.2667,0.0938 -0.09878,0.0889 -0.09878,0.25189 0,0.12841 0.04939,0.22719 0.04939,0.0988 0.182739,0.22225 l 0.404989,0.36054 q 0.118533,0.10371 0.227189,0.22225 0.108655,0.11853 0.1778,0.2667 0.06914,0.14322 0.06914,0.34078 0,0.22225 -0.09384,0.37535 -0.0889,0.14817 -0.251883,0.23213 -0.162983,0.079 -0.385233,0.079 z"
+         style="stroke-width:0.26458332"
+         id="path5657"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 95.136004,197.93933 q -0.207433,0 -0.321028,-0.079 -0.113594,-0.084 -0.153105,-0.22225 -0.03951,-0.14322 -0.03951,-0.32596 v -2.02495 H 94.2717 v -0.23706 h 0.350661 v -0.88406 H 94.9829 v 0.88406 h 0.474134 v 0.23706 H 94.9829 v 1.99038 q 0,0.20743 0.04445,0.29633 0.04939,0.084 0.207434,0.084 0.04445,0 0.09878,-0.005 0.05433,-0.01 0.103717,-0.0148 v 0.27164 q -0.07408,0.0148 -0.153105,0.0198 -0.07408,0.01 -0.148167,0.01 z"
+         style="stroke-width:0.26458332"
+         id="path5659"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 96.554931,197.9492 q -0.2667,0 -0.439561,-0.10371 -0.167922,-0.10866 -0.251883,-0.3556 -0.07902,-0.24695 -0.07902,-0.65687 v -0.72108 q 0,-0.42475 0.08396,-0.66181 0.08396,-0.24201 0.256822,-0.34079 0.172861,-0.10371 0.429683,-0.10371 0.306212,0 0.464256,0.12841 0.158044,0.12841 0.217311,0.39017 0.06421,0.25682 0.06421,0.66181 v 0.25682 h -1.1557 v 0.49883 q 0,0.27658 0.03951,0.43956 0.04445,0.15805 0.13335,0.22719 0.09384,0.0692 0.237066,0.0692 0.108656,0 0.197556,-0.0395 0.0889,-0.0444 0.138289,-0.16298 0.05433,-0.12347 0.05433,-0.34572 v -0.19756 h 0.350661 v 0.15805 q 0,0.39017 -0.162984,0.62724 -0.162983,0.23212 -0.57785,0.23212 z m -0.409927,-1.71379 h 0.8001 v -0.23707 q 0,-0.22719 -0.02469,-0.38523 -0.02469,-0.16298 -0.108655,-0.24694 -0.07902,-0.0889 -0.256823,-0.0889 -0.148166,0 -0.242005,0.0642 -0.0889,0.0642 -0.128411,0.23213 -0.03951,0.16298 -0.03951,0.46919 z"
+         style="stroke-width:0.26458332"
+         id="path5661"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 98.419517,197.9492 q -0.365478,0 -0.528461,-0.27657 -0.158045,-0.27658 -0.158045,-0.91864 v -0.52846 q 0,-0.37535 0.05433,-0.64699 0.05433,-0.27164 0.197556,-0.41981 0.148166,-0.1531 0.419805,-0.1531 0.167922,0 0.291395,0.079 0.128411,0.0741 0.212372,0.16792 v -1.34832 h 0.360539 v 4.0005 h -0.360539 v -0.20249 q -0.08396,0.0938 -0.207434,0.17286 -0.118533,0.0741 -0.281516,0.0741 z m 0.07408,-0.28151 q 0.113595,0 0.22225,-0.0543 0.108656,-0.0593 0.192617,-0.13829 v -1.98543 q -0.07408,-0.0692 -0.182739,-0.13335 -0.108656,-0.0692 -0.242006,-0.0692 -0.237066,0 -0.316089,0.21238 -0.07408,0.20743 -0.07408,0.61242 v 0.67169 q 0,0.28645 0.02963,0.48401 0.03457,0.19755 0.118534,0.30127 0.0889,0.0988 0.251883,0.0988 z"
+         style="stroke-width:0.26458332"
+         id="path5663"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 101.50254,197.93933 q -0.20743,0 -0.32103,-0.079 -0.11359,-0.084 -0.1531,-0.22225 -0.0395,-0.14322 -0.0395,-0.32596 v -2.02495 h -0.35066 v -0.23706 h 0.35066 v -0.88406 h 0.36054 v 0.88406 h 0.47413 v 0.23706 h -0.47413 v 1.99038 q 0,0.20743 0.0444,0.29633 0.0494,0.084 0.20743,0.084 0.0444,0 0.0988,-0.005 0.0543,-0.01 0.10371,-0.0148 v 0.27164 q -0.0741,0.0148 -0.1531,0.0198 -0.0741,0.01 -0.14817,0.01 z"
+         style="stroke-width:0.26458332"
+         id="path5665"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 102.23002,197.90475 v -2.85467 h 0.36548 v 0.39017 q 0.13829,-0.22719 0.31609,-0.32103 0.1778,-0.0988 0.34078,-0.0988 0.0148,0 0.0296,0 0.0148,0 0.0346,0.005 v 0.38524 q -0.0346,-0.0148 -0.084,-0.0198 -0.0494,-0.01 -0.0938,-0.01 -0.16792,0 -0.30621,0.079 -0.13335,0.079 -0.23707,0.25189 v 2.19286 z"
+         style="stroke-width:0.26458332"
+         id="path5667"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 104.12193,197.9492 q -0.16793,0 -0.29634,-0.084 -0.12841,-0.0889 -0.20249,-0.23212 -0.0741,-0.14323 -0.0741,-0.32103 0,-0.21731 0.0642,-0.37042 0.0642,-0.1531 0.19756,-0.27164 0.13828,-0.12347 0.3556,-0.23706 0.22225,-0.11854 0.53833,-0.26177 v -0.20249 q 0,-0.26176 -0.0346,-0.40993 -0.0296,-0.1531 -0.10865,-0.21731 -0.0741,-0.0642 -0.21238,-0.0642 -0.11359,0 -0.20249,0.0445 -0.0889,0.0445 -0.14323,0.1531 -0.0543,0.10372 -0.0543,0.2914 v 0.0988 l -0.3556,-0.005 q 0.005,-0.43462 0.18274,-0.64205 0.18274,-0.21237 0.59267,-0.21237 0.38029,0 0.53834,0.23212 0.15804,0.22719 0.15804,0.7112 v 1.38783 q 0,0.0741 0,0.19262 0.005,0.11359 0.01,0.21731 0.01,0.10372 0.0148,0.15804 H 104.769 q -0.0148,-0.0938 -0.0346,-0.20743 -0.0148,-0.11853 -0.0198,-0.18768 -0.0593,0.17286 -0.21237,0.30621 -0.14817,0.13335 -0.38029,0.13335 z m 0.11853,-0.30621 q 0.10865,0 0.19262,-0.0494 0.0889,-0.0543 0.15804,-0.13335 0.0741,-0.079 0.11359,-0.15804 v -0.889 q -0.21237,0.11359 -0.36547,0.20249 -0.14817,0.084 -0.24201,0.16793 -0.0938,0.084 -0.13829,0.19261 -0.0444,0.10372 -0.0444,0.24695 0,0.22719 0.0938,0.32596 0.0988,0.0938 0.23213,0.0938 z"
+         style="stroke-width:0.26458332"
+         id="path5669"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 105.76897,197.90475 v -2.59291 h -0.36548 v -0.26176 h 0.36548 v -0.29634 q 0,-0.21237 0.0346,-0.37535 0.0346,-0.16299 0.14323,-0.25682 0.11359,-0.0938 0.34572,-0.0938 0.079,0 0.15311,0.01 0.0741,0.005 0.13828,0.0247 v 0.2667 q -0.0444,-0.01 -0.10371,-0.0148 -0.0543,-0.01 -0.0988,-0.01 -0.16298,0 -0.20743,0.10372 -0.0395,0.0988 -0.0395,0.31115 v 0.33091 h 0.8001 v -0.29634 q 0,-0.21237 0.0296,-0.37535 0.0346,-0.16299 0.14323,-0.25682 0.11359,-0.0938 0.35066,-0.0938 0.079,0 0.14816,0.01 0.0741,0.005 0.14323,0.0247 v 0.2667 q -0.0494,-0.01 -0.10371,-0.0148 -0.0543,-0.01 -0.0988,-0.01 -0.16299,0 -0.20744,0.10372 -0.0444,0.0988 -0.0444,0.31115 v 0.33091 h 1.1557 v 2.85467 h -0.36053 v -2.59291 h -0.79517 v 2.59291 h -0.36053 v -2.59291 h -0.8001 v 2.59291 z m 2.32128,-3.24978 v -0.48895 h 0.36053 v 0.48895 z"
+         style="stroke-width:0.26458332"
+         id="path5671"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 109.76044,197.9492 q -0.33091,0 -0.49389,-0.14816 -0.16298,-0.14817 -0.21731,-0.40005 -0.0494,-0.25682 -0.0494,-0.57785 v -0.66675 q 0,-0.39511 0.0642,-0.647 0.0642,-0.25682 0.22719,-0.38029 0.16792,-0.12347 0.46919,-0.12347 0.30621,0 0.46426,0.11359 0.15804,0.1136 0.21237,0.32103 0.0543,0.20743 0.0543,0.48401 v 0.13335 h -0.33585 v -0.13829 q 0,-0.25188 -0.0395,-0.39017 -0.0346,-0.13829 -0.12347,-0.19262 -0.084,-0.0593 -0.22719,-0.0593 -0.16792,0 -0.25682,0.079 -0.0889,0.079 -0.11854,0.26176 -0.0296,0.1778 -0.0296,0.47907 v 0.8001 q 0,0.42968 0.084,0.60748 0.084,0.17287 0.32597,0.17287 0.16792,0 0.25188,-0.0741 0.084,-0.079 0.10866,-0.23213 0.0247,-0.1531 0.0247,-0.38029 v -0.15804 h 0.33585 v 0.13828 q 0,0.28646 -0.0543,0.50871 -0.0543,0.21731 -0.21237,0.34572 -0.15311,0.12347 -0.46426,0.12347 z"
+         style="stroke-width:0.26458332"
+         id="path5673"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="miss"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text5385">
+      <path
+         d="m 56.973012,181.2738 v -2.85467 h 0.335844 v 0.29139 q 0.143228,-0.16792 0.316089,-0.25188 0.172861,-0.0889 0.3556,-0.0889 0.148167,0 0.271639,0.079 0.128411,0.079 0.182739,0.29633 0.143228,-0.18767 0.321028,-0.28151 0.182738,-0.0938 0.380294,-0.0938 0.123472,0 0.232128,0.0593 0.113594,0.0593 0.182739,0.2025 0.06914,0.14323 0.06914,0.39017 v 2.25213 h -0.340783 v -2.24225 q 0,-0.25189 -0.07902,-0.33091 -0.07902,-0.084 -0.202495,-0.084 -0.138289,0 -0.276578,0.079 -0.138289,0.079 -0.261761,0.21731 0.0049,0.0247 0.0049,0.0543 0,0.0247 0,0.0543 v 2.25213 h -0.335844 v -2.24225 q 0,-0.25189 -0.08396,-0.33091 -0.07902,-0.084 -0.202495,-0.084 -0.13335,0 -0.271639,0.079 -0.138289,0.079 -0.261761,0.21238 v 2.36572 z"
+         style="stroke-width:0.26458332"
+         id="path5676"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 60.195791,181.2738 v -2.85467 h 0.360539 v 2.85467 z m 0,-3.24978 v -0.48895 h 0.360539 v 0.48895 z"
+         style="stroke-width:0.26458332"
+         id="path5678"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 61.811425,181.31825 q -0.340784,0 -0.543278,-0.21731 -0.202495,-0.22225 -0.232128,-0.59266 l 0.301272,-0.0889 q 0.02963,0.32596 0.153106,0.47907 0.123472,0.14816 0.345722,0.14816 0.187678,0 0.286456,-0.10371 0.103716,-0.10866 0.103716,-0.30127 0,-0.13829 -0.08396,-0.27658 -0.08396,-0.14323 -0.2667,-0.29634 l -0.385233,-0.33584 q -0.192617,-0.16298 -0.291395,-0.32597 -0.09878,-0.16298 -0.09878,-0.39017 0,-0.20743 0.08396,-0.34572 0.0889,-0.14323 0.237066,-0.21731 0.153106,-0.079 0.360539,-0.079 0.325967,0 0.493889,0.21237 0.167922,0.20743 0.182739,0.53834 l -0.256822,0.084 q -0.0099,-0.19262 -0.05927,-0.31609 -0.04939,-0.12841 -0.138289,-0.18768 -0.08396,-0.0593 -0.207433,-0.0593 -0.162983,0 -0.2667,0.0938 -0.09878,0.0889 -0.09878,0.25189 0,0.12841 0.04939,0.22719 0.04939,0.0988 0.182739,0.22225 l 0.404989,0.36053 q 0.118533,0.10372 0.227189,0.22225 0.108655,0.11854 0.1778,0.2667 0.06914,0.14323 0.06914,0.34079 0,0.22225 -0.09384,0.37535 -0.0889,0.14817 -0.251883,0.23213 -0.162983,0.079 -0.385233,0.079 z"
+         style="stroke-width:0.26458332"
+         id="path5680"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 63.60563,181.31825 q -0.340783,0 -0.543277,-0.21731 -0.202495,-0.22225 -0.232128,-0.59266 l 0.301272,-0.0889 q 0.02963,0.32596 0.153106,0.47907 0.123472,0.14816 0.345722,0.14816 0.187678,0 0.286455,-0.10371 0.103717,-0.10866 0.103717,-0.30127 0,-0.13829 -0.08396,-0.27658 -0.08396,-0.14323 -0.2667,-0.29634 l -0.385233,-0.33584 q -0.192617,-0.16298 -0.291395,-0.32597 -0.09878,-0.16298 -0.09878,-0.39017 0,-0.20743 0.08396,-0.34572 0.0889,-0.14323 0.237067,-0.21731 0.153106,-0.079 0.360539,-0.079 0.325967,0 0.493889,0.21237 0.167922,0.20743 0.182739,0.53834 l -0.256823,0.084 q -0.0099,-0.19262 -0.05927,-0.31609 -0.04939,-0.12841 -0.138289,-0.18768 -0.08396,-0.0593 -0.207433,-0.0593 -0.162984,0 -0.2667,0.0938 -0.09878,0.0889 -0.09878,0.25189 0,0.12841 0.04939,0.22719 0.04939,0.0988 0.182739,0.22225 l 0.404989,0.36053 q 0.118533,0.10372 0.227188,0.22225 0.108656,0.11854 0.1778,0.2667 0.06914,0.14323 0.06914,0.34079 0,0.22225 -0.09384,0.37535 -0.0889,0.14817 -0.251883,0.23213 -0.162984,0.079 -0.385234,0.079 z"
+         style="stroke-width:0.26458332"
+         id="path5682"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="conntrack invalid"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text5389">
+      <path
+         d="m 206.22391,49.782544 q -0.3309,0 -0.49389,-0.148166 -0.16298,-0.148167 -0.21731,-0.40005 -0.0494,-0.256823 -0.0494,-0.57785 v -0.66675 q 0,-0.395111 0.0642,-0.646995 0.0642,-0.256822 0.22719,-0.380294 0.16792,-0.123472 0.46919,-0.123472 0.30621,0 0.46426,0.113594 0.15804,0.113595 0.21237,0.321028 0.0543,0.207433 0.0543,0.484011 v 0.13335 h -0.33585 v -0.138289 q 0,-0.251883 -0.0395,-0.390172 -0.0346,-0.138289 -0.12347,-0.192617 -0.084,-0.05927 -0.22719,-0.05927 -0.16792,0 -0.25682,0.07902 -0.0889,0.07902 -0.11853,0.261761 -0.0296,0.1778 -0.0296,0.479072 v 0.8001 q 0,0.429683 0.084,0.607483 0.084,0.172861 0.32597,0.172861 0.16792,0 0.25188,-0.07408 0.084,-0.07902 0.10866,-0.232128 0.0247,-0.153105 0.0247,-0.380294 v -0.158044 h 0.33585 v 0.138288 q 0,0.286456 -0.0543,0.508706 -0.0543,0.217311 -0.21237,0.345722 -0.15311,0.123472 -0.46426,0.123472 z"
+         style="stroke-width:0.26458332"
+         id="path5685"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 208.14352,49.782544 q -0.29139,0 -0.45932,-0.123472 -0.16792,-0.128411 -0.23706,-0.365478 -0.0642,-0.242005 -0.0642,-0.587727 v -0.790223 q 0,-0.345722 0.0642,-0.582788 0.0691,-0.242006 0.23706,-0.365478 0.16793,-0.128411 0.45932,-0.128411 0.29633,0 0.45932,0.128411 0.16792,0.123472 0.23212,0.365478 0.0692,0.237066 0.0692,0.582788 v 0.790223 q 0,0.345722 -0.0692,0.587727 -0.0642,0.237067 -0.23212,0.365478 -0.16299,0.123472 -0.45932,0.123472 z m 0,-0.271639 q 0.18768,0 0.27164,-0.09878 0.0889,-0.09878 0.10865,-0.276578 0.0198,-0.1778 0.0198,-0.409928 v -0.829733 q 0,-0.232128 -0.0198,-0.404989 -0.0197,-0.1778 -0.10865,-0.276578 -0.084,-0.103716 -0.27164,-0.103716 -0.18768,0 -0.27164,0.103716 -0.084,0.09878 -0.10865,0.276578 -0.0198,0.172861 -0.0198,0.404989 v 0.829733 q 0,0.232128 0.0198,0.409928 0.0247,0.1778 0.10865,0.276578 0.084,0.09878 0.27164,0.09878 z"
+         style="stroke-width:0.26458332"
+         id="path5687"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 209.4051,49.738094 v -2.854677 h 0.36054 v 0.296333 q 0.13828,-0.148167 0.31115,-0.242005 0.17286,-0.09878 0.37535,-0.09878 0.14323,0 0.23707,0.07408 0.0988,0.06914 0.14816,0.207433 0.0543,0.13335 0.0543,0.325967 v 2.291644 h -0.36054 v -2.212622 q 0,-0.22225 -0.0691,-0.31115 -0.0692,-0.09384 -0.20743,-0.09384 -0.11854,0 -0.24695,0.07408 -0.12841,0.07408 -0.242,0.192616 v 2.350911 z"
+         style="stroke-width:0.26458332"
+         id="path5689"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 211.42117,49.738094 v -2.854677 h 0.36054 v 0.296333 q 0.13828,-0.148167 0.31115,-0.242005 0.17286,-0.09878 0.37535,-0.09878 0.14323,0 0.23707,0.07408 0.0988,0.06914 0.14816,0.207433 0.0543,0.13335 0.0543,0.325967 v 2.291644 h -0.36054 v -2.212622 q 0,-0.22225 -0.0691,-0.31115 -0.0692,-0.09384 -0.20743,-0.09384 -0.11854,0 -0.24695,0.07408 -0.12841,0.07408 -0.242,0.192616 v 2.350911 z"
+         style="stroke-width:0.26458332"
+         id="path5691"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 214.11386,49.772667 q -0.20743,0 -0.32102,-0.07902 -0.1136,-0.08396 -0.15311,-0.22225 -0.0395,-0.143227 -0.0395,-0.325966 v -2.024945 h -0.35066 V 46.88342 h 0.35066 v -0.884061 h 0.36054 v 0.884061 h 0.47413 v 0.237066 h -0.47413 v 1.990372 q 0,0.207434 0.0445,0.296334 0.0494,0.08396 0.20743,0.08396 0.0445,0 0.0988,-0.0049 0.0543,-0.0099 0.10372,-0.01482 v 0.271639 q -0.0741,0.01482 -0.15311,0.01976 -0.0741,0.0099 -0.14817,0.0099 z"
+         style="stroke-width:0.26458332"
+         id="path5693"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 214.84135,49.738094 v -2.854677 h 0.36547 v 0.390172 q 0.13829,-0.227189 0.31609,-0.321028 0.1778,-0.09878 0.34079,-0.09878 0.0148,0 0.0296,0 0.0148,0 0.0346,0.0049 v 0.385234 q -0.0346,-0.01482 -0.084,-0.01976 -0.0494,-0.0099 -0.0938,-0.0099 -0.16792,0 -0.30621,0.07902 -0.13335,0.07902 -0.23707,0.251884 v 2.192866 z"
+         style="stroke-width:0.26458332"
+         id="path5695"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 216.73325,49.782544 q -0.16792,0 -0.29633,-0.08396 -0.12841,-0.0889 -0.2025,-0.232128 -0.0741,-0.143227 -0.0741,-0.321027 0,-0.217311 0.0642,-0.370417 0.0642,-0.153105 0.19756,-0.271639 0.13829,-0.123472 0.3556,-0.237066 0.22225,-0.118534 0.53834,-0.261762 V 47.80205 q 0,-0.261761 -0.0346,-0.409928 -0.0296,-0.153105 -0.10866,-0.217311 -0.0741,-0.06421 -0.21237,-0.06421 -0.1136,0 -0.2025,0.04445 -0.0889,0.04445 -0.14322,0.153105 -0.0543,0.103717 -0.0543,0.291395 v 0.09878 l -0.3556,-0.0049 q 0.005,-0.434622 0.18274,-0.642055 0.18274,-0.212372 0.59266,-0.212372 0.3803,0 0.53834,0.232128 0.15805,0.227188 0.15805,0.711199 v 1.387828 q 0,0.07408 0,0.192617 0.005,0.113594 0.01,0.217311 0.01,0.103717 0.0148,0.158044 h -0.32103 q -0.0148,-0.09384 -0.0346,-0.207433 -0.0148,-0.118533 -0.0198,-0.187678 -0.0593,0.172861 -0.21238,0.306211 -0.14816,0.13335 -0.38029,0.13335 z m 0.11853,-0.306211 q 0.10866,0 0.19262,-0.04939 0.0889,-0.05433 0.15804,-0.13335 0.0741,-0.07902 0.1136,-0.158044 v -0.889 q -0.21237,0.113594 -0.36548,0.202494 -0.14817,0.08396 -0.242,0.167923 -0.0938,0.08396 -0.13829,0.192616 -0.0444,0.103717 -0.0444,0.246945 0,0.227189 0.0938,0.325966 0.0988,0.09384 0.23212,0.09384 z"
+         style="stroke-width:0.26458332"
+         id="path5697"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 218.90875,49.782544 q -0.3309,0 -0.49389,-0.148166 -0.16298,-0.148167 -0.21731,-0.40005 -0.0494,-0.256823 -0.0494,-0.57785 v -0.66675 q 0,-0.395111 0.0642,-0.646995 0.0642,-0.256822 0.22719,-0.380294 0.16792,-0.123472 0.46919,-0.123472 0.30621,0 0.46426,0.113594 0.15804,0.113595 0.21237,0.321028 0.0543,0.207433 0.0543,0.484011 v 0.13335 h -0.33585 v -0.138289 q 0,-0.251883 -0.0395,-0.390172 -0.0346,-0.138289 -0.12347,-0.192617 -0.084,-0.05927 -0.22719,-0.05927 -0.16792,0 -0.25682,0.07902 -0.0889,0.07902 -0.11853,0.261761 -0.0296,0.1778 -0.0296,0.479072 v 0.8001 q 0,0.429683 0.084,0.607483 0.084,0.172861 0.32597,0.172861 0.16792,0 0.25188,-0.07408 0.084,-0.07902 0.10866,-0.232128 0.0247,-0.153105 0.0247,-0.380294 v -0.158044 h 0.33585 v 0.138288 q 0,0.286456 -0.0543,0.508706 -0.0543,0.217311 -0.21237,0.345722 -0.15311,0.123472 -0.46426,0.123472 z"
+         style="stroke-width:0.26458332"
+         id="path5699"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 220.12704,49.738094 v -4.000499 h 0.36054 v 2.543527 l 0.9532,-1.397705 h 0.3803 l -0.72108,1.101372 0.69144,1.753305 h -0.36547 l -0.60255,-1.550811 -0.33584,0.469195 v 1.081616 z"
+         style="stroke-width:0.26458332"
+         id="path5701"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 223.14231,49.738094 v -2.854677 h 0.36054 v 2.854677 z m 0,-3.249788 v -0.48895 h 0.36054 v 0.48895 z"
+         style="stroke-width:0.26458332"
+         id="path5703"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 224.10601,49.738094 v -2.854677 h 0.36054 v 0.296333 q 0.13829,-0.148167 0.31115,-0.242005 0.17286,-0.09878 0.37535,-0.09878 0.14323,0 0.23707,0.07408 0.0988,0.06914 0.14817,0.207433 0.0543,0.13335 0.0543,0.325967 v 2.291644 h -0.36054 v -2.212622 q 0,-0.22225 -0.0691,-0.31115 -0.0691,-0.09384 -0.20743,-0.09384 -0.11854,0 -0.24695,0.07408 -0.12841,0.07408 -0.242,0.192616 v 2.350911 z"
+         style="stroke-width:0.26458332"
+         id="path5705"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 226.55176,49.738094 -0.61736,-2.854677 h 0.36548 l 0.46425,2.439811 0.45932,-2.439811 h 0.35066 l -0.59761,2.854677 z"
+         style="stroke-width:0.26458332"
+         id="path5707"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 228.42452,49.782544 q -0.16792,0 -0.29633,-0.08396 -0.12841,-0.0889 -0.20249,-0.232128 -0.0741,-0.143227 -0.0741,-0.321027 0,-0.217311 0.0642,-0.370417 0.0642,-0.153105 0.19755,-0.271639 0.13829,-0.123472 0.3556,-0.237066 0.22225,-0.118534 0.53834,-0.261762 V 47.80205 q 0,-0.261761 -0.0346,-0.409928 -0.0296,-0.153105 -0.10865,-0.217311 -0.0741,-0.06421 -0.21238,-0.06421 -0.11359,0 -0.20249,0.04445 -0.0889,0.04445 -0.14323,0.153105 -0.0543,0.103717 -0.0543,0.291395 v 0.09878 l -0.3556,-0.0049 q 0.005,-0.434622 0.18274,-0.642055 0.18274,-0.212372 0.59267,-0.212372 0.38029,0 0.53834,0.232128 0.15804,0.227188 0.15804,0.711199 v 1.387828 q 0,0.07408 0,0.192617 0.005,0.113594 0.01,0.217311 0.01,0.103717 0.0148,0.158044 h -0.32103 q -0.0148,-0.09384 -0.0346,-0.207433 -0.0148,-0.118533 -0.0198,-0.187678 -0.0593,0.172861 -0.21237,0.306211 -0.14817,0.13335 -0.3803,0.13335 z m 0.11854,-0.306211 q 0.10865,0 0.19261,-0.04939 0.0889,-0.05433 0.15805,-0.13335 0.0741,-0.07902 0.11359,-0.158044 v -0.889 q -0.21237,0.113594 -0.36547,0.202494 -0.14817,0.08396 -0.24201,0.167923 -0.0938,0.08396 -0.13829,0.192616 -0.0444,0.103717 -0.0444,0.246945 0,0.227189 0.0938,0.325966 0.0988,0.09384 0.23213,0.09384 z"
+         style="stroke-width:0.26458332"
+         id="path5709"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 229.94316,49.738094 v -4.000499 h 0.36053 v 4.000499 z"
+         style="stroke-width:0.26458332"
+         id="path5711"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 230.92684,49.738094 v -2.854677 h 0.36054 v 2.854677 z m 0,-3.249788 v -0.48895 h 0.36054 v 0.48895 z"
+         style="stroke-width:0.26458332"
+         id="path5713"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 232.52272,49.782544 q -0.36548,0 -0.52846,-0.276577 -0.15804,-0.276578 -0.15804,-0.918634 v -0.528461 q 0,-0.375355 0.0543,-0.646994 0.0543,-0.271639 0.19756,-0.419806 0.14817,-0.153105 0.4198,-0.153105 0.16793,0 0.2914,0.07902 0.12841,0.07408 0.21237,0.167922 v -1.348316 h 0.36054 v 4.000499 h -0.36054 V 49.5356 q -0.084,0.09384 -0.20743,0.172861 -0.11854,0.07408 -0.28152,0.07408 z m 0.0741,-0.281516 q 0.1136,0 0.22225,-0.05433 0.10866,-0.05927 0.19262,-0.138289 v -1.985433 q -0.0741,-0.06914 -0.18274,-0.13335 -0.10865,-0.06914 -0.242,-0.06914 -0.23707,0 -0.31609,0.212373 -0.0741,0.207433 -0.0741,0.612422 v 0.671689 q 0,0.286455 0.0296,0.484011 0.0346,0.197555 0.11853,0.301272 0.0889,0.09878 0.25188,0.09878 z"
+         style="stroke-width:0.26458332"
+         id="path5715"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="service traffic"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text5393">
+      <path
+         d="m 269.29161,96.273614 q -0.34078,0 -0.54328,-0.217311 -0.20249,-0.22225 -0.23213,-0.592667 l 0.30128,-0.0889 q 0.0296,0.325967 0.1531,0.479073 0.12347,0.148166 0.34572,0.148166 0.18768,0 0.28646,-0.103716 0.10372,-0.108656 0.10372,-0.301273 0,-0.138288 -0.084,-0.276577 -0.084,-0.143228 -0.2667,-0.296334 l -0.38523,-0.335844 q -0.19262,-0.162983 -0.29139,-0.325967 -0.0988,-0.162983 -0.0988,-0.390172 0,-0.207433 0.084,-0.345722 0.0889,-0.143228 0.23707,-0.217311 0.1531,-0.07902 0.36054,-0.07902 0.32596,0 0.49388,0.212372 0.16793,0.207433 0.18274,0.538339 l -0.25682,0.08396 q -0.01,-0.192617 -0.0593,-0.316089 -0.0494,-0.128411 -0.13828,-0.187678 -0.084,-0.05927 -0.20744,-0.05927 -0.16298,0 -0.2667,0.09384 -0.0988,0.0889 -0.0988,0.251884 0,0.128411 0.0494,0.227188 0.0494,0.09878 0.18274,0.22225 l 0.40499,0.360539 q 0.11853,0.103717 0.22719,0.22225 0.10866,0.118534 0.1778,0.2667 0.0691,0.143228 0.0691,0.340784 0,0.22225 -0.0938,0.375355 -0.0889,0.148167 -0.25189,0.232128 -0.16298,0.07902 -0.38523,0.07902 z"
+         style="stroke-width:0.26458332"
+         id="path5718"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 271.15002,96.273614 q -0.2667,0 -0.43956,-0.103717 -0.16792,-0.108655 -0.25188,-0.3556 -0.079,-0.246944 -0.079,-0.656872 v -0.721077 q 0,-0.424745 0.084,-0.661811 0.084,-0.242006 0.25683,-0.340784 0.17286,-0.103716 0.42968,-0.103716 0.30621,0 0.46426,0.128411 0.15804,0.128411 0.21731,0.390172 0.0642,0.256822 0.0642,0.661811 v 0.256822 h -1.1557 v 0.498828 q 0,0.276578 0.0395,0.439561 0.0444,0.158044 0.13335,0.227189 0.0938,0.06914 0.23707,0.06914 0.10866,0 0.19756,-0.03951 0.0889,-0.04445 0.13828,-0.162983 0.0543,-0.123472 0.0543,-0.345722 V 95.2562 h 0.35066 v 0.158045 q 0,0.390172 -0.16298,0.627238 -0.16298,0.232128 -0.57785,0.232128 z m -0.40993,-1.713794 h 0.8001 v -0.237067 q 0,-0.227189 -0.0247,-0.385233 -0.0247,-0.162983 -0.10866,-0.246945 -0.079,-0.0889 -0.25682,-0.0889 -0.14817,0 -0.24201,0.06421 -0.0889,0.06421 -0.12841,0.232128 -0.0395,0.162983 -0.0395,0.469194 z"
+         style="stroke-width:0.26458332"
+         id="path5720"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 272.40712,96.229164 v -2.854677 h 0.36548 v 0.390172 q 0.13829,-0.227189 0.31609,-0.321028 0.1778,-0.09878 0.34078,-0.09878 0.0148,0 0.0296,0 0.0148,0 0.0346,0.0049 v 0.385233 q -0.0346,-0.01482 -0.084,-0.01975 -0.0494,-0.0099 -0.0938,-0.0099 -0.16792,0 -0.30621,0.07902 -0.13335,0.07902 -0.23707,0.251884 v 2.192866 z"
+         style="stroke-width:0.26458332"
+         id="path5722"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 274.27834,96.229164 -0.61736,-2.854677 h 0.36548 l 0.46426,2.43981 0.45931,-2.43981 h 0.35066 l -0.5976,2.854677 z"
+         style="stroke-width:0.26458332"
+         id="path5724"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 275.70167,96.229164 v -2.854677 h 0.36054 v 2.854677 z m 0,-3.249789 v -0.48895 h 0.36054 v 0.48895 z"
+         style="stroke-width:0.26458332"
+         id="path5726"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 277.37163,96.273614 q -0.3309,0 -0.49389,-0.148167 -0.16298,-0.148166 -0.21731,-0.40005 -0.0494,-0.256822 -0.0494,-0.577849 v -0.66675 q 0,-0.395112 0.0642,-0.646995 0.0642,-0.256822 0.22719,-0.380294 0.16792,-0.123472 0.46919,-0.123472 0.30621,0 0.46426,0.113594 0.15804,0.113594 0.21237,0.321028 0.0543,0.207433 0.0543,0.484011 v 0.13335 h -0.33585 v -0.138289 q 0,-0.251883 -0.0395,-0.390172 -0.0346,-0.138289 -0.12347,-0.192617 -0.084,-0.05927 -0.22719,-0.05927 -0.16792,0 -0.25682,0.07902 -0.0889,0.07902 -0.11854,0.261761 -0.0296,0.1778 -0.0296,0.479072 v 0.8001 q 0,0.429683 0.084,0.607483 0.084,0.172861 0.32597,0.172861 0.16792,0 0.25188,-0.07408 0.084,-0.07902 0.10866,-0.232128 0.0247,-0.153105 0.0247,-0.380294 v -0.158045 h 0.33585 v 0.138289 q 0,0.286456 -0.0543,0.508706 -0.0543,0.217311 -0.21237,0.345722 -0.15311,0.123472 -0.46426,0.123472 z"
+         style="stroke-width:0.26458332"
+         id="path5728"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 279.30112,96.273614 q -0.2667,0 -0.43957,-0.103717 -0.16792,-0.108655 -0.25188,-0.3556 -0.079,-0.246944 -0.079,-0.656872 v -0.721077 q 0,-0.424745 0.084,-0.661811 0.084,-0.242006 0.25682,-0.340784 0.17286,-0.103716 0.42969,-0.103716 0.30621,0 0.46425,0.128411 0.15805,0.128411 0.21731,0.390172 0.0642,0.256822 0.0642,0.661811 v 0.256822 h -1.1557 v 0.498828 q 0,0.276578 0.0395,0.439561 0.0444,0.158044 0.13335,0.227189 0.0938,0.06914 0.23707,0.06914 0.10865,0 0.19755,-0.03951 0.0889,-0.04445 0.13829,-0.162983 0.0543,-0.123472 0.0543,-0.345722 V 95.2562 h 0.35066 v 0.158045 q 0,0.390172 -0.16298,0.627238 -0.16299,0.232128 -0.57785,0.232128 z m -0.40993,-1.713794 h 0.8001 v -0.237067 q 0,-0.227189 -0.0247,-0.385233 -0.0247,-0.162983 -0.10865,-0.246945 -0.079,-0.0889 -0.25682,-0.0889 -0.14817,0 -0.24201,0.06421 -0.0889,0.06421 -0.12841,0.232128 -0.0395,0.162983 -0.0395,0.469194 z"
+         style="stroke-width:0.26458332"
+         id="path5730"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 282.21336,96.263736 q -0.20743,0 -0.32103,-0.07902 -0.11359,-0.08396 -0.1531,-0.22225 -0.0395,-0.143228 -0.0395,-0.325967 v -2.024944 h -0.35066 v -0.237066 h 0.35066 v -0.884062 h 0.36054 v 0.884062 h 0.47413 v 0.237066 h -0.47413 v 1.990372 q 0,0.207434 0.0444,0.296334 0.0494,0.08396 0.20743,0.08396 0.0444,0 0.0988,-0.0049 0.0543,-0.0099 0.10371,-0.01482 v 0.271639 q -0.0741,0.01482 -0.1531,0.01976 -0.0741,0.0099 -0.14817,0.0099 z"
+         style="stroke-width:0.26458332"
+         id="path5732"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 282.94085,96.229164 v -2.854677 h 0.36547 v 0.390172 q 0.13829,-0.227189 0.31609,-0.321028 0.1778,-0.09878 0.34079,-0.09878 0.0148,0 0.0296,0 0.0148,0 0.0346,0.0049 v 0.385233 q -0.0346,-0.01482 -0.084,-0.01975 -0.0494,-0.0099 -0.0938,-0.0099 -0.16792,0 -0.30621,0.07902 -0.13335,0.07902 -0.23707,0.251884 v 2.192866 z"
+         style="stroke-width:0.26458332"
+         id="path5734"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 284.83275,96.273614 q -0.16792,0 -0.29633,-0.08396 -0.12842,-0.0889 -0.2025,-0.232128 -0.0741,-0.143228 -0.0741,-0.321028 0,-0.217311 0.0642,-0.370416 0.0642,-0.153106 0.19756,-0.271639 0.13829,-0.123472 0.3556,-0.237067 0.22225,-0.118533 0.53834,-0.261761 V 94.29312 q 0,-0.261761 -0.0346,-0.409928 -0.0296,-0.153105 -0.10866,-0.217311 -0.0741,-0.06421 -0.21237,-0.06421 -0.1136,0 -0.2025,0.04445 -0.0889,0.04445 -0.14322,0.153106 -0.0543,0.103717 -0.0543,0.291394 v 0.09878 l -0.3556,-0.0049 q 0.005,-0.434622 0.18274,-0.642055 0.18274,-0.212372 0.59266,-0.212372 0.3803,0 0.53834,0.232127 0.15805,0.227189 0.15805,0.7112 v 1.387828 q 0,0.07408 0,0.192617 0.005,0.113594 0.01,0.217311 0.01,0.103716 0.0148,0.158044 h -0.32103 q -0.0148,-0.09384 -0.0346,-0.207433 -0.0148,-0.118534 -0.0198,-0.187678 -0.0593,0.172861 -0.21238,0.306211 -0.14816,0.13335 -0.38029,0.13335 z m 0.11853,-0.306211 q 0.10866,0 0.19262,-0.04939 0.0889,-0.05433 0.15804,-0.13335 0.0741,-0.07902 0.1136,-0.158044 v -0.889 q -0.21237,0.113594 -0.36548,0.202494 -0.14817,0.08396 -0.24201,0.167922 -0.0938,0.08396 -0.13828,0.192617 -0.0445,0.103717 -0.0445,0.246945 0,0.227188 0.0938,0.325966 0.0988,0.09384 0.23213,0.09384 z"
+         style="stroke-width:0.26458332"
+         id="path5736"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 286.47979,96.229164 v -2.592916 h -0.36548 v -0.261761 h 0.36548 v -0.296334 q 0,-0.212372 0.0346,-0.375355 0.0346,-0.162984 0.14323,-0.256823 0.1136,-0.09384 0.34572,-0.09384 0.079,0 0.15311,0.0099 0.0741,0.0049 0.13829,0.02469 v 0.2667 q -0.0444,-0.0099 -0.10372,-0.01482 -0.0543,-0.0099 -0.0988,-0.0099 -0.16298,0 -0.20743,0.103717 -0.0395,0.09878 -0.0395,0.31115 v 0.330906 h 0.8001 v -0.296334 q 0,-0.212372 0.0296,-0.375355 0.0346,-0.162984 0.14323,-0.256823 0.11359,-0.09384 0.35066,-0.09384 0.079,0 0.14817,0.0099 0.0741,0.0049 0.14323,0.02469 v 0.2667 q -0.0494,-0.0099 -0.10372,-0.01482 -0.0543,-0.0099 -0.0988,-0.0099 -0.16298,0 -0.20743,0.103717 -0.0445,0.09878 -0.0445,0.31115 v 0.330906 h 1.1557 v 2.854677 h -0.36054 V 93.63623 h -0.79516 v 2.592916 h -0.36054 V 93.63623 h -0.8001 v 2.592916 z m 2.32128,-3.249789 v -0.48895 h 0.36054 v 0.48895 z"
+         style="stroke-width:0.26458332"
+         id="path5738"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 290.47126,96.273614 q -0.3309,0 -0.49389,-0.148167 -0.16298,-0.148166 -0.21731,-0.40005 -0.0494,-0.256822 -0.0494,-0.577849 v -0.66675 q 0,-0.395112 0.0642,-0.646995 0.0642,-0.256822 0.22719,-0.380294 0.16792,-0.123472 0.46919,-0.123472 0.30621,0 0.46426,0.113594 0.15804,0.113594 0.21237,0.321028 0.0543,0.207433 0.0543,0.484011 v 0.13335 h -0.33585 v -0.138289 q 0,-0.251883 -0.0395,-0.390172 -0.0346,-0.138289 -0.12347,-0.192617 -0.084,-0.05927 -0.22719,-0.05927 -0.16792,0 -0.25682,0.07902 -0.0889,0.07902 -0.11854,0.261761 -0.0296,0.1778 -0.0296,0.479072 v 0.8001 q 0,0.429683 0.084,0.607483 0.084,0.172861 0.32597,0.172861 0.16792,0 0.25188,-0.07408 0.084,-0.07902 0.10866,-0.232128 0.0247,-0.153105 0.0247,-0.380294 v -0.158045 h 0.33585 v 0.138289 q 0,0.286456 -0.0543,0.508706 -0.0543,0.217311 -0.21237,0.345722 -0.15311,0.123472 -0.46426,0.123472 z"
+         style="stroke-width:0.26458332"
+         id="path5740"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="to tunnel"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text5397">
+      <path
+         d="m 89.454708,123.31089 q -0.207433,0 -0.321027,-0.079 -0.113595,-0.084 -0.153106,-0.22225 -0.03951,-0.14322 -0.03951,-0.32596 v -2.02495 h -0.350661 v -0.23706 h 0.350661 v -0.88406 h 0.360539 v 0.88406 h 0.474133 v 0.23706 h -0.474133 v 1.99037 q 0,0.20744 0.04445,0.29634 0.04939,0.084 0.207433,0.084 0.04445,0 0.09878,-0.005 0.05433,-0.01 0.103717,-0.0148 v 0.27164 q -0.07408,0.0148 -0.153106,0.0198 -0.07408,0.01 -0.148167,0.01 z"
+         style="stroke-width:0.26458332"
+         id="path5743"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 90.863758,123.32076 q -0.291395,0 -0.459317,-0.12347 -0.167922,-0.12841 -0.237066,-0.36548 -0.06421,-0.242 -0.06421,-0.58772 v -0.79023 q 0,-0.34572 0.06421,-0.58278 0.06914,-0.24201 0.237066,-0.36548 0.167922,-0.12841 0.459317,-0.12841 0.296333,0 0.459317,0.12841 0.167922,0.12347 0.232127,0.36548 0.06915,0.23706 0.06915,0.58278 v 0.79023 q 0,0.34572 -0.06915,0.58772 -0.06421,0.23707 -0.232127,0.36548 -0.162984,0.12347 -0.459317,0.12347 z m 0,-0.27164 q 0.187678,0 0.271639,-0.0988 0.0889,-0.0988 0.108655,-0.27658 0.01976,-0.1778 0.01976,-0.40993 v -0.82973 q 0,-0.23213 -0.01976,-0.40499 -0.01975,-0.1778 -0.108655,-0.27658 -0.08396,-0.10371 -0.271639,-0.10371 -0.187678,0 -0.271639,0.10371 -0.08396,0.0988 -0.108655,0.27658 -0.01976,0.17286 -0.01976,0.40499 v 0.82973 q 0,0.23213 0.01976,0.40993 0.02469,0.1778 0.108655,0.27658 0.08396,0.0988 0.271639,0.0988 z"
+         style="stroke-width:0.26458332"
+         id="path5745"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 93.805175,123.31089 q -0.207434,0 -0.321028,-0.079 -0.113594,-0.084 -0.153106,-0.22225 -0.03951,-0.14322 -0.03951,-0.32596 v -2.02495 H 92.94087 v -0.23706 h 0.350661 v -0.88406 h 0.360539 v 0.88406 h 0.474133 v 0.23706 H 93.65207 v 1.99037 q 0,0.20744 0.04445,0.29634 0.04939,0.084 0.207434,0.084 0.04445,0 0.09878,-0.005 0.05433,-0.01 0.103717,-0.0148 v 0.27164 q -0.07408,0.0148 -0.153106,0.0198 -0.07408,0.01 -0.148166,0.01 z"
+         style="stroke-width:0.26458332"
+         id="path5747"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 94.927769,123.32076 q -0.143228,0 -0.242006,-0.0691 -0.09878,-0.0741 -0.153106,-0.20743 -0.04939,-0.13829 -0.04939,-0.33091 v -2.29164 h 0.360538 v 2.21262 q 0,0.22225 0.06915,0.31609 0.06914,0.0889 0.207433,0.0889 0.128411,0 0.256822,-0.079 0.13335,-0.084 0.246945,-0.20743 v -2.33115 h 0.360539 v 2.85467 h -0.360539 v -0.31609 q -0.138289,0.15805 -0.316089,0.26177 -0.1778,0.0988 -0.380294,0.0988 z"
+         style="stroke-width:0.26458332"
+         id="path5749"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 96.543325,123.27631 v -2.85467 h 0.360539 v 0.29633 q 0.138289,-0.14817 0.31115,-0.24201 0.172861,-0.0988 0.375356,-0.0988 0.143227,0 0.237066,0.0741 0.09878,0.0691 0.148167,0.20743 0.05433,0.13335 0.05433,0.32597 v 2.29164 h -0.360539 v -2.21262 q 0,-0.22225 -0.06915,-0.31115 -0.06914,-0.0938 -0.207433,-0.0938 -0.118533,0 -0.246944,0.0741 -0.128411,0.0741 -0.242006,0.19261 v 2.35091 z"
+         style="stroke-width:0.26458332"
+         id="path5751"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 98.559395,123.27631 v -2.85467 h 0.360539 v 0.29633 q 0.138288,-0.14817 0.311149,-0.24201 0.172862,-0.0988 0.375356,-0.0988 0.143228,0 0.237067,0.0741 0.09878,0.0691 0.148166,0.20743 0.05433,0.13335 0.05433,0.32597 v 2.29164 h -0.360495 v -2.21262 q 0,-0.22225 -0.06914,-0.31115 -0.06914,-0.0938 -0.207434,-0.0938 -0.118533,0 -0.246944,0.0741 -0.128411,0.0741 -0.242005,0.19261 v 2.35091 z"
+         style="stroke-width:0.26458332"
+         id="path5753"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 101.2916,123.32076 q -0.2667,0 -0.43956,-0.10371 -0.16792,-0.10866 -0.25188,-0.3556 -0.079,-0.24695 -0.079,-0.65688 v -0.72107 q 0,-0.42475 0.084,-0.66181 0.084,-0.24201 0.25682,-0.34079 0.17286,-0.10371 0.42968,-0.10371 0.30621,0 0.46426,0.12841 0.15804,0.12841 0.21731,0.39017 0.0642,0.25682 0.0642,0.66181 v 0.25682 h -1.1557 v 0.49883 q 0,0.27658 0.0395,0.43956 0.0444,0.15805 0.13335,0.22719 0.0938,0.0691 0.23706,0.0691 0.10866,0 0.19756,-0.0395 0.0889,-0.0444 0.13829,-0.16298 0.0543,-0.12347 0.0543,-0.34572 v -0.19756 h 0.35066 v 0.15805 q 0,0.39017 -0.16299,0.62724 -0.16298,0.23212 -0.57785,0.23212 z m -0.40992,-1.71379 h 0.8001 v -0.23707 q 0,-0.22719 -0.0247,-0.38523 -0.0247,-0.16298 -0.10865,-0.24694 -0.079,-0.0889 -0.25683,-0.0889 -0.14816,0 -0.242,0.0642 -0.0889,0.0642 -0.12841,0.23213 -0.0395,0.16298 -0.0395,0.46919 z"
+         style="stroke-width:0.26458332"
+         id="path5755"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 102.5734,123.27631 v -4.0005 h 0.36054 v 4.0005 z"
+         style="stroke-width:0.26458332"
+         id="path5757"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/docs/ovs-pipeline.md
+++ b/docs/ovs-pipeline.md
@@ -1,0 +1,602 @@
+# Antrea OVS Pipeline
+
+## Terminology
+
+* *Node Route Controller*: the [K8s
+  controller](https://kubernetes.io/docs/concepts/architecture/controller/)
+  which is part of the Antrea agent and watches for updates to Nodes. When a
+  Node is added, it updates the local networking configuration (e.g. configure
+  the tunnel to the new Node). When a Node is deleted, it performs the necessary
+  clean-ups.
+* *peer Node*: this is how we refer to other Nodes in the cluster, to which the
+  local Node is connected through a VXLAN or Geneve tunnel.
+* *Global Virtual MAC*: a virtual MAC address which is used as the destination
+  MAC for all tunnelled traffic across all Nodes. This simplifies networking by
+  enabling all Nodes to use this MAC address instead of the actual MAC address
+  of the appropriate remote gateway. This enables each vSwitch to act as a
+  "proxy" for the local gateway when receiving tunnelled traffic and directly
+  take care of the packet forwarding. At the moment, we use an hard-coded value
+  of aa:bb:cc:dd:ee:ff.
+* *`normal` action*: OpenFlow defines this action to submit a packet to “the
+  traditional non-OpenFlow pipeline of the switch”. That is, if a flow uses this
+  action, then the packets in the flow go through the switch in the same way
+  that they would if OpenFlow was not configured on the switch. Antrea uses this
+  action to process ARP traffic as a regular learning L2 switch would.
+* *table-miss flow entry*: a "catch-all" entry in a OpenFlow table, which is
+  used if no other flow is matched. If the table-miss flow entry does not exist,
+  by default packets unmatched by flow entries are dropped (discarded).
+* *conjunctive match fields*: an efficient way in OVS to implement conjunctive
+  matches, that is a match for which we have multiple fields, each one with a
+  set of acceptable values. See [OVS
+  fields](http://www.openvswitch.org/support/dist-docs/ovs-fields.7.txt) for
+  more information.
+* *conntrack*: a connection tracking module that can be used by OVS to match on
+  the state of a TCP, UDP, ICMP, etc., connection. See the [OVS Conntrack
+  tutorial](http://docs.openvswitch.org/en/latest/tutorials/ovs-conntrack/) for
+  more information.
+* *dmac table*: a traditional L2 switch has a "dmac" table which maps
+  learned destination MAC address to the appropriate egress port. It is often
+  the same physical table as the "smac" table (which matches on the source MAC
+  address and initiate MAC learning if the address is unknown).
+
+**This documentation currently assumes that Antrea is used in encap mode (an
+  overlay network is created between all Nodes), without IPsec enabled.**
+
+## Dumping the Flows
+
+This guide includes a representative flow dump for every table in the pipeline,
+in order to illustrate the function of each table. If you have a cluster running
+Antrea, you can dump the flows for a given Node as follows:
+```
+kubectl exec -n kube-system <ANTREA_AGENT_POD_NAME> -c antrea-ovs -- ovs-ofctl dump-flows <BRIDGE_NAME> [--no-stats] [--names]
+```
+where `<ANTREA_AGENT_POD_NAME>` is the name of the Antrea Agent Pod running on
+that Node and `<BRIDGE_NAME>` is the name of the bridge created by Antrea
+(`br-int` by default).
+
+## Registers
+
+We use 2 32-bit OVS registers to carry information throughout the pipeline:
+ * reg0 (NXM_NX_REG0):
+   - bits [0..15] are used to store the traffic source (from tunnel: 0, from
+   local gateway: 1, from local Pod: 2). It is set in the [ClassifierTable].
+   - bit 16 is used to indicate whether the destination MAC address of a packet
+   is "known", i.e. corresponds to an entry in [L2ForwardingCalcTable], which is
+   essentially a "dmac" table.
+ * reg1 (NXM_NX_REG1): it is used to store the egress OF port for the packet. It
+ is set by [DNATTable] for traffic destined to services and by
+ [L2ForwardingCalcTable] otherwise. It is consummed by [L2ForwardingOutTable] to
+ output each packet to the correct port.
+
+## Network Policy Implementation
+
+Several tables of the pipeline are dedicated to [K8s Network
+Policy](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+implementation ([EgressRuleTable], [EgressDefaultTable], [IngressRuleTable] and
+[IngressDefaultTable]).
+
+The Antrea implementation of K8s Network Policy, including the communication
+channel between the Controller and Agents, and how a Network Policy is mapped to
+OVS flows at each Node, will be described in details in a separate document. For
+the present document, we will use the Network Policy example below, and explain
+how these simple ingress and egress rules map to individual flows as we describe
+the relevant tables of our pipeline.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-network-policy
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      app: nginx
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: nginx
+    ports:
+    - protocol: TCP
+      port: 80
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          app: nginx
+    ports:
+    - protocol: TCP
+      port: 80
+```
+
+This Network Policy is applied to all Pods with the `nginx` app label in the
+`default` namespace. For these Pods, it only allows TCP traffic on port 80 from
+and to Pods which also have the `nginx` app label. Because Antrea will only
+install OVS flows for this Network Policy on Nodes for which some of the Pods
+are the target of the policy, we have scheduled 2 `nginx` Pods on the same
+Node. They received IP addresses 10.10.1.2 and 10.10.1.3 from the Antrea CNI, so
+you will see these addresses show up in the OVS flows.
+
+## Tables
+
+![OVS pipeline](/docs/assets/ovs-pipeline.svg)
+
+### ClassifierTable (0)
+
+This table is used to determine which "category" of traffic (tunnel, local
+gateway or local Pod) the packet belongs to. This is done by matching on the
+ingress port for the packet. The appropriate value is then written to bits
+[0..15] of the NXM_NX_REG0 register: 0 for tunnel, 1 for local gateway and 2 for
+local Pod. This information is used by matches in subsequent tables.
+
+If you dump the flows for this table, you may see the following:
+```
+1. table=0, priority=200,in_port=gw0 actions=load:0x1->NXM_NX_REG0[0..15],resubmit(,10)
+2. table=0, priority=200,in_port=tun0 actions=load:0->NXM_NX_REG0[0..15],resubmit(,30)
+3. table=0, priority=190,in_port="coredns5-8ec607" actions=load:0x2->NXM_NX_REG0[0..15],resubmit(,10)
+4. table=0, priority=190,in_port="coredns5-9d9530" actions=load:0x2->NXM_NX_REG0[0..15],resubmit(,10)
+5. table=0, priority=0 actions=drop
+```
+
+Flow 1 is for traffic coming in on the local gateway. Flow 2 is for traffic
+comming in through a VXLAN or Geneve tunnel (i.e. from another Node). The next
+two flows (3 and 4) are for local Pods (in this case Pods from the coredns
+deployment).
+
+Local traffic is then resubmitted to [SpoofGuardTable], while tunnel traffic
+from other Nodes is resubmitted to [ConntrackTable]. The table-miss flow entry
+will drop all unmatched packets (in practice this flow entry should almost never
+be used).
+
+### SpoofGuardTable (10)
+
+This table prevents IP and ARP
+[spoofing](https://en.wikipedia.org/wiki/Spoofing_attack) from local Pods. For
+each Pod (as identified by the ingress port), we ensure that:
+ * for IP traffic, the source IP and MAC addresses are correct, i.e. match the
+ values configured on the interface when Antrea set-up networking for the Pod.
+ * for ARP traffic, the advertised IP and MAC addresses are correct, i.e. match
+ the values configured on the interface when Antrea set-up networking for the
+ Pod.
+
+Because Antrea currently relies on kube-proxy to load-balance traffic destined
+to services, implementing that kind of IP spoofing check for traffic coming-in
+on the local gateway port is not as trivial. Traffic from local Pods destined to
+services will first go through the gateway, get load-balanced by the kube-proxy
+datapath (DNAT) then sent back through the gateway. This means that legitimate
+traffic can be received on the gateway port with a source IP belonging to a
+local Pod. We may add some fine-grained rules in the future to accomodate for
+this, but for now we just allow all IP traffic received from the gateway. We do
+have an ARP spoofing check for the gateway however, since there is no reason for
+the host to advertise a different MAC address on gw0.
+
+If you dump the flows for this table, you may see the following:
+```
+1. table=10, priority=200,ip,in_port=gw0 actions=resubmit(,30)
+2. table=10, priority=200,arp,in_port=gw0,arp_spa=10.10.0.1,arp_sha=e2:e5:a4:9b:1c:b1 actions=resubmit(,20)
+3. table=10, priority=200,ip,in_port="coredns5-8ec607",dl_src=12:9e:a6:47:d0:70,nw_src=10.10.0.2 actions=resubmit(,30)
+4. table=10, priority=200,ip,in_port="coredns5-9d9530",dl_src=ba:a8:13:ca:ed:cf,nw_src=10.10.0.3 actions=resubmit(,30)
+5. table=10, priority=200,arp,in_port="coredns5-8ec607",arp_spa=10.10.0.2,arp_sha=12:9e:a6:47:d0:70 actions=resubmit(,20)
+6. table=10, priority=200,arp,in_port="coredns5-9d9530",arp_spa=10.10.0.3,arp_sha=ba:a8:13:ca:ed:cf actions=resubmit(,20)
+7. table=10, priority=0 actions=drop
+```
+
+After this table, ARP traffic is resubmitted to [ARPResponderTable], while IP
+traffic is resubmitted to [ConnectionTrackTable]. Traffic which does not match
+any of the rules described above will be dropped by the table-miss flow entry.
+
+### ARPResponderTable (20)
+
+The main purpose of this table is to reply to ARP requests from the local
+gateway asking for the MAC address of a remote peer gateway (another Node's
+gateway). This ensures that the local Node can reach any remote Pod, which in
+particular is required for service traffic which has been load-balanced to a
+remote Pod backend by kube-proxy. Note that the table is programmed to reply to
+such ARP requests with a "Global Virtual MAC" ("Global" because it is used by
+all Antrea OVS bridges), and not with the actual MAC address of the remote
+gateway. This ensures that once the traffic is received by the remote OVS
+bridge, it can be directly forwarded to the appropriate Pod without actually
+going through the gateway. The Virtual MAC is used as the destination MAC
+address for all the traffic being tunnelled.
+
+If you dump the flows for this table, you may see the following:
+```
+1. table=20, priority=200,arp,arp_tpa=10.10.1.1,arp_op=1 actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],mod_dl_src:aa:bb:cc:dd:ee:ff,load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],load:0xaabbccddeeff->NXM_NX_ARP_SHA[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],load:0xa0a0101->NXM_OF_ARP_SPA[],IN_PORT
+2. table=20, priority=190,arp actions=NORMAL
+3. table=20, priority=0 actions=drop
+```
+
+Flow 1 is the "ARP responder" for the peer Node whose local Pod subnet is
+10.10.1.0/24. If we were to look at the routing table for the local Node, we
+would see the following "onlink" route:
+```
+10.10.1.0/24 via 10.10.1.1 dev gw0 onlink
+```
+A similar route is installed on the gateway (gw0) interface every time the
+Antrea Node Route Controller is notified that a new Node has joined the
+cluster. The route must be marked as "onlink" since the kernel does not have a
+route to the peer gateway 10.10.1.1: we trick the kernel into believing that
+10.10.1.1 is directly connected to the local Node, even though it is on the
+other side of the tunnel.
+
+Flow 2 ensures that OVS handle the remainder of ARP traffic as a regular L2
+learning switch (using the `normal` action). In particular, this takes care of
+forwarding ARP requests and replies between local Pods.
+
+The table-miss flow entry (flow 3) will drop all other packets. This flow should
+never be used because only ARP traffic should be resubmitted to this table, and
+ARP traffic will either match flow 1 or flow 2.
+
+### ConntrackTable (30)
+
+The sole purpose of this table is to invoke the `ct` action on all packets and
+set the `ct_zone` (connection tracking context) to an hard-coded value, then
+resubmit traffic to [ConntrackStateTable]. If you dump the flows for this table,
+you should only see 1 flow:
+```
+1. table=30, priority=200,ip actions=ct(table=31,zone=65520)
+```
+
+A `ct_zone` is simply used to isolate connection tracking rules. It is similar
+in spirit to the more generic Linux network namespaces, but `ct_zone` is
+specific to conntrack and has less overhead.
+
+After invoking the ct action, packets will be in the "tracked" (`trk`) state and
+all [connection tracking
+fields](http://www.openvswitch.org//support/dist-docs/ovs-fields.7.txt) will be
+set to the correct value. Packets will then move on to [ConntrackStateTable].
+
+Refer to [this
+document](http://docs.openvswitch.org/en/latest/tutorials/ovs-conntrack/) for
+more information on connection tracking in OVS.
+
+### ConntrackStateTable (31)
+
+This table handles all "tracked" packets (all packets are moved to the tracked
+state by the previous table, [ConntrackTable]). It serves the following
+purposes:
+ * keeps track of connections going through the gateway port; for all reply
+ packets belonging to such connections we overwrite the destination MAC to the
+ local gateway MAC on their way to the gateway port. This is required to handle
+ the case were a Pod connects to a service and traffic goes through DNAT. In
+ this case, if we do not use connection tracking, reply traffic from the backend
+ will go directly to the originating Pod without going first through the gateway
+ and kube-proxy. This means that the reply traffic will arrive at the
+ originating Pod with the incorrect source IP (it will be set to the backend's
+ IP instead of the service IP). So we keep track of such connections
+ (indentified by matching the ingress port against the gateway port) and for all
+ reply traffic we set the destination to the local gateway MAC.
+ * drop packets reported as invalid by conntrack
+
+If you dump the flows for this table, you should see the following:
+```
+1. table=31, priority=210,ct_state=-new+trk,ct_mark=0x20,ip,reg0=0x1/0xffff actions=resubmit(,40)
+2. table=31, priority=200,ct_state=+inv+trk,ip actions=drop
+3. table=31, priority=200,ct_state=-new+trk,ct_mark=0x20,ip actions=load:0xe2e5a49b1cb1->NXM_OF_ETH_DST[],resubmit(,40)
+4. table=31, priority=0 actions=resubmit(,40)
+```
+
+Flows 1 and 3 implement the destination MAC rewrite described above. Note that
+at this stage we have not committed any connection yet. We commit all connections
+after enforcing Network Policies, in [ConntrackCommitTable]. This is also when
+we set the `ct_mark` to `0x20` for connections to service backends.
+
+Flow 2 drops invalid traffic. All non-dropped traffic is finally resubmitted to
+the [DNATTable].
+
+### DNATTable (40)
+
+At the moment this table's only job is to send traffic destined to services
+through the local gateway, without any modifications. kube-proxy will then take
+care of load-balancing the connections across the different backends for each
+service.
+
+If you dump the flows for this table, you should see something like this:
+```
+1. table=40, priority=200,ip,nw_dst=10.96.0.0/12 actions=load:0x2->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],resubmit(,105)
+2. table=40, priority=0 actions=resubmit(,50)
+```
+
+In the example above, 10.96.0.0/12 is the service CIDR (this is the default
+value used by `kubeadm init`). This flow is not actually required for
+forwarding, but to bypass [EgressRuleTable] and [EgressDefaultTable] for service
+traffic on its way to kube-proxy through the gateway. If we omitted this flow,
+such traffic would be unconditionally dropped if a Network Policy is applied on
+the originating Pod. For such traffic, we instead enforce Network Policy egress
+rules when packets come back through the gateway and the destination IP has been
+rewritten by kube-proxy (DNAT to a backend for the service). We cannot output
+the service traffic to the gateway port directly as we haven't committed the
+connection yet; instead we store the port in NXM_NX_REG1 - similarly to how we
+process non-service traffic in [L2ForwardingCalcTable] - and resubmit it to
+[ConntrackCommitTable]. By committing the connection we ensure that reply
+traffic (traffic from the service backend which has already gone through
+kube-proxy for source IP rewrite) will not be dropped because of Network
+Policies.
+
+The table-miss flow entry (flow 2) for this table resubmits all non-service
+traffic to the next table, [EgressRuleTable].
+
+In the future this table may support an additional mode of operations, in which
+it will implement kube-proxy functionality and take care of performing
+load-balancing / DNAT on traffic destined to services.
+
+### EgressRuleTable (50)
+
+For this table, you will need to keep mind the Network Policy
+[specification](#network-policy-implementation) that we are using. We have 2
+Pods running on the same Node, with IP addresses 10.10.1.2 to 10.10.1.3. They
+are allowed to talk to each other using TCP on port 80, but nothing else.
+
+This table is used to implement the egress rules across all Network Policies. If
+you dump the flows for this table, you should see something like this:
+```
+1. table=50, priority=210,ct_state=-new+est,ip actions=resubmit(,70)
+2. table=50, priority=200,ip,nw_src=10.10.1.2 actions=conjunction(2,1/3)
+3. table=50, priority=200,ip,nw_src=10.10.1.3 actions=conjunction(2,1/3)
+4. table=50, priority=200,ip,nw_dst=10.10.1.2 actions=conjunction(2,2/3)
+5. table=50, priority=200,ip,nw_dst=10.10.1.3 actions=conjunction(2,2/3)
+6. table=50, priority=200,tcp,tp_dst=80 actions=conjunction(2,3/3)
+7. table=50, priority=190,conj_id=2,ip actions=resubmit(,70)
+8. table=50, priority=0 actions=resubmit(,60)
+```
+
+Notice how we use the OVS built-in `conjunction` action to implement policies
+efficiently. This enables us to do a conjunctive match across multiple
+dimensions (source IP, destination IP, port) efficiently without "exploding" the
+number of flows. By definition of a conjunctive match, we have at least 2
+dimensions. For our use-case we have at most 3 dimensions.
+
+The above example flows read as follow: if the source IP address is in set
+{10.10.1.2, 10.10.1.3}, and the destination IP address is in the set {10.10.1.2,
+10.10.1.3}, and the destination TCP port is in the set {80}, then use the
+`conjunction` action with id 2, which is resubmit to
+[L3ForwardingTable]. Otherwise, resubmit to [EgressDefaultTable].
+
+The only requirements on `conj_id` is for it to be a unique 32-bit integer
+within the table. At the moment we use a single custom allocator, which is
+common to [EgressRuleTable] and [IngressRuleTable]. This is why `conj_id` is set
+to 2 in the above example (1 was allocated for the ingress rule of our Network
+Policy example).
+
+If the Network Policy specification includes exceptions (`except` field), then
+the table will include additional rules, but we will not cover them in this
+document.
+
+If the `conjunction` action is matched, packets are "allowed" and resubmitted
+directly to [L3ForwardingTable]. Other packets go to [EgressDefaultTable]. If a
+connection is established - as a reminder all connections are committed in
+[ConntrackCommitTable] - its packets go straight to [L3ForwardingTable], with no
+other match required (see flow 1 above, which has the highest priority). In
+particular, this ensures that reply traffic is never dropped because of a
+Network Policy rule. However, this also means that ongoing connections are not
+affected if the K8s Network Policies are updated.
+
+One thing to keep in mind is that for service traffic, these rules are applied
+after the packets have gone through the local gateway and through kube-proxy. At
+this point the ingress port is no longer the Pod port, but the local gateway
+port. Therefore we cannot use the port as the match condition to identify if the
+Pod has been applied a Network Policy - which is what we do for the
+[IngressRuleTable] -, but instead have to use the source IP address.
+
+### EgressDefaultTable (60)
+
+This table complements [EgressRuleTable] for Network Policy egress rule
+implementation. In K8s, when a Network Policy is applied to a set of Pods, the
+default behavior for these Pods become "deny" (it becomes an [isolated
+Pod](https://kubernetes.io/docs/concepts/services-networking/network-policies/#isolated-and-non-isolated-pods)). This
+table is in charge of dropping traffic originating from Pods to which a Network
+Policy (with an egress rule) is applied, and which did not match any of the
+whitelist rules.
+
+Accordingly, based on our Network Policy example, we would expect to see flows
+to drop traffic originating from our 2 Pods (10.10.1.2 and 10.10.1.3), which is
+confirmed by dumping the flows:
+```
+1. table=60, priority=200,ip,nw_src=10.10.1.2 actions=drop
+2. table=60, priority=200,ip,nw_src=10.10.1.3 actions=drop
+3. table=60, priority=0 actions=resubmit(,70)
+```
+
+The table-miss flow entry, which is used for non-isolated Pods, resubmits
+traffic to the next table ([L3ForwardingTable]).
+
+### L3ForwardingTable (70)
+
+This is the L3 routing table. It implements the following functionality:
+
+ * Tunnelled traffic coming-in from a peer Node and destined to a local Pod is
+   directly forwarded to the Pod. This requires setting the source MAC to the
+   MAC of the local gateway interface and setting the destination MAC to the
+   Pod's MAC address. Such traffic is identified by matching on the packet's
+   destination MAC address (should be set to the Global Virtual MAC for all
+   tunnelled traffic) and its destination IP address (should match the IP
+   address of a local Pod). We therefore install one flow for each Pod created
+   locally on the Node. For example:
+```
+table=70, priority=200,ip,dl_dst=aa:bb:cc:dd:ee:ff,nw_dst=10.10.0.2 actions=mod_dl_src:e2:e5:a4:9b:1c:b1,mod_dl_dst:12:9e:a6:47:d0:70,dec_ttl,resubmit(,80)
+```
+
+ * All tunnelled traffic destined to the local gateway (i.e. for which the
+   destination IP matches the local gateway's IP) is forwarded to the gateway
+   port by rewriting the destination MAC (from the Global Virtual MAC to the
+   local gateway's MAC).
+```
+table=70, priority=200,ip,dl_dst=aa:bb:cc:dd:ee:ff,nw_dst=10.10.0.1 actions=mod_dl_dst:e2:e5:a4:9b:1c:b1,resubmit(,80)
+```
+
+ * All traffic destined to a remote Pod is forwarded through the appropriate
+   tunnel. This means that we install one flow for each peer Node, each one
+   matching the destination IP address of the packet against the Pod subnet for
+   the Node. In case of a match the source MAC is set to the local gateway MAC,
+   the destination MAC is set to the Global Virtual MAC and we set the OF
+   `tun_dst` field to the appropriate value (i.e. the IP address of the remote
+   gateway). Traffic is then resubmitted to [ConntrackCommitTable], thus
+   skipping [L2ForwardingCalcTable] and the ingress policy rules tables, which
+   are not relevant for traffic destined to a tunnel (the destination port is
+   the tunnel port and the ingress policy rules will be enforced at the
+   destination Node). For a given peer Node, the flow may look like this:
+```
+table=70, priority=200,ip,nw_dst=10.10.1.0/24 actions=dec_ttl,mod_dl_src:e2:e5:a4:9b:1c:b1,mod_dl_dst:aa:bb:cc:dd:ee:ff,load:0x1->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],load:0xc0a84d65->NXM_NX_TUN_IPV4_DST[],resubmit(,105)
+```
+
+If none of the flows described above are hit, traffic
+goes directly to [L2ForwardingCalcTable]. This is the case for external traffic,
+whose destination is outside the cluster (such traffic has already been
+forwarded to the local gateway by the local source Pod, and only L2 switching is
+required), as well as for local Pod-to-Pod traffic.
+
+### L2ForwardingCalcTable (80)
+
+This is essentially the "dmac" table of the switch. We program one flow for each
+port (gateway port, Pod ports and tunnel port), as you can see if you dump the
+flows:
+```
+1. table=80, priority=200,dl_dst=e2:e5:a4:9b:1c:b1 actions=load:0x2->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],resubmit(,90)
+2. table=80, priority=200,dl_dst=aa:bb:cc:dd:ee:ff actions=load:0x1->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],resubmit(,90)
+3. table=80, priority=200,dl_dst=12:9e:a6:47:d0:70 actions=load:0x3->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],resubmit(,90)
+4. table=80, priority=200,dl_dst=ba:a8:13:ca:ed:cf actions=load:0x4->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],resubmit(,90)
+5. table=80, priority=0 actions=resubmit(,90)
+```
+
+For each port flow (1 through 4 in the example above), we set bit 16 of the
+NXM_NX_REG0 register to indicate that there was a matching entry for the
+destination MAC address and that the packet must be forwarded. In the last table
+of the pipeline ([L2ForwardingOutTable]), we will drop all packets for which
+this bit is not set. We also use the NXM_NX_REG1 register to store the egress
+port for the packet, which will be used as a parameter to the `output` OpenFlow
+action in [L2ForwardingOutTable].
+
+All packets - whether they have a matching dmac entry or not - are then
+resubmitted to the next table, [IngressRuleTable].
+
+What about L2 multicast / broadcast traffic? ARP requests will never reach this
+table, as they will be handled by the OpenFlow `normal` action in the
+[ArpResponderTable]. As for the rest, if it is IP traffic, it will hit the
+"last" flow in this table and be resubmitted to [IngressRuleTable]. Assuming it
+makes it to the last table of the pipeline ([L2ForwardingOutTable]), it will be
+dropped there since bit 16 of the NXM_NX_REG0 will not be set. Traffic which is
+non-ARP and non-IP (assuming any can be received by the switch) is actually
+dropped much earlier in the pipeline ([SpoofGuardTable]). In the future, we may
+need to support more cases for L2 multicast / broadcast traffic.
+
+### IngressRuleTable (90)
+
+This table is very similar to [EgressRuleTable], but implements ingress rules
+for Network Policies. Once again, you will need to keep mind the Network Policy
+[specification](#network-policy-implementation) that we are using. We have 2
+Pods running on the same Node, with IP addresses 10.10.1.2 to 10.10.1.3. They
+are allowed to talk to each other using TCP on port 80, but nothing else.
+
+If you dump the flows for this table, you should see something like this:
+```
+1. table=90, priority=210,ct_state=-new+est,ip actions=resubmit(,105)
+2. table=90, priority=210,ip,nw_src=10.10.1.1 actions=resubmit(,105)
+3. table=90, priority=200,ip,nw_src=10.10.1.2 actions=conjunction(1,1/3)
+4. table=90, priority=200,ip,nw_src=10.10.1.3 actions=conjunction(1,1/3)
+5. table=90, priority=200,ip,reg1=0x3 actions=conjunction(1,2/3)
+6. table=90, priority=200,ip,reg1=0x4 actions=conjunction(1,2/3)
+7. table=90, priority=200,tcp,tp_dst=80 actions=conjunction(1,3/3)
+8. table=90, priority=190,conj_id=1,ip actions=resubmit(,105)
+9. table=90, priority=0 actions=resubmit(,100)
+```
+
+As for [EgressRuleTable], flow 1 (highest priority) ensures that for established
+connections - as a reminder all connections are committed in
+[ConntrackCommitTable] - packets go straight to [L2ForwardingOutTable], with no
+other match required.
+
+Flow 2 ensures that traffic from the local gateway cannot be dropped because of
+Network Policies. This ensures that K8s [liveness
+probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+can go through.
+
+The rest of the flows read as follows: if the source IP address is in set
+{10.10.1.2, 10.10.1.3}, and the destination OF port is in the set {3, 4} (which
+correspond to IP addresses {10.10.1.2, 10.10.1.3}, and the destination TCP port
+is in the set {80}, then use `conjunction` action with id 1, which is resubmit
+to [L2ForwardingOutTable]. Otherwise, resubmit to [IngressDefaultTable]. One
+notable difference is how we use OF ports to identify the destination of the
+traffic, while we use IP addresses in [EgressRuleTable] to identify the source
+of the traffic. We do this as an increased security measure in case a local Pod
+is misbehaving and trying to access another local Pod using the correct
+destination MAC address but a different destination IP address to bypass an
+egress Network Policy rule. This is also why the Network Policy ingress rules
+are enforced after the egress port has been determined.
+
+### IngressDefaultTable (100)
+
+This table is similar in its purpose to [EgressDefaultTable], and it complements
+[IngressRuleTable] for Network Policy ingress rule implementation. In K8s, when
+a Network Policy is applied to a set of Pods, the default behavior for these
+Pods become "deny" (it becomes an [isolated
+Pod](https://kubernetes.io/docs/concepts/services-networking/network-policies/#isolated-and-non-isolated-pods)). This
+table is in charge of dropping traffic destined to Pods to which a Network
+Policy (with an ingress rule) is applied, and which did not match any of the
+whitelist rules.
+
+Accordingly, based on our Network Policy example, we would expect to see flows
+to drop traffic destined to our 2 Pods (3 and 4), which is confirmed by dumping
+the flows:
+```
+1. table=100, priority=200,ip,reg1=0x3 actions=drop
+2. table=100, priority=200,ip,reg1=0x4 actions=drop
+3. table=100, priority=0 actions=resubmit(,105)
+```
+
+The table-miss flow entry, which is used for non-isolated Pods, resubmits
+traffic to the next table ([ConntrackCommitTable]).
+
+### ConntrackCommitTable (105)
+
+As mentionned before, this table is in charge of committing all new connections
+which are not dropped becuse of Network Policies. If you dump the flows for this
+table, you should see something like this:
+
+```
+1. table=105, priority=200,ct_state=+new+trk,ip,reg0=0x1/0xffff actions=ct(commit,table=110,zone=65520,exec(load:0x20->NXM_NX_CT_MARK[]))
+2. table=105, priority=190,ct_state=+new+trk,ip actions=ct(commit,table=110,zone=65520)
+3. table=105, priority=0 actions=resubmit(,110)
+```
+
+Flow 1 ensures that we commit connections to service backends and mark them
+with a `ct_mark` of `0x20`. This ensures that [ConntrackStateTable] can perform
+its functions correctly and rewrite the destination MAC address to the gateway's
+MAC address for service backend reply traffic.
+
+Flow 2 commits all other new connections.
+
+All traffic is then resubmitted to the next table ([L2ForwardingOutTable]).
+
+### L2ForwardingOutTable (110)
+
+It is a simple table and if you dump the flows for this table, you should only
+see 2 flows:
+
+```
+1. table=110, priority=200,ip,reg0=0x10000/0x10000 actions=output:NXM_NX_REG1[]
+2. table=110, priority=0, actions=drop
+```
+
+The first flow outputs all unicast packets to the correct port (the port was
+resolved by the "dmac" table, [L2ForwardingCalcTable]). IP packets for which
+[L2ForwardingCalcTable] did not set bit 16 of NXM_NX_REG0 will be dropped.
+
+
+[ClassifierTable]: #classifiertable-0
+[SpoofGuardTable]: #spoofguardtable-10
+[ARPResponderTable]: #arprespondertable-20
+[ConntrackTable]: #conntracktable-30
+[ConntrackStateTable]: #conntrackstatetable-31
+[DNATTable]: #dnattable-40
+[EgressRuleTable]: #egressruletable-50
+[EgressDefaultTable]: #egressdefaulttable-60
+[L3ForwardingTable]: #l3forwardingtable-70
+[L2ForwardingCalcTable]: #l2forwardingcalctable-80
+[IngressRuleTable]: #ingressruletable-90
+[IngressDefaultTable]: #ingressdefaulttable-100
+[ConntrackCommitTable]: #conntrackcommittable-105
+[L2ForwardingOutTable]: #l2forwardingouttable-110


### PR DESCRIPTION
Some detailed documentation for the OVS pipeline, including a
description of each table. This is directed at developers and people
trying to troubleshoot issues.

It includes a SVG high-level diagram of the pipeline. We use SVG
directly so it renders better on all screens and to avoid having to
check-in a "large" PNG image that may need to be updated often.

More documentation specific to the Network Policy implementation will
follow later.

Fixes #27