### PR TITLE
Cancel OpenFlow message and return error when OVS is disconnected

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 )
 
 replace (
-	github.com/contiv/ofnet => github.com/wenyingd/ofnet v0.0.0-20200116061148-fd9e64ac3ebb
+	github.com/contiv/ofnet => github.com/wenyingd/ofnet v0.0.0-20200228165500-75bbd38b6265
 	// Octant is renamed from vmware/octant to vmware-tanzu/octant since v0.9.0.
 	// However, Octant v0.9.0 K8s API is not compatible with Antrea K8s API version.
 	// Furthermore, octant v0.8 and v0.9 do not check-in some generated code required for testing

--- a/go.sum
+++ b/go.sum
@@ -337,8 +337,8 @@ github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYp
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/wenyingd/ofnet v0.0.0-20200116061148-fd9e64ac3ebb h1:FsbOGeX9oh0MQLWfja9CWbzmkMcShlgVmoP7miTDYS0=
-github.com/wenyingd/ofnet v0.0.0-20200116061148-fd9e64ac3ebb/go.mod h1:9fZ2429qI+GTHZQ9vlTk5QrasJKh3HOSqDjYw6WmzPs=
+github.com/wenyingd/ofnet v0.0.0-20200228165500-75bbd38b6265 h1:5oAfsTa8cfiFdiig+zFzVaKFYtbCZm3D7Hz1ECvqNX0=
+github.com/wenyingd/ofnet v0.0.0-20200228165500-75bbd38b6265/go.mod h1:9fZ2429qI+GTHZQ9vlTk5QrasJKh3HOSqDjYw6WmzPs=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18 h1:MPPkRncZLN9Kh4MEFmbnK4h3BD7AUmskWv2+EeZJCCs=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=


### PR DESCRIPTION
Add a context in OFSwitch instance, which is used to cancel the OpenFlow
message when the Switch is disconnected. Add timeout in both functions to
send OpenFlow message and wait for bundle reply. The implemention is in
ofnet, bump up version to leverage the fix.
Add integration test to simulate OVS restart case: remove the bridge, and
then add a new bridge with the same name.

Fixes #442 