### PR TITLE
Add NetworkPolicy information to monitoring CRDs

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -129,7 +129,7 @@ func run(o *Options) error {
 
 	go networkPolicyController.Run(stopCh)
 
-	agentMonitor := monitor.NewAgentMonitor(crdClient, o.config.OVSBridge, nodeConfig.Name, nodeConfig.PodCIDR.String(), ifaceStore, ofClient, ovsBridgeClient)
+	agentMonitor := monitor.NewAgentMonitor(crdClient, o.config.OVSBridge, nodeConfig.Name, nodeConfig.PodCIDR.String(), ifaceStore, ofClient, ovsBridgeClient, networkPolicyController)
 
 	go agentMonitor.Run(stopCh)
 

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -84,7 +84,7 @@ func run(o *Options) error {
 
 	informerFactory.Start(stopCh)
 
-	controllerMonitor := monitor.NewControllerMonitor(crdClient, nodeInformer)
+	controllerMonitor := monitor.NewControllerMonitor(crdClient, nodeInformer, networkPolicyController)
 	go controllerMonitor.Run(stopCh)
 
 	go networkPolicyController.Run(stopCh)

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -81,6 +81,18 @@ func NewNetworkPolicyController(antreaClient versioned.Interface,
 	return c
 }
 
+func (c *Controller) GetNetworkPolicyNum() int {
+	return c.ruleCache.GetNetworkPolicyNum()
+}
+
+func (c *Controller) GetAddressGroupNum() int {
+	return c.ruleCache.GetAddressGroupNum()
+}
+
+func (c *Controller) GetAppliedToGroupNum() int {
+	return c.ruleCache.GetAppliedToGroupNum()
+}
+
 // Run begins watching and processing Antrea AddressGroups, AppliedToGroups
 // and NetworkPolicies, and spawns workers that reconciles NetworkPolicy rules.
 // Run will not return until stopCh is closed.

--- a/pkg/apis/clusterinformation/v1beta1/types.go
+++ b/pkg/apis/clusterinformation/v1beta1/types.go
@@ -26,13 +26,14 @@ type AntreaAgentInfo struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Version         string                 `json:"version,omitempty"`         // Antrea binary version
-	PodRef          corev1.ObjectReference `json:"podRef,omitempty"`          // The Pod that Antrea Agent is running in
-	NodeRef         corev1.ObjectReference `json:"nodeRef,omitempty"`         // The Node that Antrea Agent is running in
-	NodeSubnet      []string               `json:"nodeSubnet,omitempty"`      // Node subnet
-	OVSInfo         OVSInfo                `json:"ovsInfo,omitempty"`         // OVS Information
-	LocalPodNum     int32                  `json:"localPodNum,omitempty"`     // The number of Pods which the agent is in charge of
-	AgentConditions []AgentCondition       `json:"agentConditions,omitempty"` // Agent condition contains types like AgentHealthy
+	Version                     string                      `json:"version,omitempty"`                     // Antrea binary version
+	PodRef                      corev1.ObjectReference      `json:"podRef,omitempty"`                      // The Pod that Antrea Agent is running in
+	NodeRef                     corev1.ObjectReference      `json:"nodeRef,omitempty"`                     // The Node that Antrea Agent is running in
+	NodeSubnet                  []string                    `json:"nodeSubnet,omitempty"`                  // Node subnet
+	OVSInfo                     OVSInfo                     `json:"ovsInfo,omitempty"`                     // OVS Information
+	NetworkPolicyControllerInfo NetworkPolicyControllerInfo `json:"networkPolicyControllerInfo,omitempty"` // Antrea Agent NetworkPolicy information
+	LocalPodNum                 int32                       `json:"localPodNum,omitempty"`                 // The number of Pods which the agent is in charge of
+	AgentConditions             []AgentCondition            `json:"agentConditions,omitempty"`             // Agent condition contains types like AgentHealthy
 }
 
 type OVSInfo struct {
@@ -75,15 +76,15 @@ type AntreaControllerInfo struct {
 	PodRef                      corev1.ObjectReference      `json:"podRef,omitempty"`                      // The Pod that Antrea Controller is running in
 	NodeRef                     corev1.ObjectReference      `json:"nodeRef,omitempty"`                     // The Node that Antrea Controller is running in
 	ServiceRef                  corev1.ObjectReference      `json:"serviceRef, omitempty"`                 // Antrea Controller Service
-	NetworkPolicyControllerInfo NetworkPolicyControllerInfo `json:"networkPolicyControllerInfo,omitempty"` // NetworkPolicy information
+	NetworkPolicyControllerInfo NetworkPolicyControllerInfo `json:"networkPolicyControllerInfo,omitempty"` // Antrea Controller NetworkPolicy information
 	ConnectedAgentNum           int32                       `json:"connectedAgentNum,omitempty"`           // Number of agents which are connected to this controller
 	ControllerConditions        []ControllerCondition       `json:"controllerConditions,omitempty"`        // Controller condition contains types like ControllerHealthy
 }
 
 type NetworkPolicyControllerInfo struct {
-	PolicyNum        int32 `json:"policyNum,omitempty"`
-	AddressGroupNum  int32 `json:"addressGroupNum,omitempty"`
-	ApplyingGroupNum int32 `json:"applyingGroupNum,omitempty"`
+	NetworkPolicyNum  int32 `json:"networkPolicyNum,omitempty"`
+	AddressGroupNum   int32 `json:"addressGroupNum,omitempty"`
+	AppliedToGroupNum int32 `json:"appliedToGroupNum,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/clusterinformation/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/clusterinformation/v1beta1/zz_generated.deepcopy.go
@@ -52,6 +52,7 @@ func (in *AntreaAgentInfo) DeepCopyInto(out *AntreaAgentInfo) {
 		copy(*out, *in)
 	}
 	in.OVSInfo.DeepCopyInto(&out.OVSInfo)
+	out.NetworkPolicyControllerInfo = in.NetworkPolicyControllerInfo
 	if in.AgentConditions != nil {
 		in, out := &in.AgentConditions, &out.AgentConditions
 		*out = make([]AgentCondition, len(*in))

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -192,6 +192,18 @@ func NewNetworkPolicyController(kubeClient clientset.Interface,
 	return n
 }
 
+func (n *NetworkPolicyController) GetNetworkPolicyNum() int {
+	return len(n.internalNetworkPolicyStore.List())
+}
+
+func (n *NetworkPolicyController) GetAddressGroupNum() int {
+	return len(n.addressGroupStore.List())
+}
+
+func (n *NetworkPolicyController) GetAppliedToGroupNum() int {
+	return len(n.appliedToGroupStore.List())
+}
+
 // toGroupSelector converts the podSelector and namespaceSelector
 // and NetworkPolicy Namespace to a networkpolicy.GroupSelector object.
 func toGroupSelector(namespace string, podSelector, nsSelector *metav1.LabelSelector) *antreatypes.GroupSelector {
@@ -576,7 +588,7 @@ func (n *NetworkPolicyController) toAntreaPeer(peers []networkingv1.NetworkPolic
 func (n *NetworkPolicyController) addNetworkPolicy(obj interface{}) {
 	np := obj.(*networkingv1.NetworkPolicy)
 	defer klog.V(2).Infof("Finished processing NetworkPolicy %s/%s ADD event", np.ObjectMeta.Namespace, np.ObjectMeta.Name)
-	// Create an internal NetworkPolicy object correspoding to this NetworkPolicy
+	// Create an internal NetworkPolicy object corresponding to this NetworkPolicy
 	// and enqueue task to internal NetworkPolicy Workqueue.
 	internalNP := n.processNetworkPolicy(np)
 	klog.V(2).Infof("Creating new internal NetworkPolicy %s/%s", internalNP.Namespace, internalNP.Name)
@@ -590,7 +602,7 @@ func (n *NetworkPolicyController) addNetworkPolicy(obj interface{}) {
 func (n *NetworkPolicyController) updateNetworkPolicy(old, cur interface{}) {
 	np := cur.(*networkingv1.NetworkPolicy)
 	defer klog.V(2).Infof("Finished processing NetworkPolicy %s/%s UPDATE event", np.ObjectMeta.Namespace, np.ObjectMeta.Name)
-	// Update an internal NetworkPolicy ID, correspoding to this NetworkPolicy and
+	// Update an internal NetworkPolicy ID, corresponding to this NetworkPolicy and
 	// enqueue task to internal NetworkPolicy Workqueue.
 	curInternalNP := n.processNetworkPolicy(np)
 	klog.V(2).Infof("Updating existing internal NetworkPolicy %s/%s", curInternalNP.Namespace, curInternalNP.Name)

--- a/pkg/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_test.go
@@ -132,7 +132,7 @@ func TestAddNetworkPolicy(t *testing.T) {
 		{
 			name: "default-allow-egress",
 			inputPolicy: &networkingv1.NetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "nsA", Name: "npA", UID: "uidA"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "nsA", Name: "npB", UID: "uidB"},
 				Spec: networkingv1.NetworkPolicySpec{
 					PodSelector: metav1.LabelSelector{},
 					PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
@@ -140,8 +140,8 @@ func TestAddNetworkPolicy(t *testing.T) {
 				},
 			},
 			expPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "npA",
+				UID:       "uidB",
+				Name:      "npB",
 				Namespace: "nsA",
 				Rules: []networking.NetworkPolicyRule{{
 					Direction: networking.DirectionOut,
@@ -156,15 +156,15 @@ func TestAddNetworkPolicy(t *testing.T) {
 		{
 			name: "default-deny-ingress",
 			inputPolicy: &networkingv1.NetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "nsA", Name: "npA", UID: "uidA"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "nsA", Name: "npC", UID: "uidC"},
 				Spec: networkingv1.NetworkPolicySpec{
 					PodSelector: metav1.LabelSelector{},
 					PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 				},
 			},
 			expPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "npA",
+				UID:       "uidC",
+				Name:      "npC",
 				Namespace: "nsA",
 				Rules: []networking.NetworkPolicyRule{
 					denyAllIngressRule,
@@ -177,15 +177,15 @@ func TestAddNetworkPolicy(t *testing.T) {
 		{
 			name: "default-deny-egress",
 			inputPolicy: &networkingv1.NetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "nsA", Name: "npA", UID: "uidA"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "nsA", Name: "npD", UID: "uidD"},
 				Spec: networkingv1.NetworkPolicySpec{
 					PodSelector: metav1.LabelSelector{},
 					PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
 				},
 			},
 			expPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "npA",
+				UID:       "uidD",
+				Name:      "npD",
 				Namespace: "nsA",
 				Rules: []networking.NetworkPolicyRule{
 					denyAllEgressRule,
@@ -198,7 +198,7 @@ func TestAddNetworkPolicy(t *testing.T) {
 		{
 			name: "rules-with-same-selectors",
 			inputPolicy: &networkingv1.NetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "nsA", Name: "npA", UID: "uidA"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "nsA", Name: "npE", UID: "uidE"},
 				Spec: networkingv1.NetworkPolicySpec{
 					PodSelector: selectorA,
 					Ingress: []networkingv1.NetworkPolicyIngressRule{
@@ -234,8 +234,8 @@ func TestAddNetworkPolicy(t *testing.T) {
 				},
 			},
 			expPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "npA",
+				UID:       "uidE",
+				Name:      "npE",
 				Namespace: "nsA",
 				Rules: []networking.NetworkPolicyRule{
 					{
@@ -271,7 +271,7 @@ func TestAddNetworkPolicy(t *testing.T) {
 		{
 			name: "rules-with-different-selectors",
 			inputPolicy: &networkingv1.NetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "nsA", Name: "npA", UID: "uidA"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "nsA", Name: "npF", UID: "uidF"},
 				Spec: networkingv1.NetworkPolicySpec{
 					PodSelector: selectorA,
 					Ingress: []networkingv1.NetworkPolicyIngressRule{
@@ -303,8 +303,8 @@ func TestAddNetworkPolicy(t *testing.T) {
 				},
 			},
 			expPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "npA",
+				UID:       "uidF",
+				Name:      "npF",
 				Namespace: "nsA",
 				Rules: []networking.NetworkPolicyRule{
 					{
@@ -358,6 +358,13 @@ func TestAddNetworkPolicy(t *testing.T) {
 			}
 		})
 	}
+	_, npc := newController()
+	for _, tt := range tests {
+		npc.addNetworkPolicy(tt.inputPolicy)
+	}
+	assert.Equal(t, npc.GetNetworkPolicyNum(), 6, "expected networkPolicy number is 6")
+	assert.Equal(t, npc.GetAddressGroupNum(), 3, "expected addressGroup number is 3")
+	assert.Equal(t, npc.GetAppliedToGroupNum(), 2, "appliedToGroup number is 2")
 }
 
 func TestDeleteNetworkPolicy(t *testing.T) {

--- a/pkg/monitor/querier.go
+++ b/pkg/monitor/querier.go
@@ -20,6 +20,8 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/klog"
+
+	"github.com/vmware-tanzu/antrea/pkg/apis/clusterinformation/v1beta1"
 )
 
 const (
@@ -33,6 +35,13 @@ const (
 type Querier interface {
 	GetSelfPod() v1.ObjectReference
 	GetSelfNode() v1.ObjectReference
+	GetNetworkPolicyControllerInfo() v1beta1.NetworkPolicyControllerInfo
+}
+
+type NetworkPolicyInfoQuerier interface {
+	GetNetworkPolicyNum() int
+	GetAddressGroupNum() int
+	GetAppliedToGroupNum() int
 }
 
 type AgentQuerier interface {
@@ -78,6 +87,14 @@ func (monitor *agentMonitor) GetOVSFlowTable() map[string]int32 {
 	return flowTable
 }
 
+func (monitor *agentMonitor) GetNetworkPolicyControllerInfo() v1beta1.NetworkPolicyControllerInfo {
+	return v1beta1.NetworkPolicyControllerInfo{
+		NetworkPolicyNum:  int32(monitor.networkPolicyInfoQuerier.GetNetworkPolicyNum()),
+		AddressGroupNum:   int32(monitor.networkPolicyInfoQuerier.GetAddressGroupNum()),
+		AppliedToGroupNum: int32(monitor.networkPolicyInfoQuerier.GetAppliedToGroupNum()),
+	}
+}
+
 // GetLocalPodNum gets the number of Pod which the Agent is in charge of.
 func (monitor *agentMonitor) GetLocalPodNum() int32 {
 	return int32(monitor.interfaceStore.GetContainerInterfaceNum())
@@ -99,4 +116,12 @@ func (monitor *controllerMonitor) GetSelfNode() v1.ObjectReference {
 
 func (monitor *controllerMonitor) GetService() v1.ObjectReference {
 	return v1.ObjectReference{Kind: "Service", Name: SERVICE_NAME}
+}
+
+func (monitor *controllerMonitor) GetNetworkPolicyControllerInfo() v1beta1.NetworkPolicyControllerInfo {
+	return v1beta1.NetworkPolicyControllerInfo{
+		NetworkPolicyNum:  int32(monitor.networkPolicyInfoQuerier.GetNetworkPolicyNum()),
+		AddressGroupNum:   int32(monitor.networkPolicyInfoQuerier.GetAddressGroupNum()),
+		AppliedToGroupNum: int32(monitor.networkPolicyInfoQuerier.GetAppliedToGroupNum()),
+	}
 }


### PR DESCRIPTION
1.And NetworkPolicy related fields (NetworkPolicyNum, AddressGroupNum, AppliedToGroupNum)
to both Controller and Agent monitoring CRDs.

2.Populate Controller NetworkPolicy related fields by information stored in the Antrea object storage.

3.Populate Agent NetworkPolicy related fields by information stored in ruleCache.

Fixes #230 