### PR TITLE
Disable workflows that push to Dockerhub for forks

### DIFF
--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'vmware-tanzu/antrea'
     runs-on: [ubuntu-18.04]
     steps:
     - uses: actions/checkout@v1
@@ -18,3 +19,10 @@ jobs:
         make
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         docker push antrea/antrea-ubuntu:latest
+  skip:
+    if: github.repository != 'vmware-tanzu/antrea'
+    runs-on: [ubuntu-18.04]
+    steps:
+      - name: Skip
+        run: |
+          echo "Skipping Antrea image update because workflow cannot be run from fork"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,7 +9,7 @@ on:
     - master
     - release-*
 jobs:
-  test-unit:
+  test-integration:
     name: Integration tests
     runs-on: [ubuntu-18.04]
     steps:

--- a/.github/workflows/update_ovs_image.yml
+++ b/.github/workflows/update_ovs_image.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'vmware-tanzu/antrea'
     runs-on: [ubuntu-18.04]
     steps:
     - uses: actions/checkout@v1
@@ -21,3 +22,10 @@ jobs:
         docker pull antrea/openvswitch:$OVS_VERSION || true
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         ./build_and_push.sh
+  skip:
+    if: github.repository != 'vmware-tanzu/antrea'
+    runs-on: [ubuntu-18.04]
+    steps:
+      - name: Skip
+        run: |
+          echo "Skipping OVS image update because workflow cannot be run from fork"


### PR DESCRIPTION
Such jobs are bound to fail - as they should - when run from a fork
(since the fork does not have permission to push to the dockerhub repo).

It is a bit verbose, and the workflows are still running (i.e. a worker
VM is created) which consummes some compute resources, but I believe the
Github team is working on improving this.

This is the best way I found to do this. I believe Github is working on
a better way to skip workflows.