### PR TITLE
Update OVS to 2.13.0

### DIFF
--- a/.github/workflows/update_ovs_image.yml
+++ b/.github/workflows/update_ovs_image.yml
@@ -15,7 +15,7 @@ jobs:
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        OVS_VERSION: 2.11.1
+        OVS_VERSION: 2.13.0
       run: |
         cd build/images/ovs/
         docker pull antrea/openvswitch-debs:$OVS_VERSION || true

--- a/build/images/Dockerfile.build.ubuntu
+++ b/build/images/Dockerfile.build.ubuntu
@@ -23,7 +23,7 @@ COPY . /antrea
 RUN make bin
 
 
-FROM antrea/openvswitch:2.11.1
+FROM antrea/openvswitch:2.13.0
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A Docker image to deploy the Antrea CNI. Takes care of building the Antrea binaries as part of building the image."

--- a/build/images/Dockerfile.ubuntu
+++ b/build/images/Dockerfile.ubuntu
@@ -10,7 +10,7 @@ RUN mkdir -p /opt/cni/bin && \
     wget -q -O - https://dl.k8s.io/network-plugins/cni-plugins-amd64-v0.7.5.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
 
 
-FROM antrea/openvswitch:2.11.1
+FROM antrea/openvswitch:2.13.0
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A Docker image to deploy the Antrea CNI. Requires the Antrea binaries to be built prior to building the image."

--- a/build/images/ovs/Dockerfile
+++ b/build/images/ovs/Dockerfile
@@ -1,13 +1,18 @@
 FROM ubuntu:18.04 as ovs-debs
 
 # Some patches may not apply cleanly if another version is provided.
-ARG OVS_VERSION=2.11.1
+ARG OVS_VERSION=2.13.0
 
 # Install dependencies for building OVS deb packages
+# We install both python2 and python3 packages (required to build the OVS debs)
+# so that this Dockerfile can be used to build different versions of OVS if
+# needed (python3 is required starting with OVS 2.13.0).
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget curl git ca-certificates build-essential fakeroot graphviz \
             bzip2 autoconf automake debhelper dh-autoreconf libssl-dev libtool openssl procps \
-            python-all python-twisted-conch python-zopeinterface python-six libunbound-dev
+            python-all python-twisted-conch python-zopeinterface python-six \
+            python3-all python3-twisted python3-zope.interface \
+            libunbound-dev
 
 COPY apply-patches.sh /
 
@@ -18,7 +23,7 @@ RUN wget -q -O - https://www.openvswitch.org/releases/openvswitch-$OVS_VERSION.t
     /apply-patches.sh && \
     DEB_BUILD_OPTIONS='parallel=8 nocheck' fakeroot debian/rules binary && \
     cd /tmp && mkdir ovs-debs && \
-    mv libopenvswitch_*.deb openvswitch-common_*.deb openvswitch-switch_*.deb python-openvswitch_*.deb \
+    mv libopenvswitch_*.deb openvswitch-common_*.deb openvswitch-switch_*.deb python*-openvswitch_*.deb \
        openvswitch-ipsec_*.deb ovs-debs/ && \
     cd / && rm -rf /tmp/openvswitch*
 

--- a/build/images/ovs/README.md
+++ b/build/images/ovs/README.md
@@ -19,7 +19,7 @@ directory. For example:
 
 ```bash
 cd build/images/ovs
-OVS_VERSION=2.11.1 ./build_and_push.sh
+OVS_VERSION=2.13.0 ./build_and_push.sh
 ```
 
 The image will be pushed to Dockerhub as `antrea/openvswitch:$OVS_VERSION`.

--- a/build/images/ovs/apply-patches.sh
+++ b/build/images/ovs/apply-patches.sh
@@ -33,3 +33,15 @@ curl https://github.com/openvswitch/ovs/commit/586cd3101e7fda54d14fb5bf12d847f35
 # We exclude 2 files which are likely to cause conflicts.
 curl https://github.com/openvswitch/ovs/commit/79eadafeb1b47a3871cb792aa972f6e4d89d1a0b.patch | \
     git apply --exclude NEWS --exclude vswitchd/ovs-vswitchd.8.in
+
+# Inspired from https://stackoverflow.com/a/24067243/4538702
+# 'sort -V' is available on Ubuntu 18.04
+function version_get() { test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" == "$1"; }
+
+if version_get "$OVS_VERSION" "2.13.0"; then
+    # OVS hardcodes the installation path to /usr/lib/python3.7/dist-packages/ but this location
+    # does not seem to be in the Python path in Ubuntu 18.04. There may be a better way to do this,
+    # but this seems like an acceptable workaround.
+    sed -i 's/python3\.7/python3\.6/' debian/openvswitch-test.install
+    sed -i 's/python3\.7/python3\.6/' debian/python3-openvswitch.install
+fi

--- a/build/images/ovs/build_and_push.sh
+++ b/build/images/ovs/build_and_push.sh
@@ -24,7 +24,7 @@ function echoerr {
 }
 
 if [ -z "$OVS_VERSION" ]; then
-    echoerr "The OVS_VERSION env variable must be set to a valid value (e.g. 2.11.1)"
+    echoerr "The OVS_VERSION env variable must be set to a valid value (e.g. 2.13.0)"
     exit 1
 fi
 


### PR DESCRIPTION
* Use OVS 2.13.0

OVS 2.13 was released in February 2020. Compared to 2.11.1 (which is the
version currently in-use by Antrea), it comes with improvements to the
userspace datapath which are useful for Kind testing.

Fixes #404 

* Add TestPingLargeMTU

Before OVS 2.12.0, the conntrack implementation of the OVS userspace
datapath did not support v4/v6 fragmentation. Now that we are using OVS
2.13.0, fragmented packets are handled correctly, which is verified by
this new TestPingLargeMTU e2e test (the test used to fail when running
Antrea on a Kind cluster).

Fixes #348