### PR TITLE
Mount xtables lock to antrea-agent container

### DIFF
--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -441,6 +441,8 @@ spec:
           mountPropagation: HostToContainer
           name: host-var-run-netns
           readOnly: true
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
       - command:
         - start_ovs
         image: antrea/antrea-ubuntu:latest
@@ -533,5 +535,9 @@ spec:
       - hostPath:
           path: /sbin/depmod
         name: host-depmod
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: xtables-lock
   updateStrategy:
     type: RollingUpdate

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -400,6 +400,8 @@ spec:
           mountPropagation: HostToContainer
           name: host-var-run-netns
           readOnly: true
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
       - command:
         - start_ovs
         image: antrea/antrea-ubuntu:latest
@@ -492,5 +494,9 @@ spec:
       - hostPath:
           path: /sbin/depmod
         name: host-depmod
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: xtables-lock
   updateStrategy:
     type: RollingUpdate

--- a/build/yamls/base/agent.yml
+++ b/build/yamls/base/agent.yml
@@ -118,6 +118,8 @@ spec:
             # When a container is created, a mount point for the network namespace is added under
             # /var/run/netns on the host, which needs to be propagated to the antrea-agent container.
             mountPropagation: HostToContainer
+          - name: xtables-lock
+            mountPath: /run/xtables.lock
         - name: antrea-ovs
           image: antrea
           command: ["start_ovs"]
@@ -177,3 +179,7 @@ spec:
         - name: host-depmod
           hostPath:
             path: /sbin/depmod
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate


### PR DESCRIPTION
In antrea-agent, iptables command sometimes failed with exit code 4 and
message "iptables: Resource temporarily unavailable.", which indicates
that errno EAGAIN is returned by the kernel and is mostly because
multiple iptables commands run concurrently. iptables has a lock
"/run/xtables.lock" to solve the concurrent issue and support "--wait"
option to wait for the xtables lock. However, antrea-agent runs in
container so its own xtables.lock was created and thus kube-proxy and
antrea-agent could still run iptables at the same time.

kube-proxy pod has mounted xtables.lock of hostPath, antrea-agent should
do the same to avoid concurrent iptables calls.

Fixes #287