### PR TITLE
Introduce networkMode config option and ipsecEncap mode for Agent

### DIFF
--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3,9 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app: antrea
-  name: antreaagentinfos.clusterinformation.crd.antrea.io
+  name: antreaagentinfos.clusterinformation.antrea.tanzu.vmware.com
 spec:
-  group: clusterinformation.crd.antrea.io
+  group: clusterinformation.antrea.tanzu.vmware.com
   names:
     kind: AntreaAgentInfo
     plural: antreaagentinfos
@@ -23,9 +23,9 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app: antrea
-  name: antreacontrollerinfos.clusterinformation.crd.antrea.io
+  name: antreacontrollerinfos.clusterinformation.antrea.tanzu.vmware.com
 spec:
-  group: clusterinformation.crd.antrea.io
+  group: clusterinformation.antrea.tanzu.vmware.com
   names:
     kind: AntreaControllerInfo
     plural: antreacontrollerinfos
@@ -71,7 +71,7 @@ rules:
   - watch
   - list
 - apiGroups:
-  - clusterinformation.crd.antrea.io
+  - clusterinformation.antrea.tanzu.vmware.com
   resources:
   - antreaagentinfos
   verbs:
@@ -80,7 +80,7 @@ rules:
   - update
   - delete
 - apiGroups:
-  - networkpolicy.antrea.io
+  - networking.antrea.tanzu.vmware.com
   resources:
   - networkpolicies
   - appliedtogroups
@@ -116,7 +116,7 @@ rules:
   - watch
   - list
 - apiGroups:
-  - clusterinformation.crd.antrea.io
+  - clusterinformation.antrea.tanzu.vmware.com
   resources:
   - antreacontrollerinfos
   verbs:
@@ -208,6 +208,13 @@ data:
     # Make sure it doesn't conflict with your existing interfaces.
     #hostGateway: gw0
 
+    # Pod network mode. Supported values are:
+    # - encapNormal (default): Pod traffic across Nodes will be transmitted over the overlay tunnels
+    # and encapsulated with the protocol decided by the tunnelType.
+    # - ipsecEncap: Pod traffic across Nodes will be transimitted over the overlay tunnels and
+    # encrypted with IPSec (ESP).
+    networkMode: ipsecEncap
+
     # Encapsulation mode for communication between Pods across Nodes, supported values:
     # - vxlan (default)
     # - geneve
@@ -219,9 +226,6 @@ data:
     # omitted, antrea-agent will default this value to 1450 to accomodate for tunnel encapsulate
     # overhead.
     #defaultMTU: 1450
-
-    # Whether or not to enable IPSec encryption of tunnel traffic.
-    enableIPSecTunnel: true
 
     # CIDR Range for services in cluster. It's required to support egress network policy, should
     # be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
@@ -241,7 +245,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-k5f958t9km
+  name: antrea-config-bhtm4dbg6h
   namespace: kube-system
 ---
 apiVersion: v1
@@ -333,7 +337,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-k5f958t9km
+          name: antrea-config-bhtm4dbg6h
         name: antrea-config
 ---
 apiVersion: apps/v1
@@ -505,7 +509,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-k5f958t9km
+          name: antrea-config-bhtm4dbg6h
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -208,6 +208,13 @@ data:
     # Make sure it doesn't conflict with your existing interfaces.
     #hostGateway: gw0
 
+    # Pod network mode. Supported values are:
+    # - encapNormal (default): Pod traffic across Nodes will be transmitted over the overlay tunnels
+    # and encapsulated with the protocol decided by the tunnelType.
+    # - ipsecEncap: Pod traffic across Nodes will be transimitted over the overlay tunnels and
+    # encrypted with IPSec (ESP).
+    #networkMode: encapNormal
+
     # Encapsulation mode for communication between Pods across Nodes, supported values:
     # - vxlan (default)
     # - geneve
@@ -219,9 +226,6 @@ data:
     # omitted, antrea-agent will default this value to 1450 to accomodate for tunnel encapsulate
     # overhead.
     #defaultMTU: 1450
-
-    # Whether or not to enable IPSec encryption of tunnel traffic.
-    #enableIPSecTunnel: false
 
     # CIDR Range for services in cluster. It's required to support egress network policy, should
     # be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
@@ -241,7 +245,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-tm7bht9mg6
+  name: antrea-config-gbmb5mm78t
   namespace: kube-system
 ---
 apiVersion: v1
@@ -324,7 +328,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-tm7bht9mg6
+          name: antrea-config-gbmb5mm78t
         name: antrea-config
 ---
 apiVersion: apps/v1
@@ -464,7 +468,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-tm7bht9mg6
+          name: antrea-config-gbmb5mm78t
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -13,6 +13,13 @@
 # Make sure it doesn't conflict with your existing interfaces.
 #hostGateway: gw0
 
+# Pod network mode. Supported values are:
+# - encapNormal (default): Pod traffic across Nodes will be transmitted over the overlay tunnels
+# and encapsulated with the protocol decided by the tunnelType.
+# - ipsecEncap: Pod traffic across Nodes will be transimitted over the overlay tunnels and
+# encrypted with IPSec (ESP).
+#networkMode: encapNormal
+
 # Encapsulation mode for communication between Pods across Nodes, supported values:
 # - vxlan (default)
 # - geneve
@@ -24,9 +31,6 @@
 # omitted, antrea-agent will default this value to 1450 to accomodate for tunnel encapsulate
 # overhead.
 #defaultMTU: 1450
