### PR TITLE
Fix filepath-unfriendly e2e log directory

### DIFF
--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -52,7 +52,7 @@ func setupTest(tb testing.TB) (*TestData, error) {
 
 func logsDirForTest(testName string) string {
 	// a filepath-friendly timestamp format.
-	const timeFormat = "Jan_2-15-04-05"
+	const timeFormat = "Jan02-15-04-05"
 	timeStamp := time.Now().Format(timeFormat)
 	logsDir := filepath.Join(testOptions.logsExportDir, fmt.Sprintf("%s.%s", testName, timeStamp))
 	return logsDir


### PR DESCRIPTION
The e2e log dir would be like:
`/tmp/antrea-test-906161942/TestIPBlockWithExcept.Dec 9-21-51-35`, which
is not filepath-friendly to copy and paste for usage. This patches
changes to use a format like "Dec09-21-51-35" to avoid spaces in the
path.