### PR TITLE
Use desired version of Go in CI test-integration

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,4 +20,5 @@ jobs:
     - name: Install OVS
       run: sudo apt-get install openvswitch-switch
     - name: Run integration tests
-      run: sudo make test-integration
+      # Use the specified go version instead of the default one installed on the Github worker VM.
+      run: sudo make GOROOT="$(go env GOROOT)" GOPATH="$(go env GOPATH)" GO="$(go env GOROOT)/bin/go" test-integration

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS         :=
 GOFLAGS         :=
 BINDIR          := $(CURDIR)/bin
 GO_FILES        := $(shell find . -type d -name '.cache' -prune -o -type f -name '*.go' -print)
-GOPATH          ?= $$(go env GOPATH)
+GOPATH          ?= $$($(GO) env GOPATH)
 DOCKER_CACHE    := $(CURDIR)/.cache
 
 .PHONY: all
@@ -67,7 +67,7 @@ docker-test-unit: $(DOCKER_CACHE)
 .PHONY: docker-tidy
 docker-tidy: $(DOCKER_CACHE)
 	@rm -f go.sum
-	@$(DOCKER_ENV) go mod tidy
+	@$(DOCKER_ENV) $(GO) mod tidy
 	@chmod -R 0755 $<
 	@chmod 0644 go.sum
 
@@ -121,7 +121,7 @@ golangci: .golangci-bin
 .linter:
 	@if ! PATH=$$PATH:$(GOPATH)/bin command -v golint > /dev/null; then \
 	  echo "===> Installing Golint <==="; \
-	  go get -u golang.org/x/lint/golint; \
+	  $(GO) get -u golang.org/x/lint/golint; \
 	fi
 
 .PHONY: lint


### PR DESCRIPTION
Fixes #245 