### PR TITLE
Enable IPSec encryption of tunnel traffic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,7 @@ build-ubuntu:
 manifest:
 	@echo "===> Generating dev manifest for Antrea <==="
 	$(CURDIR)/hack/generate-manifest.sh --mode dev > build/yamls/antrea.yml
+	$(CURDIR)/hack/generate-manifest.sh --mode dev --ipsec > build/yamls/antrea-ipsec.yml
 
 .PHONY: octant-antrea-ubuntu
 octant-antrea-ubuntu:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -213,7 +213,7 @@ data:
     # - geneve
     # - gre
     # - stt
-    #tunnelType: vxlan
+    tunnelType: gre
 
     # Default MTU to use for the host gateway interface and the network interface of each Pod. If
     # omitted, antrea-agent will default this value to 1450 to accomodate for tunnel encapsulate
@@ -221,7 +221,7 @@ data:
     #defaultMTU: 1450
 
     # Whether or not to enable IPSec encryption of tunnel traffic.
-    #enableIPSecTunnel: false
+    enableIPSecTunnel: true
 
     # CIDR Range for services in cluster. It's required to support egress network policy, should
     # be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
@@ -241,8 +241,17 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-tm7bht9mg6
+  name: antrea-config-k5f958t9km
   namespace: kube-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: antrea-ipsec
+  namespace: kube-system
+stringData:
+  psk: changeme
+type: Opaque
 ---
 apiVersion: v1
 kind: Service
@@ -324,7 +333,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-tm7bht9mg6
+          name: antrea-config-k5f958t9km
         name: antrea-config
 ---
 apiVersion: apps/v1
@@ -347,12 +356,44 @@ spec:
         component: antrea-agent
     spec:
       containers:
+      - command:
+        - start_ovs_ipsec
+        image: antrea/antrea-ubuntu:latest
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - timeout 5 container_liveness_probe ovs-ipsec
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        name: antrea-ipsec
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+        volumeMounts:
+        - mountPath: /var/run/openvswitch
+          name: host-var-run-antrea
+          subPath: openvswitch
+        - mountPath: /var/log/openvswitch
+          name: host-var-log-antrea
+          subPath: openvswitch
+        - mountPath: /var/log/strongswan
+          name: host-var-log-antrea
+          subPath: strongswan
       - args:
         - --config
         - /etc/antrea/antrea-agent.conf
         command:
         - antrea-agent
         env:
+        - name: ANTREA_IPSEC_PSK
+          valueFrom:
+            secretKeyRef:
+              key: psk
+              name: antrea-ipsec
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -464,7 +505,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-tm7bht9mg6
+          name: antrea-config-k5f958t9km
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -25,6 +25,9 @@
 # overhead.
 #defaultMTU: 1450
 
+# Whether or not to enable IPSec encryption of tunnel traffic.
+#enableIPSecTunnel: false
+
 # CIDR Range for services in cluster. It's required to support egress network policy, should
 # be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
 #serviceCIDR: 10.96.0.0/12

--- a/build/yamls/patches/ipsec/ipsecSecret.yml
+++ b/build/yamls/patches/ipsec/ipsecSecret.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: antrea-ipsec
+  namespace: kube-system
+type: Opaque
+stringData:
+  # Preshared Key used by IKE for authentication with peers.
+  psk: changeme

--- a/build/yamls/patches/ipsec/pskEnv.yml
+++ b/build/yamls/patches/ipsec/pskEnv.yml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: antrea-agent
+spec:
+  template:
+    spec:
+      containers:
+        - name: antrea-agent
+          env:
+            # Pre-shared key for IPSec IKE.
+            - name: ANTREA_IPSEC_PSK
+              valueFrom:
+                secretKeyRef:
+                  name: antrea-ipsec
+                  key: psk

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -89,10 +89,15 @@ func run(o *Options) error {
 	}
 	nodeConfig := agentInitializer.GetNodeConfig()
 
