### PR TITLE
Remove unnecessary periodical resync

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -39,9 +39,10 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/version"
 )
 
-// Determine how often we go through reconciliation (between current and desired state)
-// Same as in https://github.com/kubernetes/sample-controller/blob/master/main.go
-const informerDefaultResync time.Duration = 30 * time.Second
+// informerDefaultResync is the default resync period if a handler doesn't specify one.
+// Use the same default value as kube-controller-manager:
+// https://github.com/kubernetes/kubernetes/blob/release-1.17/pkg/controller/apis/config/v1alpha1/defaults.go#L120
+const informerDefaultResync = 12 * time.Hour
 
 // run starts Antrea agent with the given options and waits for termination signal.
 func run(o *Options) error {

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -35,9 +35,10 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/version"
 )
 
-// Determine how often we go through reconciliation (between current and desired state)
-// Same as in https://github.com/kubernetes/sample-controller/blob/master/main.go
-const informerDefaultResync time.Duration = 30 * time.Second
+// informerDefaultResync is the default resync period if a handler doesn't specify one.
+// Use the same default value as kube-controller-manager:
+// https://github.com/kubernetes/kubernetes/blob/release-1.17/pkg/controller/apis/config/v1alpha1/defaults.go#L120
+const informerDefaultResync = 12 * time.Hour
 
 // run starts Antrea Controller with the given options and waits for termination signal.
 func run(o *Options) error {

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -45,8 +45,8 @@ import (
 
 const (
 	controllerName = "AntreaAgentNodeRouteController"
-	// Interval of synchronizing node status from apiserver
-	nodeSyncPeriod = 60 * time.Second
+	// Interval of reprocessing every node.
+	nodeResyncPeriod = 60 * time.Second
 	// How long to wait before retrying the processing of a node change
 	minRetryDelay = 5 * time.Second
 	maxRetryDelay = 300 * time.Second
@@ -131,7 +131,7 @@ func NewNodeRouteController(
 				controller.enqueueNode(old)
 			},
 		},
-		nodeSyncPeriod,
+		nodeResyncPeriod,
 	)
 	return controller
 }

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -51,8 +51,10 @@ import (
 )
 
 const (
-	// Interval of synchronizing status from apiserver.
-	syncPeriod = 60 * time.Second
+	// NetworkPolicyController is the only writer of the antrea network policy
+	// storages and will keep re-enqueuing failed items until they succeed.
+	// Set resyncPeriod to 0 to disable resyncing.
+	resyncPeriod time.Duration = 0
 	// How long to wait before retrying the processing of a NetworkPolicy change.
 	minRetryDelay = 5 * time.Second
 	maxRetryDelay = 300 * time.Second
@@ -174,7 +176,7 @@ func NewNetworkPolicyController(kubeClient clientset.Interface,
 			UpdateFunc: n.updatePod,
 			DeleteFunc: n.deletePod,
 		},
-		syncPeriod,
+		resyncPeriod,
 	)
 	// Add handlers for Namespace events.
 	namespaceInformer.Informer().AddEventHandlerWithResyncPeriod(
@@ -183,7 +185,7 @@ func NewNetworkPolicyController(kubeClient clientset.Interface,
 			UpdateFunc: n.updateNamespace,
 			DeleteFunc: n.deleteNamespace,
 		},
-		syncPeriod,
+		resyncPeriod,
 	)
 	// Add handlers for NetworkPolicy events.
 	networkPolicyInformer.Informer().AddEventHandlerWithResyncPeriod(
@@ -192,7 +194,7 @@ func NewNetworkPolicyController(kubeClient clientset.Interface,
 			UpdateFunc: n.updateNetworkPolicy,
 			DeleteFunc: n.deleteNetworkPolicy,
 		},
-		syncPeriod,
+		resyncPeriod,
 	)
 	return n
 }


### PR DESCRIPTION
NetworkPolicyController (of antrea-controller) is the only writer of the
antrea network policy storages and it will keep re-enqueuing failed
items until they succeed, so there's no need to have the informers
trigger all items resync, which could introduce considerable workload in
scale cluster. This patch removes it and updates the default
resyncPeriod of informer factory to 12 hours.

NodeRouterController doesn't have heavy workload and its periodical
resync could potentially fix the routes which might be broken by
external so keep it as is.

Fixes #278