### PR TITLE
Change Pod and tunnel network interface name format

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -121,7 +121,7 @@ func (i *Initializer) setupOVSBridge() error {
 	}
 
 	if !i.enableIPSecTunnel {
-		if err := i.setupTunnelInterface(types.DefaultTunPortName); err != nil {
+		if err := i.setupDefaultTunnelInterface(types.DefaultTunPortName); err != nil {
 			return err
 		}
 	}
@@ -347,7 +347,7 @@ func (i *Initializer) setupGatewayInterface() error {
 	return nil
 }
 
-func (i *Initializer) setupTunnelInterface(tunnelPortName string) error {
+func (i *Initializer) setupDefaultTunnelInterface(tunnelPortName string) error {
 	tunnelIface, portExists := i.ifaceStore.GetInterface(tunnelPortName)
 	if portExists {
 		klog.V(2).Infof("Tunnel port %s already exists on OVS", tunnelPortName)

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -118,13 +118,13 @@ func TestInitstore(t *testing.T) {
 	if store.Len() != 2 {
 		t.Errorf("Failed to load OVS port in store")
 	}
-	container1, found1 := store.GetInterface("p1")
+	container1, found1 := store.GetContainerInterface("pod1", "ns1")
 	if !found1 {
 		t.Errorf("Failed to load OVS port into local store")
 	} else if container1.OFPort != 1 || container1.IP.String() != p1IP || container1.MAC.String() != p1MAC || container1.InterfaceName != "p1" {
 		t.Errorf("Failed to load OVS port configuration into local store")
 	}
-	_, found2 := store.GetInterface("p2")
+	_, found2 := store.GetContainerInterface("pod2", "ns2")
 	if !found2 {
 		t.Errorf("Failed to load OVS port into local store")
 	}

--- a/pkg/agent/cniserver/server_test.go
+++ b/pkg/agent/cniserver/server_test.go
@@ -208,18 +208,6 @@ func TestValidatePrevResult(t *testing.T) {
 		)
 	})
 
-	t.Run("Invalid host interface", func(t *testing.T) {
-		cniConfig := baseCNIConfig()
-		cniConfig.Ifname = ifname
-		hostIface := &current.Interface{Name: "unknown_iface"}
-		prevResult.Interfaces = []*current.Interface{hostIface, containerIface}
-		response, _ := cniServer.validatePrevResult(cniConfig.CniCmdArgs, k8sPodArgs, prevResult)
-		checkErrorResponse(
-			t, response, cnipb.ErrorCode_INVALID_NETWORK_CONFIG,
-			"prevResult does not match network configuration",
-		)
-	})
-
 	t.Run("Interface check failure", func(t *testing.T) {
 		cniConfig := baseCNIConfig()
 		cniConfig.Ifname = ifname
@@ -313,7 +301,7 @@ func TestUpdateResultIfaceConfig(t *testing.T) {
 	})
 }
 
-func TestValidateOVSPort(t *testing.T) {
+func TestValidateOVSInterface(t *testing.T) {
 	controller := gomock.NewController(t)
 	defer controller.Finish()
 	ifaceStore := interfacestore.NewInterfaceStore()
@@ -331,7 +319,7 @@ func TestValidateOVSPort(t *testing.T) {
 	containerConfig.OVSPortConfig = &interfacestore.OVSPortConfig{PortUUID: portUUID}
 
 	ifaceStore.AddInterface(containerConfig)
-	err := podConfigurator.validateOVSPort(hostIfaceName, containerMACStr, containerID, result.IPs)
+	err := podConfigurator.validateOVSInterfaceConfig(containerID, testPodName, testPodNamespace, containerMACStr, result.IPs)
 	assert.Nil(t, err, "Failed to validate OVS port configuration")
 }
 

--- a/pkg/agent/controller/networkpolicy/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/reconciler_test.go
@@ -81,9 +81,10 @@ func TestReconcilerReconcile(t *testing.T) {
 	appliedToGroup2 := newPodSet(v1beta1.PodReference{"pod2", "ns1"})
 	ifaceStore := interfacestore.NewInterfaceStore()
 	ifaceStore.AddInterface(&interfacestore.InterfaceConfig{
-		InterfaceName: util.GenerateContainerInterfaceName("pod1", "ns1"),
-		IP:            net.ParseIP("2.2.2.2"),
-		OVSPortConfig: &interfacestore.OVSPortConfig{OFPort: 1}})
+		InterfaceName:            util.GenerateContainerInterfaceName("pod1", "ns1"),
+		IP:                       net.ParseIP("2.2.2.2"),
+		ContainerInterfaceConfig: &interfacestore.ContainerInterfaceConfig{PodName: "pod1", PodNamespace: "ns1"},
+		OVSPortConfig:            &interfacestore.OVSPortConfig{OFPort: 1}})
 	protocolTCP := v1beta1.ProtocolTCP
 	port80 := int32(80)
 	// It represents named port that we can't resolve.
@@ -287,14 +288,16 @@ func TestReconcilerUpdate(t *testing.T) {
 	ifaceStore := interfacestore.NewInterfaceStore()
 	ifaceStore.AddInterface(
 		&interfacestore.InterfaceConfig{
-			InterfaceName: util.GenerateContainerInterfaceName("pod1", "ns1"),
-			IP:            net.ParseIP("2.2.2.2"),
-			OVSPortConfig: &interfacestore.OVSPortConfig{OFPort: 1}})
+			InterfaceName:            util.GenerateContainerInterfaceName("pod1", "ns1"),
+			IP:                       net.ParseIP("2.2.2.2"),
+			ContainerInterfaceConfig: &interfacestore.ContainerInterfaceConfig{PodName: "pod1", PodNamespace: "ns1"},
+			OVSPortConfig:            &interfacestore.OVSPortConfig{OFPort: 1}})
 	ifaceStore.AddInterface(
 		&interfacestore.InterfaceConfig{
-			InterfaceName: util.GenerateContainerInterfaceName("pod2", "ns1"),
-			IP:            net.ParseIP("3.3.3.3"),
-			OVSPortConfig: &interfacestore.OVSPortConfig{OFPort: 2}})
+			InterfaceName:            util.GenerateContainerInterfaceName("pod2", "ns1"),
+			IP:                       net.ParseIP("3.3.3.3"),
+			ContainerInterfaceConfig: &interfacestore.ContainerInterfaceConfig{PodName: "pod2", PodNamespace: "ns1"},
+			OVSPortConfig:            &interfacestore.OVSPortConfig{OFPort: 2}})
 	tests := []struct {
 		name                string
 		originalRule        *CompletedRule

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -259,6 +259,7 @@ func (c *Controller) deleteNodeRoute(nodeName string) error {
 				interfaceConfig.InterfaceName, nodeName, err)
 			return fmt.Errorf("failed to delete OVS tunnel port for Node %s", nodeName)
 		}
+		c.interfaceStore.DeleteInterface(interfaceConfig)
 	}
 	return nil
 }
