### PR TITLE
Implement antctl agent-info

### DIFF
--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -76,6 +76,17 @@ var CommandList = &commandList{
 			CommandGroup:        flat,
 			AddonTransform:      versionTransform,
 		},
+		{
+			Use:                 "agent-info",
+			Short:               "Print agent's basic information",
+			Long:                "Print agent's basic information including version, node subnet, OVS info, AgentConditions, etc.",
+			HandlerFactory:      new(handlers.AgentInfo),
+			GroupVersion:        &systemGroup,
+			TransformedResponse: reflect.TypeOf(handlers.AntreaAgentInfoResponse{}),
+			Agent:               true,
+			SingleObject:        true,
+			CommandGroup:        flat,
+		},
 	},
 	codec: scheme.Codecs,
 }

--- a/pkg/antctl/handlers/agentinfo.go
+++ b/pkg/antctl/handlers/agentinfo.go
@@ -1,0 +1,69 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
+
+	"github.com/vmware-tanzu/antrea/pkg/apis/clusterinformation/v1beta1"
+	"github.com/vmware-tanzu/antrea/pkg/monitor"
+)
+
+var _ Factory = new(AgentInfo)
+
+// AntreaAgentInfoResponse is the struct for the response of agent-info command.
+// It includes all fields except meta info from v1beta1.AntreaAgentInfo struct.
+type AntreaAgentInfoResponse struct {
+	Version                     string                              `json:"version,omitempty"`                     // Antrea binary version
+	PodRef                      corev1.ObjectReference              `json:"podRef,omitempty"`                      // The Pod that Antrea Agent is running in
+	NodeRef                     corev1.ObjectReference              `json:"nodeRef,omitempty"`                     // The Node that Antrea Agent is running in
+	NodeSubnet                  []string                            `json:"nodeSubnet,omitempty"`                  // Node subnet
+	OVSInfo                     v1beta1.OVSInfo                     `json:"ovsInfo,omitempty"`                     // OVS Information
+	NetworkPolicyControllerInfo v1beta1.NetworkPolicyControllerInfo `json:"networkPolicyControllerInfo,omitempty"` // Antrea Agent NetworkPolicy information
+	LocalPodNum                 int32                               `json:"localPodNum,omitempty"`                 // The number of Pods which the agent is in charge of
+	AgentConditions             []v1beta1.AgentCondition            `json:"agentConditions,omitempty"`             // Agent condition contains types like AgentHealthy
+}
+
+// AgentInfo is the implementation of the Factory interface for the agent-info command.
+type AgentInfo struct{}
+
+// Handler returns the function which can handle queries issued by agent-info commands,
+// the handler function populate component's agent-info to the response.
+func (v *AgentInfo) Handler(aq monitor.AgentQuerier, cq monitor.ControllerQuerier) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var info *AntreaAgentInfoResponse
+		if aq != nil {
+			allInfo := aq.GetAgentInfo()
+			info = &AntreaAgentInfoResponse{
+				Version:                     allInfo.Version,
+				PodRef:                      allInfo.PodRef,
+				NodeRef:                     allInfo.NodeRef,
+				OVSInfo:                     allInfo.OVSInfo,
+				NetworkPolicyControllerInfo: allInfo.NetworkPolicyControllerInfo,
+				LocalPodNum:                 allInfo.LocalPodNum,
+				AgentConditions:             allInfo.AgentConditions,
+			}
+		}
+		err := json.NewEncoder(w).Encode(info)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			klog.Errorf("Error when encoding AntreaAgentInfo to json: %v", err)
+		}
+	}
+}

