### PR TITLE
Delete stale flows on agent restart

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -43,4 +43,4 @@ jobs:
     - name: Run e2e tests
       run: |
         ./hack/generate-manifest.sh --kind | docker exec -i kind-control-plane dd of=/root/antrea.yml
-        go test github.com/vmware-tanzu/antrea/test/e2e -provider=kind
+        go test -v -timeout=20m github.com/vmware-tanzu/antrea/test/e2e -provider=kind

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -16,7 +16,6 @@ package agent
 
 import (
 	"fmt"
-	"math/rand"
 	"net"
 	"os"
 	"os/exec"
@@ -40,10 +39,12 @@ import (
 )
 
 const (
-	maxRetryForHostLink = 5
-	NodeNameEnvKey      = "NODE_NAME"
-	IPSecPSKEnvKey      = "ANTREA_IPSEC_PSK"
-	roundNumKey         = "roundNum" // round number key in externalIDs.
+	maxRetryForHostLink     = 5
+	NodeNameEnvKey          = "NODE_NAME"
+	IPSecPSKEnvKey          = "ANTREA_IPSEC_PSK"
+	roundNumKey             = "roundNum" // round number key in externalIDs.
+	initialRoundNum         = 1
+	maxRetryForRoundNumSave = 5
 )
 
 // Initializer knows how to setup host networking, OpenVSwitch, and Openflow.
@@ -219,13 +220,47 @@ func (i *Initializer) Initialize() error {
 	return nil
 }
 
+// persistRoundNum will save the provided round number to OVSDB as an external ID. To account for
+// transient failures, this (synchronous) function includes a retry mechanism.
+func persistRoundNum(num uint64, bridgeClient ovsconfig.OVSBridgeClient, interval time.Duration, maxRetries int) {
+	klog.Infof("Persisting round number %d to OVSDB", num)
+	retry := 0
+	for {
+		err := saveRoundNum(num, bridgeClient)
+		if err == nil {
+			klog.Infof("Round number %d was persisted to OVSDB", num)
+			return // success
+		}
+		klog.Errorf("Error when writing round number to OVSDB: %v", err)
+		if retry >= maxRetries {
+			break
+		}
+		time.Sleep(interval)
+	}
+	klog.Errorf("Unable to persist round number %d to OVSDB after %d tries", num, maxRetries+1)
+}
+
 // initOpenFlowPipeline sets up necessary Openflow entries, including pipeline, classifiers, conn_track, and gateway flows
+// Every time the agent is (re)started, we go through the following sequence:
+//   1. agent determines the new round number (this is done by incrementing the round number
+//   persisted in OVSDB, or if it's not available by picking round 1).
+//   2. any existing flow for which the round number matches the round number obtained from step 1
+//   is deleted.
+//   3. all required flows are installed, using the round number obtained from step 1.
+//   4. after convergence, all existing flows for which the round number matches the previous round
+//   number (i.e. the round number which was persisted in OVSDB, if any) are deleted.
+//   5. the new round number obtained from step 1 is persisted to OVSDB.
+// The rationale for not persisting the new round number until after all previous flows have been
+// deleted is to avoid a situation in which some stale flows are never deleted because of successive
+// agent restarts (with the agent crashing before step 4 can be completed). With the sequence
+// described above, We guarantee that at most two rounds of flows exist in the switch at any given
+// time.
 func (i *Initializer) initOpenFlowPipeline() error {
 	roundInfo := getRoundInfo(i.ovsBridgeClient)
 	// Setup all basic flows.
 	ofConnCh, err := i.ofClient.Initialize(roundInfo)
 	if err != nil {
-		klog.Errorf("Failed to setup basic openflow entries: %v", err)
+		klog.Errorf("Failed to initialize openflow client: %v", err)
 		return err
 	}
 
@@ -256,6 +291,24 @@ func (i *Initializer) initOpenFlowPipeline() error {
 		klog.Errorf("Failed to setup openflow entries for Cluster Service CIDR %s: %v", i.serviceCIDR, err)
 		return err
 	}
+
+	go func() {
+		// Delete stale flows from previous round. We need to wait long enough to ensure
+		// that all the flow which are still required have received an updated cookie (with
+		// the new round number), otherwise we would disrupt the dataplane. Unfortunately,
+		// the time required for convergence may be large and there is no simple way to
+		// determine when is a right time to perform the cleanup task.
+		// TODO: introduce a deterministic mechanism through which the different entities
+		// responsible for installing flows can notify the agent that this deletion
+		// operation can take place.
+		time.Sleep(10 * time.Second)
+		klog.Info("Deleting stale flows from previous round if any")
+		if err := i.ofClient.DeleteStaleFlows(); err != nil {
+			klog.Errorf("Error when deleting stale flows from previous round: %v", err)
+			return
+		}
+		persistRoundNum(roundInfo.RoundNum, i.ovsBridgeClient, 1*time.Second, maxRetryForRoundNumSave)
+	}()
 
 	go func() {
 		for {
@@ -473,9 +526,11 @@ func getRoundInfo(bridgeClient ovsconfig.OVSBridgeClient) types.RoundInfo {
 	roundInfo := types.RoundInfo{}
 	num, err := getLastRoundNum(bridgeClient)
 	if err != nil {
-		klog.Warning("No round number found in OVSDB, using a random value")
-		rand.Seed(time.Now().UnixNano())
-		num = rand.Uint64()
+		klog.Infof("No round number found in OVSDB, using %v", initialRoundNum)
+		// We use a fixed value instead of a randomly-generated value to ensure that stale
+		// flows can be properly deleted in case of multiple rapid restarts when the agent
+		// is first deployed to a Node.
+		num = initialRoundNum
 	} else {
 		roundInfo.PrevRoundNum = new(uint64)
 		*roundInfo.PrevRoundNum = num
@@ -484,11 +539,6 @@ func getRoundInfo(bridgeClient ovsconfig.OVSBridgeClient) types.RoundInfo {
 
 	num %= 1 << cookie.BitwidthRound
 	klog.Infof("Using round number %d", num)
-	err = saveRoundNum(num, bridgeClient)
-	if err != nil {
-		klog.Errorf("Writing round number failed: %v", err)
-	}
-
 	roundInfo.RoundNum = num
 
 	return roundInfo

--- a/pkg/agent/openflow/cookie/allocator.go
+++ b/pkg/agent/openflow/cookie/allocator.go
@@ -71,6 +71,12 @@ func newID(round uint64, cat Category) ID {
 	return ID(r)
 }
 
+// CookieMaskForRound returns a cookie and mask value that can be used to select
+// all flows belonging to the provided round.
+func CookieMaskForRound(round uint64) (uint64, uint64) {
+	return round << (64 - BitwidthRound), RoundMask
+}
+
 // Raw returns the unit64 type value of the ID.
 func (i ID) Raw() uint64 {
 	return uint64(i)

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow/cookie"
+	"github.com/vmware-tanzu/antrea/pkg/agent/types"
 	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
 )
 
@@ -107,6 +108,7 @@ type flowCategoryCache struct {
 }
 
 type client struct {
+	roundInfo                   types.RoundInfo
 	cookieAllocator             cookie.Allocator
 	bridge                      binding.Bridge
 	pipeline                    map[binding.TableIDType]binding.Table

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -107,7 +107,7 @@ func (mr *MockClientMockRecorder) GetFlowTableStatus() *gomock.Call {
 }
 
 // Initialize mocks base method
-func (m *MockClient) Initialize(arg0 uint64) (<-chan struct{}, error) {
+func (m *MockClient) Initialize(arg0 types.RoundInfo) (<-chan struct{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Initialize", arg0)
 	ret0, _ := ret[0].(<-chan struct{})

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -78,6 +78,20 @@ func (mr *MockClientMockRecorder) DeletePolicyRuleAddress(arg0, arg1, arg2 inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePolicyRuleAddress", reflect.TypeOf((*MockClient)(nil).DeletePolicyRuleAddress), arg0, arg1, arg2)
 }
 
+// DeleteStaleFlows mocks base method
+func (m *MockClient) DeleteStaleFlows() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteStaleFlows")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteStaleFlows indicates an expected call of DeleteStaleFlows
+func (mr *MockClientMockRecorder) DeleteStaleFlows() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStaleFlows", reflect.TypeOf((*MockClient)(nil).DeleteStaleFlows))
+}
+
 // Disconnect mocks base method
 func (m *MockClient) Disconnect() error {
 	m.ctrl.T.Helper()

--- a/pkg/agent/types/round.go
+++ b/pkg/agent/types/round.go
@@ -1,0 +1,25 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+// RoundInfo identifies the current agent "round". Each round is indentified by
+// a round number, which is incremented every time the agent is restarted. The
+// round number is persisted on the Node in OVSDB.
+type RoundInfo struct {
+	RoundNum uint64
+	// PrevRoundNum is nil if this is the first round or the previous round
+	// number could not be retrieved.
+	PrevRoundNum *uint64
+}

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -52,6 +52,7 @@ const (
 	agentContainerName   string = "antrea-agent"
 	antreaYML            string = "antrea.yml"
 	antreaIPSecYML       string = "antrea-ipsec.yml"
+	defaultBridgeName    string = "br-int"
 
 	nameSuffixLength int = 8
 )

--- a/test/e2e/performance_test.go
+++ b/test/e2e/performance_test.go
@@ -287,7 +287,7 @@ func checkRealize(policyRules int, data *TestData) (bool, error) {
 		return false, err
 	}
 	// table 90 is the ingressRuleTable where the rules in workload network policy is being applied to.
-	cmd := []string{"ovs-ofctl", "dump-flows", "br-int", "table=90"}
+	cmd := []string{"ovs-ofctl", "dump-flows", defaultBridgeName, "table=90"}
 	stdout, _, err := data.runCommandFromPod(antreaNamespace, antreaPodName, "antrea-agent", cmd)
 	if err != nil {
 		return false, err

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -32,8 +32,9 @@ import (
 )
 
 var (
-	br = "br01"
-	c  ofClient.Client
+	br        = "br01"
+	c         ofClient.Client
+	roundInfo = types.RoundInfo{0, nil}
 )
 
 const (
@@ -134,7 +135,7 @@ func TestReplayFlowsNetworkPolicyFlows(t *testing.T) {
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
-	_, err = c.Initialize(0)
+	_, err = c.Initialize(roundInfo)
 	require.Nil(t, err, "Failed to initialize OFClient")
 
 	defer func() {
@@ -196,7 +197,7 @@ func testReplayFlows(t *testing.T) {
 }
 
 func testInitialize(t *testing.T, config *testConfig) {
-	if _, err := c.Initialize(0); err != nil {
+	if _, err := c.Initialize(roundInfo); err != nil {
 		t.Errorf("Failed to initialize openflow client: %v", err)
 	}
 	for _, tableFlow := range prepareDefaultFlows() {
@@ -277,7 +278,7 @@ func TestNetworkPolicyFlows(t *testing.T) {
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 
-	_, err = c.Initialize(0)
+	_, err = c.Initialize(roundInfo)
 	require.Nil(t, err, "Failed to initialize OFClient")
 
 	defer func() {


### PR DESCRIPTION
If the antrea-agent restarts, but not the antrea-ovs container, all
existing OVS flows are preserved in ovs-vswitchd. If some changes occur
while the antrea-agent is down (e.g. a Node leaves the cluster, or
Network Policies are updated), it is possible that some of the preserved
flows are now stale and should be deleted. This is why we introduced in
the past the concept of "round number / id" which we increment every
time the agent restarts (it is persisted in OVSDB on the Node), and we
encode as part of the cookie for each flow we install. The rationale for
that is that it would enable us to identify which flows are stale after
a restart: flows which are still required would receive an updated
cookie, while stale flows would still have the old cookie (with the old
round number) and we would be able to delete them by filtering on the
cookie value.

This commit implements the mechanism described above, with the following
caveat: when the agent is initialized, we start a goroutine which sleeps for
10 seconds before deleting stale flows. This is because we want to wait
until all exisiting flows which are still required receive an update
cookie value. Without this sleep, we would be likely to observe some
"flapping" with flows being deleted and then re-installed, which would
cause issues (connectivity issues, network policies not being enforced,
...). But is 10 seconds a good value? What would be a more
"deterministic" way to decide when to do the deletion operation?

Fixes #311