### PR TITLE
Install loopback plugin on Nodes if missing

### DIFF
--- a/build/images/Dockerfile.build.ubuntu
+++ b/build/images/Dockerfile.build.ubuntu
@@ -3,8 +3,11 @@ FROM ubuntu:18.04 as cni-binaries
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget ca-certificates
 
+# Leading dot is required for the tar command below
+ENV CNI_PLUGINS="./host-local ./loopback"
+
 RUN mkdir -p /opt/cni/bin && \
-    wget -q -O - https://dl.k8s.io/network-plugins/cni-plugins-amd64-v0.7.5.tgz | tar xz -C /opt/cni/bin ./host-local
+    wget -q -O - https://dl.k8s.io/network-plugins/cni-plugins-amd64-v0.7.5.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
 
 
 FROM golang:1.13 as antrea-build

--- a/build/images/Dockerfile.ubuntu
+++ b/build/images/Dockerfile.ubuntu
@@ -3,8 +3,11 @@ FROM ubuntu:18.04 as cni-binaries
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget ca-certificates
 
+# Leading dot is required for the tar command below
+ENV CNI_PLUGINS="./host-local ./loopback"
+
 RUN mkdir -p /opt/cni/bin && \
-    wget -q -O - https://dl.k8s.io/network-plugins/cni-plugins-amd64-v0.7.5.tgz | tar xz -C /opt/cni/bin ./host-local
+    wget -q -O - https://dl.k8s.io/network-plugins/cni-plugins-amd64-v0.7.5.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
 
 
 FROM antrea/openvswitch:2.11.1

--- a/build/images/scripts/install_cni
+++ b/build/images/scripts/install_cni
@@ -10,5 +10,12 @@ install -m 644 /etc/antrea/antrea-cni.conf /host/etc/cni/net.d/10-antrea.conf
 # Install Antrea binary file
 install -m 755 /usr/local/bin/antrea-cni /host/opt/cni/bin/antrea
 
+# Install the loopback plugin if not already present
+# It is required by kubelet on Linux when using docker as the container runtime
+
+if [ ! -f /host/opt/cni/bin/loopback ]; then
+    install -m 755 /opt/cni/bin/loopback /host/opt/cni/bin/loopback
+fi
+
 # Load the OVS kernel module
 modprobe openvswitch


### PR DESCRIPTION
As part of the Antrea installation process (install_cni script). The
loopback plugin is required by kubelet on Linux when using the docker
container runtime.

Fixes #349