### PR TITLE
Create release version of antrea-octant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,9 +166,10 @@ manifest:
 	@echo "===> Generating dev manifest for Antrea <==="
 	$(CURDIR)/hack/generate-manifest.sh --mode dev > build/yamls/antrea.yml
 	$(CURDIR)/hack/generate-manifest.sh --mode dev --ipsec > build/yamls/antrea-ipsec.yml
+	$(CURDIR)/hack/generate-manifest-octant.sh --mode dev > build/yamls/antrea-octant.yml
 
 .PHONY: octant-antrea-ubuntu
 octant-antrea-ubuntu:
 	@echo "===> Building antrea/octant-antrea-ubuntu Docker image <==="
 	docker build -t antrea/octant-antrea-ubuntu -f build/images/Dockerfile.octant.ubuntu .
-	docker tag antrea/octant-antrea-ubuntu octant-antrea-ubuntu:$(DOCKER_IMG_VERSION)
+	docker tag antrea/octant-antrea-ubuntu antrea/octant-antrea-ubuntu:$(DOCKER_IMG_VERSION)

--- a/build/yamls/antrea-octant.yml
+++ b/build/yamls/antrea-octant.yml
@@ -1,5 +1,3 @@
-# yaml template for octant and antrea-octant-plugin
-# Right config parameters and Docker image must be specified.
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,72 +6,66 @@ metadata:
   name: antrea-octant
   namespace: kube-system
 spec:
-  type: NodePort
   ports:
-    - port: 80
-      targetPort: 80
+  - port: 80
+    targetPort: 80
   selector:
     app: antrea
     component: antrea-octant
+  type: NodePort
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: antrea-octant
-  namespace: kube-system
   labels:
     app: antrea
     component: antrea-octant
+  name: antrea-octant
+  namespace: kube-system
 spec:
   replicas: 1
-  strategy:
-    # Ensure the existing Pod is killed before the new one is created.
-    type: Recreate
   selector:
     matchLabels:
       app: antrea
       component: antrea-octant
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
         app: antrea
         component: antrea-octant
     spec:
+      containers:
+      - args:
+        - -v
+        command:
+        - octant
+        env:
+        - name: OCTANT_ACCEPTED_HOSTS
+          value: 0.0.0.0
+        - name: OCTANT_LISTENER_ADDR
+          value: 0.0.0.0:80
+        - name: OCTANT_DISABLE_OPEN_BROWSER
+          value: "true"
+        - name: KUBECONFIG
+          value: /kube/admin.conf
+        image: antrea/octant-antrea-ubuntu:latest
+        imagePullPolicy: IfNotPresent
+        name: antrea-octant
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - mountPath: /kube/
+          name: kubeconfig
       priorityClassName: system-cluster-critical
       tolerations:
-        # Mark it as a critical add-on.
-        - key: CriticalAddonsOnly
-          operator: Exists
-        # Allow it to schedule onto master nodes.
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
-      containers:
-        - name: antrea-octant
-          image: antrea/octant-antrea-ubuntu:latest
-          imagePullPolicy: IfNotPresent
-          # Octant start-up env
-          env:
-            # 0.0.0.0 allows all hosts
-            - name: OCTANT_ACCEPTED_HOSTS
-              value: "0.0.0.0"
-            # Port 80 can be changed according to your set up, but it should match the containerPort value in the port mapping below.
-            - name: OCTANT_LISTENER_ADDR
-              value: "0.0.0.0:80"
-            - name: OCTANT_DISABLE_OPEN_BROWSER
-              value: "true"
-            # Change admin.conf to the name of kubeconfig file in your set up.
-            - name: KUBECONFIG
-              value: "/kube/admin.conf"
-          command: ["octant"]
-          args: ["-v"]
-          ports:
-          - containerPort: 80
-          volumeMounts:
-            - name: kubeconfig
-              mountPath: /kube/
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
       volumes:
-        - name: kubeconfig
-          secret:
-            secretName: octant-kubeconfig
-            # defaultMode can be changed according to your requirements
-            defaultMode: 256
+      - name: kubeconfig
+        secret:
+          defaultMode: 256
+          secretName: octant-kubeconfig

