### PR TITLE
Add support for GRE and STT tunnels

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Also check out [@ProjectAntrea](https://twitter.com/ProjectAntrea) on Twitter!
 ## Features
 
 Antrea currently supports the following features:
-* IPv4 overlay network for a Kubernetes cluster. Either VXLAN or Geneve can
+* IPv4 overlay network for a Kubernetes cluster. VXLAN, Geneve, GRE, or STT can
 be used as the encapsulation protocol.
 * [Kubernetes Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies)
 implementation.

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -211,6 +211,8 @@ data:
     # Encapsulation mode for communication between Pods across Nodes, supported values:
     # - vxlan (default)
     # - geneve
+    # - gre
+    # - stt
     #tunnelType: vxlan
 
     # Default MTU to use for the host gateway interface and the network interface of each Pod. If
@@ -235,7 +237,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-config-fh9t4g64dc
+  name: antrea-config-48gttf992h
   namespace: kube-system
 ---
 apiVersion: v1
@@ -318,7 +320,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-fh9t4g64dc
+          name: antrea-config-48gttf992h
         name: antrea-config
 ---
 apiVersion: apps/v1
@@ -458,7 +460,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-fh9t4g64dc
+          name: antrea-config-48gttf992h
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -16,6 +16,8 @@
 # Encapsulation mode for communication between Pods across Nodes, supported values:
 # - vxlan (default)
 # - geneve
+# - gre
+# - stt
 #tunnelType: vxlan
 
 # Default MTU to use for the host gateway interface and the network interface of each Pod. If

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -43,6 +43,8 @@ type AgentConfig struct {
 	// Encapsulation mode for communication between Pods across Nodes, supported values:
 	// - vxlan (default)
 	// - geneve
+	// - gre
+	// - stt
 	TunnelType string `yaml:"tunnelType,omitempty"`
 	// Default MTU to use for the host gateway interface and the network interface of each
 	// Pod. If omitted, antrea-agent will default this value to 1450 to accommodate for tunnel

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -33,6 +33,8 @@ const (
 	defaultServiceCIDR        = "10.96.0.0/12"
 	defaultMTUVXLAN           = 1450
 	defaultMTUGeneve          = 1450
+	defaultMTUGRE             = 1462
+	defaultMTUSTT             = 1500
 )
 
 type Options struct {
@@ -76,7 +78,8 @@ func (o *Options) validate(args []string) error {
 	if err != nil {
 		return fmt.Errorf("service CIDR %s is invalid", o.config.ServiceCIDR)
 	}
-	if o.config.TunnelType != ovsconfig.VXLANTunnel && o.config.TunnelType != ovsconfig.GeneveTunnel {
+	if o.config.TunnelType != ovsconfig.VXLANTunnel && o.config.TunnelType != ovsconfig.GeneveTunnel &&
+		o.config.TunnelType != ovsconfig.GRETunnel && o.config.TunnelType != ovsconfig.STTTunnel {
 		return fmt.Errorf("tunnel type %s is invalid", o.config.TunnelType)
 	}
 	if o.config.OVSDatapathType != ovsconfig.OVSDatapathSystem && o.config.OVSDatapathType != ovsconfig.OVSDatapathNetdev {
@@ -126,6 +129,10 @@ func (o *Options) setDefaults() {
 			o.config.DefaultMTU = defaultMTUVXLAN
 		} else if o.config.TunnelType == ovsconfig.GeneveTunnel {
 			o.config.DefaultMTU = defaultMTUGeneve
+		} else if o.config.TunnelType == ovsconfig.GRETunnel {
+			o.config.DefaultMTU = defaultMTUGRE
+		} else if o.config.TunnelType == ovsconfig.STTTunnel {
+			o.config.DefaultMTU = defaultMTUSTT
 		}
 	}
 }

--- a/pkg/ovs/ovsconfig/interfaces.go
+++ b/pkg/ovs/ovsconfig/interfaces.go
@@ -17,8 +17,10 @@ package ovsconfig
 type TunnelType string
 
 const (
-	GeneveTunnel = "geneve"
 	VXLANTunnel  = "vxlan"
+	GeneveTunnel = "geneve"
+	GRETunnel    = "gre"
+	STTTunnel    = "stt"
 
 	OVSDatapathSystem = "system"
 	OVSDatapathNetdev = "netdev"

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -353,7 +353,7 @@ func (br *OVSBridge) createTunnelPort(
 	psk string,
 	externalIDs map[string]interface{}) (string, Error) {
 
-	if tunnelType != VXLANTunnel && tunnelType != GeneveTunnel {
+	if tunnelType != VXLANTunnel && tunnelType != GeneveTunnel && tunnelType != GRETunnel && tunnelType != STTTunnel {
 		return "", newInvalidArgumentsError("unsupported tunnel type: " + string(tunnelType))
 	}
 	if ofPortRequest < 0 || ofPortRequest > ofPortRequestMax {


### PR DESCRIPTION
Reasons to add GRE and STT support:
1. There is no harm to support more options.
2. So far with my tests IPSec works only for GRE (it could be due to OVS or module versions, and I am still debugging).
3. STT has best performance when NIC does not support offloading with encapsulation.