### PR TITLE
Fix grep pattern in kind-linux.sh script

### DIFF
--- a/hack/kind-linux.sh
+++ b/hack/kind-linux.sh
@@ -22,9 +22,11 @@
 # The script uses the antrea/ethtool Docker image (so that ethtool does not need to be installed on
 # the Linux host).
 
+set -eo pipefail
+
 for node in "$@"; do
     peerIdx=$(docker exec "$node" ip link | grep eth0 | awk -F[@:] '{ print $3 }' | cut -c 3-)
-    peerName=$(docker run --net=host antrea/ethtool:latest ip link | grep "$peerIdx": | awk -F[:@] '{ print $2 }' | cut -c 2-)
+    peerName=$(docker run --net=host antrea/ethtool:latest ip link | grep ^"$peerIdx": | awk -F[:@] '{ print $2 }' | cut -c 2-)
     echo "Disabling TX checksum offload for node $node ($peerName)"
     docker run --net=host --privileged antrea/ethtool:latest ethtool -K "$peerName" tx off
 done


### PR DESCRIPTION
The pattern was not specific enough and sometimes we had multiple
matches, causing the ethtool invocation to fail and preventing TX
checksum offload from being disabled properly.

Fixes #205