### PR TITLE
Group network configuration parameters to struct NetworkConfig

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -48,8 +48,8 @@ func TestGetNodeName(t *testing.T) {
 
 func compareNodeName(k, v string, t *testing.T) {
 	if k != "" {
-		_ = os.Setenv(NodeNameEnvKey, k)
-		defer os.Unsetenv(NodeNameEnvKey)
+		_ = os.Setenv(nodeNameEnvKey, k)
+		defer os.Unsetenv(nodeNameEnvKey)
 	}
 	nodeName, err := getNodeName()
 	if err != nil {

--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -35,9 +35,9 @@ import (
 	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/cniserver/ipam"
+	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
-	"github.com/vmware-tanzu/antrea/pkg/agent/types"
 	cnipb "github.com/vmware-tanzu/antrea/pkg/apis/cni/v1beta1"
 	"github.com/vmware-tanzu/antrea/pkg/apis/networking/v1beta1"
 	"github.com/vmware-tanzu/antrea/pkg/cni"
@@ -91,7 +91,7 @@ type CNIServer struct {
 	cniSocket            string
 	supportedCNIVersions map[string]bool
 	serverVersion        string
-	nodeConfig           *types.NodeConfig
+	nodeConfig           *config.NodeConfig
 	hostProcPathPrefix   string
 	defaultMTU           int
 	kubeClient           clientset.Interface
@@ -467,7 +467,7 @@ func New(
 	cniSocket, hostProcPathPrefix string,
 	defaultMTU int,
 	ovsDatapathType string,
-	nodeConfig *types.NodeConfig,
+	nodeConfig *config.NodeConfig,
 	ovsBridgeClient ovsconfig.OVSBridgeClient,
 	ofClient openflow.Client,
 	ifaceStore interfacestore.InterfaceStore,

--- a/pkg/agent/cniserver/server_test.go
+++ b/pkg/agent/cniserver/server_test.go
@@ -31,9 +31,9 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/cniserver/ipam"
 	ipamtest "github.com/vmware-tanzu/antrea/pkg/agent/cniserver/ipam/testing"
 	cniservertest "github.com/vmware-tanzu/antrea/pkg/agent/cniserver/testing"
+	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
 	openflowtest "github.com/vmware-tanzu/antrea/pkg/agent/openflow/testing"
-	"github.com/vmware-tanzu/antrea/pkg/agent/types"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"
 	cnipb "github.com/vmware-tanzu/antrea/pkg/apis/cni/v1beta1"
 	"github.com/vmware-tanzu/antrea/pkg/cni"
@@ -46,7 +46,6 @@ const (
 	ifname                  = "eth0"
 	testSocket              = "/tmp/test.sock"
 	testIpamType            = "test"
-	testBr                  = "br0"
 	testPodNamespace        = "test"
 	testPodName             = "test-1"
 	testPodInfraContainerID = "test-infra-11111111"
@@ -58,7 +57,7 @@ var routes = []string{"10.0.0.0/8,10.1.2.1", "0.0.0.0/0,10.1.2.1"}
 var dns = []string{"192.168.100.1"}
 var ips = []string{"10.1.2.100/24,10.1.2.1,4"}
 var args = cniservertest.GenerateCNIArgs(testPodName, testPodNamespace, testPodInfraContainerID)
-var testNodeConfig *types.NodeConfig
+var testNodeConfig *config.NodeConfig
 var gwIP net.IP
 
 func TestLoadNetConfig(t *testing.T) {
@@ -497,6 +496,6 @@ func init() {
 	gwIP = net.ParseIP("192.168.1.1")
 	_, nodePodCIDR, _ := net.ParseCIDR("192.168.1.0/24")
 	gwMAC, _ := net.ParseMAC("00:00:00:00:00:01")
-	gateway := &types.GatewayConfig{Link: "", IP: gwIP, MAC: gwMAC}
-	testNodeConfig = &types.NodeConfig{Bridge: testBr, Name: nodeName, PodCIDR: nodePodCIDR, GatewayConfig: gateway}
+	gateway := &config.GatewayConfig{Link: "", IP: gwIP, MAC: gwMAC}
+	testNodeConfig = &config.NodeConfig{Name: nodeName, PodCIDR: nodePodCIDR, GatewayConfig: gateway}
 }

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package types
+package config
 
 import (
 	"fmt"
 	"net"
+
+	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 )
 
 const (
@@ -35,8 +37,8 @@ func (g *GatewayConfig) String() string {
 	return fmt.Sprintf("Name %s: IP %s, MAC %s", g.Link, g.IP, g.MAC)
 }
 
+// Local Node configurations retrieved from K8s API or host networking state.
 type NodeConfig struct {
-	Bridge        string
 	Name          string
 	PodCIDR       *net.IPNet
 	NodeIPAddr    *net.IPNet
@@ -46,4 +48,12 @@ type NodeConfig struct {
 func (n *NodeConfig) String() string {
 	return fmt.Sprintf("NodeName: %s, PodCIDR: %s, NodeIP: %s, Gateway: %s",
 		n.Name, n.PodCIDR, n.NodeIPAddr, n.GatewayConfig)
+}
+
+// User provided network configuration parameters.
+type NetworkConfig struct {
+	TrafficEncapMode  TrafficEncapModeType
+	TunnelType        ovsconfig.TunnelType
+	EnableIPSecTunnel bool
+	IPSecPSK          string
 }

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -38,7 +38,6 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/iptables"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
 	"github.com/vmware-tanzu/antrea/pkg/agent/route"
-	"github.com/vmware-tanzu/antrea/pkg/agent/types"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"
 	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 )
@@ -59,22 +58,18 @@ const (
 // Controller is responsible for setting up necessary IP routes and Openflow entries for inter-node traffic.
 type Controller struct {
 	kubeClient       clientset.Interface
+	ovsBridgeClient  ovsconfig.OVSBridgeClient
+	ofClient         openflow.Client
+	routeClient      *route.Client
+	iptablesClient   *iptables.Client
+	interfaceStore   interfacestore.InterfaceStore
+	networkConfig    *config.NetworkConfig
+	nodeConfig       *config.NodeConfig
+	gatewayLink      netlink.Link
 	nodeInformer     coreinformers.NodeInformer
 	nodeLister       corelisters.NodeLister
 	nodeListerSynced cache.InformerSynced
 	queue            workqueue.RateLimitingInterface
-	ofClient         openflow.Client
-	ovsBridgeClient  ovsconfig.OVSBridgeClient
-	interfaceStore   interfacestore.InterfaceStore
-	nodeConfig       *types.NodeConfig
-	tunnelType       ovsconfig.TunnelType
-	// Pre-shared key for IPSec IKE authentication. If not empty IPSec tunnels will
-	// be enabled.
-	ipsecPSK       string
-	gatewayLink    netlink.Link
-	routeClient    *route.Client
-	iptablesClient *iptables.Client
-	encapMode      config.TrafficEncapModeType
 	// installedNodes records routes and flows installation states of Nodes.
 	// The key is the host name of the Node, the value is the route to the Node.
 	// If the flows of the Node are installed, the installedNodes must contains a key which is the host name.
@@ -91,34 +86,27 @@ func NewNodeRouteController(
 	informerFactory informers.SharedInformerFactory,
 	client openflow.Client,
 	ovsBridgeClient ovsconfig.OVSBridgeClient,
-	interfaceStore interfacestore.InterfaceStore,
-	nodeConfig *types.NodeConfig,
-	tunnelType ovsconfig.TunnelType,
-	ipsecPSK string,
 	routeClient *route.Client,
 	iptablesClient *iptables.Client,
-	encapModeStr string,
-) *Controller {
+	interfaceStore interfacestore.InterfaceStore,
+	networkConfig *config.NetworkConfig,
+	nodeConfig *config.NodeConfig) *Controller {
 	nodeInformer := informerFactory.Core().V1().Nodes()
-	_, encapMode := config.GetTrafficEncapModeFromStr(encapModeStr)
 	controller := &Controller{
 		kubeClient:       kubeClient,
+		ovsBridgeClient:  ovsBridgeClient,
+		ofClient:         client,
+		routeClient:      routeClient,
+		iptablesClient:   iptablesClient,
+		interfaceStore:   interfaceStore,
+		networkConfig:    networkConfig,
+		nodeConfig:       nodeConfig,
+		gatewayLink:      util.GetNetLink(nodeConfig.GatewayConfig.Link),
 		nodeInformer:     nodeInformer,
 		nodeLister:       nodeInformer.Lister(),
 		nodeListerSynced: nodeInformer.Informer().HasSynced,
 		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "noderoute"),
-		ofClient:         client,
-		ovsBridgeClient:  ovsBridgeClient,
-		interfaceStore:   interfaceStore,
-		nodeConfig:       nodeConfig,
-		gatewayLink:      util.GetNetLink(nodeConfig.GatewayConfig.Link),
-		installedNodes:   &sync.Map{},
-		tunnelType:       tunnelType,
-		ipsecPSK:         ipsecPSK,
-		routeClient:      routeClient,
-		iptablesClient:   iptablesClient,
-		encapMode:        encapMode,
-	}
+		installedNodes:   &sync.Map{}}
 	nodeInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(cur interface{}) {
@@ -215,7 +203,7 @@ func (c *Controller) removeStaleTunnelPorts() error {
 	// knownInterfaces is the list of interfaces currently in the local cache.
 	knownInterfaces := c.interfaceStore.GetInterfaceKeysByType(interfacestore.TunnelInterface)
 
-	if c.ipsecPSK != "" {
+	if c.networkConfig.EnableIPSecTunnel {
 		for _, node := range nodes {
 			interfaceConfig, found := c.interfaceStore.GetNodeTunnelInterface(node.Name)
 			if !found {
@@ -230,9 +218,9 @@ func (c *Controller) removeStaleTunnelPorts() error {
 			}
 
 			ifaceID := util.GenerateNodeTunnelInterfaceKey(node.Name)
-			validConfiguration := interfaceConfig.PSK == c.ipsecPSK &&
+			validConfiguration := interfaceConfig.PSK == c.networkConfig.IPSecPSK &&
 				interfaceConfig.RemoteIP.Equal(peerNodeIP) &&
-				interfaceConfig.TunnelInterfaceConfig.Type == c.tunnelType
+				interfaceConfig.TunnelInterfaceConfig.Type == c.networkConfig.TunnelType
 			if validConfiguration {
 				desiredInterfaces[ifaceID] = true
 			}
@@ -253,7 +241,7 @@ func (c *Controller) removeStaleTunnelPorts() error {
 			klog.Errorf("Interface %s can no longer be found in the interface store", ifaceID)
 			continue
 		}
-		if interfaceConfig.InterfaceName == types.DefaultTunPortName {
+		if interfaceConfig.InterfaceName == config.DefaultTunPortName {
 			continue
 		}
 		if err := c.ovsBridgeClient.DeletePort(interfaceConfig.PortUUID); err != nil {
@@ -423,7 +411,7 @@ func (c *Controller) deleteNodeRoute(nodeName string) error {
 		c.installedNodes.Delete(nodeName)
 	}
 
-	if c.ipsecPSK != "" {
+	if c.networkConfig.EnableIPSecTunnel {
 		interfaceConfig, ok := c.interfaceStore.GetNodeTunnelInterface(nodeName)
 		if !ok {
 			// Tunnel port not created for this Node.
@@ -466,7 +454,7 @@ func (c *Controller) addNodeRoute(nodeName string, node *v1.Node) error {
 	}
 	peerGatewayIP := ip.NextIP(peerPodCIDRAddr)
 
-	if c.ipsecPSK != "" {
+	if c.networkConfig.EnableIPSecTunnel {
 		// Create a separate tunnel port for the Node, as OVS IPSec monitor needs to
 		// read PSK and remote IP from the Node's tunnel interface to create IPSec
 		// security policies.
@@ -482,7 +470,7 @@ func (c *Controller) addNodeRoute(nodeName string, node *v1.Node) error {
 			peerGatewayIP,
 			*peerPodCIDR,
 			peerNodeIP,
-			types.DefaultTunOFPort)
+			config.DefaultTunOFPort)
 		if err != nil {
 			return fmt.Errorf("failed to install flows to Node %s: %v", nodeName, err)
 		}
@@ -512,10 +500,10 @@ func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) error
 	ovsExternalIDs := map[string]interface{}{ovsExternalIDNodeName: nodeName}
 	portUUID, err := c.ovsBridgeClient.CreateTunnelPortExt(
 		portName,
-		c.tunnelType,
+		c.networkConfig.TunnelType,
 		0, // ofPortRequest - let OVS allocate OFPort number.
 		nodeIP.String(),
-		c.ipsecPSK,
+		c.networkConfig.IPSecPSK,
 		ovsExternalIDs)
 	if err != nil {
 		klog.Errorf("Failed to create OVS IPSec tunnel port for Node %s: %v", nodeName, err)
@@ -526,10 +514,10 @@ func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) error
 	ovsPortConfig := &interfacestore.OVSPortConfig{PortUUID: portUUID}
 	interfaceConfig = interfacestore.NewIPSecTunnelInterface(
 		portName,
-		c.tunnelType,
+		c.networkConfig.TunnelType,
 		nodeName,
 		nodeIP,
-		c.ipsecPSK)
+		c.networkConfig.IPSecPSK)
 	interfaceConfig.OVSPortConfig = ovsPortConfig
 	c.interfaceStore.AddInterface(interfaceConfig)
 	return nil

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -35,7 +35,7 @@ type Client interface {
 	// be called to ensure that the set of OVS flows is correct. All flows programmed in the
 	// switch which match the current round number will be deleted before any new flow is
 	// installed.
-	Initialize(roundInfo types.RoundInfo, config *types.NodeConfig, encapMode config.TrafficEncapModeType) (<-chan struct{}, error)
+	Initialize(roundInfo types.RoundInfo, config *config.NodeConfig, encapMode config.TrafficEncapModeType) (<-chan struct{}, error)
 
 	// InstallGatewayFlows sets up flows related to an OVS gateway port, the gateway must exist.
 	InstallGatewayFlows(gatewayAddr net.IP, gatewayMAC net.HardwareAddr, gatewayOFPort uint32) error
@@ -273,14 +273,14 @@ func (c *client) initialize() error {
 	}
 
 	if c.encapMode.SupportsNoEncap() {
-		if err := c.flowOperations.Add(c.l2ForwardOutputInPortFlow(types.HostGatewayOFPort, cookie.Default)); err != nil {
+		if err := c.flowOperations.Add(c.l2ForwardOutputInPortFlow(config.HostGatewayOFPort, cookie.Default)); err != nil {
 			return fmt.Errorf("failed to install L2 forward same in-port and out-port flow: %v", err)
 		}
 	}
 	return nil
 }
 
-func (c *client) Initialize(roundInfo types.RoundInfo, config *types.NodeConfig, encapMode config.TrafficEncapModeType) (<-chan struct{}, error) {
+func (c *client) Initialize(roundInfo types.RoundInfo, config *config.NodeConfig, encapMode config.TrafficEncapModeType) (<-chan struct{}, error) {
 	c.nodeConfig = config
 	c.encapMode = encapMode
 	// Initiate connections to target OFswitch, and create tables on the switch.

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -27,9 +27,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow/cookie"
 	oftest "github.com/vmware-tanzu/antrea/pkg/agent/openflow/testing"
-	"github.com/vmware-tanzu/antrea/pkg/agent/types"
 )
 
 const bridgeName = "dummy-br"
@@ -39,7 +39,7 @@ func installNodeFlows(ofClient Client, cacheKey string) (int, error) {
 	gwMAC, _ := net.ParseMAC("AA:BB:CC:DD:EE:FF")
 	IP, IPNet, _ := net.ParseCIDR("10.0.1.1/24")
 	peerNodeIP := net.ParseIP("192.168.1.1")
-	err := ofClient.InstallNodeFlows(hostName, gwMAC, IP, *IPNet, peerNodeIP, types.DefaultTunOFPort)
+	err := ofClient.InstallNodeFlows(hostName, gwMAC, IP, *IPNet, peerNodeIP, config.DefaultTunOFPort)
 	client := ofClient.(*client)
 	fCacheI, ok := client.nodeFlowCache.Load(hostName)
 	if ok {
@@ -87,7 +87,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ofClient := NewClient(bridgeName)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
-			client.nodeConfig = &types.NodeConfig{}
+			client.nodeConfig = &config.NodeConfig{}
 			client.flowOperations = m
 
 			m.EXPECT().AddAll(gomock.Any()).Return(nil).Times(1)
@@ -115,7 +115,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ofClient := NewClient(bridgeName)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
-			client.nodeConfig = &types.NodeConfig{}
+			client.nodeConfig = &config.NodeConfig{}
 			client.flowOperations = m
 
 			errorCall := m.EXPECT().AddAll(gomock.Any()).Return(errors.New("Bundle error")).Times(1)
@@ -156,7 +156,7 @@ func TestFlowInstallationFailed(t *testing.T) {
 			ofClient := NewClient(bridgeName)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
-			client.nodeConfig = &types.NodeConfig{}
+			client.nodeConfig = &config.NodeConfig{}
 			client.flowOperations = m
 
 			// We generate an error for AddAll call.
@@ -190,7 +190,7 @@ func TestConcurrentFlowInstallation(t *testing.T) {
 			ofClient := NewClient(bridgeName)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
-			client.nodeConfig = &types.NodeConfig{}
+			client.nodeConfig = &config.NodeConfig{}
 			client.flowOperations = m
 
 			var concurrentCalls atomic.Value // set to true if we observe concurrent calls

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -131,7 +131,7 @@ type client struct {
 	globalConjMatchFlowCache map[string]*conjMatchFlowContext
 	// replayMutex provides exclusive access to the OFSwitch to the ReplayFlows method.
 	replayMutex sync.RWMutex
-	nodeConfig  *types.NodeConfig
+	nodeConfig  *config.NodeConfig
 	encapMode   config.TrafficEncapModeType
 }
 

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -122,7 +122,7 @@ func (mr *MockClientMockRecorder) GetFlowTableStatus() *gomock.Call {
 }
 
 // Initialize mocks base method
-func (m *MockClient) Initialize(arg0 types.RoundInfo, arg1 *types.NodeConfig, arg2 config.TrafficEncapModeType) (<-chan struct{}, error) {
+func (m *MockClient) Initialize(arg0 types.RoundInfo, arg1 *config.NodeConfig, arg2 config.TrafficEncapModeType) (<-chan struct{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Initialize", arg0, arg1, arg2)
 	ret0, _ := ret[0].(<-chan struct{})

--- a/pkg/agent/route/route.go
+++ b/pkg/agent/route/route.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/iptables"
-	"github.com/vmware-tanzu/antrea/pkg/agent/types"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"
 )
 
@@ -42,7 +41,7 @@ const (
 
 // Client is route client.
 type Client struct {
-	nodeConfig *types.NodeConfig
+	nodeConfig *config.NodeConfig
 	encapMode  config.TrafficEncapModeType
 }
 
@@ -65,14 +64,13 @@ var (
 )
 
 // NewClient returns a route client
-func NewClient() *Client {
-	return &Client{}
+func NewClient(encapMode config.TrafficEncapModeType) *Client {
+	return &Client{encapMode: encapMode}
 }
 
 // Initialize sets up route tables for Antrea.
-func (c *Client) Initialize(nodeConfig *types.NodeConfig, encapMode config.TrafficEncapModeType) error {
+func (c *Client) Initialize(nodeConfig *config.NodeConfig) error {
 	c.nodeConfig = nodeConfig
-	c.encapMode = encapMode
 	if c.encapMode.SupportsNoEncap() {
 		ServiceRtTable.Idx = AntreaServiceTableIdx
 		ServiceRtTable.Name = AntreaServiceTable

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -39,9 +39,9 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/cniserver/ipam"
 	ipamtest "github.com/vmware-tanzu/antrea/pkg/agent/cniserver/ipam/testing"
 	cniservertest "github.com/vmware-tanzu/antrea/pkg/agent/cniserver/testing"
+	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
 	openflowtest "github.com/vmware-tanzu/antrea/pkg/agent/openflow/testing"
-	agenttypes "github.com/vmware-tanzu/antrea/pkg/agent/types"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"
 	cnimsg "github.com/vmware-tanzu/antrea/pkg/apis/cni/v1beta1"
 	"github.com/vmware-tanzu/antrea/pkg/apis/networking/v1beta1"
@@ -56,7 +56,6 @@ const (
 	testPod               = "test-1"
 	testPodNamespace      = "t1"
 	testPodInfraContainer = "test-111111"
-	bridge                = "br0"
 )
 
 const (
@@ -103,7 +102,7 @@ const (
 var ipamMock *ipamtest.MockIPAMDriver
 var ovsServiceMock *ovsconfigtest.MockOVSBridgeClient
 var ofServiceMock *openflowtest.MockClient
-var testNodeConfig *agenttypes.NodeConfig
+var testNodeConfig *config.NodeConfig
 
 type Net struct {
 	Name          string                 `json:"name"`
@@ -614,8 +613,8 @@ func init() {
 	nodeName := "node1"
 	gwIP := net.ParseIP("192.168.1.1")
 	gwMAC, _ := net.ParseMAC("11:11:11:11:11:11")
-	nodeGateway := &agenttypes.GatewayConfig{IP: gwIP, MAC: gwMAC, Link: ""}
+	nodeGateway := &config.GatewayConfig{IP: gwIP, MAC: gwMAC, Link: ""}
 	_, nodePodCIDR, _ := net.ParseCIDR("192.168.1.0/24")
 
-	testNodeConfig = &agenttypes.NodeConfig{Bridge: bridge, Name: nodeName, PodCIDR: nodePodCIDR, GatewayConfig: nodeGateway}
+	testNodeConfig = &config.NodeConfig{Name: nodeName, PodCIDR: nodePodCIDR, GatewayConfig: nodeGateway}
 }

--- a/test/integration/agent/iptables_test.go
+++ b/test/integration/agent/iptables_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/iptables"
-	"github.com/vmware-tanzu/antrea/pkg/agent/types"
 )
 
 func TestSetupRules(t *testing.T) {
@@ -67,18 +66,15 @@ func TestSetupRules(t *testing.T) {
 
 		for _, mode := range modes {
 			t.Logf("Running test with Encap Mode %s", mode)
-			nodeConfig := &types.NodeConfig{}
+			nodeConfig := &config.NodeConfig{}
 			curExpected := expected
 			if !mode.SupportsNoEncap() {
 				curExpected = expected[:2]
 			}
 			_, serviceCIDR, _ = net.ParseCIDR("1.1.0.0/16")
 
-			client, err := iptables.NewClient()
-			if err != nil {
-				return fmt.Errorf("error creating iptables client: %v", err)
-			}
-			if err := client.Initialize("gw0", serviceCIDR, nodeConfig, mode); err != nil {
+			client := iptables.NewClient("gw0", serviceCIDR, mode)
+			if err := client.Initialize(nodeConfig); err != nil {
 				return fmt.Errorf("error setting up rules: %v", err)
 			}
 

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -136,7 +136,7 @@ func TestReplayFlowsNetworkPolicyFlows(t *testing.T) {
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
-	_, err = c.Initialize(roundInfo, &types.NodeConfig{}, config1.TrafficEncapModeEncap)
+	_, err = c.Initialize(roundInfo, &config1.NodeConfig{}, config1.TrafficEncapModeEncap)
 	require.Nil(t, err, "Failed to initialize OFClient")
 
 	defer func() {
@@ -198,7 +198,7 @@ func testReplayFlows(t *testing.T) {
 }
 
 func testInitialize(t *testing.T, config *testConfig) {
-	if _, err := c.Initialize(roundInfo, &types.NodeConfig{}, config1.TrafficEncapModeEncap); err != nil {
+	if _, err := c.Initialize(roundInfo, &config1.NodeConfig{}, config1.TrafficEncapModeEncap); err != nil {
 		t.Errorf("Failed to initialize openflow client: %v", err)
 	}
 	for _, tableFlow := range prepareDefaultFlows() {
@@ -279,7 +279,7 @@ func TestNetworkPolicyFlows(t *testing.T) {
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 
-	_, err = c.Initialize(roundInfo, &types.NodeConfig{}, config1.TrafficEncapModeEncap)
+	_, err = c.Initialize(roundInfo, &config1.NodeConfig{}, config1.TrafficEncapModeEncap)
 	require.Nil(t, err, "Failed to initialize OFClient")
 
 	defer func() {

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/iptables"
 	"github.com/vmware-tanzu/antrea/pkg/agent/route"
-	"github.com/vmware-tanzu/antrea/pkg/agent/types"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"
 )
 
@@ -57,8 +56,8 @@ var (
 	svcTblIdx         = route.AntreaServiceTableIdx
 	svcTblName        = route.AntreaServiceTable
 	mainTblIdx        = 254
-	gwConfig          = &types.GatewayConfig{IP: gwIP, MAC: gwMAC, Link: ""}
-	nodeConfig        = &types.NodeConfig{
+	gwConfig          = &config.GatewayConfig{IP: gwIP, MAC: gwMAC, Link: ""}
+	nodeConfig        = &config.NodeConfig{
 		Name:          "test",
 		PodCIDR:       nil,
 		NodeIPAddr:    nodeIP,
@@ -115,12 +114,12 @@ func TestRouteTable(t *testing.T) {
 	for _, tc := range tcs {
 		nodeConfig.PodCIDR = tc.podCIDR
 		t.Logf("Running test with mode %s peer cidr %s peer ip %s node config %s", tc.mode, tc.peerCIDR, tc.peerIP, nodeConfig)
-		routeClient := route.NewClient()
-		if err := routeClient.Initialize(nodeConfig, tc.mode); err != nil {
+		routeClient := route.NewClient(tc.mode)
+		if err := routeClient.Initialize(nodeConfig); err != nil {
 			t.Error(err)
 		}
 		// Call initialize twice and verify no duplicates
-		if err := routeClient.Initialize(nodeConfig, tc.mode); err != nil {
+		if err := routeClient.Initialize(nodeConfig); err != nil {
 			t.Error(err)
 		}
 		// verify route tables


### PR DESCRIPTION
Add NetworkConfig struct to group user provided network configuration
parameters - trafficEncapMode, tunnelType, enableIPSecTunnel,
ipsecPSK.
Move node_config.go from pkg/agent/types/ to pkg/agent/config/.