-
-# Whether or not to enable IPSec encryption of tunnel traffic.
-#enableIPSecTunnel: false
 
 # CIDR Range for services in cluster. It's required to support egress network policy, should
 # be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -40,6 +40,14 @@ type AgentConfig struct {
 	// Make sure it doesn't conflict with your existing interfaces.
 	// Defaults to gw0.
 	HostGateway string `yaml:"hostGateway,omitempty"`
+	// Pod network mode. Supported values are:
+	// - encapNormal (default): Pod traffic across Nodes will be transmitted over the overlay tunnels
+	// and encapsulated with the protocol decided by the tunnelType.
+	// - ipsecEncap: Pod traffic across Nodes will be transimitted over the overlay tunnels and
+	// encrypted with IPSec (ESP). Antrea uses Preshared Key (PSK) for IKE authentication. When
+	// the ipsecEncap mode is configured, the PSK value must be passed to Antrea Agent through an
+	// environment variable: ANTREA_IPSEC_PSK.
+	NetworkMode string `yaml:"networkMode,omitempty"`
 	// Encapsulation mode for communication between Pods across Nodes, supported values:
 	// - vxlan (default)
 	// - geneve
@@ -59,9 +67,4 @@ type AgentConfig struct {
 	// be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
 	// Default is 10.96.0.0/12
 	ServiceCIDR string `yaml:"serviceCIDR,omitempty"`
-	// Whether or not to enable IPSec (ESP) tunnel for Pod traffic across Nodes. Antrea uses Preshared
-	// Key (PSK) for IKE authentication. When IPSec tunnel is enabled, the PSK value must be passed to
-	// Antrea Agent through an environment variable: ANTREA_IPSEC_PSK.
-	// Defaults to false.
-	EnableIPSecTunnel bool `yaml:"enableIPSecTunnel,omitempty"`
 }

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -35,6 +35,9 @@ const (
 	defaultMTUGeneve          = 1450
 	defaultMTUGRE             = 1462
 	defaultMTUSTT             = 1500
+
+	encapNormal = "encapNormal"
+	ipsecEncap  = "ipsecEncap"
 )
 
 type Options struct {
@@ -78,6 +81,9 @@ func (o *Options) validate(args []string) error {
 	if err != nil {
 		return fmt.Errorf("service CIDR %s is invalid", o.config.ServiceCIDR)
 	}
+	if o.config.NetworkMode != encapNormal && o.config.NetworkMode != ipsecEncap {
+		return fmt.Errorf("network mode %s is invalid", o.config.NetworkMode)
+	}
 	if o.config.TunnelType != ovsconfig.VXLANTunnel && o.config.TunnelType != ovsconfig.GeneveTunnel &&
 		o.config.TunnelType != ovsconfig.GRETunnel && o.config.TunnelType != ovsconfig.STTTunnel {
 		return fmt.Errorf("tunnel type %s is invalid", o.config.TunnelType)
@@ -114,6 +120,9 @@ func (o *Options) setDefaults() {
 	}
 	if o.config.HostGateway == "" {
 		o.config.HostGateway = defaultHostGateway
+	}
+	if o.config.NetworkMode == "" {
+		o.config.NetworkMode = encapNormal
 	}
 	if o.config.TunnelType == "" {
 		o.config.TunnelType = ovsconfig.VXLANTunnel

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -124,13 +124,13 @@ mkdir configMap && cd configMap
 # YAML manifest, so our regexs need not be too robust.
 cp $KUSTOMIZATION_DIR/base/conf/antrea-agent.conf antrea-agent.conf
 if $KIND; then
-    sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*ovsDatapathType[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/ovsDatapathType: netdev/" antrea-agent.conf
+    sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*ovsDatapathType[[:space:]]*:[[:space:]]*[a-zA-Z]+[[:space:]]*$/ovsDatapathType: netdev/" antrea-agent.conf
 fi
 
 if $IPSEC; then
-    sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*enableIPSecTunnel[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/enableIPSecTunnel: true/" antrea-agent.conf
+    sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*networkMode[[:space:]]*:[[:space:]]*[a-zA-Z]+[[:space:]]*$/networkMode: ipsecEncap/" antrea-agent.conf
     # change the tunnel type to GRE which works better with IPSec encryption than other types.
-    sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*tunnelType[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/tunnelType: gre/" antrea-agent.conf
+    sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*tunnelType[[:space:]]*:[[:space:]]*[a-zA-Z]+[[:space:]]*$/tunnelType: gre/" antrea-agent.conf
 fi
 
 # unfortunately 'kustomize edit add configmap' does not support specifying 'merge' as the behavior,

--- a/pkg/agent/types/node_config.go
+++ b/pkg/agent/types/node_config.go
@@ -24,6 +24,13 @@ const (
 	HostGatewayOFPort  = 2
 )
 
+const (
+	EncapNormal NetworkMode = iota
+	IPSecEncap
+)
+
+type NetworkMode uint8
+
 type GatewayConfig struct {
 	IP   net.IP
 	MAC  net.HardwareAddr


### PR DESCRIPTION
Introduce networkMode config option, which now supports two modes:
encapNormal (for normal overlay tunnels) and ipsecEncap (for IPSec
encyption of tunnel traffic). Later, there could be more modes added
like noEncap, hybrid (encapsulation only for traffic across Nodes in
the different underlay subnets) passthrough (use cloud native
networking / underlay network for connectivity), etc..
Remove the enableIPSecTunnel option and use ipsecEncap networkMode
to enable IPSec encyption. This is also to avoid misconfiguration
of IPSec encyption when later we have noEncap and other modes -
IPSec could be enabled for only tunnel traffic.