### PR TITLE
Fix IPsec tunnel issues

### DIFF
--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -37,6 +37,9 @@ const (
 	defaultMTUGRE             = 1462
 	defaultMTUSTT             = 1500
 	defaultMTU                = 1500
+	// IPsec ESP can add a maximum of 38 bytes to the packet including the ESP
+	// header and trailer.
+	ipsecESPOverhead = 38
 )
 
 type Options struct {
@@ -152,6 +155,10 @@ func (o *Options) setDefaults() {
 			o.config.DefaultMTU = defaultMTUGRE
 		} else if o.config.TunnelType == ovsconfig.STTTunnel {
 			o.config.DefaultMTU = defaultMTUSTT
+		}
+
+		if o.config.EnableIPSecTunnel {
+			o.config.DefaultMTU -= ipsecESPOverhead
 		}
 	}
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -262,6 +262,6 @@ IP address to two OVS interface options of the tunnel interface. Then
 `ovs-monitor-ipsec` can detect the tunnel and create IPsec Security Policies
 with PSK for the remote Node, and strongSwan can create the IPsec Security
 Associations based on the Security Policies. These additional tunnel ports are
-not really used for any traffic, but are just for triggering IPsec Security
-Policy creation by `ovs-monitor-ipsec`. All tunnel traffic still goes through
-the default tunnel port (`tun0`) with OVS flow based tunneling.
+not used to send traffic to a remote Node - the tunnel traffic is still output
+to the default tunnel port (`tun0`) with OVS flow based tunneling. However, the
+traffic from a remote Node will be received from the Node's IPsec tunnel port.

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -452,11 +452,12 @@ func (c *Controller) addNodeRoute(nodeName string, node *v1.Node) error {
 	}
 	peerGatewayIP := ip.NextIP(peerPodCIDRAddr)
 
