### PR TITLE
Add iperf3 to the performance test image

### DIFF
--- a/build/images/apache-bench/Dockerfile
+++ b/build/images/apache-bench/Dockerfile
@@ -1,8 +1,0 @@
-FROM ubuntu:18.04
-
-LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
-LABEL description="A Docker image based on Ubuntu 18.04 which includes the ApacheBench tool."
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends apache2-utils && \
-    rm -rf /var/cache/apt/* /var/lib/apt/lists/*

--- a/build/images/perftool/Dockerfile
+++ b/build/images/perftool/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:18.04
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="A Docker image based on Ubuntu 18.04 which is used for performance tests."
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends apache2-utils iperf3 && \
+    rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+ENTRYPOINT "iperf3" "-s"

--- a/build/images/perftool/README.md
+++ b/build/images/perftool/README.md
@@ -1,7 +1,7 @@
 # images/perftool
 
 This Docker image is a very lightweight image based on Ubuntu 18.04 which
-includes the apache2-utils and iperf3.
+includes the apache2-utils and iperf3 packages.
 
 If you need to build a new version of the image and push it to Dockerhub, you
 can run the following:

--- a/build/images/perftool/README.md
+++ b/build/images/perftool/README.md
@@ -1,16 +1,15 @@
-# images/apache-bench
+# images/perftool
 
 This Docker image is a very lightweight image based on Ubuntu 18.04 which
-includes the apache2-utils package, and in particular the
-[ApacheBench](https://httpd.apache.org/docs/2.4/programs/ab.html) program.
+includes the apache2-utils and iperf3.
 
 If you need to build a new version of the image and push it to Dockerhub, you
 can run the following:
 
 ```bash
-cd build/images/apache-bench
-docker build -t antrea/apache-bench:latest .
-docker push antrea/apache-bench:latest
+cd build/images/perftool
+docker build -t antrea/perftool:latest .
+docker push antrea/perftool:latest
 ```
 
 The `docker push` command will fail if you do not have permission to push to the


### PR DESCRIPTION
- Add iperf3 to the performance test image for bandwidth benchmark implementation
- Rename the image name `apache-bench` to a more generic name `perftool`