### PR TITLE
[Windows] Enable Windows Pod to access external addresses

### DIFF
--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -36,7 +36,7 @@ type AgentConfig struct {
 	// 'system' is the default value and corresponds to the kernel datapath. Use 'netdev' to run
 	// OVS in userspace mode. Userspace mode requires the tun device driver to be available.
 	OVSDatapathType string `yaml:"ovsDatapathType,omitempty"`
-	// Runtime data directory used by OpenVSwitch.
+	// Runtime data directory used by Open vSwitch.
 	// Default value:
 	// - On Linux platform: /var/run/openvswitch
 	// - On Windows platform: C:\openvswitch\var\run\openvswitch

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -97,6 +97,7 @@ func (i *Initializer) setupOVSBridge() error {
 		klog.Error("Failed to create OVS bridge: ", err)
 		return err
 	}
+	i.nodeConfig.BridgeName = i.ovsBridgeClient.GetBridgeName()
 
 	// Initialize interface cache
 	if err := i.initInterfaceStore(); err != nil {
@@ -181,6 +182,10 @@ func (i *Initializer) Initialize() error {
 	}
 
 	if err := i.routeClient.Initialize(i.nodeConfig); err != nil {
+		return err
+	}
+
+	if err := i.setupExternalConnectivity(); err != nil {
 		return err
 	}
 

--- a/pkg/agent/agent_linux.go
+++ b/pkg/agent/agent_linux.go
@@ -1,0 +1,22 @@
+// +build linux
+
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+// setupExternalConnectivity returns immediately on Linux. The corresponding functions are provided in routeClient.
+func (i *Initializer) setupExternalConnectivity() error {
+	return nil
+}

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -1,0 +1,34 @@
+// +build windows
+
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"k8s.io/klog"
+)
+
+// setupExternalConnectivity installs OpenFlow entries to SNAT Pod traffic using Node IP, and then Pod could communicate
+// to the external IP address.
+func (i *Initializer) setupExternalConnectivity() error {
+	subnetCIDR := i.nodeConfig.PodCIDR
+	nodeIP := i.nodeConfig.NodeIPAddr.IP
+	// Install OpenFlow entries on the OVS to enable Pod traffic to communicate to external IP addresses.
+	if err := i.ofClient.InstallExternalFlows(nodeIP, *subnetCIDR); err != nil {
+		klog.Errorf("Failed to setup SNAT openflow entries: %v", err)
+		return err
+	}
+	return nil
+}

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -25,6 +25,9 @@ const (
 	DefaultTunPortName = "tun0"
 	DefaultTunOFPort   = 1
 	HostGatewayOFPort  = 2
+	UplinkOFPort       = 3
+	// 0xfffffffe is a reserved port number in OpenFlow protocol, which is dedicated for the Bridge interface.
+	BridgeOFPort = 0xfffffffe
 )
 
 type GatewayConfig struct {
@@ -46,6 +49,7 @@ type NodeConfig struct {
 	PodCIDR       *net.IPNet
 	NodeIPAddr    *net.IPNet
 	GatewayConfig *GatewayConfig
+	BridgeName    string
 }
 
 func (n *NodeConfig) String() string {

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -100,6 +100,11 @@ type Client interface {
 	// are removed from PolicyRule.From, else from PolicyRule.To.
 	DeletePolicyRuleAddress(ruleID uint32, addrType types.AddressType, addresses []types.Address) error
 
+	// InstallExternalFlows sets up flows to enable Pods to communicate to the external IP addresses. The corresponding
+	// OpenFlow entries include: 1) identify the packets from local Pods to the external IP address, 2) mark the traffic
+	// in the connection tracking context, and 3) SNAT the packets with Node IP.
+	InstallExternalFlows(nodeIP net.IP, localSubnet net.IPNet) error
+
 	// Disconnect disconnects the connection between client and OFSwitch.
 	Disconnect() error
 
@@ -335,6 +340,16 @@ func (c *client) Initialize(roundInfo types.RoundInfo, nodeConfig *config.NodeCo
 	return connCh, c.initialize()
 }
 
+func (c *client) InstallExternalFlows(nodeIP net.IP, localSubnet net.IPNet) error {
+	flows := c.snatFlows(config.UplinkOFPort, config.BridgeOFPort, nodeIP, cookie.SNAT)
+	flows = append(flows, c.l3ToExternalFlows(nodeIP, localSubnet, config.HostGatewayOFPort, cookie.SNAT)...)
+	if err := c.flowOperations.AddAll(flows); err != nil {
+		return fmt.Errorf("failed to install flows for external communication: %v", err)
+	}
+	c.hostNetworkingFlows = append(c.hostNetworkingFlows, flows...)
+	return nil
+}
+
 func (c *client) ReplayFlows() {
 	c.replayMutex.Lock()
 	defer c.replayMutex.Unlock()
@@ -356,6 +371,10 @@ func (c *client) ReplayFlows() {
 	addFixedFlows(c.gatewayFlows)
 	addFixedFlows(c.clusterServiceCIDRFlows)
 	addFixedFlows(c.defaultTunnelFlows)
+	// hostNetworkingFlows is used only on Windows. Replay the flows only when there are flows in this cache.
+	if len(c.hostNetworkingFlows) > 0 {
+		addFixedFlows(c.hostNetworkingFlows)
+	}
 
 	installCachedFlows := func(key, value interface{}) bool {
 		fCache := value.(flowCache)

--- a/pkg/agent/openflow/cookie/allocator.go
+++ b/pkg/agent/openflow/cookie/allocator.go
@@ -36,6 +36,7 @@ const (
 	Pod
 	Service
 	Policy
+	SNAT
 )
 
 func (c Category) String() string {
@@ -52,6 +53,8 @@ func (c Category) String() string {
 		return "Service"
 	case Policy:
 		return "Policy"
+	case SNAT:
+		return "SNAT"
 	default:
 		return "Invalid"
 	}

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -48,12 +48,14 @@ const (
 	priorityHigh   = uint16(210)
 	priorityNormal = uint16(200)
 	priorityLow    = uint16(190)
+	prioritySNAT   = uint16(180)
 	priorityMiss   = uint16(0)
 
 	// Traffic marks
 	markTrafficFromTunnel  = 0
 	markTrafficFromGateway = 1
 	markTrafficFromLocal   = 2
+	markTrafficFromUplink  = 4
 )
 
 var (
@@ -62,6 +64,9 @@ var (
 	ofPortMarkRange = binding.Range{16, 16}
 	// ofPortRegRange takes a 32-bit range of register portCacheReg to cache the ofPort number of the interface.
 	ofPortRegRange = binding.Range{0, 31}
+	// snatMarkRange takes the 17th bit of register marksReg to indicate if the packet needs to be SNATed with Node's IP
+	// or not. Its value is 0x1 if yes.
+	snatMarkRange = binding.Range{17, 17}
 )
 
 type regType uint
@@ -87,8 +92,11 @@ const (
 
 	ctZone = 0xfff0
 
-	portFoundMark = 0x1
+	portFoundMark    = 0x1
+	snatRequiredMark = 0x1
+
 	gatewayCTMark = 0x20
+	snatCTMark    = 0x40
 )
 
 var (
@@ -118,7 +126,7 @@ type client struct {
 	nodeFlowCache, podFlowCache *flowCategoryCache // cache for corresponding deletions
 	// "fixed" flows installed by the agent after initialization and which do not change during
 	// the lifetime of the client.
-	gatewayFlows, clusterServiceCIDRFlows, defaultTunnelFlows []binding.Flow
+	gatewayFlows, clusterServiceCIDRFlows, defaultTunnelFlows, hostNetworkingFlows []binding.Flow
 	// flowOperations is a wrapper interface for flow Add / Modify / Delete operations. It
 	// enables convenient mocking in unit tests.
 	flowOperations FlowOperations
@@ -231,7 +239,7 @@ func (c *client) connectionTrackFlows(category cookie.Category) (flows []binding
 			Action().ResubmitToTable(connectionTrackStateTable.GetNext()).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done(),
-		connectionTrackStateTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
+		connectionTrackStateTable.BuildFlow(priorityLow).MatchProtocol(binding.ProtocolIP).
 			MatchCTStateInv(true).MatchCTStateTrk(true).
 			Action().Drop().
 			Cookie(c.cookieAllocator.Request(category).Raw()).
@@ -622,6 +630,112 @@ func (c *client) localProbeFlow(localGatewayIP net.IP, category cookie.Category)
 		Action().ResubmitToTable(conntrackCommitTable).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
+}
+
+func (c *client) snatFlows(uplinkOfport uint32, bridgeLocalPort int, nodeIP net.IP, category cookie.Category) []binding.Flow {
+	snatIPRange := &binding.IPRange{nodeIP, nodeIP}
+	vMACInt, _ := strconv.ParseUint(strings.Replace(globalVirtualMAC.String(), ":", "", -1), 16, 64)
+	flows := []binding.Flow{
+		// Resubmit the packet from the uplink interface to conntrackTable.
+		c.pipeline[classifierTable].BuildFlow(priorityNormal).
+			MatchProtocol(binding.ProtocolIP).
+			MatchInPort(uplinkOfport).
+			Action().LoadRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
+			Action().ResubmitToTable(conntrackTable).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+		// Enforce IP packet into the conntrack zone with SNAT. If the connection is SNATed, the reply packet should use
+		// Pod IP as the destination, and then resubmit to conntrackStateTable.
+		c.pipeline[conntrackTable].BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
+			Action().CT(false, conntrackStateTable, ctZone).NAT().CTDone().
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+		// Rewrite dMAC with the global vMAC if the packet is a reply to the Pod from the external address
+		c.pipeline[conntrackStateTable].BuildFlow(priorityHigh).
+			MatchProtocol(binding.ProtocolIP).
+			MatchCTStateNew(false).MatchCTStateTrk(true).
+			MatchCTMark(snatCTMark).
+			MatchRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
+			Action().LoadRange(binding.NxmFieldDstMAC, vMACInt, binding.Range{0, 47}).
+			Action().ResubmitToTable(dnatTable).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+		// Resubmit the packet sent from local Pod to the external IP address to dnatTable.
+		c.pipeline[conntrackStateTable].BuildFlow(priorityNormal).
+			MatchProtocol(binding.ProtocolIP).
+			MatchCTStateNew(false).MatchCTStateTrk(true).
+			MatchCTMark(snatCTMark).
+			Action().ResubmitToTable(dnatTable).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+		// Output the non-SNAT packet to the bridge interface directly if it is received from the uplink interface.
+		c.pipeline[conntrackStateTable].BuildFlow(priorityNormal).
+			MatchProtocol(binding.ProtocolIP).
+			MatchInPort(uplinkOfport).
+			Action().Output(bridgeLocalPort).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+		// Resubmit the packet to L2ForwardingOutput table after the packet is SNATed. The "SNAT" packet has these
+		// characters: 1) the ct_state is "+new+trk", 2) reg1[17] is set as 1; 3) Node IP is used as the target
+		// source IP in NAT action, 4) ct_mark is set with 0x40 in the conn_track context.
+		c.pipeline[conntrackCommitTable].BuildFlow(priorityNormal).
+			MatchProtocol(binding.ProtocolIP).
+			MatchCTStateNew(true).MatchCTStateTrk(true).
+			MatchRegRange(int(marksReg), snatRequiredMark, snatMarkRange).
+			Action().CT(true, l2ForwardingOutTable, ctZone).
+			SNAT(snatIPRange, nil).
+			LoadToMark(snatCTMark).CTDone().
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+	}
+	return flows
+}
+
+func (c *client) l3ToExternalFlows(nodeIP net.IP, localSubnet net.IPNet, outputPort int, category cookie.Category) []binding.Flow {
+	flows := []binding.Flow{
+		// Resubmit the packet to L2ForwardingCalc table if it is communicating to a Service.
+		c.pipeline[l3ForwardingTable].BuildFlow(priorityNormal).
+			MatchProtocol(binding.ProtocolIP).
+			MatchRegRange(int(marksReg), markTrafficFromLocal, binding.Range{0, 15}).
+			MatchCTMark(gatewayCTMark).
+			Action().ResubmitToTable(l2ForwardingCalcTable).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+		// Resubmit the packet to L2ForwardingCalc table if it is sent to the Node IP(not to the host gateway). Since
+		// the packet is using the host gateway's MAC as dst MAC, it will be sent out from "gw0". This flow entry is to
+		// avoid SNAT on such packet, otherwise the source and destination IP are the same.
+		c.pipeline[l3ForwardingTable].BuildFlow(priorityLow).
+			MatchProtocol(binding.ProtocolIP).
+			MatchRegRange(int(marksReg), markTrafficFromLocal, binding.Range{0, 15}).
+			MatchDstIP(nodeIP).
+			Action().ResubmitToTable(l2ForwardingCalcTable).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+		// Resubmit the packet to L2ForwardingCalc table if it is a packet sent to a local Pod. This flow entry has a
+		// low priority to avoid overlapping with those packets received from tunnel port.
+		c.pipeline[l3ForwardingTable].BuildFlow(priorityLow).
+			MatchProtocol(binding.ProtocolIP).
+			MatchRegRange(int(marksReg), markTrafficFromLocal, binding.Range{0, 15}).
+			MatchDstIPNet(localSubnet).
+			Action().ResubmitToTable(l2ForwardingCalcTable).
+			Done(),
+		// Add SNAT mark on the packet that is not filtered by other flow entries in L3Forwarding table. This is the
+		// table miss if SNAT feature is enabled.
+		c.pipeline[l3ForwardingTable].BuildFlow(prioritySNAT).
+			MatchProtocol(binding.ProtocolIP).
+			MatchRegRange(int(marksReg), markTrafficFromLocal, binding.Range{0, 15}).
+			Action().LoadRegRange(int(marksReg), snatRequiredMark, snatMarkRange).
+			Action().ResubmitToTable(ingressRuleTable).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+		// Output the SNATed packet to the specified port.
+		c.pipeline[l2ForwardingOutTable].BuildFlow(priorityNormal).
+			MatchProtocol(binding.ProtocolIP).
+			MatchRegRange(int(marksReg), snatRequiredMark, snatMarkRange).
+			Action().Output(outputPort).
+			Done(),
+	}
+	return flows
 }
 
 // NewClient is the constructor of the Client interface.

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -164,6 +164,20 @@ func (mr *MockClientMockRecorder) InstallDefaultTunnelFlows(arg0 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallDefaultTunnelFlows", reflect.TypeOf((*MockClient)(nil).InstallDefaultTunnelFlows), arg0)
 }
 
+// InstallExternalFlows mocks base method
+func (m *MockClient) InstallExternalFlows(arg0 net.IP, arg1 net.IPNet) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallExternalFlows", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallExternalFlows indicates an expected call of InstallExternalFlows
+func (mr *MockClientMockRecorder) InstallExternalFlows(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallExternalFlows", reflect.TypeOf((*MockClient)(nil).InstallExternalFlows), arg0, arg1)
+}
+
 // InstallGatewayFlows mocks base method
 func (m *MockClient) InstallGatewayFlows(arg0 net.IP, arg1 net.HardwareAddr, arg2 uint32) error {
 	m.ctrl.T.Helper()

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -61,6 +61,15 @@ func (c *Client) Initialize(nodeConfig *config.NodeConfig) error {
 	if err := c.initFwRules(); err != nil {
 		return err
 	}
+	// Enable IP-Forwarding on the host gateway interface, thus the host networking stack can be used to forward the
+	// SNAT packet from local Pods. The SNAT packet is leaving the OVS pipeline with the Node's IP as the source IP,
+	// the external address as the destination IP, and the gw0's MAC as the dst MAC. Then it will be forwarded to the
+	// host network stack from the host gateway interface, and its dst MAC could be resolved to the right one. At last,
+	// the packet is sent back to OVS from the bridge Interface, and the OpenFlow entries will output it to the uplink
+	// interface directly.
+	if err := util.EnableIPForwarding(nodeConfig.GatewayConfig.Name); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -215,8 +215,8 @@ type CTAction interface {
 	LoadToMark(value uint32) CTAction
 	LoadToLabelRange(value uint64, rng *Range) CTAction
 	MoveToLabel(fromName string, fromRng, labelRng *Range) CTAction
-	// NAT action is used if the packet is not committed into the conntrack zone, and is required to leverage the
-	// original NAT configurations.
+	// NAT action translates the packet in the way that the connection was committed into the conntrack zone, e.g., if
+	// a connection was committed with SNAT, the later packets would be translated with the earlier SNAT configurations.
 	NAT() CTAction
 	// SNAT actions is used to translate the source IP to a specific address or address in a pool when committing the
 	// packet into the conntrack zone. If a single IP is used as the target address, StartIP and EndIP in the range

--- a/pkg/ovs/ovsconfig/interfaces.go
+++ b/pkg/ovs/ovsconfig/interfaces.go
@@ -42,4 +42,5 @@ type OVSBridgeClient interface {
 	GetPortList() ([]OVSPortData, Error)
 	SetInterfaceMTU(name string, MTU int) error
 	GetOVSVersion() (string, Error)
+	GetBridgeName() string
 }

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -671,3 +671,7 @@ func (br *OVSBridge) GetOVSVersion() (string, Error) {
 
 	return res[0].Rows[0].(map[string]interface{})["ovs_version"].(string), nil
 }
+
+func (br *OVSBridge) GetBridgeName() string {
+	return br.name
+}

--- a/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
+++ b/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
@@ -164,6 +164,20 @@ func (mr *MockOVSBridgeClientMockRecorder) DeletePorts(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePorts", reflect.TypeOf((*MockOVSBridgeClient)(nil).DeletePorts), arg0)
 }
 
+// GetBridgeName mocks base method
+func (m *MockOVSBridgeClient) GetBridgeName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBridgeName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetBridgeName indicates an expected call of GetBridgeName
+func (mr *MockOVSBridgeClientMockRecorder) GetBridgeName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBridgeName", reflect.TypeOf((*MockOVSBridgeClient)(nil).GetBridgeName))
+}
+
 // GetExternalIDs mocks base method
 func (m *MockOVSBridgeClient) GetExternalIDs() (map[string]string, ovsconfig.Error) {
 	m.ctrl.T.Helper()

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -101,6 +101,7 @@ func TestConnectivityFlows(t *testing.T) {
 		testInstallPodFlows,
 		testUninstallPodFlows,
 		testUninstallNodeFlows,
+		testExternalFlows,
 	} {
 		f(t, config)
 	}
@@ -175,6 +176,17 @@ func TestReplayFlowsNetworkPolicyFlows(t *testing.T) {
 	require.Nil(t, err, "Failed to AddPolicyRuleAddress")
 
 	testReplayFlows(t)
+}
+
+func testExternalFlows(t *testing.T, config *testConfig) {
+	nodeIP := net.ParseIP("10.10.10.1")
+	_, localSubnet, _ := net.ParseCIDR("172.16.1.0/24")
+	if err := c.InstallExternalFlows(nodeIP, *localSubnet); err != nil {
+		t.Errorf("Failed to install OpenFlow entries to allow Pod to communicate to the external addresses: %v", err)
+	}
+	for _, tableFlow := range prepareExternalFlows(nodeIP, localSubnet) {
+		ofTestUtils.CheckFlowExists(t, config.bridge, tableFlow.tableID, true, tableFlow.flows)
+	}
 }
 
 func testReplayFlows(t *testing.T) {
@@ -705,7 +717,7 @@ func prepareDefaultFlows() []expectTableFlows {
 			uint8(31),
 			[]*ofTestUtils.ExpectFlow{
 				{"priority=210,ct_state=-new+trk,ct_mark=0x20,ip,reg0=0x1/0xffff", "resubmit(,40)"},
-				{"priority=200,ct_state=+inv+trk,ip", "drop"},
+				{"priority=190,ct_state=+inv+trk,ip", "drop"},
 				{"priority=0", "resubmit(,40)"},
 			},
 		},
@@ -769,4 +781,81 @@ func prepareIPNetAddresses(addresses []string) []types.Address {
 		ipAddresses = append(ipAddresses, ofClient.NewIPNetAddress(*ipNet))
 	}
 	return ipAddresses
+}
+
+func prepareExternalFlows(nodeIP net.IP, localSubnet *net.IPNet) []expectTableFlows {
+	return []expectTableFlows{
+		{
+			uint8(0),
+			[]*ofTestUtils.ExpectFlow{
+				{
+					fmt.Sprintf("priority=200,ip,in_port=%d", config1.UplinkOFPort),
+					"load:0x4->NXM_NX_REG0[0..15],resubmit(,30)",
+				},
+			},
+		},
+		{
+			uint8(30),
+			[]*ofTestUtils.ExpectFlow{
+				{
+					"priority=200,ip", "ct(table=31,zone=65520,nat)",
+				},
+			},
+		},
+		{
+			uint8(31),
+			[]*ofTestUtils.ExpectFlow{
+				{
+					"priority=210,ct_state=-new+trk,ct_mark=0x40,ip,reg0=0x4/0xffff",
+					"load:0xaabbccddeeff->NXM_OF_ETH_DST[],resubmit(,40)",
+				},
+				{
+					"priority=200,ct_state=-new+trk,ct_mark=0x40,ip",
+					"resubmit(,40)",
+				},
+				{
+					fmt.Sprintf("priority=200,ip,in_port=%d", config1.UplinkOFPort),
+					"LOCAL",
+				},
+			},
+		},
+		{
+			uint8(70),
+			[]*ofTestUtils.ExpectFlow{
+				{
+					"priority=200,ct_mark=0x20,ip,reg0=0x2/0xffff", "resubmit(,80)",
+				},
+				{
+					fmt.Sprintf("priority=190,ip,reg0=0x2/0xffff,nw_dst=%s", localSubnet.String()),
+					"resubmit(,80)",
+				},
+				{
+					fmt.Sprintf("priority=190,ip,reg0=0x2/0xffff,nw_dst=%s", nodeIP.String()),
+					"resubmit(,80)",
+				},
+				{
+					"priority=180,ip,reg0=0x2/0xffff",
+					"load:0x1->NXM_NX_REG0[17],resubmit(,90)",
+				},
+			},
+		},
+		{
+			uint8(105),
+			[]*ofTestUtils.ExpectFlow{
+				{
+					"priority=200,ct_state=+new+trk,ip,reg0=0x20000/0x20000",
+					fmt.Sprintf("ct(commit,table=110,zone=65520,nat(src=%s),exec(load:0x40->NXM_NX_CT_MARK[]))", nodeIP.String()),
+				},
+			},
+		},
+		{
+			uint8(110),
+			[]*ofTestUtils.ExpectFlow{
+				{
+					"priority=200,ip,reg0=0x20000/0x20000",
+					fmt.Sprintf("output:%d", config1.HostGatewayOFPort),
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
Use OpenFlow to implement SNAT feature on Windows, and masqurade the container IP with the NodeIP.