### PR TITLE
Commit new connections after NetworkPolicy check

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -43,4 +43,4 @@ jobs:
     - name: Run e2e tests
       run: |
         ./hack/generate-manifest.sh --kind | docker exec -i kind-control-plane dd of=/root/antrea.yml
-        go test -short github.com/vmware-tanzu/antrea/test/e2e -provider=kind
+        go test github.com/vmware-tanzu/antrea/test/e2e -provider=kind

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -44,6 +44,7 @@ const (
 	TableMissActionDrop MissActionType = iota
 	TableMissActionNormal
 	TableMissActionNext
+	TableMissActionNone
 )
 
 const (

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -784,3 +784,9 @@ func (data *TestData) runWgetCommandFromTestPod(podName string, svcName string) 
 	_, _, err := data.runCommandFromPod(testNamespace, podName, busyboxContainerName, cmd)
 	return err
 }
+
+func (data *TestData) runWgetCommandFromTestPodToPodIP(podName string, podIP string) error {
+	cmd := []string{"nc", "-vz", "-w", "8", podIP, "80"}
+	_, _, err := data.runCommandFromPod(testNamespace, podName, busyboxContainerName, cmd)
+	return err
+}

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -39,7 +39,8 @@ func TestIPBlockWithExcept(t *testing.T) {
 		t.Fatalf("Error when creating nginx pod: %v", err)
 	}
 	defer deletePodWrapper(t, data, nginxPodName)
-	if _, err := data.podWaitForIP(defaultTimeout, nginxPodName); err != nil {
+	nginxPodIP, err := data.podWaitForIP(defaultTimeout, nginxPodName)
+	if err != nil {
 		t.Fatalf("Error when waiting for IP for Pod '%s': %v", nginxPodName, err)
 	}
 
@@ -109,6 +110,15 @@ func TestIPBlockWithExcept(t *testing.T) {
 	// pod1 cannot wget to service.
 	if err = data.runWgetCommandFromTestPod(podName1, svcName); err == nil {
 		t.Fatalf("Pod %s should not be able to connect Service %s, but was able to connect", podName1, svcName)
+	}
+
+	// pod0 can wget to pod IP.
+	if err = data.runWgetCommandFromTestPodToPodIP(podName0, nginxPodIP); err != nil {
+		t.Fatalf("Pod %s should be able to connect Pod %s, but was not able to connect", podName0, nginxPodIP)
+	}
+	// pod1 cannot wget to pod IP.
+	if err = data.runWgetCommandFromTestPodToPodIP(podName1, nginxPodIP); err == nil {
+		t.Fatalf("Pod %s should not be able to connect Pod %s, but was able to connect", podName1, nginxPodIP)
 	}
 }
 


### PR DESCRIPTION
Add conntrackCommit table(#105) between ingressDefault table(#100) and
L2ForwardingOut(#110) table, and packets in the new connections are committed
in this table. There is no table-miss flow in this table.

Fixes #219 