### PR TITLE
Run golangci-lint as part of CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,21 +28,18 @@ jobs:
       run: make test-unit
 
 
-  check-fmt:
-    name: Check format
+  golangci-lint:
+    name: Golangci-lint
     runs-on: [ubuntu-18.04]
     steps:
-
     - name: Set up Go 1.13
       uses: actions/setup-go@v1
       with:
         go-version: 1.13
-
     - name: Check-out code
       uses: actions/checkout@v1
-
-    - name: Check format of Go code
-      run: make test-fmt
+    - name: Run golangci-lint
+      run: make golangci
 
 
   bin:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 bin
 .mockgen
 .cache
+.golangci-bin
 
 .DS_Store
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+run:
+  tests: true
+  timeout: 5m
+  skip-files:
+    - ".*\\.pb\\.go"
+  skip-dirs-use-default: true
+
+linters:
+  disable-all: true
+  enable:
+    - misspell
+    - gofmt
+    - deadcode

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,14 @@ fmt:
 	@echo "===> Formatting Go files <==="
 	@gofmt -s -l -w $(GO_FILES)
 
+.golangci-bin:
+	@echo "===> Installing Golangci-lint <==="
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $@ v1.21.0
+
+.PHONY: golangci
+golangci: .golangci-bin
+	@GOOS=linux .golangci-bin/golangci-lint run -c .golangci.yml
+
 .PHONY: .linter
 .linter:
 	@if ! PATH=$$PATH:$(GOPATH)/bin command -v golint > /dev/null; then \
@@ -126,6 +134,7 @@ clean:
 	@rm -rf $(BINDIR)
 	@rm -rf $(DOCKER_CACHE)
 	@rm -f .mockgen .protoc
+	@rm -rf .golangci-bin
 
 # Install a specific version of gomock to avoid generating different source code
 # for the mocks every time a new version of gomock is released. If a new version
@@ -134,7 +143,7 @@ clean:
 	@echo "===> Installing Mockgen <==="
 	@go get github.com/golang/mock/gomock@1.3.1
 	@go install github.com/golang/mock/mockgen
-	@touch .mockgen
+	@touch $@
 
 .PHONY: mocks
 mocks: .mockgen

--- a/pkg/agent/cniserver/server_test.go
+++ b/pkg/agent/cniserver/server_test.go
@@ -58,7 +58,6 @@ var routes = []string{"10.0.0.0/8,10.1.2.1", "0.0.0.0/0,10.1.2.1"}
 var dns = []string{"192.168.100.1"}
 var ips = []string{"10.1.2.100/24,10.1.2.1,4"}
 var args = cniservertest.GenerateCNIArgs(testPodName, testPodNamespace, testPodInfraContainerID)
-var containerNamespace = "test"
 var testNodeConfig *types.NodeConfig
 var gwIP net.IP
 

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -74,10 +74,6 @@ func (rt regType) reg() string {
 	return fmt.Sprintf("reg%d", rt)
 }
 
-func i2h(data int64) string {
-	return fmt.Sprintf("0x%x", data)
-}
-
 const (
 	// marksReg stores traffic-source mark and pod-found mark.
 	// traffic-source resides in [0..15], pod-found resides in [16].

--- a/pkg/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_test.go
@@ -1840,22 +1840,6 @@ func getK8sNetworkPolicyPorts(proto v1.Protocol) []networkingv1.NetworkPolicyPor
 	return ports
 }
 
