### PR TITLE
Re-enable TestPodConnectivityAfterAntreaRestart on Kind

### DIFF
--- a/docs/kind.md
+++ b/docs/kind.md
@@ -56,17 +56,24 @@ antrea-agent-zsztq                   2/2     Running   0          8m56s
 antrea-controller-775f4d79f8-6tksp   1/1     Running   0          8m56s
 ```
 
-### Short Cut
-Alternatively to create a two worker Node cluster with antrea installed, do
+### Short-Cut
+
+Alternatively to create a two worker Node cluster with Antrea installed, do
 ```
 ./ci/kind/kind-setup.sh create CLUSTER_NAME
 ```
-kind-setup.sh allows user to specify number of worker Nodes, docker bridge networks/subnets
-connected to worker Nodes, and preloaded docker images. For their usages do 
+kind-setup.sh allows users to specify the number of worker Nodes, the docker
+bridge networks/subnets connected to worker Nodes, and some docker images to be
+pre-loaded in each Node. For more information on usage, run:
  ```
 ./ci/kind/kind-setup.sh help
 ```
  
+## Run the Antrea e2e tests
+
+To run the Antrea e2e test suite on your Kind cluster, please refer to [this
+document](/test/e2e#running-the-e2e-tests-on-a-kind-cluster).
+
 ## FAQ
 
 ### Why is the YAML manifest different when using Kind?

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -164,17 +164,17 @@ func (data *TestData) redeployAntrea(t *testing.T, enableIPSec bool) {
 	if err := data.waitForAntreaDaemonSetPods(defaultTimeout); err != nil {
 		t.Fatalf("Error when restarting Antrea: %v", err)
 	}
-	t.Logf("Checking CoreDNS deployment")
-	if err := data.checkCoreDNSPods(defaultTimeout); err != nil {
-		t.Fatalf("Error when checking CoreDNS deployment: %v", err)
+	// Restart CoreDNS Pods to avoid issues caused by disrupting the datapath (when restarting
+	// Antrea Agent Pods).
+	t.Logf("Restarting CoreDNS Pods")
+	if err := data.restartCoreDNSPods(defaultTimeout); err != nil {
+		t.Fatalf("Error when restarting CoreDNS Pods: %v", err)
 	}
 }
 
 // TestPodConnectivityAfterAntreaRestart checks that restarting antrea-agent does not create
 // connectivity issues between Pods.
 func TestPodConnectivityAfterAntreaRestart(t *testing.T) {
-	// See https://github.com/vmware-tanzu/antrea/issues/244
-	skipIfProviderIs(t, "kind", "test may cause subsequent tests to fail in Kind clusters")
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)


### PR DESCRIPTION
We make the test framework more robust by:
 * scheduling CoreDNS Pods on the Kind control-plane Node to avoid
   connectivity issues to CoreDNS when restarting the Antrea Agent on
   the Kind worker Node.
 * ensuring that all CoreDNS Pods are restarted (on every type of
   cluster, not just Kind) when all Antrea Agents are restarted
   (e.g. because of an update).

Fixes #244