--- a/build/yamls/octant/base/deployment.yml
+++ b/build/yamls/octant/base/deployment.yml
@@ -1,0 +1,56 @@
+# Update config parameters as needed
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: antrea-octant
+  labels:
+    component: antrea-octant
+spec:
+  strategy:
+    # Ensure the existing Pod is killed before the new one is created.
+    type: Recreate
+  selector:
+    matchLabels:
+      component: antrea-octant
+  template:
+    metadata:
+      labels:
+        component: antrea-octant
+    spec:
+      priorityClassName: system-cluster-critical
+      tolerations:
+        # Mark it as a critical add-on.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        # Allow it to schedule onto master nodes.
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      containers:
+        - name: antrea-octant
+          image: octant-antrea
+          # Octant start-up env
+          env:
+            # 0.0.0.0 allows all hosts
+            - name: OCTANT_ACCEPTED_HOSTS
+              value: "0.0.0.0"
+            # Port 80 can be changed according to your set up, but it should match the containerPort value in the port mapping below.
+            - name: OCTANT_LISTENER_ADDR
+              value: "0.0.0.0:80"
+            - name: OCTANT_DISABLE_OPEN_BROWSER
+              value: "true"
+            # Change admin.conf to the name of kubeconfig file in your set up.
+            - name: KUBECONFIG
+              value: "/kube/admin.conf"
+          command: ["octant"]
+          args: ["-v"]
+          ports:
+          - containerPort: 80
+          volumeMounts:
+            - name: kubeconfig
+              mountPath: /kube/
+      volumes:
+        - name: kubeconfig
+          secret:
+            secretName: octant-kubeconfig
+            # defaultMode can be changed according to your requirements
+            defaultMode: 256

--- a/build/yamls/octant/base/kustomization.yml
+++ b/build/yamls/octant/base/kustomization.yml
@@ -1,0 +1,11 @@
+resources:
+- service.yml
+- deployment.yml
+commonLabels:
+  app: antrea
+namespace: kube-system
+replicas:
+- count: 1
+  name: antrea-octant
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/build/yamls/octant/base/service.yml
+++ b/build/yamls/octant/base/service.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: antrea-octant
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: 80
+  selector:
+    component: antrea-octant

--- a/build/yamls/octant/patches/dev/imagePullPolicy.yml
+++ b/build/yamls/octant/patches/dev/imagePullPolicy.yml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: antrea-octant
+spec:
+  template:
+    spec:
+      containers:
+        - name: antrea-octant
+          imagePullPolicy: IfNotPresent

--- a/build/yamls/octant/patches/release/.gitignore
+++ b/build/yamls/octant/patches/release/.gitignore
@@ -1,0 +1,1 @@
+# placeholder