-// getK8sLabelSelector is a utility function to retrieve LabelSelector with
-// multiple randomly generated labels. Parameter numLabels can be used to
-// generate selector with number of labels equivalent to numLabels and hence
-// create unique LabelSelector.
-func getK8sLabelSelector(numLabels int) metav1.LabelSelector {
-	testLabels := make(map[string]string)
-	for i := 0; i < numLabels; i++ {
-		k := fmt.Sprintf("user-%d", i)
-		v := fmt.Sprintf("dev-%d", i)
-		testLabels[k] = v
-	}
-	return metav1.LabelSelector{
-		MatchLabels: testLabels,
-	}
-}
-
 func getK8sNetworkPolicyObj() *networkingv1.NetworkPolicy {
 	ns := metav1.NamespaceDefault
 	npName := "testing-1"

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -54,7 +54,7 @@ type agentMonitor struct {
 	ovsBridgeClient ovsconfig.OVSBridgeClient
 }
 
-func NewControllerMonitor(client clientset.Interface, nodeInformer coreinformers.NodeInformer) *controllerMonitor {
+func NewControllerMonitor(client clientset.Interface, nodeInformer coreinformers.NodeInformer) monitor {
 	m := &controllerMonitor{client: client, nodeInformer: nodeInformer, nodeListerSynced: nodeInformer.Informer().HasSynced}
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    nil,
@@ -65,7 +65,15 @@ func NewControllerMonitor(client clientset.Interface, nodeInformer coreinformers
 	return m
 }
 
-func NewAgentMonitor(client clientset.Interface, ovsBridge string, nodeName string, nodeSubnet string, interfaceStore interfacestore.InterfaceStore, ofClient openflow.Client, ovsBridgeClient ovsconfig.OVSBridgeClient) *agentMonitor {
+func NewAgentMonitor(
+	client clientset.Interface,
+	ovsBridge string,
+	nodeName string,
+	nodeSubnet string,
+	interfaceStore interfacestore.InterfaceStore,
+	ofClient openflow.Client,
+	ovsBridgeClient ovsconfig.OVSBridgeClient,
+) monitor {
 	return &agentMonitor{client: client, ovsBridge: ovsBridge, nodeName: nodeName, nodeSubnet: nodeSubnet, interfaceStore: interfaceStore, ofClient: ofClient, ovsBridgeClient: ovsBridgeClient}
 }
 

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -16,13 +16,9 @@ package openflow
 
 import (
 	"net"
-	"os/exec"
 	"time"
 )
 
-var executor = exec.Command
-
-type versionType = string
 type protocol = string
 type TableIDType uint8
 
@@ -92,10 +88,6 @@ type Table interface {
 	GetMissAction() MissActionType
 	Status() TableStatus
 	GetNext() TableIDType
-}
-
-type updater interface {
-	UpdateStatus(delta int)
 }
 
 type Flow interface {

--- a/test/e2e/providers/exec/docker.go
+++ b/test/e2e/providers/exec/docker.go
@@ -56,6 +56,6 @@ func RunDockerExecCommand(container string, cmd string, workdir string) (
 		return 0, "", "", err
 	}
 
-	// command is succesful
+	// command is successful
 	return 0, string(stdoutBytes), string(stderrBytes), nil
 }

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -521,18 +521,6 @@ func cmdAddDelCheckTest(testNS ns.NetNS, tc testCase, dataDir string) {
 	tester.cmdDelTest(tc, dataDir)
 }
 
-func getContainerIPMacConfig(ipamResult *current.Result) (string, string) {
-	containerMAC := ipamResult.Interfaces[1].Mac
-	containerIP := ""
-	for _, ipc := range ipamResult.IPs {
-		if ipc.Version == "4" {
-			containerIP = ipc.Address.IP.String()
-			break
-		}
-	}
-	return containerIP, containerMAC
-}
-
 func TestAntreaServerFunc(t *testing.T) {
 	controller := mock.NewController(t)
 	defer controller.Finish()


### PR DESCRIPTION
For now we enable the following linters: misspell, gofmt, deadcode
(changes have been made in the code to fix existing issues reported by
these linters). I picked these linters because the current Antrea code
was already mostly conformant with these and I think the probability of
a false positive is close to 0. More linters can be added to the list
later.

In particular, with this change we will be able to catch typos in
comments before merging a commit.