### PR TITLE
Cleanup stale gateway routes and tunnel ports on Agent startup

### DIFF
--- a/build/images/scripts/start_ovs_ipsec
+++ b/build/images/scripts/start_ovs_ipsec
@@ -19,18 +19,31 @@ function stop_agents {
     ipsec stop
 }
 
+SLEEP_PID=
+
 function quit {
     log_info $CONTAINER_NAME "Stopping OVS IPSec before quit"
     stop_agents
+    # kill background sleep process
+    if [ "$SLEEP_PID" != "" ]; then kill $SLEEP_PID > /dev/null 2>&1 || true; fi
     exit 0
 }
-trap quit Exit
+
+# Do not trap EXIT as it would then ignore the "exit 0" statement in quit and
+# exit with code 128 + SIGNAL
+trap "quit" INT TERM
 
 start_agents
 
 log_info $CONTAINER_NAME "Started the loop that checks agents status every 30 seconds"
 while true; do
-    sleep 30
+    # we run sleep in the background so that we can immediately exit when we
+    # receive SIGINT / SIGTERM
+    # see https://stackoverflow.com/questions/32041674/linux-how-to-kill-sleep
+    sleep 30 &
+    SLEEP_PID=$!
+    wait $SLEEP_PID
+
     if ! check_ovs_ipsec_status ; then
         log_warning $CONTAINER_NAME "OVS IPSec was stopped. Starting it again"
 

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
-	golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9
+	golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	google.golang.org/grpc v1.22.0
 	gopkg.in/yaml.v2 v2.2.2

