### PR TITLE
Fix ownership of ~/.kube directory in Ansible playbook for worker

### DIFF
--- a/test/e2e/infra/vagrant/playbook/roles/worker/tasks/main.yml
+++ b/test/e2e/infra/vagrant/playbook/roles/worker/tasks/main.yml
@@ -29,11 +29,13 @@
 # succesful in future runs.
 - name: Setup kubeconfig for test user
   block:
-    - name: Create .kube directory in test user home
+    - name: Create /home/{{ test_user }}/.kube directory
       file:
         path: /home/{{ test_user }}/.kube
         state: directory
-    - name: Copy kubeconfig file to .kube
+        owner: "{{ test_user }}"
+        group: "{{ test_user }}"
+    - name: Copy kubeconfig file to /home/{{ test_user }}/.kube
       copy:
         src: kube/config
         dest: /home/{{ test_user }}/.kube/config


### PR DESCRIPTION
This was done for the master role previously, but we missed the worker
role. This prevents kubectl from using ~/.kube/cache when run from a
worker, which causes performance issues.