### PR TITLE
Trigger reconciling NetworkPolicy rules upon CNI Add

### DIFF
--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -66,14 +66,18 @@ type Controller struct {
 }
 
 // NewNetworkPolicyController returns a new *Controller.
-func NewNetworkPolicyController(antreaClient versioned.Interface, ofClient openflow.Client, ifaceStore interfacestore.InterfaceStore, nodeName string) *Controller {
+func NewNetworkPolicyController(antreaClient versioned.Interface,
+	ofClient openflow.Client,
+	ifaceStore interfacestore.InterfaceStore,
+	nodeName string,
+	podUpdates <-chan v1beta1.PodReference) *Controller {
 	c := &Controller{
 		antreaClient: antreaClient,
 		nodeName:     nodeName,
 		queue:        workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "networkpolicyrule"),
 		reconciler:   newReconciler(ofClient, ifaceStore),
 	}
-	c.ruleCache = newRuleCache(c.enqueueRule)
+	c.ruleCache = newRuleCache(c.enqueueRule, podUpdates)
 	return c
 }
 

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -32,8 +32,8 @@ import (
 
 func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 	clientset := &fake.Clientset{}
-
-	controller := NewNetworkPolicyController(clientset, nil, nil, "node1")
+	ch := make(chan v1beta1.PodReference, 100)
+	controller := NewNetworkPolicyController(clientset, nil, nil, "node1", ch)
 	reconciler := newMockReconciler()
 	controller.reconciler = reconciler
 	return controller, clientset, reconciler

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1075,8 +1075,8 @@ func (n *NetworkPolicyController) syncAppliedToGroup(key string) error {
 	// Retrieve all Pods matching the podSelector.
 	pods, err = n.podLister.Pods(appliedToGroup.Selector.Namespace).List(selector)
 	for _, pod := range pods {
-		if pod.Status.PodIP == "" {
-			// No need to process Pod when IPAddress is unset.
+		if pod.Spec.NodeName == "" {
+			// No need to process Pod when it's not scheduled.
 			continue
 		}
 		podSet := podsByNodes[pod.Spec.NodeName]

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -44,6 +44,7 @@ import (
 	agenttypes "github.com/vmware-tanzu/antrea/pkg/agent/types"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"
 	cnimsg "github.com/vmware-tanzu/antrea/pkg/apis/cni/v1beta1"
+	"github.com/vmware-tanzu/antrea/pkg/apis/networkpolicy/v1beta1"
 	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 	ovsconfigtest "github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig/testing"
 )
@@ -465,7 +466,16 @@ func (tester *cmdAddDelTester) cmdDelTest(tc testCase, dataDir string) {
 func newTester() *cmdAddDelTester {
 	tester := &cmdAddDelTester{}
 	ifaceStore := interfacestore.NewInterfaceStore()
-	tester.server = cniserver.New(testSock, "", 1450, "", testNodeConfig, ovsServiceMock, ofServiceMock, ifaceStore, k8sFake.NewSimpleClientset())
+	tester.server = cniserver.New(testSock,
+		"",
+		1450,
+		"",
+		testNodeConfig,
+		ovsServiceMock,
+		ofServiceMock,
+		ifaceStore,
+		k8sFake.NewSimpleClientset(),
+		make(chan v1beta1.PodReference, 100))
 	ctx, _ := context.WithCancel(context.Background())
 	tester.ctx = ctx
 	return tester


### PR DESCRIPTION
Currently only Pods that have IPs are included in AppliedToGroups. It
makes a Pod's NetworkPolicies not enforced until it has IP assigned in
kube-apiserver, which always introduces a time slot that the Pod is not
isolated by NetworkPolicies created before it.

To enforce NetworkPolicies to Pods, antrea-agent doesn't need PodIPs
from kube-apiserver but the OFPort and IP from internal InterfaceCache.
This patch uses a channel to receive Pod update events from CNIServer
and notify NetworkPolicyController to reconcile rules related to the
updated Pods.

Fixes #197 