### PR TITLE
Avoid duplicate netlink queries

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -381,7 +381,7 @@ func (i *Initializer) setupGatewayInterface() error {
 	gwIP := &net.IPNet{IP: ip.NextIP(subnetID), Mask: localSubnet.Mask}
 	gwAddr := &netlink.Addr{IPNet: gwIP, Label: ""}
 	gwMAC := link.Attrs().HardwareAddr
-	i.nodeConfig.GatewayConfig = &config.GatewayConfig{Link: i.hostGateway, IP: gwIP.IP, MAC: gwMAC}
+	i.nodeConfig.GatewayConfig = &config.GatewayConfig{LinkIndex: link.Attrs().Index, Name: i.hostGateway, IP: gwIP.IP, MAC: gwMAC}
 	gatewayIface.IP = gwIP.IP
 	gatewayIface.MAC = gwMAC
 

--- a/pkg/agent/cniserver/server_test.go
+++ b/pkg/agent/cniserver/server_test.go
@@ -496,6 +496,6 @@ func init() {
 	gwIP = net.ParseIP("192.168.1.1")
 	_, nodePodCIDR, _ := net.ParseCIDR("192.168.1.0/24")
 	gwMAC, _ := net.ParseMAC("00:00:00:00:00:01")
-	gateway := &config.GatewayConfig{Link: "", IP: gwIP, MAC: gwMAC}
+	gateway := &config.GatewayConfig{Name: "", IP: gwIP, MAC: gwMAC}
 	testNodeConfig = &config.NodeConfig{Name: nodeName, PodCIDR: nodePodCIDR, GatewayConfig: gateway}
 }

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -28,13 +28,16 @@ const (
 )
 
 type GatewayConfig struct {
-	IP   net.IP
-	MAC  net.HardwareAddr
-	Link string
+	IP  net.IP
+	MAC net.HardwareAddr
+	// LinkIndex is the link index of host gateway.
+	LinkIndex int
+	// Name is the name of host gateway, e.g. gw0.
+	Name string
 }
 
 func (g *GatewayConfig) String() string {
-	return fmt.Sprintf("Name %s: IP %s, MAC %s", g.Link, g.IP, g.MAC)
+	return fmt.Sprintf("Name %s: IP %s, MAC %s", g.Name, g.IP, g.MAC)
 }
 
 // Local Node configurations retrieved from K8s API or host networking state.

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -65,7 +65,6 @@ type Controller struct {
 	interfaceStore   interfacestore.InterfaceStore
 	networkConfig    *config.NetworkConfig
 	nodeConfig       *config.NodeConfig
-	gatewayLink      netlink.Link
 	nodeInformer     coreinformers.NodeInformer
 	nodeLister       corelisters.NodeLister
 	nodeListerSynced cache.InformerSynced
@@ -101,7 +100,6 @@ func NewNodeRouteController(
 		interfaceStore:   interfaceStore,
 		networkConfig:    networkConfig,
 		nodeConfig:       nodeConfig,
-		gatewayLink:      util.GetNetLink(nodeConfig.GatewayConfig.Link),
 		nodeInformer:     nodeInformer,
 		nodeLister:       nodeInformer.Lister(),
 		nodeListerSynced: nodeInformer.Informer().HasSynced,
@@ -477,7 +475,7 @@ func (c *Controller) addNodeRoute(nodeName string, node *v1.Node) error {
 		c.installedNodes.Store(nodeName, nil)
 	}
 
-	routes, err := c.routeClient.AddPeerCIDRRoute(peerPodCIDR, c.gatewayLink.Attrs().Index, peerNodeIP, peerGatewayIP)
+	routes, err := c.routeClient.AddPeerCIDRRoute(peerPodCIDR, c.nodeConfig.GatewayConfig.LinkIndex, peerNodeIP, peerGatewayIP)
 	if err == nil {
 		c.installedNodes.Store(nodeName, routes)
 		err = c.iptablesClient.AddPeerCIDR(peerPodCIDR, peerNodeIP)

--- a/pkg/agent/util/net_unix.go
+++ b/pkg/agent/util/net_unix.go
@@ -47,12 +47,3 @@ func GetIPNetDeviceFromIP(localIP net.IP) (*net.IPNet, netlink.Link, error) {
 	}
 	return nil, nil, fmt.Errorf("unable to find local IP and device")
 }
-
-// GetNetLink returns dev link from name.
-func GetNetLink(dev string) netlink.Link {
-	link, err := netlink.LinkByName(dev)
-	if err != nil {
-		klog.Fatalf("cannot find dev %s: %w", dev, err)
-	}
-	return link
-}

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -613,7 +613,7 @@ func init() {
 	nodeName := "node1"
 	gwIP := net.ParseIP("192.168.1.1")
 	gwMAC, _ := net.ParseMAC("11:11:11:11:11:11")
-	nodeGateway := &config.GatewayConfig{IP: gwIP, MAC: gwMAC, Link: ""}
+	nodeGateway := &config.GatewayConfig{IP: gwIP, MAC: gwMAC, Name: ""}
 	_, nodePodCIDR, _ := net.ParseCIDR("192.168.1.0/24")
 
 	testNodeConfig = &config.NodeConfig{Name: nodeName, PodCIDR: nodePodCIDR, GatewayConfig: nodeGateway}

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -56,7 +56,7 @@ var (
 	svcTblIdx         = route.AntreaServiceTableIdx
 	svcTblName        = route.AntreaServiceTable
 	mainTblIdx        = 254
-	gwConfig          = &config.GatewayConfig{IP: gwIP, MAC: gwMAC, Link: ""}
+	gwConfig          = &config.GatewayConfig{IP: gwIP, MAC: gwMAC, Name: gwName}
 	nodeConfig        = &config.NodeConfig{
 		Name:          "test",
 		PodCIDR:       nil,
@@ -66,7 +66,6 @@ var (
 )
 
 func TestRouteTable(t *testing.T) {
-
 	if _, incontainer := os.LookupEnv("INCONTAINER"); !incontainer {
 		// test changes file system, routing table. Run in contain only
 		t.Skipf("Skip test runs only in container")
@@ -85,7 +84,7 @@ func TestRouteTable(t *testing.T) {
 		t.Error(err)
 	}
 
-	nodeConfig.GatewayConfig.Link = link.Attrs().Name
+	nodeConfig.GatewayConfig.LinkIndex = link.Attrs().Index
 
 	refRouteTablesStr, _ := ExecOutputTrim("cat /etc/iproute2/rt_tables")
 	tcs := []struct {


### PR DESCRIPTION
This patch keeps required link info of gateway device in-memory to avoid
duplicate queries.