### PR TITLE
Improve the robustness of CNI DEL processing

### DIFF
--- a/test/integration/agent/iptables_test.go
+++ b/test/integration/agent/iptables_test.go
@@ -32,7 +32,10 @@ func TestSetupRules(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create a network namespace")
 	}
-	defer testNS.Close()
+	defer func() {
+		testNS.Close()
+		testutils.UnmountNS(testNS)
+	}()
 
 	if err := testNS.Do(func(ns ns.NetNS) error {
 		client, err := iptables.NewClient("gw0")


### PR DESCRIPTION
Netns of a container might have been invalid when CNI is invoked to
do CNI Del, which could happen when container processes are terminated
by accident or they are short-running jobs. antrea-agent should try its
best-effort to clean up the networking resources as many as it can, as
the CNI spec suggests:

> Plugins should generally complete a DEL action without error even if
some resources are missing. For example, an IPAM plugin should generally
release an IP allocation and return success even if the container
network namespace no longer exists, unless that network namespace is
critical for IPAM management.

This PR improves the robustness of CNI DEL processing by not relying on
presence of netns. Instead, it deletes the host side veth to clean up
veth devices.

Besides, it unifies log messages and method names involved, removes
repeated error messages, and enhances the cleanup of integration tests.

Fixes #276