### PR TITLE
Push image octant-antrea-ubuntu to dockerhub

### DIFF
--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -19,6 +19,19 @@ jobs:
         make
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         docker push antrea/antrea-ubuntu:latest
+  build-octant-antrea-ubuntu:
+    if: github.repository == 'vmware-tanzu/antrea'
+    runs-on: [ubuntu-18.04]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build octant-antrea-ubuntu Docker image and push to registry
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          make octant-antrea-ubuntu
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          docker push antrea/octant-antrea-ubuntu:latest
   skip:
     if: github.repository != 'vmware-tanzu/antrea'
     runs-on: [ubuntu-18.04]

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -19,3 +19,16 @@ jobs:
         VERSION="${TAG:10}" make
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         docker push antrea/antrea-ubuntu:"${TAG:10}"
+  build-octant-antrea-ubuntu:
+    runs-on: [ubuntu-18.04]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build octant-antrea-ubuntu Docker image and push to registry
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          TAG: ${{ github.ref }}
+        run: |
+          VERSION="${TAG:10}" make octant-antrea-ubuntu
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          docker push antrea/octant-antrea-ubuntu:"${TAG:10}"

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,6 @@ manifest:
 
 .PHONY: octant-antrea-ubuntu
 octant-antrea-ubuntu:
-	@echo "===> Building octant-antrea-ubuntu Docker image <==="
-	docker build -t octant-antrea-ubuntu -f build/images/Dockerfile.octant.ubuntu .
-	docker tag octant-antrea-ubuntu octant-antrea-ubuntu:$(DOCKER_IMG_VERSION)
+	@echo "===> Building antrea/octant-antrea-ubuntu Docker image <==="
+	docker build -t antrea/octant-antrea-ubuntu -f build/images/Dockerfile.octant.ubuntu .
+	docker tag antrea/octant-antrea-ubuntu octant-antrea-ubuntu:$(DOCKER_IMG_VERSION)

--- a/build/yamls/antrea-octant.yml
+++ b/build/yamls/antrea-octant.yml
@@ -49,7 +49,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: antrea-octant
-          image: octant-antrea-ubuntu
+          image: antrea/octant-antrea-ubuntu:latest
           imagePullPolicy: IfNotPresent
           # Octant start-up env
           env:

--- a/docs/octant-plugin-installation.md
+++ b/docs/octant-plugin-installation.md
@@ -24,27 +24,21 @@ You can follow the sample below to run Octant and antrea-octant-plugin in Pod.
 In this example, we expose UI as a NodePort service for accessing externally.
 You can update antrea-octant.yaml according to your environment and preference.
 
-1. Build octant-antrea-ubuntu docker image.
-
-    ```
-    make octant-antrea-ubuntu
-    ```
-
-2. Create a secret that contains your kubeconfig.
+1. Create a secret that contains your kubeconfig.
 
     ```
     # Change --from-file according to kubeconfig location in your set up.
     kubectl create secret generic octant-kubeconfig --from-file=/etc/kubernetes/admin.conf -n kube-system
     ```
 
-3. You may need to update build/yamls/antrea-octant.yml according to your kubeconfig file name.
+2. You may need to update build/yamls/antrea-octant.yml according to your kubeconfig file name.
 
-4. You can change the sample according to your requirements and environment, then apply the yaml to create both deployment and NodePort service.
+3. You can change the sample according to your requirements and environment, then apply the yaml to create both deployment and NodePort service.
 
     ```
     kubectl apply -f build/yamls/antrea-octant.yml
     ```
-5. You can get the NodePort of antrea-octant service via kubectl.
+4. You can get the NodePort of antrea-octant service via kubectl.
 
     ```
     # See field NodePort
@@ -53,7 +47,11 @@ You can update antrea-octant.yaml according to your environment and preference.
 
 Now, you are supposed to see Octant is running together with antrea-octant-plugin via URL http://(IP or $HOSTNAME):NodePort.
 
-Note: If the Pod is running without any explicit issue but you can not access the URL, please take a further look at the network configurations
+Note:
+1. Docker image antrea/octant-antrea-ubuntu should be automatically downloaded when you apply antrea-octant.yml in step 3.
+If the image is not successfully downloaded which may be due to network issues, you can run command `make octant-antrea-ubuntu` to build the image locally.
+If it is the case, you need to make sure that the image exists on all the K8s nodes since the Pod of antrea-octant can run on any of them.
+2. If the Pod is running without any explicit issue but you can not access the URL, please take a further look at the network configurations
 in your environment. It may be due to the network policies or other security rules configured on your hosts.
 
 ### Deploy Octant and antrea-octant-plugin as a process

--- a/docs/octant-plugin-installation.md
+++ b/docs/octant-plugin-installation.md
@@ -50,7 +50,7 @@ Now, you are supposed to see Octant is running together with antrea-octant-plugi
 Note:
 1. Docker image antrea/octant-antrea-ubuntu should be automatically downloaded when you apply antrea-octant.yml in step 3.
 If the image is not successfully downloaded which may be due to network issues, you can run command `make octant-antrea-ubuntu` to build the image locally.
-If it is the case, you need to make sure that the image exists on all the K8s nodes since the Pod of antrea-octant can run on any of them.
+If it is the case, you need to make sure that the image exists on all the K8s Nodes since the antrea-octant Pod may run on any of them.
 2. If the Pod is running without any explicit issue but you can not access the URL, please take a further look at the network configurations
 in your environment. It may be due to the network policies or other security rules configured on your hosts.
 


### PR DESCRIPTION
Build and push octant-antrea-ubuntu to dockerhub,
so that users do not need to build the image while
deploying antrea-octant-plugin.

Related to : #261 