--- a/ci/check-manifest.sh
+++ b/ci/check-manifest.sh
@@ -25,12 +25,14 @@ function echoerr {
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 pushd $THIS_DIR/.. > /dev/null
 
-rm build/yamls/antrea.yml build/yamls/antrea-ipsec.yml
+YAMLS="build/yamls/antrea.yml build/yamls/antrea-ipsec.yml build/yamls/antrea-octant.yml"
+
+rm $YAMLS
 make manifest
-diff="$(git status --porcelain build/yamls/antrea.yml build/yamls/antrea-ipsec.yml)"
+diff="$(git status --porcelain $YAMLS)"
 
 if [ ! -z "$diff" ]; then
-    echoerr "The generated manifest YAML is not up-to-date"
+    echoerr "The generated manifest YAMLs are not up-to-date"
     echoerr "You can regenerate them with 'make manifest' and commit the changes"
     exit 1
 fi

--- a/docs/maintainers/release.md
+++ b/docs/maintainers/release.md
@@ -8,13 +8,15 @@ release. We use `<TAG>` as a placeholder for the release tag (e.g. `v0.1.0`).
     1. a commit to update the [CHANGELOG](/CHANGELOG.md).
     2. a commit to update [VERSION](/VERSION) as needed.
 
- * Generate the deployment manifest for the release:
-   `IMG_NAME=antrea/antrea-ubuntu IMG_TAG=<TAG> ./hack/generate-manifest.sh --mode release > antrea.yml`
+ * Generate the manifest files for the release:
+    1. `IMG_NAME=antrea/antrea-ubuntu IMG_TAG=<TAG> ./hack/generate-manifest.sh --mode release > antrea.yml`
+    2. `IMG_NAME=antrea/antrea-ubuntu IMG_TAG=<TAG> ./hack/generate-manifest.sh --mode release --ipsec > antrea-ipsec.yml`
+    3. `IMG_NAME=antrea/octant-antrea-ubuntu IMG_TAG=<TAG> ./hack/generate-manifest-octant.sh --mode release > antrea-octant.yml`
 
  * Make the release on Github with the release branch as the target: copy the
    relevant section of the [CHANGELOG](/CHANGELOG.md) for the release
-   description and upload the deployment manifest generated in the previous step
-   (as antrea.yml, otherwise the manifest link advertised in
+   description and upload the manifests generated in the previous step (with the
+   same file names, otherwise the manifest link advertised in
    [getting-started.md](getting-started.md) will not work!). Check the
    `pre-release` box if applicable.
 

--- a/docs/octant-plugin-installation.md
+++ b/docs/octant-plugin-installation.md
@@ -15,14 +15,15 @@ antrea-octant-plugin depends on the Antrea monitoring CRDs, AntreaControllerInfo
 To run Octant together with antrea-octant-plugin, please make sure you have these two CRDs defined in you K8s cluster.
 
 If Antrea is deployed before antrea-octant-plugin starts by using the standard deployment yaml, Antrea monitoring
-CRDs should already be added. If not, please refer to [antrea.yaml](https://github.com/vmware-tanzu/antrea/blob/master/build/yamls/antrea.yml) to
+CRDs should already be added. If not, please refer to [antrea.yaml](/build/yamls/antrea.yml) to
 create these two CRDs first.
 
 ### Deploy Octant and antrea-octant-plugin as a Pod
 
 You can follow the sample below to run Octant and antrea-octant-plugin in Pod.
 In this example, we expose UI as a NodePort service for accessing externally.
-You can update antrea-octant.yaml according to your environment and preference.
+You can update [antrea-octant.yaml](build/yamls/antrea-octant.yml) according to
+your environment and preference.
 
 1. Create a secret that contains your kubeconfig.
 
@@ -31,9 +32,9 @@ You can update antrea-octant.yaml according to your environment and preference.
     kubectl create secret generic octant-kubeconfig --from-file=/etc/kubernetes/admin.conf -n kube-system
     ```
 
-2. You may need to update build/yamls/antrea-octant.yml according to your kubeconfig file name.
+2. You may need to update [build/yamls/antrea-octant.yml](/build/yamls/antrea-octant.yml) according to your kubeconfig file name.
 
-3. You can change the sample according to your requirements and environment, then apply the yaml to create both deployment and NodePort service.
+3. You can change the sample yaml according to your requirements and environment, then apply the yaml to create both deployment and NodePort service.
 
     ```
     kubectl apply -f build/yamls/antrea-octant.yml
@@ -48,11 +49,21 @@ You can update antrea-octant.yaml according to your environment and preference.
 Now, you are supposed to see Octant is running together with antrea-octant-plugin via URL http://(IP or $HOSTNAME):NodePort.
 
 Note:
-1. Docker image antrea/octant-antrea-ubuntu should be automatically downloaded when you apply antrea-octant.yml in step 3.
-If the image is not successfully downloaded which may be due to network issues, you can run command `make octant-antrea-ubuntu` to build the image locally.
-If it is the case, you need to make sure that the image exists on all the K8s Nodes since the antrea-octant Pod may run on any of them.
-2. If the Pod is running without any explicit issue but you can not access the URL, please take a further look at the network configurations
-in your environment. It may be due to the network policies or other security rules configured on your hosts.
+1. Docker image antrea/octant-antrea-ubuntu should be automatically downloaded
+when you apply antrea-octant.yml in step 3. If the image is not successfully
+downloaded which may be due to network issues, you can run command `make
+octant-antrea-ubuntu` to build the image locally. If it is the case, you need
+to make sure that the image exists on all the K8s Nodes since the antrea-octant
+Pod may run on any of them.
+2. If the Pod is running without any explicit issue but you can not access the
+URL, please take a further look at the network configurations in your
+environment. It may be due to the network policies or other security rules
+configured on your hosts.
+3. To deploy a released version of the plugin, you can download
+`https://github.com/vmware-tanzu/antrea/releases/download/<TAG>/antrea-octant.yml`,
+where `<TAG>` (e.g. `v0.3.0`) is the desired version (should match the version
+of Antrea you are using). After making the necessary edits, you can apply the
+yaml with `kubectl`.
 
 ### Deploy Octant and antrea-octant-plugin as a process
 

--- a/hack/generate-manifest-octant.sh
+++ b/hack/generate-manifest-octant.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+_usage="Usage: $0 [--mode (dev|release)] [--keep] [--help|-h]
+Generate a YAML manifest to run Octant with the Antrea plugin, using Kustomize, and print it to
+stdout.
+        --mode (dev|release)  Choose the configuration variant that you need (default is 'dev')
+        --keep                Debug flag which will preserve the generated kustomization.yml
+        --help, -h            Print this message and exit
+
+In 'release' mode, environment variables IMG_NAME and IMG_TAG must be set.
+
+This tool uses kustomize (https://github.com/kubernetes-sigs/kustomize) to generate manifests for
+running Octant with the Antrea plugin in a Pod. You can set the KUSTOMIZE environment variable to
+the path of the kustomize binary you want us to use. Otherwise we will look for kustomize in your
+PATH and your GOPATH. If we cannot find kustomize there, we will try to install it."
+
+function print_usage {
+    echoerr "$_usage"
+}
+
+function print_help {
+    echoerr "Try '$0 --help' for more information."
+}
+
+MODE="dev"
+KEEP=false
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    --mode)
+    MODE="$2"
+    shift 2
+    ;;
+    --keep)
+    KEEP=true
+    shift
+    ;;
+    -h|--help)
+    print_usage
+    exit 0
+    ;;
+    *)    # unknown option
+    echoerr "Unknown option $1"
+    exit 1
+    ;;
+esac
+done
+
+if [ "$MODE" != "dev" ] && [ "$MODE" != "release" ]; then
+    echoerr "--mode must be one of 'dev' or 'release'"
+    print_help
+    exit 1
+fi
+
+if [ "$MODE" == "release" ] && [ -z "$IMG_NAME" ]; then
+    echoerr "In 'release' mode, environment variable IMG_NAME must be set"
+    print_help
+    exit 1
+fi
+
+if [ "$MODE" == "release" ] && [ -z "$IMG_TAG" ]; then
+    echoerr "In 'release' mode, environment variable IMG_TAG must be set"
+    print_help
+    exit 1
+fi
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+source $THIS_DIR/verify-kustomize.sh
+
+if [ -z "$KUSTOMIZE" ]; then
+    KUSTOMIZE="$(verify_kustomize)"
+elif ! $KUSTOMIZE version > /dev/null 2>&1; then
+    echoerr "$KUSTOMIZE does not appear to be a valid kustomize binary"
+    print_help
+    exit 1
+fi
+
+KUSTOMIZATION_DIR=$THIS_DIR/../build/yamls/octant
+
+TMP_DIR=$(mktemp -d $KUSTOMIZATION_DIR/overlays.XXXXXXXX)
+
+pushd $TMP_DIR > /dev/null
+
+BASE=../../base
+
+mkdir $MODE && cd $MODE
+touch kustomization.yml
+$KUSTOMIZE edit add base $BASE
+# ../../patches/$MODE may be empty so we use find and not simply cp
+find ../../patches/$MODE -name \*.yml -exec cp {} . \;
+
+if [ "$MODE" == "dev" ]; then
+    $KUSTOMIZE edit set image octant-antrea=antrea/octant-antrea-ubuntu:latest
+    $KUSTOMIZE edit add patch imagePullPolicy.yml
+fi
+
+if [ "$MODE" == "release" ]; then
+    $KUSTOMIZE edit set image octant-antrea=$IMG_NAME:$IMG_TAG
+fi
+
+$KUSTOMIZE build
+
+popd > /dev/null
+
+if $KEEP; then
+    echoerr "Kustomization file is at $TMP_DIR/$MODE/kustomization.yml"
+else
+    rm -rf $TMP_DIR
+fi

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -20,7 +20,7 @@ function echoerr {
     >&2 echo "$@"
 }
 
-_usage="Usage: $0 [--mode (dev|release)] [--kind] [--keep] [--help|-h]
+_usage="Usage: $0 [--mode (dev|release)] [--kind] [--ipsec] [--keep] [--help|-h]
 Generate a YAML manifest for Antrea using Kustomize and print it to stdout.
         --mode (dev|release)  Choose the configuration variant that you need (default is 'dev')
         --kind                Generate a manifest appropriate for running Antrea in a Kind cluster


### PR DESCRIPTION
At the moment we have a Github workflow to upload a tagged Docker image
for Octant + the Octant Antrea plugin, for each release. This is
currently broken because of a typo in the Makefile. In addition to
fixing that typo, this change introduces support for generating a
release antrea-octant.yml manifest that can be uploaded with each
release. Despite the availability of the yaml, users will likely need to
edit the file to match their environment before they can apply it. In
the future we may want to enhance the hack/generate-manifest-octant.sh
script so that user can use a single command to deploy Octant and the
Antrea plugin:

```
./hack/generate-manifest-octant.sh --image octant-antrea-ubuntu:v0.3.0 \
  --octant-accepted-hosts <X> \
  --octant-listener-addr=<Y> | kubectl apply -f -
```

Fixes #342