### PR TITLE
Implement intra-node traffic bandwidth benchmark

### DIFF
--- a/test/e2e/bandwidth_test.go
+++ b/test/e2e/bandwidth_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-// BenchmarkBandwidthIntraNode runs the benchmark of bandwidth between pods on same node.
+// BenchmarkBandwidthIntraNode runs the benchmark of bandwidth between Pods on same node.
 func BenchmarkBandwidthIntraNode(b *testing.B) {
 	withPerfTestSetup(func(data *TestData) {
 		b.StartTimer()
@@ -29,16 +29,16 @@ func BenchmarkBandwidthIntraNode(b *testing.B) {
 		podDefA := createPerfTestPodDefinition("perftest-a", perftoolContainerName, perftoolImage)
 		_, err := data.clientset.CoreV1().Pods(testNamespace).Create(podDefA)
 		if err != nil {
-			b.Fatalf("Error when creating the first perftest pod: %v", err)
+			b.Fatalf("Error when creating the first perftest Pod: %v", err)
 		}
 		podDefB := createPerfTestPodDefinition("perftest-b", perftoolContainerName, perftoolImage)
 		_, err = data.clientset.CoreV1().Pods(testNamespace).Create(podDefB)
 		if err != nil {
-			b.Fatalf("Error when creating the second perftest pod: %v", err)
+			b.Fatalf("Error when creating the second perftest Pod: %v", err)
 		}
 		podBIP, err := data.podWaitForIP(defaultTimeout, podDefB.Name)
 		if err != nil {
-			b.Fatalf("Error when getting perftest pod IP: %v", err)
+			b.Fatalf("Error when getting perftest Pod IP: %v", err)
 		}
 		stdout, _, err := data.runCommandFromPod(testNamespace, "perftest-a", perftoolContainerName, []string{"bash", "-c", fmt.Sprintf("iperf3 -c %s|grep sender|awk '{print $7,$8}'", podBIP)})
 		if err != nil {
@@ -47,11 +47,12 @@ func BenchmarkBandwidthIntraNode(b *testing.B) {
 		stdout = strings.TrimSpace(stdout)
 		results := strings.Split(stdout, " ")
 		if len(results) != 2 {
-			b.Fatalf("Error when parsing iperf result: can not parse output `%s`", stdout)
+			b.Fatalf("Error when parsing iperf result: cannot parse output `%s`", stdout)
 		}
+		// Disable default output.
+		b.ReportMetric(0, "ns/op")
 		bandwidthNum, _ := strconv.ParseFloat(results[0], 64)
 		bandwidthUnit := strings.TrimSpace(results[1])
-
-		b.ReportMetric(bandwidthNum, fmt.Sprintf("Bandwidth(%s)", bandwidthUnit))
+		b.ReportMetric(bandwidthNum, bandwidthUnit)
 	}, b)
 }

--- a/test/e2e/bandwidth_test.go
+++ b/test/e2e/bandwidth_test.go
@@ -1,0 +1,57 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// BenchmarkBandwidthIntraNode runs the benchmark of bandwidth between pods on same node.
+func BenchmarkBandwidthIntraNode(b *testing.B) {
+	withPerfTestSetup(func(data *TestData) {
+		b.StartTimer()
+
+		podDefA := createPerfTestPodDefinition("perftest-a", perftoolContainerName, perftoolImage)
+		_, err := data.clientset.CoreV1().Pods(testNamespace).Create(podDefA)
+		if err != nil {
+			b.Fatalf("Error when creating the first perftest pod: %v", err)
+		}
+		podDefB := createPerfTestPodDefinition("perftest-b", perftoolContainerName, perftoolImage)
+		_, err = data.clientset.CoreV1().Pods(testNamespace).Create(podDefB)
+		if err != nil {
+			b.Fatalf("Error when creating the second perftest pod: %v", err)
+		}
+		podBIP, err := data.podWaitForIP(defaultTimeout, podDefB.Name)
+		if err != nil {
+			b.Fatalf("Error when getting perftest pod IP: %v", err)
+		}
+		stdout, _, err := data.runCommandFromPod(testNamespace, "perftest-a", perftoolContainerName, []string{"bash", "-c", fmt.Sprintf("iperf3 -c %s|grep sender|awk '{print $7,$8}'", podBIP)})
+		if err != nil {
+			b.Fatalf("Error when running iperf3 client: %v", err)
+		}
+		stdout = strings.TrimSpace(stdout)
+		results := strings.Split(stdout, " ")
+		if len(results) != 2 {
+			b.Fatalf("Error when parsing iperf result: can not parse output `%s`", stdout)
+		}
+		bandwidthNum, _ := strconv.ParseFloat(results[0], 64)
+		bandwidthUnit := strings.TrimSpace(results[1])
+
+		b.ReportMetric(bandwidthNum, fmt.Sprintf("Bandwidth(%s)", bandwidthUnit))
+	}, b)
+}

--- a/test/e2e/bandwidth_test.go
+++ b/test/e2e/bandwidth_test.go
@@ -27,13 +27,11 @@ func BenchmarkBandwidthIntraNode(b *testing.B) {
 		b.StartTimer()
 
 		podDefA := createPerfTestPodDefinition("perftest-a", perftoolContainerName, perftoolImage)
-		_, err := data.clientset.CoreV1().Pods(testNamespace).Create(podDefA)
-		if err != nil {
+		if _, err := data.clientset.CoreV1().Pods(testNamespace).Create(podDefA); err != nil {
 			b.Fatalf("Error when creating the first perftest Pod: %v", err)
 		}
 		podDefB := createPerfTestPodDefinition("perftest-b", perftoolContainerName, perftoolImage)
-		_, err = data.clientset.CoreV1().Pods(testNamespace).Create(podDefB)
-		if err != nil {
+		if _, err := data.clientset.CoreV1().Pods(testNamespace).Create(podDefB); err != nil {
 			b.Fatalf("Error when creating the second perftest Pod: %v", err)
 		}
 		podBIP, err := data.podWaitForIP(defaultTimeout, podDefB.Name)


### PR DESCRIPTION
This CL added a new benchtest `BenchmarkBandwidthIntraNode` which runs the benchmark of bandwidth between pods on same node.

A test result on my laptop.
```
pkg: github.com/vmware-tanzu/antrea/test/e2e
BenchmarkBandwidthIntraNode-16    	       1	57308932970 ns/op	        44.5 Bandwidth(Gbits/sec)
```
The op-speed is meaningless in this test, we should only care bandwidth here.