### PR TITLE
Use golangci-lint to run golint

### DIFF
--- a/.golangci-golint.yml
+++ b/.golangci-golint.yml
@@ -1,4 +1,4 @@
-# golangci-lint configuration used for CI
+# golangci-lint configuration used to run golint only
 run:
   tests: true
   timeout: 5m
@@ -6,9 +6,10 @@ run:
     - ".*\\.pb\\.go"
   skip-dirs-use-default: true
 
+issues:
+  exclude-use-default: false
+
 linters:
   disable-all: true
   enable:
-    - misspell
-    - gofmt
-    - deadcode
+    - golint

--- a/Makefile
+++ b/Makefile
@@ -131,17 +131,9 @@ fmt:
 golangci: .golangci-bin
 	@GOOS=linux .golangci-bin/golangci-lint run -c .golangci.yml
 
-.PHONY: .linter
-.linter:
-	@if ! PATH=$$PATH:$(GOPATH)/bin command -v golint > /dev/null; then \
-	  echo "===> Installing Golint <==="; \
-	  $(GO) get -u golang.org/x/lint/golint; \
-	fi
-
 .PHONY: lint
-lint: export GOOS=linux
-lint: .linter
-	@PATH=$$PATH:$(GOPATH)/bin golint ./cmd/... ./pkg/...
+lint: .golangci-bin
+	@GOOS=linux .golangci-bin/golangci-lint run -c .golangci-golint.yml
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This simplifies the Makefile a bit and means we no longer need to
install golint separately with "go get", which can cause the go.mod file
to be modified.

Fixes #170