### PR TITLE
Populate Controller and Agent connection information

### DIFF
--- a/pkg/apiserver/storage/interfaces.go
+++ b/pkg/apiserver/storage/interfaces.go
@@ -79,4 +79,7 @@ type Interface interface {
 
 	// Watch starts watching with the specified key and selectors. Events will be sent to the returned watch.Interface.
 	Watch(ctx context.Context, key string, labelSelector labels.Selector, fieldSelector fields.Selector) (watch.Interface, error)
+
+	// GetWatchersNum gets the number of watchers for the store.
+	GetWatchersNum() int
 }

--- a/pkg/apiserver/storage/ram/store.go
+++ b/pkg/apiserver/storage/ram/store.go
@@ -234,6 +234,14 @@ func (s *store) Watch(ctx context.Context, key string, labelSelector labels.Sele
 	return watcher, nil
 }
 
+// GetWatchersNum gets the number of watchers for the store.
+func (s *store) GetWatchersNum() int {
+	s.watcherMutex.RLock()
+	defer s.watcherMutex.RUnlock()
+
+	return len(s.watchers)
+}
+
 func forgetWatcher(s *store, index int) func() {
 	return func() {
 		s.watcherMutex.Lock()

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -204,6 +204,14 @@ func (n *NetworkPolicyController) GetAppliedToGroupNum() int {
 	return len(n.appliedToGroupStore.List())
 }
 
+// GetConnectedAgentNum gets the number of Agents which are connected to this Controller.
+// Since Agent will watch all the three stores (internalNetworkPolicyStore, appliedToGroupStore, addressGroupStore),
+// the number of watchers of one of these three stores is equal to the number of connected Agents.
+// Here, we uses the number of watchers of internalNetworkPolicyStore to represent the number of connected Agents.
+func (n *NetworkPolicyController) GetConnectedAgentNum() int {
+	return n.internalNetworkPolicyStore.GetWatchersNum()
+}
+
 // toGroupSelector converts the podSelector and namespaceSelector
 // and NetworkPolicy Namespace to a networkpolicy.GroupSelector object.
 func toGroupSelector(namespace string, podSelector, nsSelector *metav1.LabelSelector) *antreatypes.GroupSelector {


### PR DESCRIPTION
1. From Controller side, this patch populates AntreaControllerInfo
field ConnectedAgentNum by the number of watchers of internalNetworkPolicyStore.

2. From Agent side, this patch populates AntreaAgentInfo
AgentCondition typed ControllerConnectionUp. The condition status
of ControllerConnectionUp will be true only if all the three
watchers from Agent side are able to watch the corresponding
resources (NetworkPolicies, AppliedToGroups, AddressGroups).

Fixes: #257 