--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -627,7 +627,7 @@ func (pc *podConfigurator) reconcile(pods []corev1.Pod) error {
 	// current list of Pods.
 	desiredInterfaces := make(map[string]bool)
 	// knownInterfaces is the list of interfaces currently in the local cache.
-	knownInterfaces := pc.ifaceStore.GetInterfaceKeys()
+	knownInterfaces := pc.ifaceStore.GetInterfaceKeysByType(interfacestore.ContainerInterface)
 
 	for _, pod := range pods {
 		// Skip Pods for which we are not in charge of the networking.
@@ -677,10 +677,6 @@ func (pc *podConfigurator) reconcile(pods []corev1.Pod) error {
 			// should not happen, nothing should have concurrent access to the interface
 			// store.
 			klog.Errorf("Interface %s can no longer be found in the interface store", ifaceID)
-			continue
-		}
-		if containerConfig.Type != interfacestore.ContainerInterface {
-			// not a container interface, skipping.
 			continue
 		}
 		klog.V(4).Infof("Deleting interface %s", ifaceID)

--- a/pkg/agent/interfacestore/interface_cache.go
+++ b/pkg/agent/interfacestore/interface_cache.go
@@ -118,6 +118,19 @@ func (c *interfaceCache) GetInterfaceKeys() []string {
 	return keys
 }
 
+func (c *interfaceCache) GetInterfaceKeysByType(interfaceType InterfaceType) []string {
+	c.RLock()
+	defer c.RUnlock()
+	keys := make([]string, 0, len(c.cache))
+	for key, v := range c.cache {
+		if v.Type != interfaceType {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	return keys
+}
+
 // GetPodInterface retrieves InterfaceConfig for the Pod.
 func (c *interfaceCache) GetContainerInterface(podName string, podNamespace string) (*InterfaceConfig, bool) {
 	key := util.GenerateContainerInterfaceKey(podName, podNamespace)

--- a/pkg/agent/interfacestore/types.go
+++ b/pkg/agent/interfacestore/types.go
@@ -74,6 +74,7 @@ type InterfaceStore interface {
 	GetContainerInterfaceNum() int
 	Len() int
 	GetInterfaceKeys() []string
+	GetInterfaceKeysByType(interfaceType InterfaceType) []string
 }
 
 // NewContainerInterface creates InterfaceConfig for a Pod.

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -16,9 +16,13 @@ package e2e
 
 import (
 	"fmt"
+	"net"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"
 )
@@ -106,15 +110,11 @@ func TestDeletePod(t *testing.T) {
 	}
 
 	doesOVSPortExist := func() bool {
-		cmd := []string{"ovs-vsctl", "port-to-br", ifName}
-		if _, stderr, err := data.runCommandFromPod(antreaNamespace, antreaPodName, ovsContainerName, cmd); err == nil {
-			return true
-		} else if strings.Contains(stderr, "no port named") {
-			return false
-		} else {
-			t.Fatalf("Error when running ovs-vsctl command on Pod '%s': %v", antreaPodName, err)
+		exists, err := data.doesOVSPortExist(antreaPodName, ifName)
+		if err != nil {
+			t.Fatalf("Cannot determine if OVS port exists: %v", err)
 		}
-		return true
+		return exists
 	}
 
 	t.Logf("Checking that the veth interface and the OVS port exist")
@@ -219,5 +219,169 @@ func TestIPAMRestart(t *testing.T) {
 
 	if podIP1 == podIP2 {
 		t.Errorf("Pods '%s' and '%s' were assigned the same IP %s", podName1, podName2, podIP1)
+	}
+}
+
+// TestReconcileGatewayRoutesOnStartup checks that when the Antrea agent is restarted, the set of
+// gateway routes is updated correctly, i.e. stale routes (for Nodes which are no longer in the
+// cluster) are removed and missing routes are added.
+func TestReconcileGatewayRoutesOnStartup(t *testing.T) {
+	if clusterInfo.numNodes < 2 {
+		t.Skipf("Skipping test as it requires 2 different nodes")
+	}
+
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	type Route struct {
+		peerPodCIDR *net.IPNet
+		peerPodGW   net.IP
+	}
+
+	nodeName := nodeName(0)
+	antreaPodName := func() string {
+		antreaPodName, err := data.getAntreaPodOnNode(nodeName)
+		if err != nil {
+			t.Fatalf("Error when retrieving the name of the Antrea Pod running on Node '%s': %v", nodeName, err)
+		}
+		t.Logf("The Antrea Pod for Node '%s' is '%s'", nodeName, antreaPodName)
+		return antreaPodName
+	}
+
+	getGatewayRoutes := func() (routes []Route, err error) {
+		cmd := fmt.Sprintf("ip route list dev %s", antreaGWName)
+		rc, stdout, _, err := RunCommandOnNode(nodeName, cmd)
+		if err != nil {
+			return nil, fmt.Errorf("error when running ip command on Node '%s': %v", nodeName, err)
+		}
+		if rc != 0 {
+			return nil, fmt.Errorf("running ip command on Node '%s' returned error", nodeName)
+		}
+		re := regexp.MustCompile(`([^\s]+) via ([^\s]+)`)
+		for _, line := range strings.Split(stdout, "\n") {
+			var err error
+			matches := re.FindStringSubmatch(line)
+			if len(matches) == 0 {
+				continue
+			}
+			route := Route{}
+			if _, route.peerPodCIDR, err = net.ParseCIDR(matches[1]); err != nil {
+				return nil, fmt.Errorf("%s is not a valid net CIDR", matches[1])
+			}
+			if route.peerPodGW = net.ParseIP(matches[2]); route.peerPodGW == nil {
+				return nil, fmt.Errorf("%s is not a valid IP", matches[2])
+			}
+			routes = append(routes, route)
+		}
+		return routes, nil
+	}
+
+	t.Logf("Retrieving gateway routes on Node '%s'", nodeName)
+	var routes []Route
+	if err := wait.PollImmediate(1*time.Second, defaultTimeout, func() (found bool, err error) {
+		routes, err = getGatewayRoutes()
+		if err != nil {
+			return false, err
+		}
+		if len(routes) < clusterInfo.numNodes-1 {
+			// Not enough routes, keep trying
+			return false, nil
+		} else if len(routes) > clusterInfo.numNodes-1 {
+			return false, fmt.Errorf("found too many gateway routes, expected %d but got %d", clusterInfo.numNodes-1, len(routes))
+		}
+		return true, nil
+	}); err == wait.ErrWaitTimeout {
+		t.Fatalf("Not enough gateway routes after %v", defaultTimeout)
+	} else if err != nil {
+		t.Fatalf("Error while waiting for gateway routes: %v", err)
+	} else {
+		t.Logf("Found all expected gateway routes")
+	}
+
+	routeToDelete := routes[0]
+	// A dummy route
+	routeToAdd := Route{}
+	_, routeToAdd.peerPodCIDR, _ = net.ParseCIDR("99.99.99.0/24")
+	routeToAdd.peerPodGW = net.ParseIP("99.99.99.1")
+
+	// We run the ip command from the antrea-agent container for delete / add since they need to
+	// be run as root and the antrea-agent container is privileged. If we used RunCommandOnNode,
+	// we may need to use "sudo" for some providers (e.g. vagrant).
+	deleteGatewayRoute := func(route Route) error {
+		cmd := []string{"ip", "route", "del", route.peerPodCIDR.String()}
+		_, _, err := data.runCommandFromPod(antreaNamespace, antreaPodName(), agentContainerName, cmd)
+		if err != nil {
+			return fmt.Errorf("error when running ip command on Node '%s': %v", nodeName, err)
+		}
+		return nil
+	}
+
+	addGatewayRoute := func(route Route) error {
+		cmd := []string{"ip", "route", "add", route.peerPodCIDR.String(), "via", route.peerPodGW.String(), "dev", antreaGWName, "onlink"}
+		_, _, err := data.runCommandFromPod(antreaNamespace, antreaPodName(), agentContainerName, cmd)
+		if err != nil {
+			return fmt.Errorf("error when running ip command on Node '%s': %v", nodeName, err)
+		}
+		return nil
+	}
+
+	t.Logf("Deleting one actual gateway route and adding a dummy one")
+	if err := deleteGatewayRoute(routeToDelete); err != nil {
+		t.Fatalf("Error when deleting route: %v", err)
+	}
+	if err := addGatewayRoute(routeToAdd); err != nil {
+		t.Fatalf("Error when adding dummy route route: %v", err)
+	}
+	defer func() {
+		// Cleanup the dummy route regardless of whether the test was a success or a
+		// failure; ignore error (there will be an error if the test is a success since the
+		// dummy route will no longer exist).
+		_ = deleteGatewayRoute(routeToAdd)
+	}()
+
+	t.Logf("Restarting antrea-agent on Node '%s'", nodeName)
+	if _, err := data.deleteAntreaAgentOnNode(nodeName, 30 /* grace period in seconds */, defaultTimeout); err != nil {
+		t.Fatalf("Error when restarting antrea-agent on Node '%s': %v", nodeName, err)
+	}
+
+	t.Logf("Checking that all Antrea DaemonSet Pods are running")
+	if err := data.waitForAntreaDaemonSetPods(defaultTimeout); err != nil {
+		t.Fatalf("Error when waiting for Antrea Pods: %v", err)
+	}
+
+	// We expect the agent to delete the extra route we added and add back the route we deleted
+	t.Logf("Waiting for gateway routes to converge")
+	if err := wait.Poll(1*time.Second, defaultTimeout, func() (bool, error) {
+		newRoutes, err := getGatewayRoutes()
+		if err != nil {
+			return false, err
+		}
+		if len(newRoutes) != len(routes) {
+			return false, nil
+		}
+		for _, route := range newRoutes {
+			if route.peerPodGW.Equal(routeToAdd.peerPodGW) {
+				// The dummy route hasn't been deleted yet, keep trying
+				return false, nil
+			}
+		}
+		// At this stage we have confirmed that the dummy route has been deleted
+		for _, route := range newRoutes {
+			if route.peerPodGW.Equal(routeToDelete.peerPodGW) {
+				// The deleted route was added back, success!
+				return true, nil
+			}
+		}
+		// We haven't found the deleted route, keep trying
+		return false, nil
+	}); err == wait.ErrWaitTimeout {
+		t.Errorf("Gateway routes did not converge after %v", defaultTimeout)
+	} else if err != nil {
+		t.Fatalf("Error while waiting for gateway routes to converge: %v", err)
+	} else {
+		t.Logf("Gateway routes successfully converged")
 	}
 }

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -139,12 +139,16 @@ func (data *TestData) redeployAntrea(t *testing.T, enableIPSec bool) {
 		err = data.deployAntrea()
 	}
 	if err != nil {
-		t.Fatalf("Error when restarting Antrea: %v", err)
+		t.Fatalf("Error when applying Antrea YAML: %v", err)
 	}
 
-	t.Logf("Waiting for all Antrea DaemonSet pods")
-	if err = data.waitForAntreaDaemonSetPods(defaultTimeout); err != nil {
+	t.Logf("Waiting for all Antrea DaemonSet Pods")
+	if err := data.waitForAntreaDaemonSetPods(defaultTimeout); err != nil {
 		t.Fatalf("Error when restarting Antrea: %v", err)
+	}
+	t.Logf("Checking CoreDNS deployment")
+	if err := data.checkCoreDNSPods(defaultTimeout); err != nil {
+		t.Fatalf("Error when checking CoreDNS deployment: %v", err)
 	}
 }
 

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -22,6 +22,22 @@ import (
 	"time"
 )
 
+func ensureAntreaRunning(tb testing.TB, data *TestData) error {
+	tb.Logf("Applying Antrea YAML")
+	if err := data.deployAntrea(); err != nil {
+		return err
+	}
+	tb.Logf("Waiting for all Antrea DaemonSet Pods")
+	if err := data.waitForAntreaDaemonSetPods(defaultTimeout); err != nil {
+		return err
+	}
+	tb.Logf("Checking CoreDNS deployment")
+	if err := data.checkCoreDNSPods(defaultTimeout); err != nil {
+		return err
+	}
+	return nil
+}
+
 func setupTest(tb testing.TB) (*TestData, error) {
 	data := &TestData{}
 	tb.Logf("Creating K8s clientset")
@@ -34,19 +50,9 @@ func setupTest(tb testing.TB) (*TestData, error) {
 	if err := data.createTestNamespace(); err != nil {
 		return nil, err
 	}
-	tb.Logf("Applying Antrea YAML")
-	if err := data.deployAntrea(); err != nil {
+	if err := ensureAntreaRunning(tb, data); err != nil {
 		return nil, err
 	}
-	tb.Logf("Waiting for all Antrea DaemonSet Pods")
-	if err := data.waitForAntreaDaemonSetPods(defaultTimeout); err != nil {
-		return nil, err
-	}
-	// TODO: CoreDNS keeps crashing at the moment, even when Antrea is running fine.
-	// t.Logf("Checking CoreDNS deployment")
-	// if err := data.checkCoreDNSPods(defaultTimeout); err != nil {
-	// 	return nil, err
-	// }
 	return data, nil
 }
 

--- a/test/e2e/ipsec_test.go
+++ b/test/e2e/ipsec_test.go
@@ -16,6 +16,11 @@ package e2e
 
 import (
 	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/util"
 )
 
 // TestIPSecTunnelConnectivity checks that Pod traffic across two Nodes over
@@ -42,4 +47,66 @@ func TestIPSecTunnelConnectivity(t *testing.T) {
 
 	// Restore normal Antrea deployment with IPSec disabled.
 	data.redeployAntrea(t, false)
+}
+
+// TestIPSecDeleteStaleTunnelPorts checks that when switching from IPsec mode to
+// non-encrypted mode, the previously created tunnel ports are deleted
+// correctly.
+func TestIPSecDeleteStaleTunnelPorts(t *testing.T) {
+	if testOptions.providerName == "kind" {
+		t.Skipf("Skipping test for the KIND provider as IPSec tunnel does not work with KIND")
+	}
+	if clusterInfo.numNodes < 2 {
+		t.Skipf("Skipping test as it requires 2 different nodes")
+	}
+
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	t.Logf("Redeploy Antrea with IPSec tunnel enabled")
+	data.redeployAntrea(t, true)
+
+	nodeName0 := nodeName(0)
+	nodeName1 := nodeName(1)
+	antreaPodName := func() string {
+		antreaPodName, err := data.getAntreaPodOnNode(nodeName0)
+		if err != nil {
+			t.Fatalf("Error when retrieving the name of the Antrea Pod running on Node '%s': %v", nodeName0, err)
+		}
+		t.Logf("The Antrea Pod for Node '%s' is '%s'", nodeName0, antreaPodName)
+		return antreaPodName
+	}
+	portName := util.GenerateNodeTunnelInterfaceName(nodeName1)
+
+	doesOVSPortExist := func() bool {
+		exists, err := data.doesOVSPortExist(antreaPodName(), portName)
+		if err != nil {
+			t.Fatalf("Cannot determine if OVS port exists: %v", err)
+		}
+		return exists
+	}
+
+	t.Logf("Checking that tunnel port has been created")
+	if err := wait.PollImmediate(1*time.Second, defaultTimeout, func() (found bool, err error) {
+		return doesOVSPortExist(), nil
+	}); err == wait.ErrWaitTimeout {
+		t.Fatalf("Timed out while waiting for OVS tunnel port to be created")
+	} else if err != nil {
+		t.Fatalf("Error while waiting for OVS tunnel port to be created")
+	}
+
+	t.Logf("Redeploy Antrea with IPSec tunnel disabled")
+	data.redeployAntrea(t, false)
+
+	t.Logf("Checking that tunnel port has been deleted")
+	if err := wait.PollImmediate(1*time.Second, defaultTimeout, func() (found bool, err error) {
+		return !doesOVSPortExist(), nil
+	}); err == wait.ErrWaitTimeout {
+		t.Fatalf("Timed out while waiting for OVS tunnel port to be deleted")
+	} else if err != nil {
+		t.Fatalf("Error while waiting for OVS tunnel port to be	deleted")
+	}
 }


### PR DESCRIPTION
In case of Agent restart, Nodes may have left the cluster while the
Agent was offline, and some gateway routes / tunnel ports may be
stale.

Even though stale routes might not create connectivity issue, they may
confuse users trying to troubleshoot networking issues, so it's better
to remove them.

Stale tunnel ports (either because a Node has left the cluster of
because the configuration is no longer valid) must be removed / updated
as well.

Another approach may be to use Resource Version when starting the watch
in the controller, as "delete" events would then be replayed, but that
would require us to store some state (latest Resource Version processed
by the controller) under /var/run and may make the main controller logic
more complex. Still I would be open to that approach as well.

Fixes #36