### PR TITLE
Allow IPSec encryption only for GRE tunnel

### DIFF
--- a/build/images/ovs/Dockerfile
+++ b/build/images/ovs/Dockerfile
@@ -24,6 +24,7 @@ LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A Docker image based on Ubuntu 18.04 which includes Open vSwitch built from source."
 
 COPY --from=ovs-debs /tmp/ovs-debs/* /tmp/ovs-debs/
+COPY charon-logging.conf /tmp
 
 # We clean-up apt cache after installing packages to reduce the size of the
 # final image
@@ -31,6 +32,5 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends iptables libstrongswan-standard-plugins && \
     (dpkg -i /tmp/ovs-debs/*.deb || apt-get -f -y --no-install-recommends install) && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/* && \
-    rm -rf /tmp/ovs-debs && \
-    CHARON_FILELOG_CONFIG="\ \ \ \ \ \ \ \ /var/log/strongswan/charon.log {\n\ \ \ \ \ \ \ \ }" && \
-    sed -i "/^.*filelog.*{/a $CHARON_FILELOG_CONFIG" /etc/strongswan.d/charon-logging.conf
+    sed -i "/^.*filelog.*{/r /tmp/charon-logging.conf" /etc/strongswan.d/charon-logging.conf && \
+    rm -rf /tmp/*

--- a/build/images/ovs/charon-logging.conf
+++ b/build/images/ovs/charon-logging.conf
@@ -1,0 +1,11 @@
+        /var/log/strongswan/charon.log {
+            # default log level for all daemon subsystems
+            default = 1
+            # flush each line to disk
+            flush_line = yes
+            # prepend connection name
+            ike_name = yes
+            # prepend timestamp
+            time_format = %b %e %T
+            time_add_ms = yes
+        }

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -257,7 +257,8 @@ data:
     # overhead.
     #defaultMTU: 1450
 
-    # Whether or not to enable IPSec encryption of tunnel traffic.
+    # Whether or not to enable IPSec encryption of tunnel traffic. IPSec encryption is supported for
+    # only the GRE tunnel type.
     enableIPSecTunnel: true
 
     # CIDR Range for services in cluster. It's required to support egress network policy, should
@@ -278,7 +279,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-k5f958t9km
+  name: antrea-config-d7h2d98bfd
   namespace: kube-system
 ---
 apiVersion: v1
@@ -370,7 +371,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-k5f958t9km
+          name: antrea-config-d7h2d98bfd
         name: antrea-config
 ---
 apiVersion: apiregistration.k8s.io/v1
@@ -560,7 +561,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-k5f958t9km
+          name: antrea-config-d7h2d98bfd
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -257,7 +257,8 @@ data:
     # overhead.
     #defaultMTU: 1450
 
-    # Whether or not to enable IPSec encryption of tunnel traffic.
+    # Whether or not to enable IPSec encryption of tunnel traffic. IPSec encryption is supported for
+    # only the GRE tunnel type.
     #enableIPSecTunnel: false
 
     # CIDR Range for services in cluster. It's required to support egress network policy, should
@@ -278,7 +279,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-tm7bht9mg6
+  name: antrea-config-476k567258
   namespace: kube-system
 ---
 apiVersion: v1
@@ -361,7 +362,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-tm7bht9mg6
+          name: antrea-config-476k567258
         name: antrea-config
 ---
 apiVersion: apiregistration.k8s.io/v1
@@ -519,7 +520,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-tm7bht9mg6
+          name: antrea-config-476k567258
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -25,7 +25,8 @@
 # overhead.
 #defaultMTU: 1450
 
-# Whether or not to enable IPSec encryption of tunnel traffic.
+# Whether or not to enable IPSec encryption of tunnel traffic. IPSec encryption is supported for
+# only the GRE tunnel type.
 #enableIPSecTunnel: false
 
 # CIDR Range for services in cluster. It's required to support egress network policy, should

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -59,9 +59,10 @@ type AgentConfig struct {
 	// be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
 	// Default is 10.96.0.0/12
 	ServiceCIDR string `yaml:"serviceCIDR,omitempty"`
-	// Whether or not to enable IPSec (ESP) tunnel for Pod traffic across Nodes. Antrea uses Preshared
-	// Key (PSK) for IKE authentication. When IPSec tunnel is enabled, the PSK value must be passed to
-	// Antrea Agent through an environment variable: ANTREA_IPSEC_PSK.
+	// Whether or not to enable IPSec (ESP) encryption for Pod traffic across Nodes. IPSec encryption
+	// is supported only for the GRE tunnel type. Antrea uses Preshared Key (PSK) for IKE
+	// authentication. When IPSec tunnel is enabled, the PSK value must be passed to Antrea Agent
+	// through an environment variable: ANTREA_IPSEC_PSK.
 	// Defaults to false.
 	EnableIPSecTunnel bool `yaml:"enableIPSecTunnel,omitempty"`
 }

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -82,6 +82,9 @@ func (o *Options) validate(args []string) error {
 		o.config.TunnelType != ovsconfig.GRETunnel && o.config.TunnelType != ovsconfig.STTTunnel {
 		return fmt.Errorf("tunnel type %s is invalid", o.config.TunnelType)
 	}
+	if o.config.EnableIPSecTunnel && o.config.TunnelType != ovsconfig.GRETunnel {
+		return fmt.Errorf("IPSec encyption is supported only for GRE tunnel")
+	}
 	if o.config.OVSDatapathType != ovsconfig.OVSDatapathSystem && o.config.OVSDatapathType != ovsconfig.OVSDatapathNetdev {
 		return fmt.Errorf("OVS datapath type %s is not supported", o.config.OVSDatapathType)
 	}


### PR DESCRIPTION
IPSec encryption works for only GRE tunnel, so changes Agent config
valiation to allow EnableIPSecTunnel only when the tunnel type is
set to GRE.
Also improve the logging config of strongSwan charon daemon.