--- a/pkg/antctl/handlers/agentinfo_test.go
+++ b/pkg/antctl/handlers/agentinfo_test.go
@@ -1,0 +1,87 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vmware-tanzu/antrea/pkg/apis/clusterinformation/v1beta1"
+	mockmonitor "github.com/vmware-tanzu/antrea/pkg/monitor/testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var antreaAgentInfo0 v1beta1.AntreaAgentInfo = v1beta1.AntreaAgentInfo{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "node0-k8",
+	},
+	Version: "1.0",
+	PodRef: corev1.ObjectReference{
+		Kind:      "Pod",
+		Namespace: "kube-system",
+		Name:      "antrea-agent-flx99",
+	},
+	NodeRef: corev1.ObjectReference{
+		Kind: "Node",
+		Name: "node0-k8",
+	},
+	NodeSubnet: []string{
+		"192.168.0.0/24",
+	},
+	OVSInfo:                     v1beta1.OVSInfo{},
+	NetworkPolicyControllerInfo: v1beta1.NetworkPolicyControllerInfo{},
+	LocalPodNum:                 1,
+	AgentConditions: []v1beta1.AgentCondition{
+		{
+			Type:   v1beta1.AgentHealthy,
+			Status: corev1.ConditionTrue,
+		},
+	},
+}
+
+func TestAgentInfo(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	testcases := map[string]struct {
+		testNode           corev1.ObjectReference
+		agentInfo          *v1beta1.AntreaAgentInfo
+		expectedOutput     string
+		expectedStatusCode int
+	}{
+		"AgentInfo": {
+			agentInfo:          &antreaAgentInfo0,
+			expectedOutput:     "{\"version\":\"1.0\",\"podRef\":{\"kind\":\"Pod\",\"namespace\":\"kube-system\",\"name\":\"antrea-agent-flx99\"},\"nodeRef\":{\"kind\":\"Node\",\"name\":\"node0-k8\"},\"ovsInfo\":{},\"networkPolicyControllerInfo\":{},\"localPodNum\":1,\"agentConditions\":[{\"type\":\"AgentHealthy\",\"status\":\"True\",\"lastHeartbeatTime\":null}]}\n",
+			expectedStatusCode: http.StatusOK,
+		},
+	}
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			req, err := http.NewRequest("GET", "/", nil)
+			assert.Nil(t, err)
+			recorder := httptest.NewRecorder()
+			aq := mockmonitor.NewMockAgentQuerier(ctrl)
+			aq.EXPECT().GetAgentInfo().Return(tc.agentInfo)
+			new(AgentInfo).Handler(aq, nil).ServeHTTP(recorder, req)
+			assert.Equal(t, tc.expectedStatusCode, recorder.Code, k)
+			assert.Equal(t, tc.expectedOutput, recorder.Body.String(), k)
+		})
+	}
+}

--- a/pkg/monitor/querier.go
+++ b/pkg/monitor/querier.go
@@ -45,6 +45,7 @@ type AgentQuerier interface {
 	Querier
 	GetOVSFlowTable() map[string]int32
 	GetLocalPodNum() int32
+	GetAgentInfo() *v1beta1.AntreaAgentInfo
 }
 
 type ControllerQuerier interface {

--- a/pkg/monitor/testing/mock_monitor.go
+++ b/pkg/monitor/testing/mock_monitor.go
@@ -49,6 +49,20 @@ func (m *MockAgentQuerier) EXPECT() *MockAgentQuerierMockRecorder {
 	return m.recorder
 }
 
+// GetAgentInfo mocks base method
+func (m *MockAgentQuerier) GetAgentInfo() *v1beta1.AntreaAgentInfo {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAgentInfo")
+	ret0, _ := ret[0].(*v1beta1.AntreaAgentInfo)
+	return ret0
+}
+
+// GetAgentInfo indicates an expected call of GetAgentInfo
+func (mr *MockAgentQuerierMockRecorder) GetAgentInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAgentInfo", reflect.TypeOf((*MockAgentQuerier)(nil).GetAgentInfo))
+}
+
 // GetLocalPodNum mocks base method
 func (m *MockAgentQuerier) GetLocalPodNum() int32 {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Issue #275 

Output should be like this:
```
{
  "metadata": {
    "name": "antrea-k8s",
    "selfLink": "/apis/clusterinformation.antrea.tanzu.vmware.com/v1beta1/antreaagentinfos/",
    "uid": "11111111",
    "resourceVersion": "11111111",
    "generation": 36,
    "creationTimestamp": "2020-02-04T10:50:20Z"
  },
  "version": "v0.3.0-dev-4452e66.dirty",
  "podRef": {
    "kind": "Pod",
    "namespace": "kube-system",
    "name": "antrea-agent-0"
  },
  "nodeRef": {
    "kind": "Node",
    "name": "node-k8s1-1"
  },
  "nodeSubnet": [
    "192.168.1.0/24"
  ],
  "ovsInfo": {
    "version": "1.0",
    "bridgeName": "br-int",
    "flowTable": {
      "0": 5,
      "10": 7,
    }
  },
  "networkPolicyControllerInfo": {},
  "localPodNum": 2,
  "agentConditions": [
    {
      "type": "AgentHealthy",
      "status": "True",
      "lastHeartbeatTime": "2020-02-04T11:25:20Z"
    },
  ]
}
```