### PR TITLE
Add user documentation and update architecture doc for IPSec

### DIFF
--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -257,8 +257,8 @@ data:
     # overhead.
     #defaultMTU: 1450
 
-    # Whether or not to enable IPSec encryption of tunnel traffic. IPSec encryption is supported for
-    # only the GRE tunnel type.
+    # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
+    # for the GRE tunnel type.
     enableIPSecTunnel: true
 
     # CIDR Range for services in cluster. It's required to support egress network policy, should
@@ -279,7 +279,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-d7h2d98bfd
+  name: antrea-config-4dk46g94gk
   namespace: kube-system
 ---
 apiVersion: v1
@@ -371,7 +371,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-d7h2d98bfd
+          name: antrea-config-4dk46g94gk
         name: antrea-config
 ---
 apiVersion: apiregistration.k8s.io/v1
@@ -561,7 +561,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-d7h2d98bfd
+          name: antrea-config-4dk46g94gk
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -257,8 +257,8 @@ data:
     # overhead.
     #defaultMTU: 1450
 
-    # Whether or not to enable IPSec encryption of tunnel traffic. IPSec encryption is supported for
-    # only the GRE tunnel type.
+    # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
+    # for the GRE tunnel type.
     #enableIPSecTunnel: false
 
     # CIDR Range for services in cluster. It's required to support egress network policy, should
@@ -279,7 +279,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-476k567258
+  name: antrea-config-mk8mcttkf7
   namespace: kube-system
 ---
 apiVersion: v1
@@ -362,7 +362,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-476k567258
+          name: antrea-config-mk8mcttkf7
         name: antrea-config
 ---
 apiVersion: apiregistration.k8s.io/v1
@@ -520,7 +520,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-476k567258
+          name: antrea-config-mk8mcttkf7
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -25,8 +25,8 @@
 # overhead.
 #defaultMTU: 1450
 
-# Whether or not to enable IPSec encryption of tunnel traffic. IPSec encryption is supported for
-# only the GRE tunnel type.
+# Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
+# for the GRE tunnel type.
 #enableIPSecTunnel: false
 
 # CIDR Range for services in cluster. It's required to support egress network policy, should

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,12 +36,22 @@ clientConnection:
 # Encapsulation mode for communication between Pods across Nodes, supported values:
 # - vxlan (default)
 # - geneve
+# - gre
+# - stt
 #tunnelType: vxlan
+
+# Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
+# for the GRE tunnel type.
+enableIPSecTunnel: true
 
 # Default MTU to use for the host gateway interface and the network interface of
 # each Pod. If omitted, antrea-agent will default this value to 1450 to accommodate
 # for tunnel encapsulate overhead.
 #defaultMTU: 1450
+
+# CIDR Range for services in cluster. It's required to support egress network policy, should
+# be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
+#serviceCIDR: 10.96.0.0/12
 
 # Mount location of the /proc directory. The default is "/host", which is appropriate when
 # antrea-agent is run as part of the Antrea DaemonSet (and the host's /proc directory is mounted

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -95,3 +95,9 @@ information.
 
 To deploy Antrea in a [Kind](https://github.com/kubernetes-sigs/kind) cluster,
 please refer to this [guide](/docs/kind.md).
+
+
+### Deploying Antrea with IPsec Encyption
+
+Antrea supports encrypting GRE tunnel traffic with IPsec. To deploy Antrea with
+IPsec encyption enabled, please refer to this [guide](/docs/ipsec-tunnel.md).

--- a/docs/ipsec-tunnel.md
+++ b/docs/ipsec-tunnel.md
@@ -1,0 +1,53 @@
+# IPsec Encryption of Tunnel Traffic with Antrea
+
+Antrea supports encrypting tunnel traffic across Nodes with IPsec ESP. At this
+moment, IPsec encyption works only for GRE tunnel (but not VXLAN, Geneve, and
+STT tunnel types).
+
+## Prerequisites
+
+IPsec requires a set of Linux kernel modules. Check the required kernel modules
+listed in the [strongSwan documentation](https://wiki.strongswan.org/projects/strongswan/wiki/KernelModules).
+Make sure the required kernel modules are loaded on the Kubernetes Nodes before
+deploying Antrea with IPsec encyption enabled.
+
+## Installation
+
+You can simply apply the [Antrea IPsec deployment yaml](/build/yamls/antrea-ipsec.yml)
+to deploy Antrea with IPsec encyption enabled. To deploy a released version of
+Antrea, pick a version from the [list of releases](https://github.com/vmware-tanzu/antrea/releases).
+Note that IPsec support was added in release 0.3.0, which means you can not
+pick a release older than 0.3.0. For any given release `<TAG>` (e.g. `v0.3.0`),
+get the Antrea IPsec deployment yaml at:
+```
+https://github.com/vmware-tanzu/antrea/releases/download/<TAG>/antrea-ipsec.yml
+```
+
+To deploy the latest version of Antrea (built from the master branch), get the
+IPsec deployment yaml at:
+```
+https://raw.githubusercontent.com/vmware-tanzu/antrea/master/build/yamls/antrea-ipsec.yml
+```
+
+Antrea leverages strongSwan as the IKE daemon, and supports using pre-shared key
+(PSK) for IKE authentication. The deployment yaml creates a Kubernetes Secret
+`antrea-ipsec` to store the PSK string. For security consideration, we recommend
+to change the default PSK string in the yaml file. You can edit the yaml file,
+and update the `psk` field in the `antrea-ipsec` Secret spec to any string you
+want to use. Check the `antrea-ipsec` Secret spec below:
+```
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: antrea-ipsec
+  namespace: kube-system
+stringData:
+  psk: changeme
+type: Opaque
+```
+
+After updating the PSK value, deploy Antrea with:
+```
+kubectl apply -f antrea-ipsec.yml
+```


### PR DESCRIPTION
Add docs/ipsec-tunnel.md that describes how to deploy Antrea with
IPSec enabled.
Add IPSec design to architecture.md.
Update docs/configration.md and add IPSec config parameters.

closes #62 