### PR TITLE
Fix generate-manifest.sh for release mode

### DIFF
--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -166,7 +166,8 @@ fi
 mkdir $MODE && cd $MODE
 touch kustomization.yml
 $KUSTOMIZE edit add base $BASE
-cp ../../patches/$MODE/*.yml .
+# ../../patches/$MODE may be empty so we use find and not simply cp
+find ../../patches/$MODE -name \*.yml -exec cp {} . \;
 
 if [ "$MODE" == "dev" ]; then
     $KUSTOMIZE edit set image antrea=antrea/antrea-ubuntu:latest


### PR DESCRIPTION
The cp command was failing because patches/release/ has no YAML files at
the moment. I ran into this issue as I was generating the YAML manifest
for v0.2.0.