### PR TITLE
Fix agent caching duplicate pod member

### DIFF
--- a/pkg/apis/networking/v1beta1/sets.go
+++ b/pkg/apis/networking/v1beta1/sets.go
@@ -114,3 +114,12 @@ func (s GroupMemberPodSet) IsSuperset(o GroupMemberPodSet) bool {
 func (s GroupMemberPodSet) Equal(o GroupMemberPodSet) bool {
 	return len(s) == len(o) && s.IsSuperset(o)
 }
+
+// Items returns the slice with contents in random order.
+func (s GroupMemberPodSet) Items() []*GroupMemberPod {
+	res := make([]*GroupMemberPod, 0, len(s))
+	for _, item := range s {
+		res = append(res, item)
+	}
+	return res
+}


### PR DESCRIPTION
When iterating a slice and storing its items' address, must not use the
address of the loop iterator variable as it's the same address taking
different values in each loop iteration, otherwise the stored items
would eventually contain only the last item.
See https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable

This patch fixes it and hardens the unit test to validate the value of
stored items, instead of their keys.

Fixes #381