### PR TITLE
Add sonobuoy wrapper script to run Antrea K8s community tests

### DIFF
--- a/ci/jenkins/README.md
+++ b/ci/jenkins/README.md
@@ -1,22 +1,43 @@
 ## Antrea CI: Jenkins
 
 ### Reasons for Jenkins
-We have tests as Github Action but Jenkins allows tests running on a cluster of multiple nodes and offers better environment setup options.
+We have tests as Github Actions but Jenkins allows tests running on a cluster of
+multiple nodes and offers better environment setup options.
 
 ### List of Jenkins jobs
-* [e2e](https://github.com/vmware-tanzu/antrea/tree/master/test/e2e): end-to-end tests for Antrea.
-* conformance: community tests using sonobuoy, focusing on "Conformance", and skipping "Slow", "Serial", "Disruptive", "Flaky", "Feature", "sig-cli", "sig-storage", "sig-auth", "sig-api-machinery", "sig-apps" and "sig-node".
-* network policy: community tests using sonobuoy, focusing on "Feature:NetworkPolicy", and skipping "allow ingress access from updated pod" and "named port".
-Test "named port" will be supported soon, see issue [#122](https://github.com/vmware-tanzu/antrea/issues/122).  
-Test "allow ingress access from updated pod" fails because of a bug in the test definition, see issue [#85908](https://github.com/kubernetes/kubernetes/issues/85908).
+* e2e: [end-to-end tests](/test/e2e) for Antrea.
+* conformance: community tests using sonobuoy, focusing on "Conformance", and
+  skipping "Slow", "Serial", "Disruptive", "Flaky", "Feature", "sig-cli",
+  "sig-storage", "sig-auth", "sig-api-machinery", "sig-apps" and "sig-node".
+* network policy: community tests using sonobuoy, focusing on
+  "Feature:NetworkPolicy".
+
+If you need to run the K8s community tests locally, you may use the
+[ci/run-k8s-e2e-tests.sh](/ci/run-k8s-e2e-tests.sh) script. It takes care of
+installing the correct version of
+[sonobuoy](https://github.com/vmware-tanzu/sonobuoy) and running the correct
+subset of community tests for Antrea:
+* To run conformance tests: `./run-k8s-e2e-tests.sh --e2e-conformance
+  [--kubeconfig <Kubeconfig>]`.
+* To run network policy tests: `./run-k8s-e2e-tests.sh --e2e-network-policy
+  [--kubeconfig <Kubeconfig>]`.
+* To run a single test by name: `./run-k8s-e2e-tests.sh --e2e-focus <TestRegex>
+  [--kubeconfig <Kubeconfig>]`.
 
 ### Requirements
-Yaml files under [`ci/jenkins/jobs`](https://github.com/vmware-tanzu/antrea/tree/master/ci/jenkins/jobs) can be generated via jenkins-job-builder. If you want to try out the tests on your local jenkins setup, please notice the following requirements:
+Yaml files under [ci/jenkins/jobs](/ci/jenkins/jobs) can be generated via
+jenkins-job-builder. If you want to try out the tests on your local jenkins
+setup, please notice the following requirements:
 * Jenkins setup
   * Plugins: ghprb, throttle-concurrents
-* Install [jenkins-job-builder](https://docs.openstack.org/infra/jenkins-job-builder/index.html)
-* Define your `ANTREA_GIT_CREDENTIAL` which is the credential for your private repo
-* Define your `ghpr_auth`, `antrea_admin_list`, `antrea_org_list` and `antrea_white_list` as [defaults](https://docs.openstack.org/infra/jenkins-job-builder/definition.html#defaults) variables in a separate file
+* Install
+  [jenkins-job-builder](https://docs.openstack.org/infra/jenkins-job-builder/index.html)
+* Define your `ANTREA_GIT_CREDENTIAL` which is the credential for your private
+  repo
+* Define your `ghpr_auth`, `antrea_admin_list`, `antrea_org_list` and
+  `antrea_white_list` as
+  [defaults](https://docs.openstack.org/infra/jenkins-job-builder/definition.html#defaults)
+  variables in a separate file
 
 ### Apply the jobs
 Run the command to test if jobs can be generated correctly.  

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -297,7 +297,7 @@
             - prepare-antrea
             - builder-conformance:
                 focus_regex: '\[Feature:NetworkPolicy\]'
-                skip_regex: '.*allow ingress access from updated pod.*'
+                skip_regex: ''
           trigger_phrase: .*/test-(networkpolicy|all).*
           allow_whitelist_orgs_as_admins: true
           admin_list: '{antrea_admin_list}'

--- a/ci/run-k8s-e2e-tests.sh
+++ b/ci/run-k8s-e2e-tests.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+RUN_CONFORMANCE=false
+RUN_NETWORK_POLICY=false
+RUN_E2E_FOCUS=""
+KUBECONFIG_OPTION=""
+KUBE_CONFORMANCE_IMAGE_VERSION="v1.18.0-beta.0"
+
+_usage="Usage: $0 [--e2e-conformance] [--e2e-network-policy] [--e2e-focus <TestRegex>] [--kubeconfig <Kubeconfig>] [--kube-conformance-image-version <ConformanceImageVersion>]
+Run the K8s e2e community tests (Conformance & Network Policy) which are relevant to Project Antrea,
+using the sonobuoy tool.
+        --e2e-conformance                                         Run Conformance tests.
+        --e2e-network-policy                                      Run Network Policy tests.
+        --e2e-all                                                 Run both Conformance and Network Policy tests.
+        --e2e-focus TestRegex                                     Run only tests matching a specific regex, this is useful to run a single tests for example.
+        --kubeconfig Kubeconfig                                   Explicit path to Kubeconfig file. You may also set the KUBECONFIG environment variable.
+        --kube-conformance-image-version ConformanceImageVersion  Use specific version of the Conformance tests container image. Default is $KUBE_CONFORMANCE_IMAGE_VERSION.
+        --help, -h                                                Print this message and exit
+
+This tool uses sonobuoy (https://github.com/vmware-tanzu/sonobuoy) to run the K8s e2e community
+tests which are relevant to Antrea. You can set the SONOBUOY environment variable to the path of the
+sonobuoy binary you want to use. Otherwise we will look for sonobuoy in your PATH. If we cannot find
+sonobuoy there, we will try to install it."
+
+function print_usage {
+    echoerr "$_usage"
+}
+
+function print_help {
+    echoerr "Try '$0 --help' for more information."
+}
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    --kubeconfig)
+    KUBECONFIG_OPTION="--kubeconfig $2"
+    shift 2
+    ;;
+    --kube-conformance-image-version)
+    KUBE_CONFORMANCE_IMAGE_VERSION="$2"
+    shift 2
+    ;;
+    --e2e-conformance)
+    RUN_CONFORMANCE=true
+    shift
+    ;;
+    --e2e-network-policy)
+    RUN_NETWORK_POLICY=true
+    shift
+    ;;
+    --e2e-all)
+    RUN_CONFORMANCE=true
+    RUN_NETWORK_POLICY=true
+    shift
+    ;;
+    --e2e-focus)
+    RUN_E2E_FOCUS="$2"
+    shift 2
+    ;;
+    -h|--help)
+    print_usage
+    exit 0
+    ;;
+    *)    # unknown option
+    echoerr "Unknown option $1"
+    exit 1
+    ;;
+esac
+done
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+source $THIS_DIR/verify-sonobuoy.sh
+
+if [ -z "$SONOBUOY" ]; then
+    SONOBUOY="$(verify_sonobuoy)"
+elif ! $SONOBUOY version > /dev/null 2>&1; then
+    echoerr "$SONOBUOY does not appear to be a valid sonobuoy binary"
+    print_help
+    exit 1
+fi
+
+echoerr "Using this sonobuoy: $SONOBUOY"
+
+function run_sonobuoy() {
+    local focus_regex="$1"
+    local skip_regex="$2"
+    $SONOBUOY delete --wait $KUBECONFIG_OPTION
+    echo "Running tests with sonobuoy. While test is running, check logs with: $SONOBUOY $KUBECONFIG_OPTION logs -f."
+    $SONOBUOY run --wait \
+              $KUBECONFIG_OPTION \
+              --kube-conformance-image-version $KUBE_CONFORMANCE_IMAGE_VERSION \
+              --e2e-focus "$focus_regex" --e2e-skip "$skip_regex"
+    results=$($SONOBUOY retrieve $KUBECONFIG_OPTION)
+    $SONOBUOY results $results   
+}
+
+function run_conformance() {
+    run_sonobuoy "\[Conformance\]" "\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]"
+}
+
+function run_network_policy() {
+    run_sonobuoy "\[Feature:NetworkPolicy\]" ""
+}
+
+if $RUN_CONFORMANCE; then
+    run_conformance
+fi
+
+if $RUN_NETWORK_POLICY; then
+    run_network_policy
+fi
+
+if [[ $RUN_E2E_FOCUS != "" ]]; then
+    run_sonobuoy "$RUN_E2E_FOCUS" ""
+fi
+
+echoerr "Deleting sonobuoy resources because tests were successful"
+$SONOBUOY delete --wait $KUBECONFIG_OPTION

--- a/ci/verify-sonobuoy.sh
+++ b/ci/verify-sonobuoy.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_SONOBUOY_BINDIR="/tmp/antrea"
+_SONOBUOY_TARBALL="/tmp/sonobuoy.tar.gz"
+_MIN_SONOBUOY_VERSION="v0.17.2"
+
+install_sonobuoy() {
+    local ostype=""
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+        ostype="linux"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        ostype="darwin"
+    else
+        >&2 echo "Unsupported OS type $OSTYPE"
+        return 1
+    fi
+    >&2 echo "Installing sonobuoy"
+    local sonobuoy_url="https://github.com/vmware-tanzu/sonobuoy/releases/download/${_MIN_SONOBUOY_VERSION}/sonobuoy_${_MIN_SONOBUOY_VERSION:1}_${ostype}_amd64.tar.gz"
+    curl -sLo "$_SONOBUOY_TARBALL" "${sonobuoy_url}" || return 1
+    mkdir -p "$_SONOBUOY_BINDIR" || return 1
+    tar -xzf "$_SONOBUOY_TARBALL" -C "$_SONOBUOY_BINDIR" || return 1
+    rm -f "$_SONOBUOY_TARBALL"
+    sonobuoy="$_SONOBUOY_BINDIR/sonobuoy"
+    chmod +x "$sonobuoy"
+    echo "$sonobuoy"
+}
+
+# Ensures the sonobuoy tool exists and is a viable version, or installs it.
+verify_sonobuoy() {
+    # If sonobuoy is not available on the path, get it.
+    local sonobuoy="$(PATH=$PATH:$_SONOBUOY_BINDIR command -v sonobuoy)"
+    if [ ! -x "$sonobuoy" ]; then
+        install_sonobuoy
+        return $?
+    fi
+
+    # Verify version if sonobuoy was already installed.
+    local sonobuoy_version="$($sonobuoy version --short)"
+    sonobuoy_version="${sonobuoy_version##*/}"
+    if [ "${sonobuoy_version}" == "${_MIN_SONOBUOY_VERSION}" ]; then
+        # If version is exact match, stop here.
+        echo "$sonobuoy"
+        return 0
+    fi
+    if [[ "${_MIN_SONOBUOY_VERSION}" != $(echo -e "${_MIN_SONOBUOY_VERSION}\n${sonobuoy_version}" | sort -V | head -n1) ]]; then
+        >&2 echo "Your version of sonobuoy is not recent enough, installing version ${_MIN_SONOBUOY_VERSION}"
+        install_sonobuoy
+        return $?
+    fi
+    echo "$sonobuoy"
+}


### PR DESCRIPTION
 * Add sonobuoy wrapper script to run Antrea K8s community tests

The wrapper script provides a convenient way to run the subset of K8s
community tests which are relevant to Antrea. The tests are the same as
the ones we use for CI (and maybe the Jenkins jobs could use this script
to run the tests, in order to avoid duplication?).

At the moment the script requires a working cluster, but we can provide
yet-another-script (or extend ci/kind/test-e2e-kind.sh) to take care of
  1) creating an appropriate Kind cluster, and
  2) running the community tests.

At the moment the script does not support running a locally-modified
version of the upstream tests, but this is something we should
investigate and consider adding in the future.

 * Update README for Jenkins CI tests

The document was not updated when the list of tests was updated in the
job's YAML file.

The document was also updated so that lines wrap at 80 characters.