### PR TITLE
Still use flow based tunnel when IPSec encyption is enabled

### DIFF
--- a/docs/ovs-pipeline.md
+++ b/docs/ovs-pipeline.md
@@ -40,7 +40,7 @@
   address and initiate MAC learning if the address is unknown).
 
 **This documentation currently assumes that Antrea is used in encap mode (an
-  overlay network is created between all Nodes), without IPsec enabled.**
+  overlay network is created between all Nodes).**
 
 ## Dumping the Flows
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -121,10 +121,8 @@ func (i *Initializer) setupOVSBridge() error {
 		return err
 	}
 
-	if !i.enableIPSecTunnel {
-		if err := i.setupDefaultTunnelInterface(types.DefaultTunPortName); err != nil {
-			return err
-		}
+	if err := i.setupDefaultTunnelInterface(types.DefaultTunPortName); err != nil {
+		return err
 	}
 
 	// Setup host gateway interface
@@ -273,13 +271,10 @@ func (i *Initializer) initOpenFlowPipeline() error {
 		return err
 	}
 
-	// When IPSec encyption is enabled, no flow is needed for the default tunnel interface.
-	if !i.enableIPSecTunnel {
-		// Setup flow entries for the default tunnel port interface.
-		if err := i.ofClient.InstallDefaultTunnelFlows(types.DefaultTunOFPort); err != nil {
-			klog.Errorf("Failed to setup openflow entries for tunnel interface: %v", err)
-			return err
-		}
+	// Setup flow entries for the default tunnel port interface.
+	if err := i.ofClient.InstallDefaultTunnelFlows(types.DefaultTunOFPort); err != nil {
+		klog.Errorf("Failed to setup openflow entries for tunnel interface: %v", err)
+		return err
 	}
 
 	// Setup flow entries to enable service connectivity. Upstream kube-proxy is leveraged to


### PR DESCRIPTION
Change to use flow based tunnel for IPSec encyption as well, so OVS
flows will be the same no matter IPSec is enabled or not. A separate
tunnel port/interface is still created for each remote Node, which is
required for the OVS IPSec monitor daemon to detect the new tunnel and
create IPSec security policies for the Node using psk and remote_ip
options of the tunnel interface.