### PR TITLE
Use consistent mechanism to skip tests on Kind cluster

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -43,4 +43,4 @@ jobs:
     - name: Run e2e tests
       run: |
         ./hack/generate-manifest.sh --kind | docker exec -i kind-control-plane dd of=/root/antrea.yml
-        go test -short github.com/vmware-tanzu/antrea/test/e2e -provider=kind
+        go test github.com/vmware-tanzu/antrea/test/e2e -provider=kind

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -226,9 +226,7 @@ func TestIPAMRestart(t *testing.T) {
 // gateway routes is updated correctly, i.e. stale routes (for Nodes which are no longer in the
 // cluster) are removed and missing routes are added.
 func TestReconcileGatewayRoutesOnStartup(t *testing.T) {
-	if clusterInfo.numNodes < 2 {
-		t.Skipf("Skipping test as it requires 2 different nodes")
-	}
+	skipIfNumNodesLessThan(t, 2)
 
 	data, err := setupTest(t)
 	if err != nil {

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -114,9 +114,7 @@ func (data *TestData) testPodConnectivityDifferentNodes(t *testing.T) {
 // TestPodConnectivityDifferentNodes checks that Pods running on different Nodes can reach each
 // other, by creating multiple Pods across distinct Nodes and having them ping each other.
 func TestPodConnectivityDifferentNodes(t *testing.T) {
-	if clusterInfo.numNodes < 2 {
-		t.Skipf("Skipping test as it requires 2 different nodes")
-	}
+	skipIfNumNodesLessThan(t, 2)
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)
@@ -157,9 +155,8 @@ func (data *TestData) redeployAntrea(t *testing.T, enableIPSec bool) {
 // TestPodConnectivityAfterAntreaRestart checks that restarting antrea-agent does not create
 // connectivity issues between Pods.
 func TestPodConnectivityAfterAntreaRestart(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping TestPodConnectivityAfterAntreaRestart in short mode")
-	}
+	// See https://github.com/vmware-tanzu/antrea/issues/244
+	skipIfProviderIs(t, "kind", "test may cause subsequent tests to fail in Kind clusters")
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)
@@ -181,9 +178,7 @@ func TestPodConnectivityAfterAntreaRestart(t *testing.T) {
 // replaying flows. More precisely this tests check that Pod connectivity is not broken after a
 // restart.
 func TestOVSRestart(t *testing.T) {
-	if testOptions.providerName == "kind" {
-		t.Skipf("Skipping test for the KIND provider as stopping OVS daemons create connectivity issues")
-	}
+	skipIfProviderIs(t, "kind", "stopping OVS daemons create connectivity issues")
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -22,6 +22,18 @@ import (
 	"time"
 )
 
+func skipIfProviderIs(t *testing.T, name string, reason string) {
+	if testOptions.providerName == "kind" {
+		t.Skipf("Skipping test for the '%s' provider: %s", name, reason)
+	}
+}
+
+func skipIfNumNodesLessThan(t *testing.T, required int) {
+	if clusterInfo.numNodes < required {
+		t.Skipf("Skipping test as it requires %d different Nodes but cluster only has %d", required, clusterInfo.numNodes)
+	}
+}
+
 func ensureAntreaRunning(tb testing.TB, data *TestData) error {
 	tb.Logf("Applying Antrea YAML")
 	if err := data.deployAntrea(); err != nil {

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -23,7 +23,7 @@ import (
 )
 
 func skipIfProviderIs(t *testing.T, name string, reason string) {
-	if testOptions.providerName == "kind" {
+	if testOptions.providerName == name {
 		t.Skipf("Skipping test for the '%s' provider: %s", name, reason)
 	}
 }

--- a/test/e2e/ipsec_test.go
+++ b/test/e2e/ipsec_test.go
@@ -27,12 +27,8 @@ import (
 // the IPSec tunnel, by creating multiple Pods across distinct Nodes and having
 // them ping each other.
 func TestIPSecTunnelConnectivity(t *testing.T) {
-	if testOptions.providerName == "kind" {
-		t.Skipf("Skipping test for the KIND provider as IPSec tunnel does not work with KIND")
-	}
-	if clusterInfo.numNodes < 2 {
-		t.Skipf("Skipping test as it requires 2 different nodes")
-	}
+	skipIfProviderIs(t, "kind", "IPSec tunnel does not work with Kind")
+	skipIfNumNodesLessThan(t, 2)
 
 	data, err := setupTest(t)
 	if err != nil {
@@ -53,12 +49,8 @@ func TestIPSecTunnelConnectivity(t *testing.T) {
 // non-encrypted mode, the previously created tunnel ports are deleted
 // correctly.
 func TestIPSecDeleteStaleTunnelPorts(t *testing.T) {
-	if testOptions.providerName == "kind" {
-		t.Skipf("Skipping test for the KIND provider as IPSec tunnel does not work with KIND")
-	}
-	if clusterInfo.numNodes < 2 {
-		t.Skipf("Skipping test as it requires 2 different nodes")
-	}
+	skipIfProviderIs(t, "kind", "IPSec tunnel does not work with Kind")
+	skipIfNumNodesLessThan(t, 2)
 
 	data, err := setupTest(t)
 	if err != nil {


### PR DESCRIPTION
We should always use the provider name, and not rely on the "-short"
command-line option.