+	ipsecTunOFPort := int32(0)
 	if c.networkConfig.EnableIPSecTunnel {
 		// Create a separate tunnel port for the Node, as OVS IPSec monitor needs to
 		// read PSK and remote IP from the Node's tunnel interface to create IPSec
 		// security policies.
-		if err = c.createIPSecTunnelPort(nodeName, peerNodeIP); err != nil {
+		if ipsecTunOFPort, err = c.createIPSecTunnelPort(nodeName, peerNodeIP); err != nil {
 			return err
 		}
 	}
@@ -465,10 +466,11 @@ func (c *Controller) addNodeRoute(nodeName string, node *v1.Node) error {
 		err = c.ofClient.InstallNodeFlows(
 			nodeName,
 			c.nodeConfig.GatewayConfig.MAC,
-			peerGatewayIP,
 			*peerPodCIDR,
+			peerGatewayIP,
 			peerNodeIP,
-			config.DefaultTunOFPort)
+			config.DefaultTunOFPort,
+			uint32(ipsecTunOFPort))
 		if err != nil {
 			return fmt.Errorf("failed to install flows to Node %s: %v", nodeName, err)
 		}
@@ -484,41 +486,51 @@ func (c *Controller) addNodeRoute(nodeName string, node *v1.Node) error {
 }
 
 // createIPSecTunnelPort creates an IPSec tunnel port for the remote Node if the
-// tunnel does not exist.
-func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) error {
+// tunnel does not exist, and returns the ofport number.
+func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) (int32, error) {
 	interfaceConfig, ok := c.interfaceStore.GetNodeTunnelInterface(nodeName)
 	if ok {
 		// TODO: check if Node IP, PSK, or tunnel type changes. This can
 		// happen if removeStaleTunnelPorts fails to remove a "stale"
 		// tunnel port for which the configuration has changed.
-		return nil
+		if interfaceConfig.OFPort != 0 {
+			return interfaceConfig.OFPort, nil
+		}
+	} else {
+		portName := util.GenerateNodeTunnelInterfaceName(nodeName)
+		ovsExternalIDs := map[string]interface{}{ovsExternalIDNodeName: nodeName}
+		portUUID, err := c.ovsBridgeClient.CreateTunnelPortExt(
+			portName,
+			c.networkConfig.TunnelType,
+			0, // ofPortRequest - let OVS allocate OFPort number.
+			nodeIP.String(),
+			c.networkConfig.IPSecPSK,
+			ovsExternalIDs)
+		if err != nil {
+			return 0, fmt.Errorf("failed to create IPSec tunnel port for Node %s", nodeName)
+		}
+		klog.Infof("Created IPSec tunnel port %s for Node %s", portName, nodeName)
+
+		ovsPortConfig := &interfacestore.OVSPortConfig{PortUUID: portUUID}
+		interfaceConfig = interfacestore.NewIPSecTunnelInterface(
+			portName,
+			c.networkConfig.TunnelType,
+			nodeName,
+			nodeIP,
+			c.networkConfig.IPSecPSK)
+		interfaceConfig.OVSPortConfig = ovsPortConfig
+		c.interfaceStore.AddInterface(interfaceConfig)
 	}
 
-	portName := util.GenerateNodeTunnelInterfaceName(nodeName)
-	ovsExternalIDs := map[string]interface{}{ovsExternalIDNodeName: nodeName}
-	portUUID, err := c.ovsBridgeClient.CreateTunnelPortExt(
-		portName,
-		c.networkConfig.TunnelType,
-		0, // ofPortRequest - let OVS allocate OFPort number.
-		nodeIP.String(),
-		c.networkConfig.IPSecPSK,
-		ovsExternalIDs)
+	// GetOFPort will wait for up to 1 second for OVSDB to report the OFPort number.
+	ofPort, err := c.ovsBridgeClient.GetOFPort(interfaceConfig.InterfaceName)
 	if err != nil {
-		klog.Errorf("Failed to create OVS IPSec tunnel port for Node %s: %v", nodeName, err)
-		return fmt.Errorf("failed to create IPSec tunnel port for Node %s", nodeName)
+		// Could be a temporary OVSDB connection failure or timeout.
+		// Let NodeRouteController retry at errors.
+		return 0, fmt.Errorf("failed to get of_port of IPSec tunnel port for Node %s", nodeName)
 	}
-	klog.Infof("Created IPSec tunnel port %s for Node %s", portName, nodeName)
-
-	ovsPortConfig := &interfacestore.OVSPortConfig{PortUUID: portUUID}
-	interfaceConfig = interfacestore.NewIPSecTunnelInterface(
-		portName,
-		c.networkConfig.TunnelType,
-		nodeName,
-		nodeIP,
-		c.networkConfig.IPSecPSK)
-	interfaceConfig.OVSPortConfig = ovsPortConfig
-	c.interfaceStore.AddInterface(interfaceConfig)
-	return nil
+	interfaceConfig.OFPort = ofPort
+	return ofPort, nil
 }
 
 // ParseTunnelInterfaceConfig initializes and returns an InterfaceConfig struct

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -37,9 +37,9 @@ const bridgeName = "dummy-br"
 func installNodeFlows(ofClient Client, cacheKey string) (int, error) {
 	hostName := cacheKey
 	gwMAC, _ := net.ParseMAC("AA:BB:CC:DD:EE:FF")
-	IP, IPNet, _ := net.ParseCIDR("10.0.1.1/24")
+	gwIP, IPNet, _ := net.ParseCIDR("10.0.1.1/24")
 	peerNodeIP := net.ParseIP("192.168.1.1")
-	err := ofClient.InstallNodeFlows(hostName, gwMAC, IP, *IPNet, peerNodeIP, config.DefaultTunOFPort)
+	err := ofClient.InstallNodeFlows(hostName, gwMAC, *IPNet, gwIP, peerNodeIP, config.DefaultTunOFPort, 0)
 	client := ofClient.(*client)
 	fCacheI, ok := client.nodeFlowCache.Load(hostName)
 	if ok {

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -179,17 +179,17 @@ func (mr *MockClientMockRecorder) InstallGatewayFlows(arg0, arg1, arg2 interface
 }
 
 // InstallNodeFlows mocks base method
-func (m *MockClient) InstallNodeFlows(arg0 string, arg1 net.HardwareAddr, arg2 net.IP, arg3 net.IPNet, arg4 net.IP, arg5 uint32) error {
+func (m *MockClient) InstallNodeFlows(arg0 string, arg1 net.HardwareAddr, arg2 net.IPNet, arg3, arg4 net.IP, arg5, arg6 uint32) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallNodeFlows", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "InstallNodeFlows", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallNodeFlows indicates an expected call of InstallNodeFlows
-func (mr *MockClientMockRecorder) InstallNodeFlows(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallNodeFlows(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallNodeFlows", reflect.TypeOf((*MockClient)(nil).InstallNodeFlows), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallNodeFlows", reflect.TypeOf((*MockClient)(nil).InstallNodeFlows), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // InstallPodFlows mocks base method

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -227,7 +227,7 @@ func testInstallServiceFlows(t *testing.T, config *testConfig) {
 
 func testInstallNodeFlows(t *testing.T, config *testConfig) {
 	for _, node := range config.peers {
-		err := c.InstallNodeFlows(node.name, config.localGateway.mac, node.gateway, node.subnet, node.nodeAddress, config.tunnelOFPort)
+		err := c.InstallNodeFlows(node.name, config.localGateway.mac, node.subnet, node.gateway, node.nodeAddress, config.tunnelOFPort, 0)
 		if err != nil {
 			t.Fatalf("Failed to install Openflow entries for node connectivity: %v", err)
 		}


### PR DESCRIPTION
Check and update tun0 tunnel type after Agent starts
If the configured tunnel type changed, Agent will remove the existing
tunnel port, and create a new one with the new type.
closes #421 

Deduct ESP header size from interface MTU when IPsec is enabled
closes #417 

Add classification flow for IPsec tunnel ports
Since packets from a remote Node are still input from the Node's IPsec tunnel port, a tunnel classification flow should be added for each IPsec tunnel port; otherwise the packets will be dropped.
closes #422