-	nodeRouteController := noderoute.NewNodeRouteController(k8sClient,
+	nodeRouteController := noderoute.NewNodeRouteController(
+		k8sClient,
 		informerFactory,
 		ofClient,
-		nodeConfig)
+		ovsBridgeClient,
+		ifaceStore,
+		nodeConfig,
+		ovsconfig.TunnelType(o.config.TunnelType),
+		agentInitializer.GetIPSecPSK())
 
 	// podUpdates is a channel for receiving Pod updates from CNIServer and
 	// notifying NetworkPolicyController to reconcile rules related to the

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -101,10 +101,10 @@ func TestInitstore(t *testing.T) {
 
 	ovsPort1 := ovsconfig.OVSPortData{UUID: uuid1, Name: "p1", IFName: "p1", OFPort: 1,
 		ExternalIDs: convertExternalIDMap(cniserver.BuildOVSPortExternalIDs(
-			interfacestore.NewContainerInterface(uuid1, "pod1", "ns1", "netns1", p1NetMAC, p1NetIP)))}
+			interfacestore.NewContainerInterface("p1", uuid1, "pod1", "ns1", p1NetMAC, p1NetIP)))}
 	ovsPort2 := ovsconfig.OVSPortData{UUID: uuid2, Name: "p2", IFName: "p2", OFPort: 2,
 		ExternalIDs: convertExternalIDMap(cniserver.BuildOVSPortExternalIDs(
-			interfacestore.NewContainerInterface(uuid2, "pod2", "ns2", "netns2", p2NetMAC, p2NetIP)))}
+			interfacestore.NewContainerInterface("p2", uuid2, "pod2", "ns2", p2NetMAC, p2NetIP)))}
 	initOVSPorts := []ovsconfig.OVSPortData{ovsPort1, ovsPort2}
 
 	mockOVSBridgeClient.EXPECT().GetPortList().Return(initOVSPorts, ovsconfig.NewTransactionError(fmt.Errorf("Failed to list OVS ports"), true))
