### PR TITLE
Preserve OVS datapath flows after an agent restart

### DIFF
--- a/build/images/ovs/Dockerfile
+++ b/build/images/ovs/Dockerfile
@@ -1,17 +1,22 @@
 FROM ubuntu:18.04 as ovs-debs
 
+# Some patches may not apply cleanly if another version is provided.
 ARG OVS_VERSION=2.11.1
 
 # Install dependencies for building OVS deb packages
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget ca-certificates build-essential fakeroot graphviz \
+    apt-get install -y --no-install-recommends wget curl git ca-certificates build-essential fakeroot graphviz \
             bzip2 autoconf automake debhelper dh-autoreconf libssl-dev libtool openssl procps \
             python-all python-twisted-conch python-zopeinterface python-six libunbound-dev
+
+COPY apply-patches.sh /
 
 # Download OVS source code and build debs
 RUN wget -q -O - https://www.openvswitch.org/releases/openvswitch-$OVS_VERSION.tar.gz  | tar xz -C /tmp && \
     rm -rf openvswitch-$OVS_VERSION.tar.gz && \
-    cd /tmp/openvswitch* && DEB_BUILD_OPTIONS='parallel=8 nocheck' fakeroot debian/rules binary && \
+    cd /tmp/openvswitch* && \
+    /apply-patches.sh && \
+    DEB_BUILD_OPTIONS='parallel=8 nocheck' fakeroot debian/rules binary && \
     cd /tmp && mkdir ovs-debs && \
     mv libopenvswitch_*.deb openvswitch-common_*.deb openvswitch-switch_*.deb python-openvswitch_*.deb \
        openvswitch-ipsec_*.deb ovs-debs/ && \

--- a/build/images/ovs/apply-patches.sh
+++ b/build/images/ovs/apply-patches.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script applies unreleased patches (or released in a more recent version
+# of OVS than the one Antrea is using) to OVS before building it. It needs to be
+# run from the root of the OVS source tree.
+
+set -eo pipefail
+
+# We cannot use 3-way merge unless we are in a git repository. If we need 3-way
+# merge, we will need to clone the repository with git instead of downloading a
+# release tarball (see Dockerfile).
+
+# These 2 patches (post 2.13.0) ensures that datapath flows are not deleted on
+# ovs-vswitchd exit by default. Antrea relies on this to support hitless upgrade
+# of the Agent DaemonSet.
+# The second patch depends on the first one.
+curl https://github.com/openvswitch/ovs/commit/586cd3101e7fda54d14fb5bf12d847f35d968627.patch | \
+    git apply
+# We exclude 2 files which are likely to cause conflicts.
+curl https://github.com/openvswitch/ovs/commit/79eadafeb1b47a3871cb792aa972f6e4d89d1a0b.patch | \
+    git apply --exclude NEWS --exclude vswitchd/ovs-vswitchd.8.in

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -62,24 +62,10 @@ func TestIPBlockWithExcept(t *testing.T) {
 		}
 	}()
 
-	podName0 := randName("test-pod-networkpolicy-")
-	if err := data.createBusyboxPodOnNode(podName0, workerNode); err != nil {
-		t.Fatalf("Error when creating busybox test Pod: %v", err)
-	}
-	defer deletePodWrapper(t, data, podName0)
-	if _, err := data.podWaitForIP(defaultTimeout, podName0); err != nil {
-		t.Fatalf("Error when waiting for IP for Pod '%s': %v", podName0, err)
-	}
-
-	podName1 := randName("test-pod-networkpolicy-")
-	if err := data.createBusyboxPodOnNode(podName1, workerNode); err != nil {
-		t.Fatalf("Error when creating busybox test Pod: %v", err)
-	}
-	defer deletePodWrapper(t, data, podName1)
-	podIP1, err := data.podWaitForIP(defaultTimeout, podName1)
-	if err != nil {
-		t.Fatalf("Error when waiting for IP for Pod '%s': %v", podName1, err)
-	}
+	podNames, podIPs, cleanupFn := createTestBusyboxPods(t, data, 2, workerNode)
+	defer cleanupFn()
+	podName0 := podNames[0]
+	podName1, podIP1 := podNames[1], podIPs[1]
 
 	// Both pods cannot connect to service.
 	if err = data.runNetcatCommandFromTestPod(podName0, svcName, 80); err == nil {


### PR DESCRIPTION
* Preserve OVS datapath flows after an agent restart

Without this patch, when the antrea-ovs container exits gracefully
(e.g. as part of a RollingUpdate for the DaemonSet), datapath flows are
deleted, which breaks existing connections. It takes 10 seconds for
exiting connections to start working again. A recent OVS patch changed
the default behavior of ovs-vswitchd so that datapath flows are no
longer deleted on exit. Because this patch is not yet available in any
released OVS version (and won't be for > 6 months), we apply it manually
when we build our base OVS Docker image.

This is a step towards non-disruptive upgrade. However, there are other
factors in play: 1) when the OVS daemons are stopped, the VXLAN device
(vxlan_sys_4789) goes away, which impacts connectivity between Nodes,
and 2) when ovs-vswitchd restarts, datapath flows are flushed and we
have to wait until the Antrea Agent has replayed the flows.

* Disable new e2e test for Kind

When using the netdev datapath, packet forwarding is done by the
ovs-vswitchd daemon itself, so even existing connections are broken.

* Use arping instead of ping for test

When using ping the test can be flaky: if one of the hosts need to send
an ARP request to refresh its ARP entry while the test is ongoing, odds
are that there is no cached flow in the datapath. If this happens, the
host will mark the ARP entry has "incomplete" and the ping will start
failing.

Fixes #355