### PR TITLE
Share Antrea Docker image between Kind e2e tests

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -9,18 +9,35 @@ on:
     - master
     - release-*
 jobs:
-
+  build-antrea-image:
+    name: Build Antrea image to be used for Kind e2e tests
+    runs-on: [ubuntu-18.04]
+    steps:
+    - uses: actions/checkout@v2
+    - run: make
+    - name: Save Antrea image to tarball
+      run:  docker save -o antrea-ubuntu.tar antrea/antrea-ubuntu:latest
+    - name: Upload Antrea image for subsequent jobs
+      uses: actions/upload-artifact@v1
+      with:
+        name: antrea-ubuntu
+        path: antrea-ubuntu.tar
 
   test-e2e-encap:
     name: E2e tests on a Kind cluster on Linux
+    needs: build-antrea-image
     runs-on: [ubuntu-18.04]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
       with:
         go-version: 1.13
-    - name: Build Antrea image
-      run: make
+    - name: Download Antrea image from previous job
+      uses: actions/download-artifact@v1
+      with:
+        name: antrea-ubuntu
+    - name: Load Antrea image
+      run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
     - name: Install Kind
       env:
         KIND_VERSION: v0.7.0
@@ -36,44 +53,54 @@ jobs:
 
   test-e2e-noencap:
     name: E2e tests on a Kind cluster on Linux (noEncap)
+    needs: build-antrea-image
     runs-on: [ubuntu-18.04]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v1
-        with:
-          go-version: 1.13
-      - name: Build Antrea image
-        run: make
-      - name: Install Kind
-        env:
-          KIND_VERSION: v0.7.0
-        run: |
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
-      - name: Run e2e tests
-        run: |
-          ./ci/kind/test-e2e-kind.sh noEncap
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - name: Download Antrea image from previous job
+      uses: actions/download-artifact@v1
+      with:
+        name: antrea-ubuntu
+    - name: Load Antrea image
+      run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
+    - name: Install Kind
+      env:
+        KIND_VERSION: v0.7.0
+      run: |
+        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
+        chmod +x ./kind
+        sudo mv kind /usr/local/bin
+    - name: Run e2e tests
+      run: |
+        ./ci/kind/test-e2e-kind.sh noEncap
 
 
 
   test-e2e-hybrid:
     name: E2e tests on a Kind cluster on Linux (hybrid)
+    needs: build-antrea-image
     runs-on: [ubuntu-18.04]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v1
-        with:
-          go-version: 1.13
-      - name: Build Antrea image
-        run: make
-      - name: Install Kind
-        env:
-          KIND_VERSION: v0.7.0
-        run: |
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
-      - name: Run e2e tests
-        run: |
-          ./ci/kind/test-e2e-kind.sh hybrid
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - name: Download Antrea image from previous job
+      uses: actions/download-artifact@v1
+      with:
+        name: antrea-ubuntu
+    - name: Load Antrea image
+      run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
+    - name: Install Kind
+      env:
+        KIND_VERSION: v0.7.0
+      run: |
+        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
+        chmod +x ./kind
+        sudo mv kind /usr/local/bin
+    - name: Run e2e tests
+      run: |
+        ./ci/kind/test-e2e-kind.sh hybrid


### PR DESCRIPTION
To avoid having to re-build the image every time. This reduces the
amount of compute resources we use and may help with job completion
time.