### PR TITLE
Fix API groups for CRDs

### DIFF
--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3,9 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app: antrea
-  name: antreaagentinfos.clusterinformation.crd.antrea.io
+  name: antreaagentinfos.clusterinformation.antrea.tanzu.vmware.com
 spec:
-  group: clusterinformation.crd.antrea.io
+  group: clusterinformation.antrea.tanzu.vmware.com
   names:
     kind: AntreaAgentInfo
     plural: antreaagentinfos
@@ -23,9 +23,9 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app: antrea
-  name: antreacontrollerinfos.clusterinformation.crd.antrea.io
+  name: antreacontrollerinfos.clusterinformation.antrea.tanzu.vmware.com
 spec:
-  group: clusterinformation.crd.antrea.io
+  group: clusterinformation.antrea.tanzu.vmware.com
   names:
     kind: AntreaControllerInfo
     plural: antreacontrollerinfos
@@ -71,7 +71,7 @@ rules:
   - watch
   - list
 - apiGroups:
-  - clusterinformation.crd.antrea.io
+  - clusterinformation.antrea.tanzu.vmware.com
   resources:
   - antreaagentinfos
   verbs:
@@ -80,7 +80,7 @@ rules:
   - update
   - delete
 - apiGroups:
-  - networkpolicy.antrea.io
+  - networking.antrea.tanzu.vmware.com
   resources:
   - networkpolicies
   - appliedtogroups
@@ -116,7 +116,7 @@ rules:
   - watch
   - list
 - apiGroups:
-  - clusterinformation.crd.antrea.io
+  - clusterinformation.antrea.tanzu.vmware.com
   resources:
   - antreacontrollerinfos
   verbs:
@@ -125,7 +125,7 @@ rules:
   - update
   - delete
 - apiGroups:
-  - clusterinformation.crd.antrea.io
+  - clusterinformation.antrea.tanzu.vmware.com
   resources:
   - antreaagentinfos
   verbs:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -125,7 +125,7 @@ rules:
   - update
   - delete
 - apiGroups:
-  - clusterinformation.crd.antrea.io
+  - clusterinformation.antrea.tanzu.vmware.com
   resources:
   - antreaagentinfos
   verbs:

--- a/build/yamls/base/controller-rbac.yml
+++ b/build/yamls/base/controller-rbac.yml
@@ -38,7 +38,7 @@ rules:
       - update
       - delete
   - apiGroups:
-      - clusterinformation.crd.antrea.io
+      - clusterinformation.antrea.tanzu.vmware.com
     resources:
       - antreaagentinfos
     verbs:

--- a/ci/check-manifest.sh
+++ b/ci/check-manifest.sh
@@ -25,9 +25,9 @@ function echoerr {
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 pushd $THIS_DIR/.. > /dev/null
 
-rm build/yamls/antrea.yml
+rm build/yamls/antrea.yml build/yamls/antrea-ipsec.yml
 make manifest
-diff="$(git status --porcelain build/yamls/antrea.yml)"
+diff="$(git status --porcelain build/yamls/antrea.yml build/yamls/antrea-ipsec.yml)"
 
 if [ ! -z "$diff" ]; then
     echoerr "The generated manifest YAML is not up-to-date"


### PR DESCRIPTION
API groups for CRDs  are not changed in some yaml file
and this can cause operations on CRDs fail.

This patch fixes the issue by changing them to
clusterinformation.antrea.tanzu.vmware.com.