### PR TITLE
[Windows] Add windows branch in github UT and integration test workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
     - master
+    - windows
     - release-*
   push:
     branches:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
     - master
+    - windows
     - release-*
   push:
     branches:


### PR DESCRIPTION
This patch is to keep the UT and integration test can be passed when we
make changes for windows platform. Currently, these tests only run on
linux platform. After essential windows patches checked in, we should
also add windows platform in workflow.