@@ -354,7 +355,7 @@ func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) (int3
 			return interfaceConfig.OFPort, nil
 		}
 	} else {
-		portName := util.GenerateTunnelInterfaceName(nodeName)
+		portName := util.GenerateNodeTunnelInterfaceName(nodeName)
 		ovsExternalIDs := map[string]interface{}{ovsExternalIDNodeName: nodeName}
 		portUUID, err := c.ovsBridgeClient.CreateTunnelPortExt(
 			portName,
@@ -367,9 +368,11 @@ func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) (int3
 			klog.Errorf("Failed to create OVS IPSec tunnel port for Node %s: %v", nodeName, err)
 			return 0, fmt.Errorf("failed to create IPSec tunnel port for Node %s", nodeName)
 		}
+		klog.Infof("Created IPSec tunnel port %s for Node %s", portName, nodeName)
+
 		ovsPortConfig := &interfacestore.OVSPortConfig{PortUUID: portUUID}
 		interfaceConfig = interfacestore.NewIPSecTunnelInterface(
-			nodeName,
+			portName,
 			c.tunnelType,
 			nodeName,
 			nodeIP,

--- a/pkg/agent/interfacestore/types.go
+++ b/pkg/agent/interfacestore/types.go
@@ -52,9 +52,9 @@ type TunnelInterfaceConfig struct {
 }
 
 type InterfaceConfig struct {
-	// Unique ID of the interface. Used as name of OVS port and interface.
+	Type InterfaceType
+	// Unique name of the interface, also used for the OVS port name.
 	InterfaceName string
-	Type          InterfaceType
 	IP            net.IP
 	MAC           net.HardwareAddr
 	*OVSPortConfig
@@ -67,13 +67,13 @@ type InterfaceConfig struct {
 type InterfaceStore interface {
 	Initialize(interfaces []*InterfaceConfig)
 	AddInterface(interfaceConfig *InterfaceConfig)
-	DeleteInterface(interfaceName string)
-	GetInterface(interfaceName string) (*InterfaceConfig, bool)
+	DeleteInterface(interfaceConfig *InterfaceConfig)
+	GetInterface(interfaceKey string) (*InterfaceConfig, bool)
 	GetContainerInterface(podName string, podNamespace string) (*InterfaceConfig, bool)
 	GetNodeTunnelInterface(nodeName string) (*InterfaceConfig, bool)
 	GetContainerInterfaceNum() int
 	Len() int
-	GetInterfaceIDs() []string
+	GetInterfaceKeys() []string
 }
 
 // NewContainerInterface creates InterfaceConfig for a Pod.

--- a/pkg/agent/util/net_test.go
+++ b/pkg/agent/util/net_test.go
@@ -24,8 +24,8 @@ func TestGenerateContainerInterfaceName(t *testing.T) {
 	podNamespace := "namespace1"
 	podName0 := "pod0"
 	iface0 := GenerateContainerInterfaceName(podName0, podNamespace)
-	if len(iface0) != interfaceNameLength {
-		t.Errorf("Failed to ensure length of interface name %s == %d", iface0, interfaceNameLength)
+	if len(iface0) > interfaceNameLength {
+		t.Errorf("Failed to ensure length of interface name %s <= %d", iface0, interfaceNameLength)
 	}
 	if !strings.HasPrefix(iface0, fmt.Sprintf("%s-", podName0)) {
 		t.Errorf("failed to use podName as prefix: %s", iface0)
@@ -35,7 +35,7 @@ func TestGenerateContainerInterfaceName(t *testing.T) {
 	if len(iface1) != interfaceNameLength {
 		t.Errorf("Failed to ensure length of interface name as %d", interfaceNameLength)
 	}
-	if !strings.HasPrefix(iface1, "pod1abcd") {
+	if !strings.HasPrefix(iface1, "pod1-abc") {
 		t.Errorf("failed to use first 8 valid characters")
 	}
 	podName2 := "pod1-abcde-54321"


### PR DESCRIPTION
For a Pod interface, use "pod/<Pod-Namespace-name>/<Pod-name>" to be
the key, and "<Pod-Namespace-name>/<Pod-name>" for the prefix.
For a Node's tunnel interface, use "node/<Node-name>" to be the key,
and "<Node-name>" for the prefix.
No more remove '-' in the prefix, and no more append extra bytes to
the prefix when it is shorter than the length limit.
Also change interfaceCache to use interface key as the map key.