### PR TITLE
Add octant version check to tidy-check.sh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/streamrail/concurrent-map v0.0.0-20160823150647-8bf1e9bacbf6 // indirect
 	github.com/stretchr/testify v1.3.0
 	github.com/vishvananda/netlink v1.0.0
-	github.com/vmware/octant v0.0.0-00010101000000-000000000000
+	github.com/vmware/octant v0.8.0
 	golang.org/x/crypto v0.0.0-20191128160524-b544559bb6d1
 	golang.org/x/exp v0.0.0-20190121172915-509febef88a4
 	golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933 // indirect

--- a/hack/tidy-check.sh
+++ b/hack/tidy-check.sh
@@ -28,6 +28,7 @@ TMP_MOD_FILE="$TMP_DIR/go.mod"
 TMP_SUM_FILE="$TMP_DIR/go.sum"
 TARGET_GO_VERSION="1.13"
 TARGET_GO_VERSION_PATTERN="go$TARGET_GO_VERSION.*"
+TARGET_OCTANT="github.com/vmware/octant v0.8.0"
 
 # if Go environment variable is set, use it as it is, otherwise default to "go"
 : "${GO:=go}"
@@ -91,8 +92,15 @@ function failed {
 function check {
   MOD_DIFF=$(diff "$MOD_FILE" "$TMP_MOD_FILE")
   SUM_DIFF=$(diff "$SUM_FILE" "$TMP_SUM_FILE")
+  OCTANT_VERSION_CHECK=$(grep -c "$TARGET_OCTANT" "$MOD_FILE")
   if [ -n "$MOD_DIFF" ] || [ -n "$SUM_DIFF" ]; then
     echoerr "dependencies are not tidy"
+    general_help
+    clean
+    exit 1
+  # TODO: Remove Octant version check after finding another compatible Octant release.
+  elif [ $OCTANT_VERSION_CHECK -eq 0 ]; then
+    echoerr "cannot find expected Octant version v0.8.0"
     general_help
     clean
     exit 1


### PR DESCRIPTION
We use octant@v0.8.0 instead of latest octant due to
K8s API compatibility issue. We may accidentally change the octant
version in go.mod to v0.0.0-00010101000000-000000000000 when executing command
like 'make mocks', which will cause 'go get' command failure mentioned in issue:#111.

This patch adds octant version check to tidy-checks to avoid the issue.