### PR TITLE
Split a policy rule into Openflow rules based on resolved ports

### DIFF
--- a/pkg/agent/controller/networkpolicy/cache_test.go
+++ b/pkg/agent/controller/networkpolicy/cache_test.go
@@ -119,8 +119,8 @@ func (r *dirtyRuleRecorder) Record(ruleID string) {
 	r.eventCh <- ruleID
 }
 
-func newAppliedToGroupMember(name, namespace string) *v1beta1.GroupMemberPod {
-	return &v1beta1.GroupMemberPod{Pod: &v1beta1.PodReference{Name: name, Namespace: namespace}}
+func newAppliedToGroupMember(name, namespace string, containerPorts ...v1beta1.NamedPort) *v1beta1.GroupMemberPod {
+	return &v1beta1.GroupMemberPod{Pod: &v1beta1.PodReference{Name: name, Namespace: namespace}, Ports: containerPorts}
 }
 
 func newAddressGroupMember(ip string) *v1beta1.GroupMemberPod {

--- a/pkg/agent/controller/networkpolicy/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/reconciler_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang/mock/gomock"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
@@ -31,33 +32,63 @@ import (
 )
 
 var (
-	addressGroup1   = v1beta1.NewGroupMemberPodSet(newAddressGroupMember("1.1.1.1"))
-	addressGroup2   = v1beta1.NewGroupMemberPodSet(newAddressGroupMember("1.1.1.2"))
-	appliedToGroup1 = v1beta1.NewGroupMemberPodSet(newAppliedToGroupMember("pod1", "ns1"))
-	appliedToGroup2 = v1beta1.NewGroupMemberPodSet(newAppliedToGroupMember("pod2", "ns1"))
-	appliedToGroup3 = v1beta1.NewGroupMemberPodSet(newAppliedToGroupMember("pod3", "ns1"))
+	addressGroup1 = v1beta1.NewGroupMemberPodSet(newAddressGroupMember("1.1.1.1"))
+	addressGroup2 = v1beta1.NewGroupMemberPodSet(newAddressGroupMember("1.1.1.2"))
+
+	appliedToGroup1                     = v1beta1.NewGroupMemberPodSet(newAppliedToGroupMember("pod1", "ns1"))
+	appliedToGroup2                     = v1beta1.NewGroupMemberPodSet(newAppliedToGroupMember("pod2", "ns1"))
+	appliedToGroup3                     = v1beta1.NewGroupMemberPodSet(newAppliedToGroupMember("pod3", "ns1"))
+	appliedToGroupWithSameContainerPort = v1beta1.NewGroupMemberPodSet(
+		newAppliedToGroupMember("pod1", "ns1", v1beta1.NamedPort{Name: "http", Protocol: v1beta1.ProtocolTCP, Port: 80}),
+		newAppliedToGroupMember("pod3", "ns1", v1beta1.NamedPort{Name: "http", Protocol: v1beta1.ProtocolTCP, Port: 80}),
+	)
+	appliedToGroupWithDiffContainerPort = v1beta1.NewGroupMemberPodSet(
+		newAppliedToGroupMember("pod1", "ns1", v1beta1.NamedPort{Name: "http", Protocol: v1beta1.ProtocolTCP, Port: 80}),
+		newAppliedToGroupMember("pod3", "ns1", v1beta1.NamedPort{Name: "http", Protocol: v1beta1.ProtocolTCP, Port: 443}),
+	)
+
+	protocolTCP   = v1beta1.ProtocolTCP
+	port80        = intstr.FromInt(80)
+	port443       = intstr.FromInt(443)
+	portHTTP      = intstr.FromString("http")
+	serviceTCP80  = v1beta1.Service{Protocol: &protocolTCP, Port: &port80}
+	serviceTCP443 = v1beta1.Service{Protocol: &protocolTCP, Port: &port443}
+	serviceTCP    = v1beta1.Service{Protocol: &protocolTCP}
+	serviceHTTP   = v1beta1.Service{Protocol: &protocolTCP, Port: &portHTTP}
+
+	services1     = []v1beta1.Service{serviceTCP80}
+	servicesHash1 = hashServices(services1)
+	services2     = []v1beta1.Service{serviceTCP}
+	servicesHash2 = hashServices(services2)
 )
 
 func TestReconcilerForget(t *testing.T) {
 	tests := []struct {
-		name             string
-		lastRealizeds    map[string]*lastRealized
-		args             string
-		expectedOFRuleID uint32
-		wantErr          bool
+		name              string
+		lastRealizeds     map[string]*lastRealized
+		args              string
+		expectedOFRuleIDs []uint32
+		wantErr           bool
 	}{
 		{
 			"unknown-rule",
-			map[string]*lastRealized{"foo": {ofID: 8}},
+			map[string]*lastRealized{"foo": {ofIDs: map[servicesHash]uint32{servicesHash1: 8}}},
 			"unknown-rule-id",
-			0,
+			nil,
 			false,
 		},
 		{
-			"known-rule",
-			map[string]*lastRealized{"foo": {ofID: 8}},
+			"known-single-ofrule",
+			map[string]*lastRealized{"foo": {ofIDs: map[servicesHash]uint32{servicesHash1: 8}}},
 			"foo",
-			uint32(8),
+			[]uint32{8},
+			false,
+		},
+		{
+			"known-multiple-ofrule",
+			map[string]*lastRealized{"foo": {ofIDs: map[servicesHash]uint32{servicesHash1: 8, servicesHash2: 9}}},
+			"foo",
+			[]uint32{8, 9},
 			false,
 		},
 	}
@@ -67,10 +98,12 @@ func TestReconcilerForget(t *testing.T) {
 			defer controller.Finish()
 			ifaceStore := interfacestore.NewInterfaceStore()
 			mockOFClient := openflowtest.NewMockClient(controller)
-			if tt.expectedOFRuleID == 0 {
+			if len(tt.expectedOFRuleIDs) == 0 {
 				mockOFClient.EXPECT().UninstallPolicyRuleFlows(gomock.Any()).Times(0)
 			} else {
-				mockOFClient.EXPECT().UninstallPolicyRuleFlows(tt.expectedOFRuleID)
+				for _, ofID := range tt.expectedOFRuleIDs {
+					mockOFClient.EXPECT().UninstallPolicyRuleFlows(ofID)
+				}
 			}
 			r := newReconciler(mockOFClient, ifaceStore)
 			for key, value := range tt.lastRealizeds {
@@ -89,14 +122,14 @@ func TestReconcilerReconcile(t *testing.T) {
 		InterfaceName:            util.GenerateContainerInterfaceName("pod1", "ns1"),
 		IP:                       net.ParseIP("2.2.2.2"),
 		ContainerInterfaceConfig: &interfacestore.ContainerInterfaceConfig{PodName: "pod1", PodNamespace: "ns1"},
-		OVSPortConfig:            &interfacestore.OVSPortConfig{OFPort: 1}})
-	protocolTCP := v1beta1.ProtocolTCP
-	port80 := intstr.FromInt(80)
-	// It represents named port that we can't resolve for now.
-	portHTTP := intstr.FromString("http")
-	service1 := v1beta1.Service{Protocol: &protocolTCP, Port: &port80}
-	service2 := v1beta1.Service{Protocol: &protocolTCP}
-	service3 := v1beta1.Service{Protocol: &protocolTCP, Port: &portHTTP}
+		OVSPortConfig:            &interfacestore.OVSPortConfig{OFPort: 1},
+	})
+	ifaceStore.AddInterface(&interfacestore.InterfaceConfig{
+		InterfaceName:            util.GenerateContainerInterfaceName("pod3", "ns1"),
+		IP:                       net.ParseIP("3.3.3.3"),
+		ContainerInterfaceConfig: &interfacestore.ContainerInterfaceConfig{PodName: "pod3", PodNamespace: "ns1"},
+		OVSPortConfig:            &interfacestore.OVSPortConfig{OFPort: 3},
+	})
 	_, ipNet1, _ := net.ParseCIDR("10.10.0.0/16")
 	_, ipNet2, _ := net.ParseCIDR("10.20.0.0/16")
 	_, ipNet3, _ := net.ParseCIDR("10.20.1.0/24")
@@ -113,27 +146,28 @@ func TestReconcilerReconcile(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		args           *CompletedRule
-		expectedOFRule *types.PolicyRule
-		wantErr        bool
+		name            string
+		args            *CompletedRule
+		expectedOFRules []*types.PolicyRule
+		wantErr         bool
 	}{
 		{
 			"ingress-rule",
 			&CompletedRule{
-				rule:          &rule{ID: "ingress-rule", Direction: v1beta1.DirectionIn, Services: []v1beta1.Service{service1, service2}},
+				rule:          &rule{ID: "ingress-rule", Direction: v1beta1.DirectionIn, Services: []v1beta1.Service{serviceTCP80, serviceTCP}},
 				FromAddresses: addressGroup1,
 				ToAddresses:   nil,
 				Pods:          appliedToGroup1,
 			},
-			&types.PolicyRule{
-				ID:         1,
-				Direction:  networkingv1.PolicyTypeIngress,
-				From:       []types.Address{ipStringToOFAddress("1.1.1.1")},
-				ExceptFrom: nil,
-				To:         []types.Address{openflow.NewOFPortAddress(1)},
-				ExceptTo:   nil,
-				Service:    servicesToNetworkPolicyPort([]v1beta1.Service{service1, service2}),
+			[]*types.PolicyRule{
+				{
+					Direction:  networkingv1.PolicyTypeIngress,
+					From:       ipsToOFAddresses(sets.NewString("1.1.1.1")),
+					ExceptFrom: nil,
+					To:         ofPortsToOFAddresses(sets.NewInt32(1)),
+					ExceptTo:   nil,
+					Service:    servicesToNetworkPolicyPort([]v1beta1.Service{serviceTCP80, serviceTCP}),
+				},
 			},
 			false,
 		},
@@ -145,14 +179,15 @@ func TestReconcilerReconcile(t *testing.T) {
 				ToAddresses:   nil,
 				Pods:          appliedToGroup2,
 			},
-			&types.PolicyRule{
-				ID:         1,
-				Direction:  networkingv1.PolicyTypeIngress,
-				From:       []types.Address{ipStringToOFAddress("1.1.1.1")},
-				ExceptFrom: nil,
-				To:         []types.Address{},
-				ExceptTo:   nil,
-				Service:    nil,
+			[]*types.PolicyRule{
+				{
+					Direction:  networkingv1.PolicyTypeIngress,
+					From:       ipsToOFAddresses(sets.NewString("1.1.1.1")),
+					ExceptFrom: nil,
+					To:         []types.Address{},
+					ExceptTo:   nil,
+					Service:    nil,
+				},
 			},
 			false,
 		},
@@ -163,27 +198,28 @@ func TestReconcilerReconcile(t *testing.T) {
 					ID:        "ingress-rule",
 					Direction: v1beta1.DirectionIn,
 					From:      v1beta1.NetworkPolicyPeer{IPBlocks: []v1beta1.IPBlock{ipBlock1, ipBlock2}},
-					Services:  []v1beta1.Service{service1, service2},
+					Services:  []v1beta1.Service{serviceTCP80, serviceTCP},
 				},
 				FromAddresses: addressGroup1,
 				ToAddresses:   nil,
 				Pods:          appliedToGroup1,
 			},
-			&types.PolicyRule{
-				ID:        1,
-				Direction: networkingv1.PolicyTypeIngress,
-				From: []types.Address{
-					ipStringToOFAddress("1.1.1.1"),
-					openflow.NewIPNetAddress(*ipNet1),
-					openflow.NewIPNetAddress(*ipNet2),
+			[]*types.PolicyRule{
+				{
+					Direction: networkingv1.PolicyTypeIngress,
+					From: []types.Address{
+						openflow.NewIPAddress(net.ParseIP("1.1.1.1")),
+						openflow.NewIPNetAddress(*ipNet1),
+						openflow.NewIPNetAddress(*ipNet2),
+					},
+					ExceptFrom: []types.Address{
+						openflow.NewIPNetAddress(*ipNet3),
+						openflow.NewIPNetAddress(*ipNet4),
+					},
+					To:       ofPortsToOFAddresses(sets.NewInt32(1)),
+					ExceptTo: nil,
+					Service:  servicesToNetworkPolicyPort([]v1beta1.Service{serviceTCP80, serviceTCP}),
 				},
-				ExceptFrom: []types.Address{
-					openflow.NewIPNetAddress(*ipNet3),
-					openflow.NewIPNetAddress(*ipNet4),
-				},
-				To:       []types.Address{openflow.NewOFPortAddress(1)},
-				ExceptTo: nil,
-				Service:  servicesToNetworkPolicyPort([]v1beta1.Service{service1, service2}),
 			},
 			false,
 		},
@@ -197,31 +233,79 @@ func TestReconcilerReconcile(t *testing.T) {
 				},
 				Pods: appliedToGroup1,
 			},
-			&types.PolicyRule{
-				ID:        1,
-				Direction: networkingv1.PolicyTypeIngress,
-				From:      []types.Address{},
-				To:        []types.Address{openflow.NewOFPortAddress(1)},
-				Service:   nil,
+			[]*types.PolicyRule{
+				{
+					Direction: networkingv1.PolicyTypeIngress,
+					From:      []types.Address{},
+					To:        ofPortsToOFAddresses(sets.NewInt32(1)),
+					Service:   nil,
+				},
 			},
 			false,
 		},
 		{
-			"ingress-rule-with-unsupported-namedport",
+			"ingress-rule-with-unresolvable-namedport",
 			&CompletedRule{
 				rule: &rule{
 					ID:        "ingress-rule",
 					Direction: v1beta1.DirectionIn,
-					Services:  []v1beta1.Service{service3},
+					Services:  []v1beta1.Service{serviceHTTP},
 				},
 				Pods: appliedToGroup1,
 			},
-			&types.PolicyRule{
-				ID:        1,
-				Direction: networkingv1.PolicyTypeIngress,
-				From:      []types.Address{},
-				To:        []types.Address{openflow.NewOFPortAddress(1)},
-				Service:   []*networkingv1.NetworkPolicyPort{},
+			[]*types.PolicyRule{
+				{
+					Direction: networkingv1.PolicyTypeIngress,
+					From:      []types.Address{},
+					To:        ofPortsToOFAddresses(sets.NewInt32(1)),
+					Service:   []*networkingv1.NetworkPolicyPort{},
+				},
+			},
+			false,
+		},
+		{
+			"ingress-rule-with-same-namedport",
+			&CompletedRule{
+				rule: &rule{
+					ID:        "ingress-rule",
+					Direction: v1beta1.DirectionIn,
+					Services:  []v1beta1.Service{serviceHTTP},
+				},
+				Pods: appliedToGroupWithSameContainerPort,
+			},
+			[]*types.PolicyRule{
+				{
+					Direction: networkingv1.PolicyTypeIngress,
+					From:      []types.Address{},
+					To:        ofPortsToOFAddresses(sets.NewInt32(1, 3)),
+					Service:   servicesToNetworkPolicyPort([]v1beta1.Service{serviceTCP80}),
+				},
+			},
+			false,
+		},
+		{
+			"ingress-rule-with-diff-namedport",
+			&CompletedRule{
+				rule: &rule{
+					ID:        "ingress-rule",
+					Direction: v1beta1.DirectionIn,
+					Services:  []v1beta1.Service{serviceHTTP},
+				},
+				Pods: appliedToGroupWithDiffContainerPort,
+			},
+			[]*types.PolicyRule{
+				{
+					Direction: networkingv1.PolicyTypeIngress,
+					From:      []types.Address{},
+					To:        ofPortsToOFAddresses(sets.NewInt32(1)),
+					Service:   servicesToNetworkPolicyPort([]v1beta1.Service{serviceTCP80}),
+				},
+				{
+					Direction: networkingv1.PolicyTypeIngress,
+					From:      []types.Address{},
+					To:        ofPortsToOFAddresses(sets.NewInt32(3)),
+					Service:   servicesToNetworkPolicyPort([]v1beta1.Service{serviceTCP443}),
+				},
 			},
 			false,
 		},
@@ -233,14 +317,15 @@ func TestReconcilerReconcile(t *testing.T) {
 				ToAddresses:   addressGroup1,
 				Pods:          appliedToGroup1,
 			},
-			&types.PolicyRule{
-				ID:         1,
-				Direction:  networkingv1.PolicyTypeEgress,
-				From:       []types.Address{ipStringToOFAddress("2.2.2.2")},
-				ExceptFrom: nil,
-				To:         []types.Address{ipStringToOFAddress("1.1.1.1")},
-				ExceptTo:   nil,
-				Service:    nil,
+			[]*types.PolicyRule{
+				{
+					Direction:  networkingv1.PolicyTypeEgress,
+					From:       ipsToOFAddresses(sets.NewString("2.2.2.2")),
+					ExceptFrom: nil,
+					To:         ipsToOFAddresses(sets.NewString("1.1.1.1")),
+					ExceptTo:   nil,
+					Service:    nil,
+				},
 			},
 			false,
 		},
@@ -256,21 +341,22 @@ func TestReconcilerReconcile(t *testing.T) {
 				ToAddresses:   addressGroup1,
 				Pods:          appliedToGroup1,
 			},
-			&types.PolicyRule{
-				ID:         1,
-				Direction:  networkingv1.PolicyTypeEgress,
-				From:       []types.Address{ipStringToOFAddress("2.2.2.2")},
-				ExceptFrom: nil,
-				To: []types.Address{
-					ipStringToOFAddress("1.1.1.1"),
-					openflow.NewIPNetAddress(*ipNet1),
-					openflow.NewIPNetAddress(*ipNet2),
+			[]*types.PolicyRule{
+				{
+					Direction:  networkingv1.PolicyTypeEgress,
+					From:       ipsToOFAddresses(sets.NewString("2.2.2.2")),
+					ExceptFrom: nil,
+					To: []types.Address{
+						openflow.NewIPAddress(net.ParseIP("1.1.1.1")),
+						openflow.NewIPNetAddress(*ipNet1),
+						openflow.NewIPNetAddress(*ipNet2),
+					},
+					ExceptTo: []types.Address{
+						openflow.NewIPNetAddress(*ipNet3),
+						openflow.NewIPNetAddress(*ipNet4),
+					},
+					Service: nil,
 				},
-				ExceptTo: []types.Address{
-					openflow.NewIPNetAddress(*ipNet3),
-					openflow.NewIPNetAddress(*ipNet4),
-				},
-				Service: nil,
 			},
 			false,
 		},
@@ -280,7 +366,9 @@ func TestReconcilerReconcile(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 			mockOFClient := openflowtest.NewMockClient(controller)
-			mockOFClient.EXPECT().InstallPolicyRuleFlows(gomock.Eq(tt.expectedOFRule))
+			for _, ofRule := range tt.expectedOFRules {
+				mockOFClient.EXPECT().InstallPolicyRuleFlows(gomock.Any(), gomock.Eq(ofRule))
+			}
 			r := newReconciler(mockOFClient, ifaceStore)
 			if err := r.Reconcile(tt.args); (err != nil) != tt.wantErr {
 				t.Fatalf("Reconcile() error = %v, wantErr %v", err, tt.wantErr)
@@ -325,10 +413,10 @@ func TestReconcilerUpdate(t *testing.T) {
 				FromAddresses: addressGroup2,
 				Pods:          appliedToGroup2,
 			},
-			[]types.Address{ipStringToOFAddress("1.1.1.2")},
-			[]types.Address{openflow.NewOFPortAddress(2)},
-			[]types.Address{ipStringToOFAddress("1.1.1.1")},
-			[]types.Address{openflow.NewOFPortAddress(1)},
+			ipsToOFAddresses(sets.NewString("1.1.1.2")),
+			ofPortsToOFAddresses(sets.NewInt32(2)),
+			ipsToOFAddresses(sets.NewString("1.1.1.1")),
+			ofPortsToOFAddresses(sets.NewInt32(1)),
 			false,
 		},
 		{
@@ -343,10 +431,10 @@ func TestReconcilerUpdate(t *testing.T) {
 				ToAddresses: addressGroup2,
 				Pods:        appliedToGroup2,
 			},
-			[]types.Address{ipStringToOFAddress("3.3.3.3")},
-			[]types.Address{ipStringToOFAddress("1.1.1.2")},
-			[]types.Address{ipStringToOFAddress("2.2.2.2")},
-			[]types.Address{ipStringToOFAddress("1.1.1.1")},
+			ipsToOFAddresses(sets.NewString("3.3.3.3")),
+			ipsToOFAddresses(sets.NewString("1.1.1.2")),
+			ipsToOFAddresses(sets.NewString("2.2.2.2")),
+			ipsToOFAddresses(sets.NewString("1.1.1.1")),
 			false,
 		},
 		{
@@ -361,10 +449,10 @@ func TestReconcilerUpdate(t *testing.T) {
 				FromAddresses: addressGroup2,
 				Pods:          appliedToGroup3,
 			},
-			[]types.Address{ipStringToOFAddress("1.1.1.2")},
+			ipsToOFAddresses(sets.NewString("1.1.1.2")),
 			[]types.Address{},
-			[]types.Address{ipStringToOFAddress("1.1.1.1")},
-			[]types.Address{openflow.NewOFPortAddress(1)},
+			ipsToOFAddresses(sets.NewString("1.1.1.1")),
+			ofPortsToOFAddresses(sets.NewInt32(1)),
 			false,
 		},
 		{
@@ -380,9 +468,9 @@ func TestReconcilerUpdate(t *testing.T) {
 				Pods:        appliedToGroup3,
 			},
 			[]types.Address{},
-			[]types.Address{ipStringToOFAddress("1.1.1.2")},
-			[]types.Address{ipStringToOFAddress("2.2.2.2")},
-			[]types.Address{ipStringToOFAddress("1.1.1.1")},
+			ipsToOFAddresses(sets.NewString("1.1.1.2")),
+			ipsToOFAddresses(sets.NewString("2.2.2.2")),
+			ipsToOFAddresses(sets.NewString("1.1.1.1")),
 			false,
 		},
 	}
@@ -391,7 +479,7 @@ func TestReconcilerUpdate(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 			mockOFClient := openflowtest.NewMockClient(controller)
-			mockOFClient.EXPECT().InstallPolicyRuleFlows(gomock.Any())
+			mockOFClient.EXPECT().InstallPolicyRuleFlows(gomock.Any(), gomock.Any())
 			if len(tt.expectedAddedFrom) > 0 {
 				mockOFClient.EXPECT().AddPolicyRuleAddress(gomock.Any(), types.SrcAddress, gomock.Eq(tt.expectedAddedFrom))
 			}

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -79,7 +79,7 @@ type Client interface {
 	// NetworkPolicy rule. Each ingress/egress policy rule installs Openflow entries on two tables, one for
 	// ruleTable and the other for dropTable. If a packet does not pass the ruleTable, it will be dropped by the
 	// dropTable.
-	InstallPolicyRuleFlows(rule *types.PolicyRule) error
+	InstallPolicyRuleFlows(ruleID uint32, rule *types.PolicyRule) error
 
 	// UninstallPolicyRuleFlows removes the Openflow entry relevant to the specified NetworkPolicy rule.
 	// UninstallPolicyRuleFlows will do nothing if no Openflow entry for the rule is installed.

--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -121,7 +121,6 @@ func TestInstallPolicyRuleFlows(t *testing.T) {
 	c = prepareClient(ctrl)
 	ruleID1 := uint32(101)
 	rule1 := &types.PolicyRule{
-		ID:        ruleID1,
 		Direction: v1.PolicyTypeEgress,
 		From:      parseAddresses([]string{"192.168.1.30", "192.168.1.50"}),
 	}
@@ -144,7 +143,6 @@ func TestInstallPolicyRuleFlows(t *testing.T) {
 
 	ruleID2 := uint32(102)
 	rule2 := &types.PolicyRule{
-		ID:        ruleID2,
 		Direction: v1.PolicyTypeEgress,
 		From:      parseAddresses([]string{"192.168.1.40", "192.168.1.50"}),
 		To:        parseAddresses([]string{"0.0.0.0/0"}),
@@ -163,7 +161,7 @@ func TestInstallPolicyRuleFlows(t *testing.T) {
 	assert.Equal(t, 3, getChangedFlowOPCount(matchFlows2, insertion))
 	err = c.applyConjunctiveMatchFlows(ctxChanges2)
 	require.Nil(t, err)
-	err = c.InstallPolicyRuleFlows(rule2)
+	err = c.InstallPolicyRuleFlows(ruleID2, rule2)
 	require.Nil(t, err)
 	checkConjunctionConfig(t, ruleID2, 1, 2, 1, 0)
 
@@ -174,7 +172,6 @@ func TestInstallPolicyRuleFlows(t *testing.T) {
 	npPort1 := &v1.NetworkPolicyPort{Protocol: &tcpProtocol, Port: &port1}
 	npPort2 := &v1.NetworkPolicyPort{Protocol: &tcpProtocol, Port: &port2}
 	rule3 := &types.PolicyRule{
-		ID:        ruleID3,
 		Direction: v1.PolicyTypeEgress,
 		From:      parseAddresses([]string{"192.168.1.40", "192.168.1.60"}),
 		To:        parseAddresses([]string{"192.168.2.0/24"}),
@@ -196,7 +193,7 @@ func TestInstallPolicyRuleFlows(t *testing.T) {
 	assert.Equal(t, 1, getChangedFlowOPCount(matchFlows3, modification))
 	err = c.applyConjunctiveMatchFlows(ctxChanges3)
 	require.Nil(t, err)
-	err = c.InstallPolicyRuleFlows(rule3)
+	err = c.InstallPolicyRuleFlows(ruleID3, rule3)
 	require.Nil(t, err, "Failed to invoke InstallPolicyRuleFlows")
 	checkConjunctionConfig(t, ruleID3, 3, 2, 1, 2)
 

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -207,17 +207,17 @@ func (mr *MockClientMockRecorder) InstallPodFlows(arg0, arg1, arg2, arg3, arg4 i
 }
 
 // InstallPolicyRuleFlows mocks base method
-func (m *MockClient) InstallPolicyRuleFlows(arg0 *types.PolicyRule) error {
+func (m *MockClient) InstallPolicyRuleFlows(arg0 uint32, arg1 *types.PolicyRule) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallPolicyRuleFlows", arg0)
+	ret := m.ctrl.Call(m, "InstallPolicyRuleFlows", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallPolicyRuleFlows indicates an expected call of InstallPolicyRuleFlows
-func (mr *MockClientMockRecorder) InstallPolicyRuleFlows(arg0 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallPolicyRuleFlows(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPolicyRuleFlows", reflect.TypeOf((*MockClient)(nil).InstallPolicyRuleFlows), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPolicyRuleFlows", reflect.TypeOf((*MockClient)(nil).InstallPolicyRuleFlows), arg0, arg1)
 }
 
 // IsConnected mocks base method

--- a/pkg/agent/types/networkpolicy.go
+++ b/pkg/agent/types/networkpolicy.go
@@ -41,7 +41,6 @@ type Address interface {
 
 // PolicyRule groups configurations to set up conjunctive match for egress/ingress policy rules.
 type PolicyRule struct {
-	ID         uint32
 	Direction  v1.PolicyType
 	From       []Address
 	ExceptFrom []Address

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -407,16 +407,30 @@ func (data *TestData) deleteAntrea(timeout time.Duration) error {
 	return err
 }
 
+// getImageName gets the image name from the fully qualified URI.
+// For example: "gcr.io/kubernetes-e2e-test-images/agnhost:2.8" gets "agnhost".
+func getImageName(uri string) string {
+	registryAndImage := strings.Split(uri, ":")[0]
+	paths := strings.Split(registryAndImage, "/")
+	return paths[len(paths)-1]
+}
+
 // createPodOnNode creates a pod in the test namespace with a container whose type is decided by imageName.
 // Pod will be scheduled on the specified Node (if nodeName is not empty).
-func (data *TestData) createPodOnNode(name string, nodeName string, imageName string, command []string) error {
+func (data *TestData) createPodOnNode(name string, nodeName string, image string, command []string, args []string, env []v1.EnvVar, ports []v1.ContainerPort) error {
+	// image could be a fully qualified URI which can't be used as container name and label value,
+	// extract the image name from it.
+	imageName := getImageName(image)
 	podSpec := v1.PodSpec{
 		Containers: []v1.Container{
 			{
 				Name:            imageName,
-				Image:           imageName,
+				Image:           image,
 				ImagePullPolicy: v1.PullIfNotPresent,
 				Command:         command,
+				Args:            args,
+				Env:             env,
+				Ports:           ports,
 			},
 		},
 		RestartPolicy: v1.RestartPolicyNever,
@@ -455,7 +469,7 @@ func (data *TestData) createPodOnNode(name string, nodeName string, imageName st
 // Pod will be scheduled on the specified Node (if nodeName is not empty).
 func (data *TestData) createBusyboxPodOnNode(name string, nodeName string) error {
 	sleepDuration := 3600 // seconds
-	return data.createPodOnNode(name, nodeName, "busybox", []string{"sleep", strconv.Itoa(sleepDuration)})
+	return data.createPodOnNode(name, nodeName, "busybox", []string{"sleep", strconv.Itoa(sleepDuration)}, nil, nil, nil)
 }
 
 // createBusyboxPod creates a Pod in the test namespace with a single busybox container.
@@ -466,12 +480,22 @@ func (data *TestData) createBusyboxPod(name string) error {
 // createNginxPodOnNode creates a Pod in the test namespace with a single nginx container. The
 // Pod will be scheduled on the specified Node (if nodeName is not empty).
 func (data *TestData) createNginxPodOnNode(name string, nodeName string) error {
-	return data.createPodOnNode(name, nodeName, "nginx", []string{})
+	return data.createPodOnNode(name, nodeName, "nginx", []string{}, nil, nil, nil)
 }
 
 // createNginxPod creates a Pod in the test namespace with a single nginx container.
 func (data *TestData) createNginxPod(name string) error {
 	return data.createNginxPodOnNode(name, "")
+}
+
+// createServerPod creates a Pod that can listen to specified port and have named port set.
+func (data *TestData) createServerPod(name string, portName string, portNum int) error {
+	// See https://github.com/kubernetes/kubernetes/blob/master/test/images/agnhost/porter/porter.go#L17 for the image's detail.
+	image := "gcr.io/kubernetes-e2e-test-images/agnhost:2.8"
+	cmd := "porter"
+	env := v1.EnvVar{Name: fmt.Sprintf("SERVE_PORT_%d", portNum), Value: "foo"}
+	port := v1.ContainerPort{Name: portName, ContainerPort: int32(portNum)}
+	return data.createPodOnNode(name, "", image, nil, []string{cmd}, []v1.EnvVar{env}, []v1.ContainerPort{port})
 }
 
 // deletePod deletes a Pod in the test namespace.
@@ -818,13 +842,13 @@ func (data *TestData) runPingCommandFromTestPod(podName string, targetIP string,
 	return err
 }
 
-func (data *TestData) runNetcatCommandFromTestPod(podName string, svcName string) error {
-	// Retrying several times to avoid flakes as the test involves DNS (coredns) and Service/Endpoints (kube-proxy).
+func (data *TestData) runNetcatCommandFromTestPod(podName string, server string, port int) error {
+	// Retrying several times to avoid flakes as the test may involve DNS (coredns) and Service/Endpoints (kube-proxy).
 	cmd := []string{
 		"/bin/sh",
 		"-c",
-		fmt.Sprintf("for i in $(seq 1 5); do nc -vz -w 4 %s.%s %d && exit 0 || sleep 1; done; exit 1",
-			svcName, testNamespace, 80),
+		fmt.Sprintf("for i in $(seq 1 5); do nc -vz -w 4 %s %d && exit 0 || sleep 1; done; exit 1",
+			server, port),
 	}
 	stdout, stderr, err := data.runCommandFromPod(testNamespace, podName, busyboxContainerName, cmd)
 	if err == nil {

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -19,6 +19,7 @@ import (
 
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestIPBlockWithExcept(t *testing.T) {
@@ -81,10 +82,10 @@ func TestIPBlockWithExcept(t *testing.T) {
 	}
 
 	// Both pods cannot connect to service.
-	if err = data.runNetcatCommandFromTestPod(podName0, svcName); err == nil {
+	if err = data.runNetcatCommandFromTestPod(podName0, svcName, 80); err == nil {
 		t.Fatalf("Pod %s should not be able to connect Service %s, but was able to connect", podName0, svcName)
 	}
-	if err = data.runNetcatCommandFromTestPod(podName1, svcName); err == nil {
+	if err = data.runNetcatCommandFromTestPod(podName1, svcName, 80); err == nil {
 		t.Fatalf("Pod %s should not be able to connect Service %s, but was able to connect", podName1, svcName)
 	}
 
@@ -100,12 +101,112 @@ func TestIPBlockWithExcept(t *testing.T) {
 	}()
 
 	// pod0 can connect to service.
-	if err = data.runNetcatCommandFromTestPod(podName0, svcName); err != nil {
+	if err = data.runNetcatCommandFromTestPod(podName0, svcName, 80); err != nil {
 		t.Fatalf("Pod %s should be able to connect Service %s, but was not able to connect: %v", podName0, svcName, err)
 	}
 	// pod1 cannot connect to service.
-	if err = data.runNetcatCommandFromTestPod(podName1, svcName); err == nil {
+	if err = data.runNetcatCommandFromTestPod(podName1, svcName, 80); err == nil {
 		t.Fatalf("Pod %s should not be able to connect Service %s, but was able to connect", podName1, svcName)
+	}
+}
+
+func TestDifferentNamedPorts(t *testing.T) {
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	server0Name := randName("test-server-")
+	server0Port := 80
+	if err = data.createServerPod(server0Name, "http", server0Port); err != nil {
+		t.Fatalf("Error when creating server pod: %v", err)
+	}
+	defer deletePodWrapper(t, data, server0Name)
+	server0IP, err := data.podWaitForIP(defaultTimeout, server0Name)
+	if err != nil {
+		t.Fatalf("Error when waiting for IP for Pod '%s': %v", server0Name, err)
+	}
+
+	server1Name := randName("test-server-")
+	server1Port := 8080
+	if err = data.createServerPod(server1Name, "http", server1Port); err != nil {
+		t.Fatalf("Error when creating server pod: %v", err)
+	}
+	defer deletePodWrapper(t, data, server1Name)
+	server1IP, err := data.podWaitForIP(defaultTimeout, server1Name)
+	if err != nil {
+		t.Fatalf("Error when waiting for IP for Pod '%s': %v", server1Name, err)
+	}
+
+	client0Name := randName("test-client-")
+	if err := data.createBusyboxPod(client0Name); err != nil {
+		t.Fatalf("Error when creating busybox test Pod: %v", err)
+	}
+	defer deletePodWrapper(t, data, client0Name)
+	if _, err := data.podWaitForIP(defaultTimeout, client0Name); err != nil {
+		t.Fatalf("Error when waiting for IP for Pod '%s': %v", client0Name, err)
+	}
+
+	client1Name := randName("test-client-")
+	if err := data.createBusyboxPod(client1Name); err != nil {
+		t.Fatalf("Error when creating busybox test Pod: %v", err)
+	}
+	defer deletePodWrapper(t, data, client1Name)
+	if _, err := data.podWaitForIP(defaultTimeout, client1Name); err != nil {
+		t.Fatalf("Error when waiting for IP for Pod '%s': %v", client1Name, err)
+	}
+
+	// Both clients can connect to both servers.
+	for _, clientName := range []string{client0Name, client1Name} {
+		if err = data.runNetcatCommandFromTestPod(clientName, server0IP, server0Port); err != nil {
+			t.Fatalf("Pod %s should be able to connect %s:%d, but was not able to connect", clientName, server0IP, server0Port)
+		}
+		if err = data.runNetcatCommandFromTestPod(clientName, server1IP, server1Port); err != nil {
+			t.Fatalf("Pod %s should be able to connect %s:%d, but was not able to connect", clientName, server1IP, server1Port)
+		}
+	}
+
+	spec := &networkingv1.NetworkPolicySpec{
+		// Apply to all Pods.
+		PodSelector: metav1.LabelSelector{},
+		// Allow client0 to access named port: "http".
+		Ingress: []networkingv1.NetworkPolicyIngressRule{{
+			Ports: []networkingv1.NetworkPolicyPort{{
+				Port: &intstr.IntOrString{Type: intstr.String, StrVal: "http"},
+			}},
+			From: []networkingv1.NetworkPolicyPeer{{
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"antrea-e2e": client0Name,
+					},
+				}},
+			},
+		}},
+	}
+	np, err := data.createNetworkPolicy("test-networkpolicy-allow-client0-to-http", spec)
+	if err != nil {
+		t.Fatalf("Error when creating network policy: %v", err)
+	}
+	defer func() {
+		if err = data.deleteNetworkpolicy(np); err != nil {
+			t.Fatalf("Error when deleting network policy: %v", err)
+		}
+	}()
+
+	// client0 can connect to both servers.
+	if err = data.runNetcatCommandFromTestPod(client0Name, server0IP, server0Port); err != nil {
+		t.Fatalf("Pod %s should be able to connect %s:%d, but was not able to connect", client0Name, server0IP, server0Port)
+	}
+	if err = data.runNetcatCommandFromTestPod(client0Name, server1IP, server1Port); err != nil {
+		t.Fatalf("Pod %s should be able to connect %s:%d, but was not able to connect", client0Name, server1IP, server1Port)
+	}
+	// client1 cannot connect to both servers.
+	if err = data.runNetcatCommandFromTestPod(client1Name, server0IP, server0Port); err == nil {
+		t.Fatalf("Pod %s should not be able to connect %s:%d, but was able to connect", client1Name, server0IP, server0Port)
+	}
+	if err = data.runNetcatCommandFromTestPod(client1Name, server1IP, server1Port); err == nil {
+		t.Fatalf("Pod %s should not be able to connect %s:%d, but was able to connect", client1Name, server1IP, server1Port)
 	}
 }
 

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -156,7 +156,6 @@ func TestReplayFlowsNetworkPolicyFlows(t *testing.T) {
 	npPort1 := &v1.NetworkPolicyPort{Protocol: &tcpProtocol, Port: &port2}
 	toIPList := prepareIPAddresses(toList)
 	rule := &types.PolicyRule{
-		ID:         ruleID,
 		Direction:  v1.PolicyTypeIngress,
 		From:       prepareIPAddresses(fromList),
 		ExceptFrom: prepareIPAddresses(exceptFromList),
@@ -164,7 +163,7 @@ func TestReplayFlowsNetworkPolicyFlows(t *testing.T) {
 		Service:    []*v1.NetworkPolicyPort{npPort1},
 	}
 
-	err = c.InstallPolicyRuleFlows(rule)
+	err = c.InstallPolicyRuleFlows(ruleID, rule)
 	require.Nil(t, err, "Failed to InstallPolicyRuleFlows")
 
 	err = c.AddPolicyRuleAddress(ruleID, types.SrcAddress, prepareIPNetAddresses([]string{"192.168.5.0/24", "192.169.1.0/24"}))
@@ -299,7 +298,6 @@ func TestNetworkPolicyFlows(t *testing.T) {
 	npPort1 := &v1.NetworkPolicyPort{Protocol: &tcpProtocol, Port: &port2}
 	toIPList := prepareIPAddresses(toList)
 	rule := &types.PolicyRule{
-		ID:         ruleID,
 		Direction:  v1.PolicyTypeIngress,
 		From:       prepareIPAddresses(fromList),
 		ExceptFrom: prepareIPAddresses(exceptFromList),
@@ -307,9 +305,9 @@ func TestNetworkPolicyFlows(t *testing.T) {
 		Service:    []*v1.NetworkPolicyPort{npPort1},
 	}
 
-	err = c.InstallPolicyRuleFlows(rule)
+	err = c.InstallPolicyRuleFlows(ruleID, rule)
 	require.Nil(t, err, "Failed to InstallPolicyRuleFlows")
-	checkConjunctionFlows(t, ingressRuleTable, ingressDefaultTable, contrackCommitTable, priorityNormal, rule, assert.True)
+	checkConjunctionFlows(t, ingressRuleTable, ingressDefaultTable, contrackCommitTable, priorityNormal, ruleID, rule, assert.True)
 	checkDefaultDropFlows(t, ingressDefaultTable, priorityNormal, types.DstAddress, toIPList, true)
 
 	addedFrom := prepareIPNetAddresses([]string{"192.168.5.0/24", "192.169.1.0/24"})
@@ -335,12 +333,11 @@ func TestNetworkPolicyFlows(t *testing.T) {
 	udpProtocol := coreV1.ProtocolUDP
 	npPort2 := &v1.NetworkPolicyPort{Protocol: &udpProtocol, Port: &port3}
 	rule2 := &types.PolicyRule{
-		ID:        ruleID2,
 		Direction: v1.PolicyTypeIngress,
 		To:        toIPList2,
 		Service:   []*v1.NetworkPolicyPort{npPort2},
 	}
-	err = c.InstallPolicyRuleFlows(rule2)
+	err = c.InstallPolicyRuleFlows(ruleID2, rule2)
 	require.Nil(t, err, "Failed to InstallPolicyRuleFlows")
 
 	// Dump flows
@@ -358,7 +355,7 @@ func TestNetworkPolicyFlows(t *testing.T) {
 
 	err = c.UninstallPolicyRuleFlows(ruleID)
 	require.Nil(t, err, "Failed to DeletePolicyRuleService")
-	checkConjunctionFlows(t, ingressRuleTable, ingressDefaultTable, contrackCommitTable, priorityNormal, rule, assert.False)
+	checkConjunctionFlows(t, ingressRuleTable, ingressDefaultTable, contrackCommitTable, priorityNormal, ruleID, rule, assert.False)
 	checkDefaultDropFlows(t, ingressDefaultTable, priorityNormal, types.DstAddress, toIPList, false)
 }
 
@@ -450,12 +447,11 @@ func checkDeleteAddress(t *testing.T, ruleTable uint8, priority int, ruleID uint
 	}
 }
 
-func checkConjunctionFlows(t *testing.T, ruleTable uint8, dropTable uint8, allowTable uint8, priority int, rule *types.PolicyRule, testFunc func(t assert.TestingT, value bool, msgAndArgs ...interface{}) bool) {
-	ruleID := rule.ID
+func checkConjunctionFlows(t *testing.T, ruleTable uint8, dropTable uint8, allowTable uint8, priority int, ruleID uint32, rule *types.PolicyRule, testFunc func(t assert.TestingT, value bool, msgAndArgs ...interface{}) bool) {
 	flowList, err := ofTestUtils.OfctlDumpTableFlows(br, ruleTable)
 	require.Nil(t, err, "Failed to dump flows")
 
-	conjunctionActionMatch := fmt.Sprintf("priority=%d,conj_id=%d,ip", priority-10, rule.ID)
+	conjunctionActionMatch := fmt.Sprintf("priority=%d,conj_id=%d,ip", priority-10, ruleID)
 	flow := &ofTestUtils.ExpectFlow{MatchStr: conjunctionActionMatch, ActStr: fmt.Sprintf("resubmit(,%d)", allowTable)}
 	testFunc(t, ofTestUtils.OfctlFlowMatch(flowList, ruleTable, flow), "Failed to update conjunction action flow")
 


### PR DESCRIPTION
A policy rule will be split into multiple Openflow rules based on the
named port resolving result. Pods that have same port numbers for the
port names defined in the rule will share an Openflow rule.

Add an e2e test for the different named ports case.

Fixes #122 