### PR TITLE
Add template files for jenkins on cloud

### DIFF
--- a/ci/cluster-api/vsphere/templates/cluster.yaml
+++ b/ci/cluster-api/vsphere/templates/cluster.yaml
@@ -1,0 +1,54 @@
+apiVersion: cluster.x-k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  name: CLUSTERNAME
+  namespace: CLUSTERNAMESPACE
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 100.96.0.0/11
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+      - 100.64.0.0/13
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    kind: VSphereCluster
+    name: CLUSTERNAME
+    namespace: CLUSTERNAMESPACE
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: VSphereCluster
+metadata:
+  name: CLUSTERNAME
+  namespace: CLUSTERNAMESPACE
+spec:
+  cloudProviderConfiguration:
+    global:
+      insecure: true
+      secretName: cloud-provider-vsphere-credentials
+      secretNamespace: kube-system
+    network:
+      name: NETWORKNAME
+    providerConfig:
+      cloud:
+        controllerImage: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.1.0
+      storage:
+        attacherImage: quay.io/k8scsi/csi-attacher:v1.1.1
+        controllerImage: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.1
+        livenessProbeImage: quay.io/k8scsi/livenessprobe:v1.1.0
+        metadataSyncerImage: gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.1
+        nodeDriverImage: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.1
+        provisionerImage: quay.io/k8scsi/csi-provisioner:v1.2.1
+        registrarImage: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+    virtualCenter:
+      VCENTERNAME:
+        datacenters: DATACENTERNAME
+    workspace:
+      datacenter: DATACENTERNAME
+      datastore: WorkloadDatastore
+      folder: antrea
+      resourcePool: 'RESOURCEPOOLPATH'
+      server: VCENTERNAME
+  server: VCENTERNAME

--- a/ci/cluster-api/vsphere/templates/controlplane.yaml
+++ b/ci/cluster-api/vsphere/templates/controlplane.yaml
@@ -1,0 +1,72 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+kind: KubeadmConfig
+metadata:
+  name: CLUSTERNAME-controlplane-0
+  namespace: CLUSTERNAMESPACE
+spec:
+  clusterConfiguration:
+    apiServer:
+      extraArgs:
+        cloud-provider: external
+    controllerManager:
+      extraArgs:
+        cloud-provider: external
+    imageRepository: k8s.gcr.io
+  initConfiguration:
+    nodeRegistration:
+      criSocket: /var/run/containerd/containerd.sock
+      kubeletExtraArgs:
+        cloud-provider: external
+      name: '{{ ds.meta_data.hostname }}'
+  preKubeadmCommands:
+  - hostname "{{ ds.meta_data.hostname }}"
+  - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+  - echo "127.0.0.1   localhost {{ ds.meta_data.hostname }}" >>/etc/hosts
+  - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+  users:
+  - name: capv
+    sshAuthorizedKeys:
+    - SSHAUTHORIZEDKEYS
+    sudo: ALL=(ALL) NOPASSWD:ALL
+---
+apiVersion: cluster.x-k8s.io/v1alpha2
+kind: Machine
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: CLUSTERNAME
+    cluster.x-k8s.io/control-plane: "true"
+  name: CLUSTERNAME-controlplane-0
+  namespace: CLUSTERNAMESPACE
+spec:
+  bootstrap:
+    configRef:
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      kind: KubeadmConfig
+      name: CLUSTERNAME-controlplane-0
+      namespace: CLUSTERNAMESPACE
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    kind: VSphereMachine
+    name: CLUSTERNAME-controlplane-0
+    namespace: CLUSTERNAMESPACE
+  version: 1.16.2
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: VSphereMachine
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: CLUSTERNAME
+    cluster.x-k8s.io/control-plane: "true"
+  name: CLUSTERNAME-controlplane-0
+  namespace: CLUSTERNAMESPACE
+spec:
+  datacenter: DATACENTERNAME
+  diskGiB: 40
+  memoryMiB: 4096
+  network:
+    devices:
+    - dhcp4: true
+      dhcp6: false
+      networkName: NETWORKNAME
+  numCPUs: 4
+  template: ubuntu-1804-kube-v1.16.2

--- a/ci/cluster-api/vsphere/templates/machinedeployment.yaml
+++ b/ci/cluster-api/vsphere/templates/machinedeployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+kind: KubeadmConfigTemplate
+metadata:
+  name: CLUSTERNAME-md-0
+  namespace: CLUSTERNAMESPACE
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+          kubeletExtraArgs:
+            cloud-provider: external
+          name: '{{ ds.meta_data.hostname }}'
+      preKubeadmCommands:
+      - hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+      - echo "127.0.0.1   localhost {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+      users:
+      - name: capv
+        sshAuthorizedKeys:
+        - SSHAUTHORIZEDKEYS
+        sudo: ALL=(ALL) NOPASSWD:ALL
+---
+apiVersion: cluster.x-k8s.io/v1alpha2
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: CLUSTERNAME
+  name: CLUSTERNAME-md-0
+  namespace: CLUSTERNAMESPACE
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: CLUSTERNAME
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: CLUSTERNAME
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+          kind: KubeadmConfigTemplate
+          name: CLUSTERNAME-md-0
+          namespace: CLUSTERNAMESPACE
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+        kind: VSphereMachineTemplate
+        name: CLUSTERNAME-md-0
+        namespace: CLUSTERNAMESPACE
+      version: 1.16.2
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: VSphereMachineTemplate
+metadata:
+  name: CLUSTERNAME-md-0
+  namespace: CLUSTERNAMESPACE
+spec:
+  template:
+    spec:
+      datacenter: DATACENTERNAME
+      diskGiB: 40
+      memoryMiB: 4096
+      network:
+        devices:
+        - dhcp4: true
+          dhcp6: false
+          networkName: NETWORKNAME
+      numCPUs: 4
+      template: ubuntu-1804-kube-v1.16.2

--- a/ci/cluster-api/vsphere/templates/namespace.yaml
+++ b/ci/cluster-api/vsphere/templates/namespace.yaml
@@ -1,0 +1,10 @@
+{
+  "apiVersion": "v1",
+  "kind": "Namespace",
+  "metadata": {
+    "name": "NAMESPACENAME",
+    "labels": {
+      "antrea-ci": "true"
+    }
+  }
+}

--- a/ci/jenkins/ssh-config
+++ b/ci/jenkins/ssh-config
@@ -1,0 +1,8 @@
+Host CONTROLPLANENODE
+    SendEnv LANG LC_*
+    HashKnownHosts yes
+    GSSAPIAuthentication yes
+    GSSAPIDelegateCredentials no
+    HostName MASTERNODEIP
+    Port 22
+    User capv


### PR DESCRIPTION
Issue #253 
* templates files for creating workload cluster
* ssh-config template

When the ci jenkins is moved to cloud, these template files will be used for jenkins job setup.