### PR TITLE
Use Kind v0.7.0 for CI

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -21,7 +21,7 @@ jobs:
       run: make
     - name: Install Kind
       env:
-        KIND_VERSION: v0.6.0
+        KIND_VERSION: v0.7.0
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
         chmod +x ./kind


### PR DESCRIPTION
v0.7.0 is the latest version of Kind. The default Node image for this
version of Kind is a Kubernetes v1.17.0 image.