### PR TITLE
Fix ownership of ~/.kube directory created in Ansible playbook

### DIFF
--- a/test/e2e/infra/vagrant/playbook/roles/master/tasks/main.yml
+++ b/test/e2e/infra/vagrant/playbook/roles/master/tasks/main.yml
@@ -37,6 +37,8 @@
       file:
         path: /home/{{ test_user }}/.kube
         state: directory
+        owner: "{{ test_user }}"
+        group: "{{ test_user }}"
     - name: Copy kubeconfig file to /home/{{ test_user }}/.kube
       copy:
         src: /etc/kubernetes/admin.conf


### PR DESCRIPTION
The directory was owned by root which prevented kubectl from using
~/.kube/cache. This became an issue for K8s 1.17.0 because of the low
burst value when throttling API discovery requests. It ended up taking a
minute to run "kubectl get -A all" on the cluster created with Vagrant.

See https://github.com/kubernetes/kubernetes/issues/86149 and
https://github.com/kubernetes/kubernetes/issues/86462.