### PR TITLE
Skip TestPodConnectivityAfterAntreaRestart in Kind CI

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -43,4 +43,4 @@ jobs:
     - name: Run e2e tests
       run: |
         ./hack/generate-manifest.sh --kind | docker exec -i kind-control-plane dd of=/root/antrea.yml
-        go test github.com/vmware-tanzu/antrea/test/e2e -provider=kind
+        go test -short github.com/vmware-tanzu/antrea/test/e2e -provider=kind

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -123,6 +123,9 @@ func TestPodConnectivityDifferentNodes(t *testing.T) {
 // TestPodConnectivityAfterAntreaRestart checks that restarting antrea-agent does not create
 // connectivity issues between Pods.
 func TestPodConnectivityAfterAntreaRestart(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping TestPodConnectivityAfterAntreaRestart in short mode")
+	}
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -781,8 +781,11 @@ func (data *TestData) runPingCommandFromTestPod(podName string, targetIP string,
 
 func (data *TestData) runWgetCommandFromTestPod(podName string, svcName string) error {
 	cmd := []string{"nc", "-vz", "-w", "8", svcName + "." + testNamespace, "80"}
-	_, _, err := data.runCommandFromPod(testNamespace, podName, busyboxContainerName, cmd)
-	return err
+	stdout, stderr, err := data.runCommandFromPod(testNamespace, podName, busyboxContainerName, cmd)
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("nc stdout: <%v>, stderr: <%v>, err: <%v>", stdout, stderr, err)
 }
 
 func (data *TestData) runWgetCommandFromTestPodToPodIP(podName string, podIP string) error {

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -22,10 +22,6 @@ import (
 )
 
 func TestIPBlockWithExcept(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping TestIPBlockWithExcept in short mode")
-	}
-
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)
@@ -105,7 +101,7 @@ func TestIPBlockWithExcept(t *testing.T) {
 
 	// pod0 can wget to service.
 	if err = data.runWgetCommandFromTestPod(podName0, svcName); err != nil {
-		t.Fatalf("Pod %s should be able to connect Service %s, but was not able to connect", podName0, svcName)
+		t.Fatalf("Pod %s should be able to connect Service %s, but was not able to connect: %v", podName0, svcName, err)
 	}
 	// pod1 cannot wget to service.
 	if err = data.runWgetCommandFromTestPod(podName1, svcName); err == nil {
@@ -114,7 +110,7 @@ func TestIPBlockWithExcept(t *testing.T) {
 
 	// pod0 can wget to pod IP.
 	if err = data.runWgetCommandFromTestPodToPodIP(podName0, nginxPodIP); err != nil {
-		t.Fatalf("Pod %s should be able to connect Pod %s, but was not able to connect", podName0, nginxPodIP)
+		t.Fatalf("Pod %s should be able to connect Pod %s, but was not able to connect: %v", podName0, nginxPodIP, err)
 	}
 	// pod1 cannot wget to pod IP.
 	if err = data.runWgetCommandFromTestPodToPodIP(podName1, nginxPodIP); err == nil {


### PR DESCRIPTION
TestPodConnectivityAfterAntreaRestart destroys and recreates dataplane
which affects existing connection between components (e.g coredns and
antrea-controller) and kube-apiserver somehow and they don't receive
events stream in some time. Since it only happens on Kind cluster, it
might be related to the dataplane implementation.

Before we can resolve it, skip the test in case of tests depending on
coredns and antrea-controller failing.

Related to #244