### PR TITLE
Get and populate OVS connection conditions

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -86,11 +86,19 @@ type Client interface {
 
 	// Disconnect disconnects the connection between client and OFSwitch.
 	Disconnect() error
+
+	// IsConnected returns the connection status between client and OFSwitch. The return value is true if the OFSwitch is connected.
+	IsConnected() bool
 }
 
 // GetFlowTableStatus returns an array of flow table status.
 func (c *client) GetFlowTableStatus() []binding.TableStatus {
 	return c.bridge.DumpTableStatus()
+}
+
+// IsConnected returns the connection status between client and OFSwitch.
+func (c *client) IsConnected() bool {
+	return c.bridge.IsConnected()
 }
 
 // addMissingFlows adds any flow from flows which is not currently in the flow cache. The function

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -204,6 +204,20 @@ func (mr *MockClientMockRecorder) InstallPolicyRuleFlows(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPolicyRuleFlows", reflect.TypeOf((*MockClient)(nil).InstallPolicyRuleFlows), arg0)
 }
 
+// IsConnected mocks base method
+func (m *MockClient) IsConnected() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsConnected")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsConnected indicates an expected call of IsConnected
+func (mr *MockClientMockRecorder) IsConnected() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsConnected", reflect.TypeOf((*MockClient)(nil).IsConnected))
+}
+
 // UninstallNodeFlows mocks base method
 func (m *MockClient) UninstallNodeFlows(arg0 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/apis/clusterinformation/v1beta1/types.go
+++ b/pkg/apis/clusterinformation/v1beta1/types.go
@@ -46,11 +46,13 @@ type AgentConditionType string
 
 const (
 	AgentHealthy           AgentConditionType = "AgentHealthy"           // Status is always set to be True and LastHeartbeatTime is used to check Agent health status.
-	ControllerConnectionUp AgentConditionType = "ControllerConnectionUp" // Status False is caused by the reasons: AgentControllerConnectionDown
+	ControllerConnectionUp AgentConditionType = "ControllerConnectionUp" // Status True/False is used to mark the connection status between Agent and Controller.
+	OVSDBConnectionUp      AgentConditionType = "OVSDBConnectionUp"      // Status True/False is used to mark OVSDB connection status.
+	OpenflowConnectionUp   AgentConditionType = "OpenflowConnectionUp"   // Status True/False is used to mark Openflow connection status.
 )
 
 type AgentCondition struct {
-	Type              AgentConditionType     `json:"type"`              // One of the AgentConditionType listed above, AgentHealthy or ControllerConnectionUp
+	Type              AgentConditionType     `json:"type"`              // One of the AgentConditionType listed above
 	Status            corev1.ConditionStatus `json:"status"`            // Mark certain type status, one of True, False, Unknown
 	LastHeartbeatTime metav1.Time            `json:"lastHeartbeatTime"` // The timestamp when AntreaAgentInfo is created/updated, ideally heartbeat interval is 60s
 	Reason            string                 `json:"reason,omitempty"`  // Brief reason


### PR DESCRIPTION
1.Get Openflow connection condition via function
isConnected exposed by Openflow client.

2.Get OVSDB connection condition via a dummy version query.

3.Populate both Openflow connection condition and
OVSDB connection condition to Agent monitoring CRD.

Fixes: #289 