### PR TITLE
[Windows] Implement Pod configuration on Windows with HNS Endpoint

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -121,14 +121,10 @@ func run(o *Options) error {
 		o.config.CNISocket,
 		o.config.HostProcPathPrefix,
 		o.config.DefaultMTU,
-		o.config.OVSDatapathType,
 		nodeConfig,
-		ovsBridgeClient,
-		ofClient,
-		ifaceStore,
 		k8sClient,
 		podUpdates)
-	err = cniServer.Initialize()
+	err = cniServer.Initialize(ovsBridgeClient, ofClient, ifaceStore, o.config.OVSDatapathType)
 	if err != nil {
 		return fmt.Errorf("error initializing CNI server: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/vmware-tanzu/antrea
 go 1.13
 
 require (
+	github.com/Microsoft/hcsshim v0.8.6
 	github.com/TomCodeLV/OVSDB-golang-lib v0.0.0-20200116135253-9bbdfadcd881
 	github.com/blang/semver v3.5.0+incompatible
 	github.com/cenk/hub v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/GeertJohan/go.rice v1.0.0/go.mod h1:eH6gbSOAUv07dQuZVnBmoDP8mgsM1rtix
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+qxleU=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
+github.com/Microsoft/hcsshim v0.8.6 h1:ZfF0+zZeYdzMIVMZHKtDKJvLHj76XCuVae/jNkjj0IA=
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46 h1:lsxEuwrXEAokXB9qhlbKWPpo3KMLZQ5WB5WLQRW1uq0=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=

--- a/pkg/agent/cniserver/interface_configuration_linux.go
+++ b/pkg/agent/cniserver/interface_configuration_linux.go
@@ -1,0 +1,336 @@
+// +build linux
+
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cniserver
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/plugins/pkg/ip"
+	"github.com/containernetworking/plugins/pkg/ipam"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/j-keck/arping"
+	"github.com/vishvananda/netlink"
+	"k8s.io/klog"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/util"
+	"github.com/vmware-tanzu/antrea/pkg/agent/util/ethtool"
+	cnipb "github.com/vmware-tanzu/antrea/pkg/apis/cni/v1beta1"
+	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
+)
+
+type ifConfigurator struct {
+	ovsDatapathType string
+}
+
+func newInterfaceConfigurator(ovsDatapathType string) (*ifConfigurator, error) {
+	return &ifConfigurator{ovsDatapathType: ovsDatapathType}, nil
+}
+
+// setupInterfaces creates a veth pair: containerIface is in the container
+// network namespace and hostIface is in the host network namespace.
+func (ic *ifConfigurator) setupInterfaces(
+	podName, podNamespace, ifname string,
+	netns ns.NetNS,
+	mtu int) (hostIface *current.Interface, containerIface *current.Interface, err error) {
+	hostVethName := util.GenerateContainerInterfaceName(podName, podNamespace)
+	hostIface = &current.Interface{}
+	containerIface = &current.Interface{}
+
+	if err := netns.Do(func(hostNS ns.NetNS) error {
+		hostVeth, containerVeth, err := ip.SetupVethWithName(ifname, hostVethName, mtu, hostNS)
+		if err != nil {
+			return err
+		}
+		klog.V(2).Infof("Setup interfaces host: %s, container %s", hostVeth.Name, containerVeth.Name)
+		containerIface.Name = containerVeth.Name
+		containerIface.Mac = containerVeth.HardwareAddr.String()
+		containerIface.Sandbox = netns.Path()
+		hostIface.Name = hostVeth.Name
+		hostIface.Mac = hostVeth.HardwareAddr.String()
+		// OVS netdev datapath doesn't support TX checksum offloading, i.e. if packet
+		// arrives with bad/no checksum it will be sent to the output port with same bad/no checksum.
+		if ic.ovsDatapathType == ovsconfig.OVSDatapathNetdev {
+			if err := ethtool.EthtoolTXHWCsumOff(containerVeth.Name); err != nil {
+				return fmt.Errorf("error when disabling TX checksum offload on container veth: %v", err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, nil, err
+	}
+
+	return hostIface, containerIface, nil
+}
+
+// configureContainerAddr takes the result of the IPAM plugin, and adds the appropriate IP
+// addresses and routes to the interface. It then sends a gratuitous ARP to the network.
+func configureContainerAddr(netns ns.NetNS, containerInterface *current.Interface, result *current.Result) error {
+	if err := netns.Do(func(containerNs ns.NetNS) error {
+		if err := ipam.ConfigureIface(containerInterface.Name, result); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// advertiseContainerAddr sends 3 GARP packets in another goroutine with 50ms interval. It's because Openflow entries are
+// installed async, and the gratuitous ARP could be sent out after the Openflow entries are installed. Using another
+// goroutine to ensure the processing of CNI ADD request is not blocked.
+func (ic *ifConfigurator) advertiseContainerAddr(containerNetNS string, containerIfaceName string, result *current.Result) error {
+	netns, err := ns.GetNS(containerNetNS)
+	if err != nil {
+		klog.Errorf("Failed to open netns with %s: %v", containerNetNS, err)
+		return err
+	}
+	defer netns.Close()
+	if err := netns.Do(func(containerNs ns.NetNS) error {
+		go func() {
+			// The container veth must exist when this function is called, and do not check error here.
+			containerVeth, err := net.InterfaceByName(containerIfaceName)
+			if err != nil {
+				klog.Errorf("Failed to find container interface %s in ns %s", containerIfaceName, netns.Path())
+				return
+			}
+			var targetIP net.IP
+			for _, ipc := range result.IPs {
+				if ipc.Version == "4" {
+					targetIP = ipc.Address.IP
+					arping.GratuitousArpOverIface(ipc.Address.IP, *containerVeth)
+				}
+			}
+			if targetIP == nil {
+				klog.Warning("Failed to find a valid IP address for Gratuitous ARP, not send GARP")
+				return
+			}
+			count := 0
+			for count < 3 {
+				select {
+				case <-time.Tick(50 * time.Millisecond):
+					// Send gratuitous ARP to network in case of stale mappings for this IP address
+					// (e.g. if a previous - deleted - Pod was using the same IP).
+					arping.GratuitousArpOverIface(targetIP, *containerVeth)
+				}
+				count++
+			}
+		}()
+		return nil
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ic *ifConfigurator) configureContainerLink(
+	podName string,
+	podNameSpace string,
+	containerID string,
+	containerNetNS string,
+	containerIFDev string,
+	mtu int,
+	result *current.Result,
+) error {
+	netns, err := ns.GetNS(containerNetNS)
+	if err != nil {
+		return fmt.Errorf("failed to open netns %s: %v", containerNetNS, err)
+	}
+	defer netns.Close()
+	// Create veth pair and link up
+	hostIface, containerIface, err := ic.setupInterfaces(podName, podNameSpace, containerIFDev, netns, mtu)
+	if err != nil {
+		return fmt.Errorf("failed to create veth devices for container %s: %v", containerID, err)
+	}
+
+	result.Interfaces = []*current.Interface{hostIface, containerIface}
+
+	// Note that configuring IP will send gratuitous ARP, it must be executed
+	// after Pod Openflow entries are installed, otherwise gratuitous ARP would
+	// be dropped.
+	klog.V(2).Infof("Configuring IP address for container %s", containerID)
+	if err = configureContainerAddr(netns, containerIface, result); err != nil {
+		return fmt.Errorf("failed to configure IP address for container %s: %v", containerID, err)
+	}
+	return nil
+}
+
+func (ic *ifConfigurator) removeContainerLink(containerID, hostInterfaceName string) error {
+	klog.V(2).Infof("Deleting veth devices for container %s", containerID)
+	// Don't return an error if the device is already removed as CniDel can be called multiple times.
+	if err := ip.DelLinkByName(hostInterfaceName); err != nil {
+		if err != ip.ErrLinkNotFound {
+			return fmt.Errorf("failed to delete veth devices for container %s: %v", containerID, err)
+		}
+		klog.V(2).Infof("Did not find interface %s for container %s", hostInterfaceName, containerID)
+	}
+	return nil
+}
+
+func parseContainerIfaceFromResults(cfgArgs *cnipb.CniCmdArgs, prevResult *current.Result) *current.Interface {
+	for _, intf := range prevResult.Interfaces {
+		if intf.Name == cfgArgs.Ifname {
+			return intf
+		}
+	}
+	return nil
+}
+
+func (ic *ifConfigurator) checkContainerInterface(
+	containerNetns, containerID string,
+	containerIface *current.Interface,
+	containerIPs []*current.IPConfig,
+	containerRoutes []*cnitypes.Route) (*vethPair, error) {
+	var contVeth *vethPair
+	// Check netns configuration
+	if containerNetns != containerIface.Sandbox {
+		klog.Errorf("Sandbox in prevResult %s doesn't match configured netns: %s",
+			containerIface.Sandbox, containerNetns)
+		return nil, fmt.Errorf("sandbox in prevResult %s doesn't match configured netns: %s",
+			containerIface.Sandbox, containerNetns)
+	}
+	netns, err := ns.GetNS(containerNetns)
+	if err != nil {
+		klog.Errorf("Failed to check netns config %s: %v", containerNetns, err)
+		return nil, err
+	}
+	defer netns.Close()
+	// Check container interface configuration
+	if err := netns.Do(func(netNS ns.NetNS) error {
+		var errlink error
+		// Check container link config
+		contVeth, errlink = validateContainerInterface(containerIface)
+		if errlink != nil {
+			return errlink
+		}
+		// Check container IP config
+		if err := ip.ValidateExpectedInterfaceIPs(containerIface.Name, containerIPs); err != nil {
+			return err
+		}
+		// Check container route config
+		if err := ip.ValidateExpectedRoute(containerRoutes); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		klog.Errorf("Failed to check container %s interface configurations in netns %s: %v",
+			containerID, containerNetns, err)
+		return nil, err
+	}
+	return contVeth, nil
+}
+
+func validateContainerInterface(intf *current.Interface) (*vethPair, error) {
+	link, err := validateInterface(intf, true)
+	if err != nil {
+		return nil, err
+	}
+
+	linkName := link.Attrs().Name
+	veth := &vethPair{}
+	_, veth.peerIndex, err = ip.GetVethPeerIfindex(linkName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get veth peer index for veth %s: %v", linkName, err)
+	}
+	veth.ifIndex = link.Attrs().Index
+	if intf.Mac != link.Attrs().HardwareAddr.String() {
+		return nil, fmt.Errorf("interface %s MAC %s doesn't match container MAC: %s",
+			intf.Name, intf.Mac, link.Attrs().HardwareAddr.String())
+	}
+	veth.name = linkName
+	return veth, nil
+}
+
+func (ic *ifConfigurator) validateContainerPeerInterface(interfaces []*current.Interface, containerVeth *vethPair) (*vethPair, error) {
+	// Iterate all the passed interfaces and look up the host interface by
+	// matching the veth peer interface index.
+	for _, hostIntf := range interfaces {
+		if hostIntf.Sandbox != "" {
+			// Not in the default Namespace. Must be the container interface.
+			continue
+		}
+		link, err := validateInterface(hostIntf, false)
+		if err != nil {
+			klog.Errorf("Failed to validate interface %s: %v", hostIntf.Name, err)
+			continue
+		}
+
+		if link.Attrs().Index != containerVeth.peerIndex {
+			continue
+		}
+
+		hostVeth := &vethPair{ifIndex: link.Attrs().Index, name: link.Attrs().Name}
+		_, hostVeth.peerIndex, err = ip.GetVethPeerIfindex(hostVeth.name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get veth peer index for host interface %s: %v",
+				hostIntf.Name, err)
+		}
+
+		if hostVeth.peerIndex != containerVeth.ifIndex {
+			return nil, fmt.Errorf("host interface %s peer index doesn't match container interface %s index",
+				hostIntf.Name, containerVeth.name)
+		}
+
+		if hostIntf.Mac != "" {
+			if hostIntf.Mac != link.Attrs().HardwareAddr.String() {
+				klog.Errorf("Host interface %s MAC %s doesn't match link address %s",
+					hostIntf.Name, hostIntf.Mac, link.Attrs().HardwareAddr.String())
+				return nil, fmt.Errorf("host interface %s MAC %s doesn't match",
+					hostIntf.Name, hostIntf.Mac)
+			}
+		}
+		return hostVeth, nil
+
+	}
+
+	return nil, fmt.Errorf("peer veth interface not found for container interface %s",
+		containerVeth.name)
+}
+
+func validateInterface(intf *current.Interface, inNetns bool) (netlink.Link, error) {
+	if intf.Name == "" {
+		return nil, fmt.Errorf("interface name is missing")
+	}
+	if inNetns {
+		if intf.Sandbox == "" {
+			return nil, fmt.Errorf("interface %s is expected in netns", intf.Name)
+		}
+	} else {
+		if intf.Sandbox != "" {
+			return nil, fmt.Errorf("interface %s is expected not in netns", intf.Name)
+		}
+	}
+
+	link, err := netlink.LinkByName(intf.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find link for interface %s", intf.Name)
+	}
+
+	_, isVeth := link.(*netlink.Veth)
+	if !isVeth {
+		return nil, fmt.Errorf("interface %s is not of type veth", intf.Name)
+	}
+	return link, nil
+}
+
+func (ic *ifConfigurator) getOVSInterfaceType() int {
+	return defaultOVSInterfaceType
+}

--- a/pkg/agent/cniserver/interface_configuration_windows.go
+++ b/pkg/agent/cniserver/interface_configuration_windows.go
@@ -1,0 +1,344 @@
+// +build windows
+
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cniserver
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+
+	"github.com/Microsoft/hcsshim"
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"k8s.io/klog"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/util"
+	cnipb "github.com/vmware-tanzu/antrea/pkg/apis/cni/v1beta1"
+)
+
+const (
+	notFoundHNSEndpoint = "The endpoint was not found"
+)
+
+type endpoint struct {
+	hnsEP      *hcsshim.HNSEndpoint
+	containers []string
+}
+
+type ifConfigurator struct {
+	hnsNetwork *hcsshim.HNSNetwork
+	epCache    *sync.Map
+}
+
+func newInterfaceConfigurator(ovsDataPathType string) (*ifConfigurator, error) {
+	eps, err := hcsshim.HNSListEndpointRequest()
+	if err != nil {
+		return nil, err
+	}
+	epCache := &sync.Map{}
+	for i := range eps {
+		hnsEP := eps[i]
+		ep := &endpoint{
+			hnsEP: &hnsEP,
+		}
+		epCache.Store(hnsEP.Name, ep)
+	}
+	return &ifConfigurator{
+		epCache: epCache,
+	}, nil
+
+}
+
+func (ic *ifConfigurator) addEndpoint(ep *endpoint) {
+	ic.epCache.Store(ep.hnsEP.Name, ep)
+}
+
+// ensureHNSNetwork checks if the target HNSNetwork is created on the node or not. If the HNSNetwork does not exit,
+// return error.
+func (ic *ifConfigurator) ensureHNSNetwork() error {
+	if ic.hnsNetwork != nil {
+		return nil
+	}
+	hnsNetwork, err := hcsshim.GetHNSNetworkByName(util.LocalHNSNetwork)
+	if err != nil {
+		return err
+	}
+	ic.hnsNetwork = hnsNetwork
+	return nil
+}
+
+func (ic *ifConfigurator) getEndpoint(name string) (*endpoint, bool) {
+	value, ok := ic.epCache.Load(name)
+	if !ok {
+		return nil, false
+	}
+	ep, _ := value.(*endpoint)
+	return ep, true
+}
+
+func (ic *ifConfigurator) delEndpoint(name string) {
+	ic.epCache.Delete(name)
+}
+
+// configureContainerLink creates a HNSEndpoint for the container using the IPAM result, and then attach it on the container interface.
+func (ic *ifConfigurator) configureContainerLink(
+	podName string,
+	podNameSpace string,
+	containerID string,
+	containerNetNS string,
+	containerIFDev string,
+	mtu int,
+	result *current.Result,
+) error {
+	// Create HNS Endpoint.
+	endpoint, err := ic.createContainerLink(podName, podNameSpace, containerNetNS, result)
+	if err != nil {
+		return err
+	}
+	// Attach HNSEndpoint to the container. Note that HNSEndpoint must be attached to the container before adding OVS port,
+	// otherwise an error will be returned when creating OVS port.
+	klog.V(2).Infof("Configuring IP address for container %s", containerID)
+	containerIface, err := attachContainerLink(endpoint, containerID, containerNetNS, containerIFDev)
+	if err != nil {
+		klog.V(2).Infof("Failed to attach HNS Endpoint to the container, remove it.")
+		ic.removeHNSEndpoint(endpoint, containerID)
+		return fmt.Errorf("failed to configure container IP: %v", err)
+	}
+
+	hostIface := &current.Interface{
+		Name:    endpoint.hnsEP.Name,
+		Mac:     endpoint.hnsEP.MacAddress,
+		Sandbox: "",
+	}
+	result.Interfaces = []*current.Interface{hostIface, containerIface}
+
+	containerIP, _ := findContainerIPConfig(result.IPs)
+	// Update IPConfig with the index of target interface in the result. The index is used in CNI CmdCheck.
+	ifaceIdx := 1
+	containerIP.Interface = &ifaceIdx
+	return nil
+}
+
+// createContainerLink creates HNSEndpoint using the IP configuration in the IPAM result.
+func (ic *ifConfigurator) createContainerLink(podName string, podNameSpace string, containerID string, result *current.Result) (hostLink *endpoint, err error) {
+	epName := util.GenerateContainerInterfaceName(podName, podNameSpace)
+	// Search endpoint from local cache.
+	ep, found := ic.getEndpoint(epName)
+	if found {
+		return ep, nil
+	}
+
+	// Create a new Endpoint if not found.
+	if err := ic.ensureHNSNetwork(); err != nil {
+		return nil, err
+	}
+	containerIP, err := findContainerIPConfig(result.IPs)
+	if err != nil {
+		return nil, err
+	}
+	epRequest := &hcsshim.HNSEndpoint{
+		Name:           epName,
+		VirtualNetwork: ic.hnsNetwork.Id,
+		DNSServerList:  strings.Join(result.DNS.Nameservers, ","),
+		DNSSuffix:      result.DNS.Domain,
+		GatewayAddress: containerIP.Gateway.String(),
+		IPAddress:      containerIP.Address.IP,
+	}
+	hnsEP, err := epRequest.Create()
+	if err != nil {
+		return nil, err
+	}
+	ep = &endpoint{
+		hnsEP: hnsEP,
+	}
+	// Add the new created Endpoint into local cache.
+	ic.addEndpoint(ep)
+	return ep, nil
+}
+
+// attachContainerLink takes the result of the IPAM plugin, and adds the appropriate IP
+// addresses and routes to the interface. It then sends a gratuitous ARP to the network.
+func attachContainerLink(ep *endpoint, containerID, sandbox, containerIFDev string) (*current.Interface, error) {
+	var found bool
+	for _, c := range ep.containers {
+		if c == containerID {
+			found = true
+		}
+	}
+
+	if !found {
+		if err := hcsshim.HotAttachEndpoint(containerID, ep.hnsEP.Id); err != nil {
+			return nil, err
+		}
+		ep.containers = append(ep.containers, containerID)
+	}
+	containerIface := &current.Interface{
+		Name:    strings.Join([]string{ep.hnsEP.Name, containerIFDev}, "_"),
+		Mac:     ep.hnsEP.MacAddress,
+		Sandbox: sandbox,
+	}
+	return containerIface, nil
+}
+
+// advertiseContainerAddr returns immediately as the address is advertised automatically after it is configured on an
+// network interface on Windows.
+func (ic *ifConfigurator) advertiseContainerAddr(containerNetNS string, containerIfaceName string, result *current.Result) error {
+	klog.V(2).Info("Send gratuitous ARP from container interface is not supported on Windows, return nil")
+	return nil
+}
+
+// removeContainerLink removes the HNSEndpoint attached on the Pod.
+func (ic *ifConfigurator) removeContainerLink(containerID, epName string) error {
+	ep, found := ic.getEndpoint(epName)
+	if !found {
+		return nil
+	}
+	return ic.removeHNSEndpoint(ep, containerID)
+}
+
+// removeHNSEndpoint removes the HNSEndpoint from HNS and local cache.
+func (ic *ifConfigurator) removeHNSEndpoint(endpoint *endpoint, containerID string) error {
+	epName := endpoint.hnsEP.Name
+	// Remove HNSEndpoint.
+	_, err := endpoint.hnsEP.Delete()
+	if err != nil {
+		if !strings.Contains(err.Error(), notFoundHNSEndpoint) {
+			klog.Errorf("Failed to delete container interface %s: %v", containerID, err)
+			return err
+		}
+	}
+	// Delete HNSEndpoint from local cache.
+	ic.delEndpoint(epName)
+	return nil
+}
+
+func parseContainerIfaceFromResults(cfgArgs *cnipb.CniCmdArgs, prevResult *current.Result) *current.Interface {
+	for _, intf := range prevResult.Interfaces {
+		if strings.HasSuffix(intf.Name, cfgArgs.Ifname) {
+			return intf
+		}
+	}
+	return nil
+}
+
+// checkContainerInterface finds the virtual interface of the container, and compares the network configurations with
+// the previous result.
+func (ic *ifConfigurator) checkContainerInterface(
+	sandboxID, containerID string,
+	containerIface *current.Interface,
+	containerIPs []*current.IPConfig,
+	containerRoutes []*cnitypes.Route) (*vethPair, error) {
+
+	// Check container sandbox configuration.
+	if sandboxID != containerIface.Sandbox {
+		return nil, fmt.Errorf("sandbox in prevResult %s doesn't match configured netns: %s",
+			containerIface.Sandbox, sandboxID)
+	}
+	hnsEP := strings.Split(containerIface.Name, "_")[0]
+	containerIfaceName := fmt.Sprintf("%s (%s)", util.ContainerVNICPrefix, hnsEP)
+	intf, err := net.InterfaceByName(containerIfaceName)
+	if err != nil {
+		klog.Errorf("Failed to get container %s interface: %v", containerID, err)
+		return nil, err
+	}
+	// Check container MAC configuration.
+	if intf.HardwareAddr.String() != containerIface.Mac {
+		klog.Errorf("Container MAC in prevResult %s doesn't match configured address: %s", containerIface.Mac, intf.HardwareAddr.String())
+		return nil, fmt.Errorf("container MAC in prevResult %s doesn't match configured address: %s", containerIface.Mac, intf.HardwareAddr.String())
+	}
+
+	// Parse container IP configuration from previous result.
+	var containerIPConfig *current.IPConfig
+	for _, ipConfig := range containerIPs {
+		if ipConfig.Interface != nil {
+			containerIPConfig = ipConfig
+		}
+	}
+	if containerIPConfig == nil {
+		return nil, fmt.Errorf("not find container IP configuration from result")
+	}
+	// Check container IP configuration.
+	if err := validateExpectedInterfaceIPs(containerIPConfig, intf); err != nil {
+		return nil, err
+	}
+
+	// Todo: add check for container route configuration.
+	contVeth := &vethPair{
+		name:    hnsEP,
+		ifIndex: intf.Index,
+	}
+	return contVeth, nil
+}
+
+// validateExpectedInterfaceIPs checks if the vNIC for the container has configured with correct IP address.
+func validateExpectedInterfaceIPs(containerIPConfig *current.IPConfig, intf *net.Interface) error {
+	addrs, err := intf.Addrs()
+	if err != nil {
+		return err
+	}
+
+	for _, addr := range addrs {
+		if strings.Contains(addr.String(), containerIPConfig.Address.String()) {
+			return nil
+		}
+	}
+	return fmt.Errorf("container IP %s not exist on target interface %d", containerIPConfig.Address.String(), intf.Index)
+}
+
+// validateContainerPeerInterface checks HNSEndpoint configuration.
+func (ic *ifConfigurator) validateContainerPeerInterface(interfaces []*current.Interface, containerVeth *vethPair) (*vethPair, error) {
+	// Iterate all the passed interfaces and look up the host interface by
+	// matching the veth peer interface index.
+	for _, hostIntf := range interfaces {
+		if hostIntf.Sandbox != "" {
+			// Not in the default Namespace. Must be the container interface.
+			continue
+		}
+
+		expectedContainerIfname := containerVeth.name
+		if hostIntf.Name != expectedContainerIfname {
+			klog.Errorf("Host interface name %s doesn't match configured name %s", hostIntf.Name, expectedContainerIfname)
+			return nil, fmt.Errorf("Host interface name %s doesn't match configured name %s", hostIntf.Name, expectedContainerIfname)
+		}
+
+		ep, err := hcsshim.GetHNSEndpointByName(hostIntf.Name)
+		if err != nil {
+			klog.Errorf("Failed to get HNSEndpoint %s: %v", hostIntf.Name, err)
+			return nil, err
+		}
+		if hostIntf.Mac != ep.MacAddress {
+			klog.Errorf("Host interface %s MAC %s doesn't match link address %s",
+				hostIntf.Name, hostIntf.Mac, ep.MacAddress)
+			return nil, fmt.Errorf("host interface %s MAC %s doesn't match",
+				hostIntf.Name, hostIntf.Mac)
+		}
+		return &vethPair{
+			name:      ep.Name,
+			peerIndex: containerVeth.ifIndex,
+		}, nil
+
+	}
+
+	return nil, fmt.Errorf("peer veth interface not found for container interface %s",
+		containerVeth.name)
+}
+
+// getOVSInterfaceType returns "internal". Windows uses internal OVS interface for container vNIC.
+func (ic *ifConfigurator) getOVSInterfaceType() int {
+	return internalOVSInterfaceType
+}

--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -17,23 +17,17 @@ package cniserver
 import (
 	"encoding/json"
 	"fmt"
+	"net"
+
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
-	"github.com/containernetworking/plugins/pkg/ip"
-	"github.com/containernetworking/plugins/pkg/ipam"
-	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/j-keck/arping"
-	"github.com/vishvananda/netlink"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
-	"net"
-	"time"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"
-	"github.com/vmware-tanzu/antrea/pkg/agent/util/ethtool"
 	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 )
 
@@ -58,12 +52,26 @@ const (
 	ovsExternalIDPodNamespace = "pod-namespace"
 )
 
+const (
+	defaultOVSInterfaceType int = iota
+	internalOVSInterfaceType
+)
+
+type interfaceConfigurator interface {
+	configureContainerLink(podName, podNameSpace, containerID, containerNetNS, containerIFDev string, mtu int, result *current.Result) error
+	advertiseContainerAddr(containerNetNS string, containerIfaceName string, result *current.Result) error
+	removeContainerLink(containerID, hostInterfaceName string) error
+	checkContainerInterface(containerNetns, containerID string, containerIface *current.Interface, containerIPs []*current.IPConfig, containerRoutes []*cnitypes.Route) (*vethPair, error)
+	validateContainerPeerInterface(interfaces []*current.Interface, containerVeth *vethPair) (*vethPair, error)
+	getOVSInterfaceType() int
+}
+
 type podConfigurator struct {
 	ovsBridgeClient ovsconfig.OVSBridgeClient
 	ofClient        openflow.Client
 	ifaceStore      interfacestore.InterfaceStore
 	gatewayMAC      net.HardwareAddr
-	ovsDatapathType string
+	ifConfigurator  interfaceConfigurator
 }
 
 func newPodConfigurator(
@@ -72,191 +80,33 @@ func newPodConfigurator(
 	ifaceStore interfacestore.InterfaceStore,
 	gatewayMAC net.HardwareAddr,
 	ovsDatapathType string,
-) *podConfigurator {
-	return &podConfigurator{ovsBridgeClient, ofClient, ifaceStore, gatewayMAC, ovsDatapathType}
-}
-
-// setupInterfaces creates a veth pair: containerIface is in the container
-// network namespace and hostIface is in the host network namespace.
-func (pc *podConfigurator) setupInterfaces(
-	podName, podNamespace, ifname string,
-	netns ns.NetNS,
-	mtu int) (hostIface *current.Interface, containerIface *current.Interface, err error) {
-	hostVethName := util.GenerateContainerInterfaceName(podName, podNamespace)
-	hostIface = &current.Interface{}
-	containerIface = &current.Interface{}
-
-	if err := netns.Do(func(hostNS ns.NetNS) error {
-		hostVeth, containerVeth, err := ip.SetupVethWithName(ifname, hostVethName, mtu, hostNS)
-		if err != nil {
-			return err
-		}
-		klog.V(2).Infof("Setup interfaces host: %s, container %s", hostVeth.Name, containerVeth.Name)
-		containerIface.Name = containerVeth.Name
-		containerIface.Mac = containerVeth.HardwareAddr.String()
-		containerIface.Sandbox = netns.Path()
-		hostIface.Name = hostVeth.Name
-		hostIface.Mac = hostVeth.HardwareAddr.String()
-		// OVS netdev datapath doesn't support TX checksum offloading, i.e. if packet
-		// arrives with bad/no checksum it will be sent to the output port with same bad/no checksum.
-		if pc.ovsDatapathType == ovsconfig.OVSDatapathNetdev {
-			if err := ethtool.EthtoolTXHWCsumOff(containerVeth.Name); err != nil {
-				return fmt.Errorf("error when disabling TX checksum offload on container veth: %v", err)
-			}
-		}
-		return nil
-	}); err != nil {
-		return nil, nil, err
-	}
-
-	return hostIface, containerIface, nil
-}
-
-// configureContainerAddr takes the result of the IPAM plugin, and adds the appropriate IP
-// addresses and routes to the interface. It then sends a gratuitous ARP to the network.
-func configureContainerAddr(netns ns.NetNS, containerInterface *current.Interface, result *current.Result) error {
-	var containerVeth *net.Interface
-	if err := netns.Do(func(containerNs ns.NetNS) error {
-		var err error
-		containerVeth, err = net.InterfaceByName(containerInterface.Name)
-		if err != nil {
-			klog.Errorf("Failed to find container interface %s in ns %s", containerInterface.Name, netns.Path())
-			return err
-		}
-		if err := ipam.ConfigureIface(containerInterface.Name, result); err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	if containerVeth != nil {
-		// Send 3 GARP packets in another goroutine with 50ms interval. It's because Openflow entries are installed async,
-		// and the gratuitous ARP could be sent out after the Openflow entries are installed. Using another goroutine
-		// ensures the processing of CNI ADD request is not blocked.
-		go func() {
-			netns.Do(func(containerNs ns.NetNS) error {
-				count := 0
-				for count < 3 {
-					select {
-					case <-time.Tick(50 * time.Millisecond):
-						// Send gratuitous ARP to network in case of stale mappings for this IP address
-						// (e.g. if a previous - deleted - Pod was using the same IP).
-						for _, ipc := range result.IPs {
-							if ipc.Version == "4" {
-								arping.GratuitousArpOverIface(ipc.Address.IP, *containerVeth)
-							}
-						}
-					}
-					count++
-				}
-				return nil
-			})
-		}()
-	}
-	return nil
-}
-
-func validateInterface(intf *current.Interface, inNetns bool) (netlink.Link, error) {
-	if intf.Name == "" {
-		return nil, fmt.Errorf("interface name is missing")
-	}
-	if inNetns {
-		if intf.Sandbox == "" {
-			return nil, fmt.Errorf("interface %s is expected in netns", intf.Name)
-		}
-	} else {
-		if intf.Sandbox != "" {
-			return nil, fmt.Errorf("interface %s is expected not in netns", intf.Name)
-		}
-	}
-
-	link, err := netlink.LinkByName(intf.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find link for interface %s", intf.Name)
-	}
-
-	_, isVeth := link.(*netlink.Veth)
-	if !isVeth {
-		return nil, fmt.Errorf("interface %s is not of type veth", intf.Name)
-	}
-	return link, nil
-}
-
-func validateContainerInterface(intf *current.Interface) (*vethPair, error) {
-	link, err := validateInterface(intf, true)
+) (*podConfigurator, error) {
+	ifConfigurator, err := newInterfaceConfigurator(ovsDatapathType)
 	if err != nil {
 		return nil, err
 	}
-
-	linkName := link.Attrs().Name
-	veth := &vethPair{}
-	_, veth.peerIndex, err = ip.GetVethPeerIfindex(linkName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get veth peer index for veth %s: %v", linkName, err)
-	}
-	veth.ifIndex = link.Attrs().Index
-	if intf.Mac != link.Attrs().HardwareAddr.String() {
-		return nil, fmt.Errorf("interface %s MAC %s doesn't match container MAC: %s",
-			intf.Name, intf.Mac, link.Attrs().HardwareAddr.String())
-	}
-	veth.name = linkName
-	return veth, nil
+	return &podConfigurator{
+		ovsBridgeClient: ovsBridgeClient,
+		ofClient:        ofClient,
+		ifaceStore:      ifaceStore,
+		gatewayMAC:      gatewayMAC,
+		ifConfigurator:  ifConfigurator,
+	}, nil
 }
 
-func validateContainerPeerInterface(interfaces []*current.Interface, containerVeth *vethPair) (*vethPair, error) {
-	// Interate all the passed interfaces and look up the host interface by
-	// matching the veth peer interface index.
-	for _, hostIntf := range interfaces {
-		if hostIntf.Sandbox != "" {
-			// Not in the default Namespace. Must be the container interface.
-			continue
+func findContainerIPConfig(ips []*current.IPConfig) (*current.IPConfig, error) {
+	for _, ipc := range ips {
+		if ipc.Version == "4" {
+			return ipc, nil
 		}
-		link, err := validateInterface(hostIntf, false)
-		if err != nil {
-			klog.Errorf("Failed to validate interface %s: %v",
-				hostIntf.Name, err)
-			continue
-		}
-
-		if link.Attrs().Index != containerVeth.peerIndex {
-			continue
-		}
-
-		hostVeth := &vethPair{ifIndex: link.Attrs().Index, name: link.Attrs().Name}
-		_, hostVeth.peerIndex, err = ip.GetVethPeerIfindex(hostVeth.name)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get veth peer index for host interface %s: %v",
-				hostIntf.Name, err)
-		}
-
-		if hostVeth.peerIndex != containerVeth.ifIndex {
-			return nil, fmt.Errorf("host interface %s peer index doesn't match container interface %s index",
-				hostIntf.Name, containerVeth.name)
-		}
-
-		if hostIntf.Mac != "" {
-			if hostIntf.Mac != link.Attrs().HardwareAddr.String() {
-				klog.Errorf("Host interface %s MAC %s doesn't match link address %s",
-					hostIntf.Name, hostIntf.Mac, link.Attrs().HardwareAddr.String())
-				return nil, fmt.Errorf("host interface %s MAC %s doesn't match",
-					hostIntf.Name, hostIntf.Mac)
-			}
-		}
-		return hostVeth, nil
-
 	}
-
-	return nil, fmt.Errorf("peer veth interface not found for container interface %s",
-		containerVeth.name)
+	return nil, fmt.Errorf("failed to find a valid IP address")
 }
 
 func parseContainerIP(ips []*current.IPConfig) (net.IP, error) {
-	for _, ipc := range ips {
-		if ipc.Version == "4" {
-			return ipc.Address.IP, nil
-		}
+	ipc, err := findContainerIPConfig(ips)
+	if err == nil {
+		return ipc.Address.IP, nil
 	}
 	return nil, fmt.Errorf("failed to find a valid IP address")
 }
@@ -336,25 +186,32 @@ func (pc *podConfigurator) configureInterfaces(
 	mtu int,
 	result *current.Result,
 ) error {
-	netns, err := ns.GetNS(containerNetNS)
+	err := pc.ifConfigurator.configureContainerLink(podName, podNameSpace, containerID, containerNetNS, containerIFDev, mtu, result)
 	if err != nil {
-		return fmt.Errorf("failed to open netns %s: %v", containerNetNS, err)
+		return err
 	}
-	defer netns.Close()
-	// Create veth pair and link up
-	hostIface, containerIface, err := pc.setupInterfaces(podName, podNameSpace, containerIFDev, netns, mtu)
-	if err != nil {
-		return fmt.Errorf("failed to create veth devices for container %s: %v", containerID, err)
-	}
+	hostIface := result.Interfaces[0]
+	containerIface := result.Interfaces[1]
+
 	// Delete veth pair if any failure occurs in later manipulation.
 	success := false
 	defer func() {
 		if !success {
-			ip.DelLinkByName(hostIface.Name)
+			pc.ifConfigurator.removeContainerLink(containerID, hostIface.Name)
 		}
 	}()
 
-	result.Interfaces = []*current.Interface{hostIface, containerIface}
+	// Check if the OVS configurations for the container exists or not. If yes, return immediately. This check is
+	// used on Windows, for Kubelet on Windows will call CNI Add for both the infrastructure container and the workload
+	// container. But there should be only one OVS port created for the same Pod. And if the OVS port is added more than
+	// once, OVS will return an error.
+	_, found := pc.ifaceStore.GetContainerInterface(podName, podNameSpace)
+	if found {
+		klog.V(2).Infof("Found an existed OVS port with podName %s podNamespace %s, returning", podName, podNameSpace)
+		// Mark the operation as successful, otherwise the container link might be removed by mistake.
+		success = true
+		return nil
+	}
 
 	// Use the outer veth interface name as the OVS port name.
 	ovsPortName := hostIface.Name
@@ -362,7 +219,8 @@ func (pc *podConfigurator) configureInterfaces(
 
 	// create OVS Port and add attach container configuration into external_ids
 	klog.V(2).Infof("Adding OVS port %s for container %s", ovsPortName, containerID)
-	portUUID, err := pc.setupContainerOVSPort(containerConfig, ovsPortName)
+	ovsAttachInfo := BuildOVSPortExternalIDs(containerConfig)
+	portUUID, err := pc.createOVSPort(ovsPortName, ovsAttachInfo)
 	if err != nil {
 		return fmt.Errorf("failed to add OVS port for container %s: %v", containerID, err)
 	}
@@ -390,28 +248,31 @@ func (pc *podConfigurator) configureInterfaces(
 		}
 	}()
 
-	// Note that configuring IP will send gratuitous ARP, it must be executed
-	// after Pod Openflow entries are installed, otherwise gratuitous ARP would
-	// be dropped.
-	klog.V(2).Infof("Configuring IP address for container %s", containerID)
-	if err = configureContainerAddr(netns, containerIface, result); err != nil {
-		return fmt.Errorf("failed to configure IP address for container %s: %v", containerID, err)
-	}
-
 	containerConfig.OVSPortConfig = &interfacestore.OVSPortConfig{PortUUID: portUUID, OFPort: ofPort}
 	// Add containerConfig into local cache
 	pc.ifaceStore.AddInterface(containerConfig)
+
+	// Note that the IP address should be advertised after Pod OpenFlow entries are installed, otherwise the packet might
+	// be dropped by OVS.
+	if err = pc.ifConfigurator.advertiseContainerAddr(containerNetNS, containerIface.Name, result); err != nil {
+		klog.Errorf("Failed to advertise IP address for container %s: %v", containerID, err)
+	}
 	// Mark the manipulation as success to cancel deferred operations.
 	success = true
 	klog.Infof("Configured interfaces for container %s", containerID)
 	return nil
 }
 
-func (pc *podConfigurator) setupContainerOVSPort(
-	containerConfig *interfacestore.InterfaceConfig,
-	ovsPortName string) (string, error) {
-	ovsAttchInfo := BuildOVSPortExternalIDs(containerConfig)
-	if portUUID, err := pc.ovsBridgeClient.CreatePort(ovsPortName, ovsPortName, ovsAttchInfo); err != nil {
+func (pc *podConfigurator) createOVSPort(ovsPortName string, ovsAttachInfo map[string]interface{}) (string, error) {
+	var portUUID string
+	var err error
+	switch pc.ifConfigurator.getOVSInterfaceType() {
+	case internalOVSInterfaceType:
+		portUUID, err = pc.ovsBridgeClient.CreateInternalPort(ovsPortName, 0, ovsAttachInfo)
+	default:
+		portUUID, err = pc.ovsBridgeClient.CreatePort(ovsPortName, ovsPortName, ovsAttachInfo)
+	}
+	if err != nil {
 		klog.Errorf("Failed to add OVS port %s, remove from local cache: %v", ovsPortName, err)
 		return "", err
 	} else {
@@ -441,13 +302,8 @@ func (pc *podConfigurator) removeInterfaces(podName, podNamespace, containerID s
 	// classifier flow in table 0 which has only in_port as the match condition, then
 	// step 4 can remove flows owned by Pod B by mistake.
 	// Note that deleting the interface attached to an OVS port can release the ofport.
-	klog.V(2).Infof("Deleting veth devices for container %s", containerID)
-	// Don't return an error if the device is already removed as CniDel can be called multiple times.
-	if err := ip.DelLinkByName(containerConfig.InterfaceName); err != nil {
-		if err != ip.ErrLinkNotFound {
-			return fmt.Errorf("failed to delete veth devices for container %s: %v", containerID, err)
-		}
-		klog.V(2).Infof("Did not find interface %s for container %s", containerConfig.InterfaceName, containerID)
+	if err := pc.ifConfigurator.removeContainerLink(containerID, containerConfig.InterfaceName); err != nil {
+		return err
 	}
 
 	klog.V(2).Infof("Deleting OVS port %s for container %s", containerConfig.PortUUID, containerID)
@@ -465,17 +321,9 @@ func (pc *podConfigurator) checkInterfaces(
 	containerID, containerNetNS, podName, podNamespace string,
 	containerIface *current.Interface,
 	prevResult *current.Result) error {
-	netns, err := ns.GetNS(containerNetNS)
-	if err != nil {
-		klog.Errorf("Failed to check netns config %s: %v", containerNetNS, err)
-		return err
-	}
-	defer netns.Close()
-
-	if containerVeth, err := pc.checkContainerInterface(
+	if containerVeth, err := pc.ifConfigurator.checkContainerInterface(
 		containerNetNS,
 		containerID,
-		netns,
 		containerIface,
 		prevResult.IPs,
 		prevResult.Routes); err != nil {
@@ -493,52 +341,13 @@ func (pc *podConfigurator) checkInterfaces(
 	return nil
 }
 
-func (pc *podConfigurator) checkContainerInterface(
-	containerNetns, containerID string,
-	netns ns.NetNS,
-	containerIface *current.Interface,
-	containerIPs []*current.IPConfig,
-	containerRoutes []*cnitypes.Route) (*vethPair, error) {
-	var contVeth *vethPair
-	// Check netns configuration
-	if containerNetns != containerIface.Sandbox {
-		klog.Errorf("Sandbox in prevResult %s doesn't match configured netns: %s",
-			containerIface.Sandbox, containerNetns)
-		return nil, fmt.Errorf("sandbox in prevResult %s doesn't match configured netns: %s",
-			containerIface.Sandbox, containerNetns)
-	}
-	// Check container interface configuration
-	if err := netns.Do(func(netNS ns.NetNS) error {
-		var errlink error
-		// Check container link config
-		contVeth, errlink = validateContainerInterface(containerIface)
-		if errlink != nil {
-			return errlink
-		}
-		// Check container IP config
-		if err := ip.ValidateExpectedInterfaceIPs(containerIface.Name, containerIPs); err != nil {
-			return err
-		}
-		// Check container route config
-		if err := ip.ValidateExpectedRoute(containerRoutes); err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
-		klog.Errorf("Failed to check container %s interface configurations in netns %s: %v",
-			containerID, containerNetns, err)
-		return nil, err
-	}
-	return contVeth, nil
-}
-
 func (pc *podConfigurator) checkHostInterface(
 	containerID, podName, podNamespace string,
 	containerIntf *current.Interface,
 	containerVeth *vethPair,
 	containerIPs []*current.IPConfig,
 	interfaces []*current.Interface) error {
-	hostVeth, errlink := validateContainerPeerInterface(interfaces, containerVeth)
+	hostVeth, errlink := pc.ifConfigurator.validateContainerPeerInterface(interfaces, containerVeth)
 	if errlink != nil {
 		klog.Errorf("Failed to check container %s interface on the host: %v",
 			containerID, errlink)

--- a/pkg/agent/cniserver/server_test.go
+++ b/pkg/agent/cniserver/server_test.go
@@ -119,6 +119,8 @@ func TestIPAMService(t *testing.T) {
 	ipamMock := ipamtest.NewMockIPAMDriver(controller)
 	_ = ipam.RegisterIPAMDriver(testIpamType, ipamMock)
 	cniServer := newCNIServer(t)
+	ifaceStore := interfacestore.NewInterfaceStore()
+	cniServer.podConfigurator = &podConfigurator{ifaceStore: ifaceStore}
 
 	require.True(t, ipam.IsIPAMTypeValid(testIpamType), "Failed to register IPAM service")
 	require.False(t, ipam.IsIPAMTypeValid("not_a_valid_IPAM_driver"))
@@ -130,18 +132,28 @@ func TestIPAMService(t *testing.T) {
 
 	t.Run("Error on ADD", func(t *testing.T) {
 		ipamMock.EXPECT().Add(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("IPAM add error"))
-		// A rollback will be tried if add failed.
-		ipamMock.EXPECT().Del(gomock.Any(), gomock.Any()).Return(fmt.Errorf("IPAM del error")).Times(1)
 		response, err := cniServer.CmdAdd(cxt, &requestMsg)
 		require.Nil(t, err, "expected no rpc error")
 		checkErrorResponse(t, response, cnipb.ErrorCode_IPAM_FAILURE, "IPAM add error")
 	})
 
 	t.Run("Error on DEL", func(t *testing.T) {
+		// Prepare cached IPAM result which will be deleted later.
+		ipamMock.EXPECT().Add(gomock.Any(), gomock.Any()).Times(1)
+		cniConfig, _ := cniServer.checkRequestMessage(&requestMsg)
+		podKey := util.GenerateContainerInterfaceName(string(cniConfig.K8S_POD_NAME), string(cniConfig.K8S_POD_NAMESPACE))
+		_, err := ipam.ExecIPAMAdd(cniConfig.CniCmdArgs, cniConfig.IPAM.Type, podKey)
+
 		ipamMock.EXPECT().Del(gomock.Any(), gomock.Any()).Return(fmt.Errorf("IPAM delete error"))
 		response, err := cniServer.CmdDel(cxt, &requestMsg)
 		require.Nil(t, err, "expected no rpc error")
 		checkErrorResponse(t, response, cnipb.ErrorCode_IPAM_FAILURE, "IPAM delete error")
+
+		// Cached result would be removed after a successful retry of IPAM DEL.
+		ipamMock.EXPECT().Del(gomock.Any(), gomock.Any()).Return(nil)
+		err = ipam.ExecIPAMDelete(cniConfig.CniCmdArgs, cniConfig.IPAM.Type, podKey)
+		require.Nil(t, err, "expected no Del error")
+
 	})
 
 	t.Run("Error on CHECK", func(t *testing.T) {
@@ -149,6 +161,45 @@ func TestIPAMService(t *testing.T) {
 		response, err := cniServer.CmdCheck(cxt, &requestMsg)
 		require.Nil(t, err, "expected no rpc error")
 		checkErrorResponse(t, response, cnipb.ErrorCode_IPAM_FAILURE, "IPAM check error")
+	})
+
+	t.Run("Idempotent Call of IPAM ADD/DEL for the same Pod", func(t *testing.T) {
+		ipamMock.EXPECT().Add(gomock.Any(), gomock.Any()).Times(1)
+		ipamMock.EXPECT().Del(gomock.Any(), gomock.Any()).Times(1)
+		cniConfig, response := cniServer.checkRequestMessage(&requestMsg)
+		require.Nil(t, response, "expected no rpc error")
+		podKey := util.GenerateContainerInterfaceName(string(cniConfig.K8S_POD_NAME), string(cniConfig.K8S_POD_NAMESPACE))
+		ipamResult, err := ipam.ExecIPAMAdd(cniConfig.CniCmdArgs, cniConfig.IPAM.Type, podKey)
+		require.Nil(t, err, "expected no IPAM add error")
+		ipamResult2, err := ipam.ExecIPAMAdd(cniConfig.CniCmdArgs, cniConfig.IPAM.Type, podKey)
+		require.Nil(t, err, "expected no IPAM add error")
+		assert.Equal(t, ipamResult, ipamResult2)
+		err = ipam.ExecIPAMDelete(cniConfig.CniCmdArgs, cniConfig.IPAM.Type, podKey)
+		require.Nil(t, err, "expected no IPAM del error")
+		err = ipam.ExecIPAMDelete(cniConfig.CniCmdArgs, cniConfig.IPAM.Type, podKey)
+		require.Nil(t, err, "expected no IPAM del error")
+	})
+
+	t.Run("Idempotent Call of IPAM ADD/DEL for the same Pod with different containers", func(t *testing.T) {
+		ipamMock.EXPECT().Add(gomock.Any(), gomock.Any()).Times(1)
+		ipamMock.EXPECT().Del(gomock.Any(), gomock.Any()).Times(1)
+		cniConfig, response := cniServer.checkRequestMessage(&requestMsg)
+		require.Nil(t, response, "expected no rpc error")
+		podKey := util.GenerateContainerInterfaceName(string(cniConfig.K8S_POD_NAME), string(cniConfig.K8S_POD_NAMESPACE))
+		ipamResult, err := ipam.ExecIPAMAdd(cniConfig.CniCmdArgs, cniConfig.IPAM.Type, podKey)
+		require.Nil(t, err, "expected no IPAM add error")
+		workerContainerID := "test-infra-2222222"
+		args2 := cniservertest.GenerateCNIArgs(testPodName, testPodNamespace, workerContainerID)
+		requestMsg2, _ := newRequest(args2, networkCfg, "", t)
+		cniConfig2, response := cniServer.checkRequestMessage(&requestMsg2)
+		require.Nil(t, response, "expected no rpc error")
+		ipamResult2, err := ipam.ExecIPAMAdd(cniConfig2.CniCmdArgs, cniConfig.IPAM.Type, podKey)
+		require.Nil(t, err, "expected no IPAM add error")
+		assert.Equal(t, ipamResult, ipamResult2)
+		err = ipam.ExecIPAMDelete(cniConfig.CniCmdArgs, cniConfig.IPAM.Type, podKey)
+		require.Nil(t, err, "expected no IPAM del error")
+		err = ipam.ExecIPAMDelete(cniConfig2.CniCmdArgs, cniConfig.IPAM.Type, podKey)
+		require.Nil(t, err, "expected no IPAM del error")
 	})
 }
 
@@ -212,6 +263,7 @@ func TestValidatePrevResult(t *testing.T) {
 		cniConfig.Ifname = ifname
 		cniConfig.Netns = "invalid_netns"
 		prevResult.Interfaces = []*current.Interface{hostIface, containerIface}
+		cniServer.podConfigurator, _ = newPodConfigurator(nil, nil, nil, nil, "")
 		response, _ := cniServer.validatePrevResult(cniConfig.CniCmdArgs, k8sPodArgs, prevResult)
 		checkErrorResponse(t, response, cnipb.ErrorCode_CHECK_INTERFACE_FAILURE, "")
 	})
@@ -328,11 +380,10 @@ func TestRemoveInterface(t *testing.T) {
 	mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
 	mockOFClient := openflowtest.NewMockClient(controller)
 	ifaceStore := interfacestore.NewInterfaceStore()
-	podConfigurator := &podConfigurator{
-		ovsBridgeClient: mockOVSBridgeClient,
-		ofClient:        mockOFClient,
-		ifaceStore:      ifaceStore,
-	}
+	gwMAC, _ := net.ParseMAC("00:00:11:11:11:11")
+	podConfigurator, err := newPodConfigurator(mockOVSBridgeClient, mockOFClient, ifaceStore, gwMAC, "system")
+	require.Nil(t, err, "No error expected in podConfigurator constructor")
+
 	containerMAC, _ := net.ParseMAC("aa:bb:cc:dd:ee:ff")
 	containerIP := net.ParseIP("1.1.1.1")
 

--- a/pkg/agent/util/net_windows.go
+++ b/pkg/agent/util/net_windows.go
@@ -1,0 +1,20 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+const (
+	LocalHNSNetwork     = "antrea-hnsnetwork"
+	ContainerVNICPrefix = "vEthernet"
+)

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 // Copyright 2019 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -477,13 +479,10 @@ func newTester() *cmdAddDelTester {
 	tester.server = cniserver.New(testSock,
 		"",
 		1450,
-		"",
 		testNodeConfig,
-		ovsServiceMock,
-		ofServiceMock,
-		ifaceStore,
 		k8sFake.NewSimpleClientset(),
 		make(chan v1beta1.PodReference, 100))
+	tester.server.Initialize(ovsServiceMock, ofServiceMock, ifaceStore, "")
 	ctx, _ := context.WithCancel(context.Background())
 	tester.ctx = ctx
 	return tester

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build linux
+
 package agent
 
 import (


### PR DESCRIPTION
1. Use linux and windows as suffix for OS specific functions under pkg/agent/cniserver.
2. Use OVS internal port for Pod vNIC on Windows, while using OVS port on Linux.
3. HNSEndpoint is created and attached on a Windows container to work as the vNIC.
4. kubelet calls CNI Add for both the sandbox and workload container. Only one
    HNSEndpoint is created for the containers in the same Pod, and attached on all
    the containers in the same Pod.
5. GARP is not needed to be sent explicitly on Windows, which could be send out by
    the system automatically after an IP address is added on the network Interface.