### PR TITLE
Support NodePort service with Local externalTrafficPolicy

### DIFF
--- a/pkg/agent/iptables/iptables.go
+++ b/pkg/agent/iptables/iptables.go
@@ -89,6 +89,8 @@ func (c *Client) SetupRules() error {
 		// Note: Since L3 forwarding flows are installed, direct inter-Pod traffic won't go through host gateway interface,
 		// only Pod-Service-Pod traffic will go through it.
 		{FilterTable, AntreaForwardChain, []string{"-i", c.hostGateway, "-o", c.hostGateway}, AcceptTarget, nil, "Antrea: accept inter pod traffic"},
+		// Accept external-to-Pod traffic. This allows NodePort traffic to be forwarded even if the default FORWARD policy is DROP.
+		{FilterTable, AntreaForwardChain, []string{"!", "-i", c.hostGateway, "-o", c.hostGateway}, AcceptTarget, nil, "Antrea: accept external to pod traffic"},
 		// Mark Pod-to-external traffic which are received via host gateway interface but not sent via it for later masquerading in NAT table.
 		{FilterTable, AntreaForwardChain, []string{"-i", c.hostGateway, "!", "-o", c.hostGateway}, MarkTarget, []string{"--set-xmark", masqueradeMark}, "Antrea: mark pod to external traffic"},
 		// Accept Pod-to-external traffic which are received via host gateway interface but not sent via it.

--- a/test/integration/agent/iptables_test.go
+++ b/test/integration/agent/iptables_test.go
@@ -1,0 +1,83 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/iptables"
+)
+
+func TestSetupRules(t *testing.T) {
+	testNS, err := testutils.NewNS()
+	if err != nil {
+		t.Fatalf("Failed to create a network namespace")
+	}
+	defer testNS.Close()
+
+	if err := testNS.Do(func(ns ns.NetNS) error {
+		client, err := iptables.NewClient("gw0")
+		if err != nil {
+			return fmt.Errorf("error creating iptables client: %v", err)
+		}
+		if err := client.SetupRules(); err != nil {
+			return fmt.Errorf("error setting up rules: %v", err)
+		}
+
+		expectedOutput := `:ANTREA-FORWARD - [0:0]
+-A FORWARD -m comment --comment "Antrea: jump to Antrea forwarding rules" -j ANTREA-FORWARD
+-A ANTREA-FORWARD -i gw0 -o gw0 -m comment --comment "Antrea: accept inter pod traffic" -j ACCEPT
+-A ANTREA-FORWARD ! -i gw0 -o gw0 -m comment --comment "Antrea: accept external to pod traffic" -j ACCEPT
+-A ANTREA-FORWARD -i gw0 ! -o gw0 -m comment --comment "Antrea: mark pod to external traffic" -j MARK --set-xmark 0x400/0x400
+-A ANTREA-FORWARD -i gw0 ! -o gw0 -m comment --comment "Antrea: accept pod to external traffic" -j ACCEPT`
+		out, err := exec.Command(
+			"bash", "-c", "iptables-save -t filter | grep -i antrea",
+		).Output()
+		if err != nil {
+			return fmt.Errorf("error executing iptables-save : %v", err)
+		}
+
+		actualOutput := strings.TrimSpace(string(out))
+		if !assert.Equal(t, expectedOutput, actualOutput) {
+			return fmt.Errorf("iptables-save output doesn't match")
+		}
+
+		expectedOutput = `:ANTREA-POSTROUTING - [0:0]
+-A POSTROUTING -m comment --comment "Antrea: jump to Antrea postrouting rules" -j ANTREA-POSTROUTING
+-A ANTREA-POSTROUTING -m mark --mark 0x400/0x400 -m comment --comment "Antrea: masquerade traffic requiring SNAT" -j MASQUERADE`
+		out, err = exec.Command(
+			"bash", "-c", "iptables-save -t nat | grep -i antrea",
+		).Output()
+		if err != nil {
+			return fmt.Errorf("error executing iptables-save : %v", err)
+		}
+
+		actualOutput = strings.TrimSpace(string(out))
+		if !assert.Equal(t, expectedOutput, actualOutput) {
+			return fmt.Errorf("iptables-save output doesn't match")
+		}
+
+		return nil
+	}); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
The FORWARD rules managed by kube-proxy doesn't accept non masqueraded traffic explicitly, so traffic accessing NodePort service with Local externalTrafficPolicy was dropped when the default FORWARD policy was DROP.

This PR fixes it by accepting such traffic with antrea FORWARD rules. It also adds an integration test for iptables code.

Fixes #265 

Other CNI plugins like flannel and calico support it in a similar way, so there should be no concern that it breaks host security policy.
For example: flannel appends rules to allow such traffic explicitly:
```
-A FORWARD -s <POD CIDR> -j ACCEPT
-A FORWARD -d <POD CIDR> -j ACCEPT
```
