### PR TITLE
Rewrite dst MAC with host gateway's MAC

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -180,6 +180,8 @@ func (c *client) InstallGatewayFlows(gatewayAddr net.IP, gatewayMAC net.Hardware
 		return err
 	} else if err := c.flowOperations.Add(c.gatewayARPSpoofGuardFlow(gatewayOFPort)); err != nil {
 		return err
+	} else if err := c.flowOperations.Add(c.ctRewriteDstMACFlow(gatewayMAC)); err != nil {
+		return err
 	} else if err := c.flowOperations.Add(c.l3ToGatewayFlow(gatewayAddr, gatewayMAC)); err != nil {
 		return err
 	} else if err := c.flowOperations.Add(c.l2ForwardCalcFlow(gatewayMAC, gatewayOFPort)); err != nil {

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -110,7 +110,7 @@ type Flow interface {
 type Action interface {
 	LoadARPOperation(value uint16) FlowBuilder
 	LoadRegRange(regID int, value uint32, to Range) FlowBuilder
-	LoadRange(name string, addr uint32, to Range) FlowBuilder
+	LoadRange(name string, addr uint64, to Range) FlowBuilder
 	Move(from, to string) FlowBuilder
 	MoveRange(fromName, toName string, from, to Range) FlowBuilder
 	Resubmit(port uint16, table TableIDType) FlowBuilder

--- a/pkg/ovs/openflow/ofctrl_action.go
+++ b/pkg/ovs/openflow/ofctrl_action.go
@@ -183,8 +183,8 @@ func (a *ofFlowAction) LoadARPOperation(value uint16) FlowBuilder {
 }
 
 // LoadRange is an action to Load data to the target field at specified range.
-func (a *ofFlowAction) LoadRange(name string, value uint32, rng Range) FlowBuilder {
-	a.builder.ofFlow.LoadReg(name, uint64(value), rng.ToNXRange())
+func (a *ofFlowAction) LoadRange(name string, value uint64, rng Range) FlowBuilder {
+	a.builder.ofFlow.LoadReg(name, value, rng.ToNXRange())
 	return a.builder
 }
 

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -441,7 +441,7 @@ func (mr *MockActionMockRecorder) LoadARPOperation(arg0 interface{}) *gomock.Cal
 }
 
 // LoadRange mocks base method
-func (m *MockAction) LoadRange(arg0 string, arg1 uint32, arg2 openflow.Range) openflow.FlowBuilder {
+func (m *MockAction) LoadRange(arg0 string, arg1 uint64, arg2 openflow.Range) openflow.FlowBuilder {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadRange", arg0, arg1, arg2)
 	ret0, _ := ret[0].(openflow.FlowBuilder)

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -504,6 +504,13 @@ func prepareGatewayFlows(gwIP net.IP, gwMAC net.HardwareAddr, gwOFPort uint32, v
 			},
 		},
 		{
+			uint8(31),
+			[]*ofTestUtils.ExpectFlow{
+				{"priority=200,ct_state=-new+trk,ct_mark=0x20,ip",
+					fmt.Sprintf("load:0x%s->NXM_OF_ETH_DST[],resubmit(,40)", strings.Replace(gwMAC.String(), ":", "", -1))},
+			},
+		},
+		{
 			uint8(10),
 			[]*ofTestUtils.ExpectFlow{
 				{fmt.Sprintf("priority=200,arp,in_port=%d", gwOFPort), "resubmit(,20)"},
@@ -615,8 +622,7 @@ func prepareDefaultFlows() []expectTableFlows {
 			uint8(31),
 			[]*ofTestUtils.ExpectFlow{
 				{"priority=210,ct_state=-new+trk,ct_mark=0x20,ip,reg0=0x1/0xffff", "resubmit(,40)"},
-				{"priority=200,ct_state=+new+trk,ip,reg0=0x1/0xffff", "ct(commit,table=40,zone=65520,exec(load:0x20->NXM_NX_CT_MARK[],move:NXM_OF_ETH_SRC[]->NXM_NX_CT_LABEL[0..47]))"},
-				{"priority=200,ct_state=-new+trk,ct_mark=0x20,ip", "move:NXM_NX_CT_LABEL[0..47]->NXM_OF_ETH_DST[],resubmit(,40)"},
+				{"priority=200,ct_state=+new+trk,ip,reg0=0x1/0xffff", "ct(commit,table=40,zone=65520,exec(load:0x20->NXM_NX_CT_MARK[])"},
 				{"priority=200,ct_state=+inv+trk,ip", "drop"},
 				{"priority=190,ct_state=+new+trk,ip", "ct(commit,table=40,zone=65520)"},
 				{"priority=80,ip", "resubmit(,40)"},


### PR DESCRIPTION
Rewrite dst MAC with host gateway's MAC for the packets sent back from the
Endpoint located on the same Node as the sender, and not use ct_label as the
cache for dynamic learning.

Fixes #211 