### PR TITLE
Update jenkins jobs for Antrea CI on VMC

### DIFF
--- a/ci/jenkins/README.md
+++ b/ci/jenkins/README.md
@@ -4,13 +4,24 @@
 We have tests as Github Actions but Jenkins allows tests running on a cluster of
 multiple nodes and offers better environment setup options.
 
+### Jenkins on cloud
+At the moment these Jenkins jobs are running on VMC (VMware on AWS). As a
+result, all jobs' results and details are available publicly
+[here](https://jenkins.antrea-ci.rocks/). We are using Cluster API for vSphere
+([CAPV](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere)) for
+creating and managing workload clusters. For each job build, a completely new
+workload cluster will be created. As soon as the build finishes, the cluster
+should be deleted. This ensures that all tests are run on a clean testbed.
+
 ### List of Jenkins jobs
-* e2e: [end-to-end tests](/test/e2e) for Antrea.
-* conformance: community tests using sonobuoy, focusing on "Conformance", and
-  skipping "Slow", "Serial", "Disruptive", "Flaky", "Feature", "sig-cli",
+* [e2e](https://jenkins.antrea-ci.rocks/job/antrea-e2e-for-pull-request/):
+  [end-to-end tests](/test/e2e) for Antrea.
+* [conformance](https://jenkins.antrea-ci.rocks/job/antrea-conformance-for-pull-request/):
+  community tests using sonobuoy, focusing on "Conformance", and skipping "Slow",
+  "Serial", "Disruptive", "Flaky", "Feature", "sig-cli",
   "sig-storage", "sig-auth", "sig-api-machinery", "sig-apps" and "sig-node".
-* network policy: community tests using sonobuoy, focusing on
-  "Feature:NetworkPolicy".
+* [network policy](https://jenkins.antrea-ci.rocks/job/antrea-networkpolicy-for-pull-request/):
+  community tests using sonobuoy, focusing on "Feature:NetworkPolicy".
 
 If you need to run the K8s community tests locally, you may use the
 [ci/run-k8s-e2e-tests.sh](/ci/run-k8s-e2e-tests.sh) script. It takes care of
@@ -49,3 +60,9 @@ Run the command to apply these jobs.
 ```bash
 jenkins-jobs update -r ci/jenkins/jobs
 ```
+
+### Jenkins job updater
+To follow GitOps best practices, there is a job-updater job in Jenkins to detect
+any change in [ci/jenkins/jobs](/ci/jenkins/jobs) for every 15 min. As long as
+a PR to modify code under that path is merged, Jenkins jobs on cloud should be
+updated with new code.

--- a/ci/jenkins/jobs/job-templates.yaml
+++ b/ci/jenkins/jobs/job-templates.yaml
@@ -6,7 +6,6 @@
     builders: '{builders}'
     concurrent: true
     description: '{description}'
-    disabled: false
     project-type: freestyle
     properties:
     - build-discarder:
@@ -25,13 +24,13 @@
     publishers: '{publishers}'
     scm:
     - git:
-        branches: '{branches}'
+        branches:
+          - ${{sha1}}
         credentials-id: '{git_credentials_id}'
         name: origin
         refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
         url: 'https://github.com/{org_repo}'
         wipe-workspace: true
-        included-regions: '{included_regions}'
     triggers:
     - github-pull-request:
         admin-list: '{admin_list}'
@@ -53,7 +52,56 @@
         error-status: '{error_status}'
         triggered-status: '{triggered_status}'
         started-status: '{started_status}'
+    wrappers: '{wrappers}'
+
+- job-template:
+    name: '{name}-{test_name}-for-testbed'
+    node: '{node}'
+    block-downstream: false
+    block-upstream: false
+    builders: '{builders}'
+    concurrent: true
+    description: '{description}'
+    project-type: freestyle
+    parameters: '{parameters}'
+    properties:
+    - build-discarder:
+        artifact-days-to-keep: -1
+        artifact-num-to-keep: -1
+        days-to-keep: 7
+        num-to-keep: 30
+
+- job-template:
+    name: '{name}-{test_name}-for-period'
+    block-downstream: false
+    block-upstream: false
+    builders: '{builders}'
+    concurrent: true
+    description: '{description}'
+    project-type: freestyle
+    properties:
+    - build-discarder:
+        artifact-days-to-keep: -1
+        artifact-num-to-keep: -1
+        days-to-keep: 7
+        num-to-keep: 30
+    triggers:
     - pollscm:
         cron: '{cron}'
         ignore-post-commit-hooks: '{ignore_post_commit_hooks}'
-    wrappers: '{wrappers}'
+    scm:
+    - git:
+        branches: '{branches}'
+        credentials-id: '{git_credentials_id}'
+        name: origin
+        refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
+        url: 'https://github.com/{org_repo}'
+        wipe-workspace: true
+        included-regions: '{included_regions}'
+
+- job-template:
+    name: '{name}-{test_name}-for-gc'
+    builders: '{builders}'
+    description: '{description}'
+    triggers:
+    - timed: '{timed}'

--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -2,9 +2,112 @@
     name: builder-job-updater
     builders:
       - shell: |-
-          cp /var/jenkins_home/tmp/defaults.yaml ci/jenkins/jobs
+          cp /var/lib/jenkins/utils/defaults.yaml ci/jenkins/jobs
           jenkins-jobs update -r ci/jenkins/jobs
           rm ci/jenkins/jobs/defaults.yaml
+
+- builder:
+    name: builder-workload-cluster-setup
+    builders:
+      - shell: |-
+          #!/bin/bash
+          cluster="${JOB_NAME}-${BUILD_NUMBER}"
+          newNS="${cluster}"
+          echo "=== This cluster is: ${cluster} ==="
+          echo "=== This namespace is: ${newNS} ==="
+          echo "CLUSTERNAME=${cluster}" >> ci_properties.txt
+
+          WORK_HOME="/var/lib/jenkins"
+          export KUBECONFIG="${WORK_HOME}/kubeconfig-mgmt"
+
+          echo '=== Generate key pair ==='
+          mkdir -p ${WORKSPACE}/jenkins/key
+          ssh-keygen -b 2048 -t rsa -f  "${WORKSPACE}/jenkins/key/antrea-ci-key" -q -N ""
+          publickey="$(cat ${WORKSPACE}/jenkins/key/antrea-ci-key.pub)"
+
+          echo "=== namespace value substitution ==="
+          mkdir -p ${WORKSPACE}/jenkins/out
+          cp ci/cluster-api/vsphere/templates/* ${WORKSPACE}/jenkins/out
+          manifests=("cluster" "controlplane" "machinedeployment")
+          for f in "${manifests[@]}"
+          do
+            sed -i "s/CLUSTERNAMESPACE/${newNS}/g" "${WORKSPACE}/jenkins/out/${f}.yaml"
+            sed -i "s/CLUSTERNAME/${cluster}/g" "${WORKSPACE}/jenkins/out/${f}.yaml"
+            sed -i "s|SSHAUTHORIZEDKEYS|${publickey}|g" "${WORKSPACE}/jenkins/out/${f}.yaml"
+          done
+          sed -i "s/NAMESPACENAME/${newNS}/g" "${WORKSPACE}/jenkins/out/namespace.yaml"
+
+          echo "=== network spec value substitution==="
+          cluster_defaults="${WORK_HOME}/utils/CLUSTERDEFAULTS"
+          while IFS= read -r line
+          do
+            IFS='=' read -ra kv <<< "$line"
+            for f in "${manifests[@]}"
+            do
+              sed -i "s|${kv[0]}|${kv[1]}|g" "${WORKSPACE}/jenkins/out/${f}.yaml"
+            done
+          done < "$cluster_defaults"
+
+          echo '=== Create a cluster in management cluster ==='
+          kubectl apply -f "${WORKSPACE}/jenkins/out/namespace.yaml"
+          kubectl apply -f "${WORKSPACE}/jenkins/out/cluster.yaml"
+          kubectl apply -f "${WORKSPACE}/jenkins/out/controlplane.yaml"
+          kubectl apply -f "${WORKSPACE}/jenkins/out/machinedeployment.yaml"
+
+          echo '=== Try to get secret for 10 min ==='
+          for t in {1..10}
+          do
+            sleep 1m
+            echo '=== Get kubeconfig (try for 1m) ==='
+            if kubectl get secret ${cluster}-kubeconfig -n${newNS} ; then
+              kubectl get secret ${cluster}-kubeconfig -n${newNS} -o=jsonpath='{.data.value}' | \
+                { base64 -d 2>/dev/null ; } >"${WORKSPACE}/jenkins/out/kubeconfig"
+              touch jenkins/SECRET_EXIST
+              break
+            fi
+          done
+
+          if !(test -f jenkins/SECRET_EXIST); then
+            echo "=== Fail to get secret ==="
+            exit 1
+          else
+            echo "=== Setup cluster succeeded ==="
+          fi
+
+- builder:
+    name: builder-workload-cluster-cleanup
+    builders:
+      - shell: |-
+          cluster="${CLUSTERNAME}"
+
+          echo '=== Clean up cluster ==='
+          export KUBECONFIG="/var/lib/jenkins/kubeconfig-mgmt"
+          kubectl delete Machine ${cluster}-controlplane-0 -n ${cluster} || true
+          kubectl delete MachineDeployment ${cluster}-md-0 -n ${cluster} || true
+          kubectl delete cluster ${cluster} -n ${cluster} || true
+          kubectl delete ns ${cluster} || true
+
+          rm -rf "${WORKSPACE}/jenkins"
+          echo "=== Cleanup cluster ${cluster} succeeded ==="
+
+- builder:
+    name: builder-workload-cluster-gc
+    builders:
+      - shell: |-
+          #!/bin/bash
+          echo "=== Auto cleanup starts ==="
+          export KUBECONFIG="/var/lib/jenkins/kubeconfig-mgmt"
+
+          kubectl get namespace -l antrea-ci | awk '$3 ~ "[0-9][hd]" && $2 ~ "Active" {print $1}' | while read cluster_name; do
+            echo "=== Currently ${cluster_name} has been live for more than 1h ==="
+            kubectl delete Machine ${cluster_name}-controlplane-0 -n ${cluster_name} || true
+            kubectl delete MachineDeployment ${cluster_name}-md-0 -n ${cluster_name} || true
+            kubectl delete Cluster ${cluster_name} -n ${cluster_name} || true
+            kubectl delete ns ${cluster_name} || true
+            echo "=== Old namespace ${cluster_name} is deleted !!! ==="
+          done
+
+          echo "=== Auto cleanup finished ==="
 
 - builder:
     name: builder-list-tests
@@ -45,14 +148,14 @@
       - shell: 'exit 1 # fail on purpose'
 
 - builder:
-    name: prepare-antrea
+    name: builder-prepare-antrea
     builders:
       - shell: |-
           echo ====== Cleanup Antrea Installation ======
 
-          export KUBECONFIG=/var/lib/jenkins/kube.conf
+          export KUBECONFIG="${WORKSPACE}/jenkins/out/kubeconfig"
           kubectl delete daemonset antrea-agent -n kube-system || true
-          kubectl delete -f /var/lib/jenkins/antrea.yml || true
+          kubectl delete -f "${WORKSPACE}/build/yamls/antrea.yml" || true
           kubectl delete ns antrea-test || true
       - shell: |-
           echo ====== Building Antrea for the Following Commit ======
@@ -66,43 +169,62 @@
           export PATH=$GOROOT/bin:$PATH
 
           make clean
+          docker pull antrea/openvswitch --all-tags
           docker images | grep 'antrea-ubuntu' | awk '{print $3}' | xargs -r docker rmi || true
           docker images | grep '<none>' | awk '{print $3}' | xargs -r docker rmi || true
           make
+          
+          sed -i "s|#serviceCIDR: 10.96.0.0/12|serviceCIDR: 100.64.0.0/13|g" build/yamls/antrea.yml
       - shell: |-
           echo ====== Delivering Antrea to all the Nodes ======
+          export KUBECONFIG="${WORKSPACE}/jenkins/out/kubeconfig"
 
-          export KUBECONFIG=/var/lib/jenkins/kube.conf
-
-          cp -f build/yamls/*.yml /var/lib/jenkins
           docker save -o antrea-ubuntu.tar antrea/antrea-ubuntu:latest
 
-          kubectl get nodes -o wide --no-headers=true | awk '$3 != "master" {print $6}' | while read IP; do
-          rsync -avr --progress --inplace -e "ssh -o StrictHostKeyChecking=no" antrea-ubuntu.tar jenkins@${IP}:/var/lib/jenkins/antrea-ubuntu.tar
-          ssh -o StrictHostKeyChecking=no -n jenkins@${IP} "docker images | grep 'antrea-ubuntu' | awk '{print \$3}' | xargs -r docker rmi ; docker load -i /var/lib/jenkins/antrea-ubuntu.tar ; docker images | grep '<none>' | awk '{print \$3}' | xargs -r docker rmi" || true
+          kubectl get nodes -o wide --no-headers=true | awk '$3 == "master" {print $6}' | while read master_ip; do
+            scp -o StrictHostKeyChecking=no -i jenkins/key/antrea-ci-key build/yamls/*.yml capv@${master_ip}:~
+          done
+
+          kubectl get nodes -o wide --no-headers=true | awk '{print $6}' | while read IP; do
+            rsync -avr --progress --inplace -e "ssh -o StrictHostKeyChecking=no -i jenkins/key/antrea-ci-key" antrea-ubuntu.tar capv@${IP}:/home/capv/antrea-ubuntu.tar
+            ssh -o StrictHostKeyChecking=no -i jenkins/key/antrea-ci-key -n capv@${IP} "sudo crictl images | grep 'antrea-ubuntu' | awk '{print \$3}' | xargs -r crictl rmi ; sudo ctr images import /home/capv/antrea-ubuntu.tar ; sudo crictl images | grep '<none>' | awk '{print \$3}' | xargs -r crictl rmi" || true
           done
 
 - builder:
     name: builder-e2e
     builders:
       - shell: |-
+          #!/bin/bash
           echo ====== Running Antrea E2E Tests ======
 
           export GO111MODULE=on
-          export JENKINS_HOME=/var/lib/jenkins
-          export GOPATH=$JENKINS_HOME/go
+          export WORK_HOME=/var/lib/jenkins
+          export GOPATH=$WORK_HOME/go
           export GOROOT=/usr/local/go
-          export GOCACHE=$JENKINS_HOME/.cache/go-build
+          export GOCACHE=$WORK_HOME/.cache/go-build
           export PATH=$GOROOT/bin:$PATH
-          export KUBECONFIG=$JENKINS_HOME/kube.conf
+          export KUBECONFIG=${WORKSPACE}/jenkins/out/kubeconfig
+          cluster="${JOB_NAME}-${BUILD_NUMBER}"
 
           mkdir -p test/e2e/infra/vagrant/playbook/kube
-          cp -f "${JENKINS_HOME}/kube.conf" test/e2e/infra/vagrant/playbook/kube/config
-          cp -f "${JENKINS_HOME}/ssh-config" test/e2e/infra/vagrant/ssh-config
+          cp -f "${WORKSPACE}/jenkins/out/kubeconfig" test/e2e/infra/vagrant/playbook/kube/config
+
+          echo "=== Generate ssh-config ==="
+          cp -f ci/jenkins/ssh-config test/e2e/infra/vagrant/ssh-config
+          kubectl get nodes -o wide --no-headers=true | awk '$3 == "master" {print $6}' | while read master_ip; do
+            echo "=== Master node ip: ${master_ip} ==="
+            sed -i "s/MASTERNODEIP/${master_ip}/g" test/e2e/infra/vagrant/ssh-config
+
+            echo "=== Move kubeconfig to master ==="
+            ssh -o StrictHostKeyChecking=no -i jenkins/key/antrea-ci-key -n capv@${master_ip} "mkdir .kube"
+            scp -o StrictHostKeyChecking=no -i jenkins/key/antrea-ci-key jenkins/out/kubeconfig capv@${master_ip}:~/.kube/config
+          done
+          sed -i "s/CONTROLPLANENODE/${cluster}-controlplane-0/g" test/e2e/infra/vagrant/ssh-config
+          echo "    IdentityFile ${WORKSPACE}/jenkins/key/antrea-ci-key" >> test/e2e/infra/vagrant/ssh-config
 
           set +e
           mkdir -p `pwd`/antrea-test-logs
-          go test -v github.com/vmware-tanzu/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs
+          go test -v github.com/vmware-tanzu/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs -timeout=20m
 
           test_rc=$?
           set -e
@@ -111,28 +233,35 @@
 
           echo ====== Cleanup Antrea Installation ======
 
-          for antrea_yml in /var/lib/jenkins/*.yml
+          for antrea_yml in build/yamls/*.yml
           do
             kubectl delete -f ${antrea_yml} --ignore-not-found=true || true
           done
 
           kubectl delete ns antrea-test || true
 
-          exit "$test_rc"
+          if [ "$test_rc" == "1" ]
+          then
+            echo "=== TEST FAILURE !!! ==="
+            exit 1
+          fi
+          echo "=== TEST SUCCESS !!! ==="
+          exit 0
 
 - builder:
     name: builder-conformance
     builders:
       - shell: |-
+          #!/bin/bash
           echo ====== Running Antrea Conformance Tests ======
 
           export GO111MODULE=on
-          export JENKINS_HOME=/var/lib/jenkins
-          export GOPATH=$JENKINS_HOME/go
+          export WORK_HOME=/var/lib/jenkins
+          export GOPATH=$WORK_HOME/go
           export GOROOT=/usr/local/go
-          export GOCACHE=$JENKINS_HOME/.cache/go-build
+          export GOCACHE=$WORK_HOME/.cache/go-build
           export PATH=$GOROOT/bin:$PATH
-          export KUBECONFIG=$JENKINS_HOME/kube.conf
+          export KUBECONFIG=$WORKSPACE/jenkins/out/kubeconfig
 
           kubectl apply -f build/yamls/antrea.yml
           kubectl rollout restart deployment/coredns -n kube-system
@@ -140,27 +269,32 @@
           kubectl rollout status deployment.apps/antrea-controller -n kube-system
           kubectl rollout status daemonset/antrea-agent -n kube-system
 
-          # Run sonobouy
-          sonobuoy delete --wait
-          sonobuoy run --wait --e2e-focus "{focus_regex}" --e2e-skip "{skip_regex}" --e2e-parallel y
-          results="$(sonobuoy retrieve)"
-          echo '=== Print all results ==='
-          sonobuoy results "$results"
-          echo '=== Print failed cases if any ==='
-          sonobuoy results "$results" >> RESULT
+          kubectl get nodes -o wide --no-headers=true | awk '$3 == "master" {{print $6}}' | while read master_ip; do
+            echo "=== Move kubeconfig to master ==="
+            ssh -o StrictHostKeyChecking=no -i jenkins/key/antrea-ci-key -n capv@${{master_ip}} "mkdir .kube"
+            scp -o StrictHostKeyChecking=no -i jenkins/key/antrea-ci-key jenkins/out/kubeconfig capv@${{master_ip}}:~/.kube/config
 
-          test_rc=0
-          if grep -Fxq "Failed tests:" RESULT
-          then
-            echo "Failed cases exist."
-            test_rc=1
-          else
-            echo "All tests passed."
-          fi
+            echo  "=== Run sonobouy ==="
+            sonobuoy delete --wait --kubeconfig jenkins/out/kubeconfig
+            sonobuoy run --wait --e2e-focus '{focus_regex}' --e2e-skip '{skip_regex}' --e2e-parallel y --kube-conformance-image-version v1.18.0-beta.1 --kubeconfig jenkins/out/kubeconfig
+            sonobuoy retrieve --kubeconfig jenkins/out/kubeconfig
+            echo '=== Print all results ==='
+            sonobuoy results *sonobuoy*.tar.gz
+            echo '=== Print failed cases if any ==='
+            sonobuoy results *sonobuoy*.tar.gz >> RESULT
 
-          # Clean up sonobouy resources
-          sonobuoy delete --wait
-          rm RESULT
+            if grep -Fxq "Failed tests:" RESULT
+            then
+              echo "Failed cases exist."
+              touch TEST_FAILURE
+            else
+              echo "All tests passed."
+            fi
+
+            echo "=== Clean up sonobouy resources ==="
+            sonobuoy delete --wait --kubeconfig jenkins/out/kubeconfig
+            rm RESULT
+          done
 
           echo ====== Cleanup Antrea Installation ======
 
@@ -171,4 +305,8 @@
           
           kubectl delete ns antrea-test || true
 
-          exit "$test_rc"
+          if !(test -f TEST_FAILURE); then
+            echo "=== SUCCESS !!! ==="
+            exit 0
+          fi
+          echo "=== FAILURE !!! ==="

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -1,41 +1,39 @@
 - project:
-    name: antrea-automation
-    git_credentials_id: ANTREA_GIT_CREDENTIAL
-    org_repo: vmware-tanzu/antrea
     # ghpr_auth, antrea_admin_list, antrea_org_list and antrea_white_list
     # should be defined as a global variable somewhere else
+    name: antrea
+    git_credentials_id: ANTREA_GIT_CREDENTIAL
+    org_repo: vmware-tanzu/antrea
     jobs:
-      - '{name}-{test_name}-for-pull-request':
+      - '{name}-{test_name}-for-period':
           test_name: job-updater
-          node: null
           description: 'This is for updating all antrea jobs.'
           builders:
             - builder-job-updater
-          trigger_phrase: null
-          allow_whitelist_orgs_as_admins: false
-          admin_list: []
-          org_list: []
-          white_list:
-          - nobody123_nobody123_
-          only_trigger_phrase: false
-          trigger_permit_all: true
-          throttle_concurrent_builds_category:
-          throttle_concurrent_builds_enabled: 'false'
-          status_context: should_disappear # this value doesn't matter.
-          status_url: null
-          success_status: --none--
-          failure_status: --none--
-          error_status: --none--
-          triggered_status: --none--
-          started_status: --none--
-          wrappers: []
-          publishers: []
           branches:
           - '*/master'
           included_regions:
           - ci/jenkins/jobs/.*
-          cron: 'H/10 * * * *'
+          cron: 'H/15 * * * *'
           ignore_post_commit_hooks: false
+      - '{name}-{test_name}-for-gc':
+          test_name: workload-cluster
+          description: 'This is for deleting useless workload clusters.'
+          builders:
+            - builder-workload-cluster-gc
+          timed: 'H * * * *'
+      - '{name}-{test_name}-for-testbed':
+          test_name: cleanup
+          node: null
+          description: 'This is for deleting workload clusters.'
+          builders:
+            - builder-workload-cluster-cleanup
+          parameters:
+            - string:
+                default: ''
+                description: 'The cluster name of the last finished build.'
+                name: CLUSTERNAME
+                trim: 'true'
       - '{name}-{test_name}-for-pull-request':
           test_name: list-tests
           node: null
@@ -66,11 +64,6 @@
                     credential-id: '{git_credentials_id}'
                     variable: GH_CREDENTIAL
           publishers: []
-          branches:
-          - ${{sha1}}
-          included_regions: []
-          cron: ''
-          ignore_post_commit_hooks: null
       - '{name}-{test_name}-for-pull-request':
           test_name: e2e-pending-label
           node: null
@@ -95,17 +88,13 @@
           started_status: null
           wrappers: []
           publishers: []
-          branches:
-          - ${{sha1}}
-          included_regions: []
-          cron: ''
-          ignore_post_commit_hooks: null
       - '{name}-{test_name}-for-pull-request':
           test_name: e2e
           node: 'antrea-e2e-test'
           description: 'This is the {test_name} test for {name}.'
           builders:
-            - prepare-antrea
+            - builder-workload-cluster-setup
+            - builder-prepare-antrea
             - builder-e2e
           trigger_phrase: .*/test-(e2e|all).*
           allow_whitelist_orgs_as_admins: true
@@ -118,7 +107,7 @@
             - e2e-lock-per-testbed
           throttle_concurrent_builds_enabled: 'true'
           status_context: jenkins-e2e
-          status_url: --none--
+          status_url: null
           success_status: Build finished.
           failure_status: Failed. Add comment /test-e2e to re-trigger.
           error_status: Failed. Add comment /test-e2e to re-trigger.
@@ -133,11 +122,10 @@
               default-excludes: true
               fingerprint: false
               only-if-success: false
-          branches:
-          - ${{sha1}}
-          included_regions: []
-          cron: ''
-          ignore_post_commit_hooks: null
+          - trigger-parameterized-builds:
+            - project:
+              - antrea-cleanup-for-testbed
+              property-file: 'ci_properties.txt'
       - '{name}-{test_name}-for-pull-request':
           test_name: e2e-skip
           node: null
@@ -163,11 +151,6 @@
           started_status: null
           wrappers: []
           publishers: []
-          branches:
-          - ${{sha1}}
-          included_regions: []
-          cron: ''
-          ignore_post_commit_hooks: null
       - '{name}-{test_name}-for-pull-request':
           test_name: conformance-pending-label
           node: null
@@ -192,17 +175,13 @@
           started_status: null
           wrappers: []
           publishers: []
-          branches:
-          - ${{sha1}}
-          included_regions: []
-          cron: ''
-          ignore_post_commit_hooks: null
       - '{name}-{test_name}-for-pull-request':
           test_name: conformance
           node: 'antrea-e2e-test'
           description: 'This is the {test_name} test for {name}.'
           builders:
-            - prepare-antrea
+            - builder-workload-cluster-setup
+            - builder-prepare-antrea
             - builder-conformance:
                 focus_regex: '\[Conformance\]'
                 skip_regex: '\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]'
@@ -217,19 +196,25 @@
             - e2e-lock-per-testbed
           throttle_concurrent_builds_enabled: 'true'
           status_context: jenkins-conformance
-          status_url: --none--
+          status_url: null
           success_status: Build finished.
           failure_status: Failed. Add comment /test-conformance to re-trigger.
           error_status: Failed. Add comment /test-conformance to re-trigger.
           triggered_status: null
           started_status: null
           wrappers: []
-          publishers: []
-          branches:
-          - ${{sha1}}
-          included_regions: []
-          cron: ''
-          ignore_post_commit_hooks: null
+          publishers:
+          - archive:
+              allow-empty: true
+              artifacts: '*sonobuoy*.tar.gz'
+              case-sensitive: true
+              default-excludes: true
+              fingerprint: false
+              only-if-success: false
+          - trigger-parameterized-builds:
+            - project:
+              - antrea-cleanup-for-testbed
+              property-file: 'ci_properties.txt'
       - '{name}-{test_name}-for-pull-request':
           test_name: conformance-skip
           node: null
@@ -255,11 +240,6 @@
           started_status: null
           wrappers: []
           publishers: []
-          branches:
-          - ${{sha1}}
-          included_regions: []
-          cron: ''
-          ignore_post_commit_hooks: null
       - '{name}-{test_name}-for-pull-request':
           test_name: networkpolicy-pending-label
           node: null
@@ -284,20 +264,16 @@
           started_status: null
           wrappers: []
           publishers: []
-          branches:
-          - ${{sha1}}
-          included_regions: []
-          cron: ''
-          ignore_post_commit_hooks: null
       - '{name}-{test_name}-for-pull-request':
           test_name: networkpolicy
           node: 'antrea-e2e-test'
           description: 'This is the {test_name} test for {name}.'
           builders:
-            - prepare-antrea
+            - builder-workload-cluster-setup
+            - builder-prepare-antrea
             - builder-conformance:
                 focus_regex: '\[Feature:NetworkPolicy\]'
-                skip_regex: ''
+                skip_regex: 'SKIP_NO_TESTCASE'
           trigger_phrase: .*/test-(networkpolicy|all).*
           allow_whitelist_orgs_as_admins: true
           admin_list: '{antrea_admin_list}'
@@ -309,19 +285,25 @@
             - e2e-lock-per-testbed
           throttle_concurrent_builds_enabled: 'true'
           status_context: jenkins-networkpolicy
-          status_url: --none--
+          status_url: null
           success_status: Build finished.
           failure_status: Failed. Add comment /test-networkpolicy to re-trigger.
           error_status: Failed. Add comment /test-networkpolicy to re-trigger.
           triggered_status: null
           started_status: null
           wrappers: []
-          publishers: []
-          branches:
-          - ${{sha1}}
-          included_regions: []
-          cron: ''
-          ignore_post_commit_hooks: null
+          publishers:
+          - archive:
+              allow-empty: true
+              artifacts: '*sonobuoy*.tar.gz'
+              case-sensitive: true
+              default-excludes: true
+              fingerprint: false
+              only-if-success: false
+          - trigger-parameterized-builds:
+            - project:
+              - antrea-cleanup-for-testbed
+              property-file: 'ci_properties.txt'
       - '{name}-{test_name}-for-pull-request':
           test_name: networkpolicy-skip
           node: null
@@ -347,8 +329,3 @@
           started_status: null
           wrappers: []
           publishers: []
-          branches:
-          - ${{sha1}}
-          included_regions: []
-          cron: ''
-          ignore_post_commit_hooks: null


### PR DESCRIPTION
Issue #253 
* Implement jobs for jenkins on vmc, so the jenkins logs can be exposed to the public
* Use default value for credentials and network config
* Add job-updater, which will update jenkins jobs when code under
ci/jenkins/jobs change
* Update README file with changes