@@ -121,7 +121,7 @@ func TestInitstore(t *testing.T) {
 	container1, found1 := store.GetInterface("p1")
 	if !found1 {
 		t.Errorf("Failed to load OVS port into local store")
-	} else if container1.OFPort != 1 || container1.IP.String() != p1IP || container1.MAC.String() != p1MAC || container1.IfaceName != "p1" {
+	} else if container1.OFPort != 1 || container1.IP.String() != p1IP || container1.MAC.String() != p1MAC || container1.InterfaceName != "p1" {
 		t.Errorf("Failed to load OVS port configuration into local store")
 	}
 	_, found2 := store.GetInterface("p2")

--- a/pkg/agent/controller/networkpolicy/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/reconciler_test.go
@@ -80,8 +80,10 @@ func TestReconcilerReconcile(t *testing.T) {
 	appliedToGroup1 := newPodSet(v1beta1.PodReference{"pod1", "ns1"})
 	appliedToGroup2 := newPodSet(v1beta1.PodReference{"pod2", "ns1"})
 	ifaceStore := interfacestore.NewInterfaceStore()
-	ifaceStore.AddInterface(util.GenerateContainerInterfaceName("pod1", "ns1"),
-		&interfacestore.InterfaceConfig{IP: net.ParseIP("2.2.2.2"), OVSPortConfig: &interfacestore.OVSPortConfig{OFPort: 1}})
+	ifaceStore.AddInterface(&interfacestore.InterfaceConfig{
+		InterfaceName: util.GenerateContainerInterfaceName("pod1", "ns1"),
+		IP:            net.ParseIP("2.2.2.2"),
+		OVSPortConfig: &interfacestore.OVSPortConfig{OFPort: 1}})
 	protocolTCP := v1beta1.ProtocolTCP
 	port80 := int32(80)
 	// It represents named port that we can't resolve.
@@ -283,10 +285,16 @@ func TestReconcilerReconcile(t *testing.T) {
 
 func TestReconcilerUpdate(t *testing.T) {
 	ifaceStore := interfacestore.NewInterfaceStore()
-	ifaceStore.AddInterface(util.GenerateContainerInterfaceName("pod1", "ns1"),
-		&interfacestore.InterfaceConfig{IP: net.ParseIP("2.2.2.2"), OVSPortConfig: &interfacestore.OVSPortConfig{OFPort: 1}})
-	ifaceStore.AddInterface(util.GenerateContainerInterfaceName("pod2", "ns1"),
-		&interfacestore.InterfaceConfig{IP: net.ParseIP("3.3.3.3"), OVSPortConfig: &interfacestore.OVSPortConfig{OFPort: 2}})
+	ifaceStore.AddInterface(
+		&interfacestore.InterfaceConfig{
+			InterfaceName: util.GenerateContainerInterfaceName("pod1", "ns1"),
+			IP:            net.ParseIP("2.2.2.2"),
+			OVSPortConfig: &interfacestore.OVSPortConfig{OFPort: 1}})
+	ifaceStore.AddInterface(
+		&interfacestore.InterfaceConfig{
+			InterfaceName: util.GenerateContainerInterfaceName("pod2", "ns1"),
+			IP:            net.ParseIP("3.3.3.3"),
+			OVSPortConfig: &interfacestore.OVSPortConfig{OFPort: 2}})
 	tests := []struct {
 		name                string
 		originalRule        *CompletedRule

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -33,8 +33,11 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
 
+	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
 	"github.com/vmware-tanzu/antrea/pkg/agent/types"
+	"github.com/vmware-tanzu/antrea/pkg/agent/util"
+	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 )
 
 const (
@@ -45,6 +48,8 @@ const (
 	maxRetryDelay = 300 * time.Second
 	// Default number of workers processing a node change
 	defaultWorkers = 4
+
+	ovsExternalIDNodeName = "node-name"
 )
 
 // Controller is responsible for setting up necessary IP routes and Openflow entries for inter-node traffic.
@@ -55,8 +60,14 @@ type Controller struct {
 	nodeListerSynced cache.InformerSynced
 	queue            workqueue.RateLimitingInterface
 	ofClient         openflow.Client
+	ovsBridgeClient  ovsconfig.OVSBridgeClient
+	interfaceStore   interfacestore.InterfaceStore
 	nodeConfig       *types.NodeConfig
-	gatewayLink      netlink.Link
+	tunnelType       ovsconfig.TunnelType
+	// Pre-shared key for IPSec IKE authentication. If not empty IPSec tunnels will
+	// be enabled.
+	ipsecPSK    string
+	gatewayLink netlink.Link
 	// installedNodes records routes and flows installation states of Nodes.
 	// The key is the host name of the Node, the value is the route to the Node.
 	// If the flows of the Node are installed, the installedNodes must contains a key which is the host name.
@@ -70,7 +81,11 @@ func NewNodeRouteController(
 	kubeClient clientset.Interface,
 	informerFactory informers.SharedInformerFactory,
 	client openflow.Client,
+	ovsBridgeClient ovsconfig.OVSBridgeClient,
+	interfaceStore interfacestore.InterfaceStore,
 	config *types.NodeConfig,
+	tunnelType ovsconfig.TunnelType,
+	ipsecPSK string,
 ) *Controller {
 	nodeInformer := informerFactory.Core().V1().Nodes()
 	link, _ := netlink.LinkByName(config.GatewayConfig.Name)
@@ -82,10 +97,13 @@ func NewNodeRouteController(
 		nodeListerSynced: nodeInformer.Informer().HasSynced,
 		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "noderoute"),
 		ofClient:         client,
+		ovsBridgeClient:  ovsBridgeClient,
+		interfaceStore:   interfaceStore,
 		nodeConfig:       config,
 		gatewayLink:      link,
 		installedNodes:   &sync.Map{},
-	}
+		tunnelType:       tunnelType,
+		ipsecPSK:         ipsecPSK}
 	nodeInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(cur interface{}) {
@@ -206,67 +224,203 @@ func (c *Controller) syncNodeRoute(nodeName string) error {
 	// methods.
 
 	if node, err := c.nodeLister.Get(nodeName); err != nil {
-		klog.Infof("Deleting routes and flow entries to Node %s", nodeName)
-		route, flowsAreInstalled := c.installedNodes.Load(nodeName)
-		if route != nil {
-			if err = netlink.RouteDel(route.(*netlink.Route)); err != nil {
-				return fmt.Errorf("failed to delete the route to Node %s: %v", nodeName, err)
-			}
-			c.installedNodes.Store(nodeName, nil)
+		return c.deleteNodeRoute(nodeName)
+	} else {
+		return c.addNodeRoute(nodeName, node)
+	}
+}
+
+func (c *Controller) deleteNodeRoute(nodeName string) error {
+	klog.Infof("Deleting routes and flows to Node %s", nodeName)
+
+	route, flowsAreInstalled := c.installedNodes.Load(nodeName)
+	if route != nil {
+		if err := netlink.RouteDel(route.(*netlink.Route)); err != nil {
+			return fmt.Errorf("failed to delete the route to Node %s: %v", nodeName, err)
 		}
-		if flowsAreInstalled {
-			if err = c.ofClient.UninstallNodeFlows(nodeName); err != nil {
-				return fmt.Errorf("failed to uninstall flows to Node %s: %v", nodeName, err)
-			}
+		c.installedNodes.Store(nodeName, nil)
+	}
+
+	if flowsAreInstalled {
+		if err := c.ofClient.UninstallNodeFlows(nodeName); err != nil {
+			return fmt.Errorf("failed to uninstall flows to Node %s: %v", nodeName, err)
 		}
 		c.installedNodes.Delete(nodeName)
-	} else if route, flowsAreInstalled := c.installedNodes.Load(nodeName); route == nil {
-		klog.Infof("Adding routes and flows to Node %s, podCIDR: %s, addresses: %v",
-			nodeName, node.Spec.PodCIDR, node.Status.Addresses)
-		if node.Spec.PodCIDR == "" {
-			klog.V(1).Infof("PodCIDR is empty for peer node %s", nodeName)
+	}
+
+	if c.ipsecPSK != "" {
+		interfaceConfig, ok := c.interfaceStore.GetNodeTunnelInterface(nodeName)
+		if !ok {
+			// Tunnel port not created for this Node.
 			return nil
 		}
-
-		peerPodCIDRAddr, peerPodCIDR, err := net.ParseCIDR(node.Spec.PodCIDR)
-		if err != nil {
-			return fmt.Errorf("failed to parse PodCIDR %s", node.Spec.PodCIDR)
+		if err := c.ovsBridgeClient.DeletePort(interfaceConfig.PortUUID); err != nil {
+			klog.Errorf("Failed to delete OVS tunnel port %s for Node %s: %v",
+				interfaceConfig.InterfaceName, nodeName, err)
+			return fmt.Errorf("failed to delete OVS tunnel port for Node %s", nodeName)
 		}
-		peerNodeIP, err := getNodeAddr(node)
-		if err != nil {
-			return fmt.Errorf("failed to retrieve IP address of Node %s: %v", nodeName, err)
-		}
-		peerGatewayIP := ip.NextIP(peerPodCIDRAddr)
-
-		if !flowsAreInstalled { // then install flows
-			err = c.ofClient.InstallNodeFlows(nodeName, c.nodeConfig.GatewayConfig.MAC, peerGatewayIP, *peerPodCIDR, peerNodeIP)
-			if err != nil {
-				return fmt.Errorf("failed to install flows to Node %s: %v", nodeName, err)
-			}
-			c.installedNodes.Store(nodeName, nil)
-		}
-		// install route
-		route := &netlink.Route{
-			Dst:       peerPodCIDR,
-			Flags:     int(netlink.FLAG_ONLINK),
-			LinkIndex: c.gatewayLink.Attrs().Index,
-			Gw:        peerGatewayIP,
-		}
-
-		err = netlink.RouteAdd(route)
-		// This is likely to be caused by an agent restart and so should not happen once we
-		// handle state reconciliation on restart properly. However, it is probably better
-		// to handle this case gracefully for the time being.
-		if err == unix.EEXIST {
-			klog.Warningf("Route to Node %s already exists, replacing it", nodeName)
-			err = netlink.RouteReplace(route)
-		}
-		if err != nil {
-			return fmt.Errorf("failed to install route to Node %s with netlink: %v", nodeName, err)
-		}
-		c.installedNodes.Store(nodeName, route)
 	}
 	return nil
+}
+
+func (c *Controller) addNodeRoute(nodeName string, node *v1.Node) error {
+	entry, flowsAreInstalled := c.installedNodes.Load(nodeName)
+	if entry != nil {
+		// Route is already added for this Node.
+		return nil
+	}
+
+	klog.Infof("Adding routes and flows to Node %s, podCIDR: %s, addresses: %v",
+		nodeName, node.Spec.PodCIDR, node.Status.Addresses)
+
+	if node.Spec.PodCIDR == "" {
+		klog.Errorf("PodCIDR is empty for Node %s", nodeName)
+		// Does not help to return an error and trigger controller retries.
+		return nil
+	}
+	peerPodCIDRAddr, peerPodCIDR, err := net.ParseCIDR(node.Spec.PodCIDR)
+	if err != nil {
+		klog.Errorf("Failed to parse PodCIDR %s for Node %s", node.Spec.PodCIDR, nodeName)
+		return nil
+	}
+	peerNodeIP, err := getNodeAddr(node)
+	if err != nil {
+		klog.Errorf("Failed to retrieve IP address of Node %s: %v", nodeName, err)
+		return nil
+	}
+	peerGatewayIP := ip.NextIP(peerPodCIDRAddr)
+
+	var tunOFPort int32
+	var remoteIP net.IP
+	if c.ipsecPSK != "" {
+		// Create a separate tunnel port for the Node, as OVS does not support flow
+		// based tunnel for IPSec.
+		if tunOFPort, err = c.createIPSecTunnelPort(nodeName, peerNodeIP); err != nil {
+			return err
+		}
+		remoteIP = nil
+	} else {
+		// Use the default tunnel port.
+		tunOFPort = types.DefaultTunOFPort
+		// Flow based tunnel. Set remote IP in the OVS flow.
+		remoteIP = peerNodeIP
+	}
+
+	if !flowsAreInstalled { // then install flows
+		err = c.ofClient.InstallNodeFlows(
+			nodeName,
+			c.nodeConfig.GatewayConfig.MAC,
+			peerGatewayIP,
+			*peerPodCIDR,
+			remoteIP,
+			uint32(tunOFPort))
+		if err != nil {
+			return fmt.Errorf("failed to install flows to Node %s: %v", nodeName, err)
+		}
+		c.installedNodes.Store(nodeName, nil)
+	}
+
+	// install route
+	route := &netlink.Route{
+		Dst:       peerPodCIDR,
+		Flags:     int(netlink.FLAG_ONLINK),
+		LinkIndex: c.gatewayLink.Attrs().Index,
+		Gw:        peerGatewayIP,
+	}
+
+	err = netlink.RouteAdd(route)
+	// This is likely to be caused by an agent restart and so should not happen once we
+	// handle state reconciliation on restart properly. However, it is probably better
+	// to handle this case gracefully for the time being.
+	if err == unix.EEXIST {
+		klog.Warningf("Route to Node %s already exists, replacing it", nodeName)
+		err = netlink.RouteReplace(route)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to install route to Node %s with netlink: %v", nodeName, err)
+	}
+	c.installedNodes.Store(nodeName, route)
+	return nil
+}
+
+// createIPSecTunnelPort creates an IPSec tunnel port for the remote Node if the
+// tunnel does not exist, and returns the ofport number.
+func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) (int32, error) {
+	interfaceConfig, ok := c.interfaceStore.GetNodeTunnelInterface(nodeName)
+	if ok {
+		// TODO: check if Node IP, PSK, or tunnel type changes or handle it in
+		// reconciliation.
+		if interfaceConfig.OFPort != 0 {
+			return interfaceConfig.OFPort, nil
+		}
+	} else {
+		portName := util.GenerateTunnelInterfaceName(nodeName)
+		ovsExternalIDs := map[string]interface{}{ovsExternalIDNodeName: nodeName}
+		portUUID, err := c.ovsBridgeClient.CreateTunnelPortExt(
+			portName,
+			c.tunnelType,
+			0, // ofPortRequest - let OVS allocate OFPort number.
+			nodeIP.String(),
+			c.ipsecPSK,
+			ovsExternalIDs)
+		if err != nil {
+			klog.Errorf("Failed to create OVS IPSec tunnel port for Node %s: %v", nodeName, err)
+			return 0, fmt.Errorf("failed to create IPSec tunnel port for Node %s", nodeName)
+		}
+		ovsPortConfig := &interfacestore.OVSPortConfig{PortUUID: portUUID}
+		interfaceConfig = interfacestore.NewIPSecTunnelInterface(
+			nodeName,
+			c.tunnelType,
+			nodeName,
+			nodeIP,
+			c.ipsecPSK)
+		interfaceConfig.OVSPortConfig = ovsPortConfig
+		c.interfaceStore.AddInterface(interfaceConfig)
+	}
+
+	// GetOFPort will wait for up to 1 second for OVSDB to report the OFPort number.
+	ofPort, err := c.ovsBridgeClient.GetOFPort(interfaceConfig.InterfaceName)
+	if err != nil {
+		// Could be a temporary OVSDB connection failure or timeout.
+		// Let NodeRouteController retry at errors.
+		klog.Errorf("Failed to get of_port of the tunnel port for Node %s: %v", nodeName, err)
+		return 0, fmt.Errorf("failed to get of_port of IPSec tunnel port for Node %s", nodeName)
+	}
+	interfaceConfig.OFPort = ofPort
+	return ofPort, nil
+}
+
+// ParseTunnelInterfaceConfig initializes and returns an InterfaceConfig struct
+// for a tunnel interface. It reads tunnel type, remote IP, IPSec PSK from the
+// OVS interface options, and NodeName from the OVS port external_ids.
+// nil is returned, if the OVS port and interface configurations are not valid
+// for a tunnel interface.
+func ParseTunnelInterfaceConfig(
+	portData *ovsconfig.OVSPortData,
+	portConfig *interfacestore.OVSPortConfig) *interfacestore.InterfaceConfig {
+	if portData.Options == nil {
+		klog.V(2).Infof("OVS port %s has no options", portData.Name)
+		return nil
+	}
+	remoteIP, psk := ovsconfig.ParseTunnelInterfaceOptions(portData)
+
+	var interfaceConfig *interfacestore.InterfaceConfig
+	var nodeName string
+	if portData.ExternalIDs != nil {
+		nodeName = portData.ExternalIDs[ovsExternalIDNodeName]
+	}
+	if psk != "" {
+		interfaceConfig = interfacestore.NewIPSecTunnelInterface(
+			portData.Name,
+			ovsconfig.TunnelType(portData.IFType),
+			nodeName,
+			remoteIP,
+			psk)
+	} else {
+		interfaceConfig = interfacestore.NewTunnelInterface(portData.Name, ovsconfig.TunnelType(portData.IFType))
+	}
+	interfaceConfig.OVSPortConfig = portConfig
+	return interfaceConfig
 }
 
 // getNodeAddr gets the available IP address of a Node. getNodeAddr will first try to get the

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow/cookie"
 	oftest "github.com/vmware-tanzu/antrea/pkg/agent/openflow/testing"
+	"github.com/vmware-tanzu/antrea/pkg/agent/types"
 )
 
 const bridgeName = "dummy-br"
@@ -38,7 +39,7 @@ func installNodeFlows(ofClient Client, cacheKey string) (int, error) {
 	gwMAC, _ := net.ParseMAC("AA:BB:CC:DD:EE:FF")
 	IP, IPNet, _ := net.ParseCIDR("10.0.1.1/24")
 	peerNodeIP := net.ParseIP("192.168.1.1")
-	err := ofClient.InstallNodeFlows(hostName, gwMAC, IP, *IPNet, peerNodeIP)
+	err := ofClient.InstallNodeFlows(hostName, gwMAC, IP, *IPNet, peerNodeIP, types.DefaultTunOFPort)
 	client := ofClient.(*client)
 	fCacheI, _ := client.nodeFlowCache.Load(hostName)
 	return len(fCacheI.(flowCache)), err

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -134,6 +134,20 @@ func (mr *MockClientMockRecorder) InstallClusterServiceCIDRFlows(arg0, arg1 inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallClusterServiceCIDRFlows", reflect.TypeOf((*MockClient)(nil).InstallClusterServiceCIDRFlows), arg0, arg1)
 }
 
+// InstallDefaultTunnelFlows mocks base method
+func (m *MockClient) InstallDefaultTunnelFlows(arg0 uint32) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallDefaultTunnelFlows", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallDefaultTunnelFlows indicates an expected call of InstallDefaultTunnelFlows
+func (mr *MockClientMockRecorder) InstallDefaultTunnelFlows(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallDefaultTunnelFlows", reflect.TypeOf((*MockClient)(nil).InstallDefaultTunnelFlows), arg0)
+}
+
 // InstallGatewayFlows mocks base method
 func (m *MockClient) InstallGatewayFlows(arg0 net.IP, arg1 net.HardwareAddr, arg2 uint32) error {
 	m.ctrl.T.Helper()
@@ -149,17 +163,17 @@ func (mr *MockClientMockRecorder) InstallGatewayFlows(arg0, arg1, arg2 interface
 }
 
 // InstallNodeFlows mocks base method
-func (m *MockClient) InstallNodeFlows(arg0 string, arg1 net.HardwareAddr, arg2 net.IP, arg3 net.IPNet, arg4 net.IP) error {
+func (m *MockClient) InstallNodeFlows(arg0 string, arg1 net.HardwareAddr, arg2 net.IP, arg3 net.IPNet, arg4 net.IP, arg5 uint32) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallNodeFlows", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "InstallNodeFlows", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallNodeFlows indicates an expected call of InstallNodeFlows
-func (mr *MockClientMockRecorder) InstallNodeFlows(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallNodeFlows(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallNodeFlows", reflect.TypeOf((*MockClient)(nil).InstallNodeFlows), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallNodeFlows", reflect.TypeOf((*MockClient)(nil).InstallNodeFlows), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // InstallPodFlows mocks base method
@@ -188,20 +202,6 @@ func (m *MockClient) InstallPolicyRuleFlows(arg0 *types.PolicyRule) error {
 func (mr *MockClientMockRecorder) InstallPolicyRuleFlows(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPolicyRuleFlows", reflect.TypeOf((*MockClient)(nil).InstallPolicyRuleFlows), arg0)
-}
-
-// InstallTunnelFlows mocks base method
-func (m *MockClient) InstallTunnelFlows(arg0 uint32) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallTunnelFlows", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// InstallTunnelFlows indicates an expected call of InstallTunnelFlows
-func (mr *MockClientMockRecorder) InstallTunnelFlows(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallTunnelFlows", reflect.TypeOf((*MockClient)(nil).InstallTunnelFlows), arg0)
 }
 
 // UninstallNodeFlows mocks base method

--- a/pkg/agent/types/node_config.go
+++ b/pkg/agent/types/node_config.go
@@ -18,6 +18,12 @@ import (
 	"net"
 )
 
+const (
+	DefaultTunPortName = "tun0"
+	DefaultTunOFPort   = 1
+	HostGatewayOFPort  = 2
+)
+
 type GatewayConfig struct {
 	IP   net.IP
 	MAC  net.HardwareAddr

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -24,23 +24,34 @@ import (
 
 const (
 	interfaceNameLength   = 15
-	podNamePrefixLength   = 8
-	containerKeyConnector = `-`
+	interfacePrefixLength = 8
 )
 
-// Calculates a suitable interface name using the pod namespace and pod name. The output should be
-// deterministic (so that multiple calls to GenerateContainerInterfaceName with the same parameters
-// return the same value). The output should have length interfaceNameLength (15). The probability of
-// collision should be neglectable.
-func GenerateContainerInterfaceName(podName string, podNamespace string) string {
+func generateInterfaceName(id string, name string) string {
 	hash := sha1.New()
-	podID := fmt.Sprintf("%s/%s", podNamespace, podName)
-	io.WriteString(hash, podID)
-	podKey := hex.EncodeToString(hash.Sum(nil))
-	name := strings.Replace(podName, "-", "", -1)
-	if len(name) > podNamePrefixLength {
-		name = name[:podNamePrefixLength]
+	io.WriteString(hash, id)
+	interfaceKey := hex.EncodeToString(hash.Sum(nil))
+	prefix := strings.Replace(name, "-", "", -1)
+	if len(prefix) > interfacePrefixLength {
+		prefix = prefix[:interfacePrefixLength]
 	}
-	podKeyLength := interfaceNameLength - len(name) - len(containerKeyConnector)
-	return strings.Join([]string{name, podKey[:podKeyLength]}, containerKeyConnector)
+	interfaceKeyLength := interfaceNameLength - (len(prefix) + 1)
+	return fmt.Sprintf("%s-%s", prefix, interfaceKey[:interfaceKeyLength])
+}
+
+// GenerateContainerInterfaceName generates a unique interface name using the
+// Pod's Namespace and name. The output should be deterministic (so that
+// multiple calls to GenerateContainerInterfaceName with the same parameters
+// return the same value). The output has the length of interfaceNameLength(15).
+// The probability of collision should be neglectable.
+func GenerateContainerInterfaceName(podName string, podNamespace string) string {
+	id := fmt.Sprintf("%s/%s", podNamespace, podName)
+	return generateInterfaceName(id, podName)
+}
+
+// GenerateTunnelInterfaceName generates a unique interface name for the tunnel
+// to the Node, using the Node's name.
+func GenerateTunnelInterfaceName(nodeName string) string {
+	id := fmt.Sprintf("node/%s", nodeName)
+	return generateInterfaceName(id, nodeName)
 }

--- a/pkg/agent/util/net_test.go
+++ b/pkg/agent/util/net_test.go
@@ -25,7 +25,7 @@ func TestGenerateContainerInterfaceName(t *testing.T) {
 	podName0 := "pod0"
 	iface0 := GenerateContainerInterfaceName(podName0, podNamespace)
 	if len(iface0) != interfaceNameLength {
-		t.Errorf("Failed to ensure length of interface name %s as %d", iface0, interfaceNameLength)
+		t.Errorf("Failed to ensure length of interface name %s == %d", iface0, interfaceNameLength)
 	}
 	if !strings.HasPrefix(iface0, fmt.Sprintf("%s-", podName0)) {
 		t.Errorf("failed to use podName as prefix: %s", iface0)

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -89,11 +89,11 @@ func TestDeletePod(t *testing.T) {
 	ifName := util.GenerateContainerInterfaceName(podName, testNamespace)
 	t.Logf("Host interface name for Pod is '%s'", ifName)
 
-	var AntreaPodName string
-	if AntreaPodName, err = data.getAntreaPodOnNode(nodeName); err != nil {
+	var antreaPodName string
+	if antreaPodName, err = data.getAntreaPodOnNode(nodeName); err != nil {
 		t.Fatalf("Error when retrieving the name of the Antrea Pod running on Node '%s': %v", nodeName, err)
 	}
-	t.Logf("The Antrea Pod for Node '%s' is '%s'", nodeName, AntreaPodName)
+	t.Logf("The Antrea Pod for Node '%s' is '%s'", nodeName, antreaPodName)
 
 	doesInterfaceExist := func() bool {
 		cmd := fmt.Sprintf("ip link show %s", ifName)
@@ -107,12 +107,12 @@ func TestDeletePod(t *testing.T) {
 
 	doesOVSPortExist := func() bool {
 		cmd := []string{"ovs-vsctl", "port-to-br", ifName}
-		if _, stderr, err := data.runCommandFromPod(AntreaNamespace, AntreaPodName, OVSContainerName, cmd); err == nil {
+		if _, stderr, err := data.runCommandFromPod(antreaNamespace, antreaPodName, ovsContainerName, cmd); err == nil {
 			return true
 		} else if strings.Contains(stderr, "no port named") {
 			return false
 		} else {
-			t.Fatalf("Error when running ovs-vsctl command on Pod '%s': %v", AntreaPodName, err)
+			t.Fatalf("Error when running ovs-vsctl command on Pod '%s': %v", antreaPodName, err)
 		}
 		return true
 	}

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -124,7 +124,7 @@ func exportLogs(tb testing.TB, data *TestData) {
 			return nil
 		}
 		defer w.Close()
-		cmd := fmt.Sprintf("kubectl -n %s logs --all-containers %s", AntreaNamespace, podName)
+		cmd := fmt.Sprintf("kubectl -n %s logs --all-containers %s", antreaNamespace, podName)
 		stdout := runKubectl(cmd)
 		if stdout == "" {
 			return nil
@@ -140,7 +140,7 @@ func exportLogs(tb testing.TB, data *TestData) {
 			return nil
 		}
 		defer w.Close()
-		cmd := fmt.Sprintf("kubectl -n %s describe pod %s", AntreaNamespace, podName)
+		cmd := fmt.Sprintf("kubectl -n %s describe pod %s", antreaNamespace, podName)
 		stdout := runKubectl(cmd)
 		if stdout == "" {
 			return nil

--- a/test/e2e/infra/vagrant/push_antrea.sh
+++ b/test/e2e/infra/vagrant/push_antrea.sh
@@ -9,6 +9,7 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 pushd $THIS_DIR
 
 ANTREA_YML=$THIS_DIR/../../../../build/yamls/antrea.yml
+ANTREA_IPSEC_YML=$THIS_DIR/../../../../build/yamls/antrea-ipsec.yml
 
 if [ ! -f ssh-config ]; then
     echo "File ssh-config does not exist in current directory"
@@ -64,12 +65,12 @@ waitForNodes "${pids[@]}"
 echo "Done!"
 
 echo "Copying Antrea deployment YAML to every node..."
-scp -F ssh-config $ANTREA_YML k8s-node-master:~/ &
+scp -F ssh-config $ANTREA_YML $ANTREA_IPSEC_YML k8s-node-master:~/ &
 pids[0]=$!
 # Loop over all worker nodes and copy image to each one
 for ((i=1; i<=$NUM_WORKERS; i++)); do
     name="k8s-node-worker-$i"
-    scp -F ssh-config $ANTREA_YML $name:~/ &
+    scp -F ssh-config $ANTREA_YML $ANTREA_IPSEC_YML $name:~/ &
     pids[$i]=$!
 done
 # Wait for all child processes to complete

--- a/test/e2e/ipsec_test.go
+++ b/test/e2e/ipsec_test.go
@@ -1,0 +1,45 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"testing"
+)
+
+// TestIPSecTunnelConnectivity checks that Pod traffic across two Nodes over
+// the IPSec tunnel, by creating multiple Pods across distinct Nodes and having
+// them ping each other.
+func TestIPSecTunnelConnectivity(t *testing.T) {
+	if testOptions.providerName == "kind" {
+		t.Skipf("Skipping test for the KIND provider as IPSec tunnel does not work with KIND")
+	}
+	if clusterInfo.numNodes < 2 {
+		t.Skipf("Skipping test as it requires 2 different nodes")
+	}
+
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	t.Logf("Redeploy Antrea with IPSec tunnel enabled")
+	data.redeployAntrea(t, true)
+
+	data.testPodConnectivityDifferentNodes(t)
+
+	// Restore normal Antrea deployment with IPSec disabled.
+	data.redeployAntrea(t, false)
+}

--- a/test/e2e/performance_test.go
+++ b/test/e2e/performance_test.go
@@ -292,7 +292,7 @@ func checkRealize(policyRules int, data *TestData) (bool, error) {
 	}
 	// table 90 is the ingressRuleTable where the rules in workload network policy is being applied to.
 	cmd := []string{"ovs-ofctl", "dump-flows", "br-int", "table=90"}
-	stdout, _, err := data.runCommandFromPod(AntreaNamespace, antreaPodName, "antrea-agent", cmd)
+	stdout, _, err := data.runCommandFromPod(antreaNamespace, antreaPodName, "antrea-agent", cmd)
 	if err != nil {
 		return false, err
 	}

--- a/test/integration/ovs/openflow_test_utils.go
+++ b/test/integration/ovs/openflow_test_utils.go
@@ -55,13 +55,13 @@ func CheckFlowExists(t *testing.T, br string, tableID uint8, exist bool, flows [
 	if exist {
 		for _, flow := range flows {
 			if !OfctlFlowMatch(flowList, tableID, flow) {
-				t.Errorf("Failed to install flow on table %d with match='%s', actions='%s'", tableID, flow.MatchStr, flow.ActStr)
+				t.Errorf("Failed to install flow:\n%v\nExisting flows:\n%v", flow, flowList)
 			}
 		}
 	} else {
 		for _, flow := range flows {
 			if OfctlFlowMatch(flowList, tableID, flow) {
-				t.Errorf("Failed to uninstall flow on table %d with match='%s', actions='%s'", tableID, flow.MatchStr, flow.ActStr)
+				t.Errorf("Failed to uninstall flow:\n%v\nExisting flows:\n%v", flow, flowList)
 			}
 		}
 	}


### PR DESCRIPTION
1. Create a separate OVS tunnel port for each remote Node.
2. Change L3 forwarding flows to support outputting to the IPSec tunnel port.
3. Add yamls to enable IPSec encryption and add a new container in the Agent DS to run IPSec daemons.

Will add e2e tests in the same PR.