### PR TITLE
[Windows] Connect to ovs bridge using named pipe

### DIFF
--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -36,6 +36,11 @@ type AgentConfig struct {
 	// 'system' is the default value and corresponds to the kernel datapath. Use 'netdev' to run
 	// OVS in userspace mode. Userspace mode requires the tun device driver to be available.
 	OVSDatapathType string `yaml:"ovsDatapathType,omitempty"`
+	// Runtime data directory used by OpenVSwitch.
+	// Default value:
+	// - On Linux platform: /var/run/openvswitch
+	// - On Windows platform: C:\openvswitch\var\run\openvswitch
+	OVSRunDir string `yaml:"ovsRunDir,omitempty"`
 	// Name of the interface antrea-agent will create and use for host <--> pod communication.
 	// Make sure it doesn't conflict with your existing interfaces.
 	// Defaults to gw0.

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -127,6 +127,9 @@ func (o *Options) setDefaults() {
 	if o.config.OVSDatapathType == "" {
 		o.config.OVSDatapathType = ovsconfig.OVSDatapathSystem
 	}
+	if o.config.OVSRunDir == "" {
+		o.config.OVSRunDir = ovsconfig.DefaultOVSRunDir
+	}
 	if o.config.HostGateway == "" {
 		o.config.HostGateway = defaultHostGateway
 	}

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -30,9 +30,13 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow/cookie"
 	oftest "github.com/vmware-tanzu/antrea/pkg/agent/openflow/testing"
+	ofconfig "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
+	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 )
 
 const bridgeName = "dummy-br"
+
+var bridgeMgmtAddr = ofconfig.GetMgmtAddress(ovsconfig.DefaultOVSRunDir, bridgeName)
 
 func installNodeFlows(ofClient Client, cacheKey string) (int, error) {
 	hostName := cacheKey
@@ -84,7 +88,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockFlowOperations(ctrl)
-			ofClient := NewClient(bridgeName)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}
@@ -112,7 +116,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockFlowOperations(ctrl)
-			ofClient := NewClient(bridgeName)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}
@@ -153,7 +157,7 @@ func TestFlowInstallationFailed(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockFlowOperations(ctrl)
-			ofClient := NewClient(bridgeName)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}
@@ -187,7 +191,7 @@ func TestConcurrentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockFlowOperations(ctrl)
-			ofClient := NewClient(bridgeName)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -579,8 +579,8 @@ func (c *client) localProbeFlow(localGatewayIP net.IP, category cookie.Category)
 }
 
 // NewClient is the constructor of the Client interface.
-func NewClient(bridgeName string) Client {
-	bridge := binding.NewOFBridge(bridgeName)
+func NewClient(bridgeName, mgmtAddr string) Client {
+	bridge := binding.NewOFBridge(bridgeName, mgmtAddr)
 	c := &client{
 		bridge: bridge,
 		pipeline: map[binding.TableIDType]binding.Table{

--- a/pkg/ovs/openflow/default.go
+++ b/pkg/ovs/openflow/default.go
@@ -12,26 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ovsconfig
+// +build !windows
+
+package openflow
 
 import (
-	"path/filepath"
-	"strings"
-	"time"
+	"path"
 )
 
-const (
-	DefaultOVSRunDir = `C:\openvswitch\var\run\openvswitch`
-
-	defaultConnNetwork = "winpipe"
-	namedPipePrefix    = `\\.\pipe\`
-	// Wait up to 2 seconds when get port, the operation of port creation
-	// takes longer on Windows platform than on Linux.
-	defaultGetPortTimeout = 2 * time.Second
-)
-
-func GetConnAddress(ovsRunDir string) string {
-	addr := filepath.Join(filepath.FromSlash(ovsRunDir), defaultOVSDBFile)
-	addr = strings.Replace(addr, string(filepath.Separator), "", -1)
-	return namedPipePrefix + addr
+func GetMgmtAddress(ovsRunDir, brName string) string {
+	return path.Join(ovsRunDir, brName+".mgmt")
 }

--- a/pkg/ovs/openflow/default_windows.go
+++ b/pkg/ovs/openflow/default_windows.go
@@ -12,26 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ovsconfig
+package openflow
 
 import (
 	"path/filepath"
 	"strings"
-	"time"
 )
 
-const (
-	DefaultOVSRunDir = `C:\openvswitch\var\run\openvswitch`
+const namedPipePrefix = `\\.\pipe\`
 
-	defaultConnNetwork = "winpipe"
-	namedPipePrefix    = `\\.\pipe\`
-	// Wait up to 2 seconds when get port, the operation of port creation
-	// takes longer on Windows platform than on Linux.
-	defaultGetPortTimeout = 2 * time.Second
-)
-
-func GetConnAddress(ovsRunDir string) string {
-	addr := filepath.Join(filepath.FromSlash(ovsRunDir), defaultOVSDBFile)
+func GetMgmtAddress(ovsRunDir, brName string) string {
+	sockFile := brName + ".mgmt"
+	addr := filepath.Join(filepath.FromSlash(ovsRunDir), sockFile)
 	addr = strings.Replace(addr, string(filepath.Separator), "", -1)
 	return namedPipePrefix + addr
 }

--- a/pkg/ovs/ovsconfig/default.go
+++ b/pkg/ovs/ovsconfig/default.go
@@ -1,12 +1,34 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build !windows
 
 package ovsconfig
 
-import "time"
+import (
+	"path"
+	"time"
+)
 
 const (
+	DefaultOVSRunDir = "/var/run/openvswitch"
+
 	defaultConnNetwork = "unix"
-	defaultConnAddress = "/run/openvswitch/db.sock"
 	// Wait up to 1 second when get port.
 	defaultGetPortTimeout = 1 * time.Second
 )
+
+func GetConnAddress(ovsRunDir string) string {
+	return path.Join(ovsRunDir, defaultOVSDBFile)
+}

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/klog"
 )
 
+const defaultOVSDBFile = "db.sock"
+
 type OVSBridge struct {
 	ovsdb        *ovsdb.OVSDB
 	name         string
@@ -59,9 +61,6 @@ const (
 // "/run/openvswitch/db.sock" will be used.
 // Returns the OVSDB struct on success.
 func NewOVSDBConnectionUDS(address string) (*ovsdb.OVSDB, Error) {
-	if address == "" {
-		address = defaultConnAddress
-	}
 	klog.Infof("Connecting to OVSDB at address %s", address)
 
 	// For the sake of debugging, we keep logging messages until the

--- a/pkg/ovs/ovsconfig/ovsconfig_test.go
+++ b/pkg/ovs/ovsconfig/ovsconfig_test.go
@@ -1,0 +1,61 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovsconfig
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	ofconfig "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
+)
+
+const (
+	ovsRunDirWin      = `C:\openvswitch\var\run\openvswitch`
+	ovsRunDirWinSlash = `C:/openvswitch/var/run/openvswitch`
+	ovsRunDirUnix     = `/var/run/openvswitch`
+)
+
+func TestGetOVSDBConnNetAddress(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		expectedAddr := `\\.\pipe\C:openvswitchvarrunopenvswitchdb.sock`
+		addr := GetConnAddress(ovsRunDirWin)
+		assert.Equal(t, expectedAddr, addr)
+
+		addr = GetConnAddress(ovsRunDirWinSlash)
+		assert.Equal(t, expectedAddr, addr)
+	} else {
+		expectedAddr := "/var/run/openvswitch/db.sock"
+		addr := GetConnAddress(ovsRunDirUnix)
+		assert.Equal(t, expectedAddr, addr)
+	}
+}
+
+func TestGetOVSMgmtAddress(t *testing.T) {
+	brName := "br"
+	if runtime.GOOS == "windows" {
+		expectedAddr := `\\.\pipe\C:openvswitchvarrunopenvswitchbr.mgmt`
+		mgmtAddr := ofconfig.GetMgmtAddress(ovsRunDirWin, brName)
+		assert.Equal(t, expectedAddr, mgmtAddr)
+
+		mgmtAddr = ofconfig.GetMgmtAddress(ovsRunDirWinSlash, brName)
+		assert.Equal(t, expectedAddr, mgmtAddr)
+	} else {
+		expectedAddr := `/var/run/openvswitch/br.mgmt`
+		mgmtAddr := ofconfig.GetMgmtAddress(ovsRunDirUnix, brName)
+		assert.Equal(t, expectedAddr, mgmtAddr)
+	}
+}

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -28,13 +28,16 @@ import (
 	ofClient "github.com/vmware-tanzu/antrea/pkg/agent/openflow"
 	"github.com/vmware-tanzu/antrea/pkg/agent/types"
 	"github.com/vmware-tanzu/antrea/pkg/apis/networking/v1beta1"
+	ofconfig "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
+	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 	ofTestUtils "github.com/vmware-tanzu/antrea/test/integration/ovs"
 )
 
 var (
-	br        = "br01"
-	c         ofClient.Client
-	roundInfo = types.RoundInfo{0, nil}
+	br             = "br01"
+	c              ofClient.Client
+	roundInfo      = types.RoundInfo{0, nil}
+	bridgeMgmtAddr = ofconfig.GetMgmtAddress(ovsconfig.DefaultOVSRunDir, br)
 )
 
 const (
@@ -78,7 +81,7 @@ type testConfig struct {
 }
 
 func TestConnectivityFlows(t *testing.T) {
-	c = ofClient.NewClient(br)
+	c = ofClient.NewClient(br, bridgeMgmtAddr)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 	defer func() {
@@ -104,7 +107,7 @@ func TestConnectivityFlows(t *testing.T) {
 }
 
 func TestReplayFlowsConnectivityFlows(t *testing.T) {
-	c = ofClient.NewClient(br)
+	c = ofClient.NewClient(br, bridgeMgmtAddr)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -131,7 +134,7 @@ func TestReplayFlowsConnectivityFlows(t *testing.T) {
 }
 
 func TestReplayFlowsNetworkPolicyFlows(t *testing.T) {
-	c = ofClient.NewClient(br)
+	c = ofClient.NewClient(br, bridgeMgmtAddr)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -273,7 +276,7 @@ func testUninstallPodFlows(t *testing.T, config *testConfig) {
 }
 
 func TestNetworkPolicyFlows(t *testing.T) {
-	c = ofClient.NewClient(br)
+	c = ofClient.NewClient(br, bridgeMgmtAddr)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 

--- a/test/integration/ovs/address.go
+++ b/test/integration/ovs/address.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build !windows
 
 package ovs

--- a/test/integration/ovs/address_windows.go
+++ b/test/integration/ovs/address_windows.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ovs
 
 const defaultOVSDBAddress = `\\.\pipe\C:openvswitchvarrunopenvswitchdb.sock`

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
+	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 )
 
 var (
@@ -64,6 +65,11 @@ var (
 	vMAC, _          = net.ParseMAC("aa:bb:cc:dd:ee:ff")
 )
 
+func newOFBridge(brName string) binding.Bridge {
+	bridgeMgmtAddr := binding.GetMgmtAddress(ovsconfig.DefaultOVSRunDir, brName)
+	return binding.NewOFBridge(brName, bridgeMgmtAddr)
+}
+
 func TestDeleteFlowStrict(t *testing.T) {
 	br := "br02"
 	err := PrepareOVSBridge(br)
@@ -77,7 +83,7 @@ func TestDeleteFlowStrict(t *testing.T) {
 		}
 	}()
 
-	bridge := binding.NewOFBridge(br)
+	bridge := newOFBridge(br)
 	table = bridge.CreateTable(3, 4, binding.TableMissActionNext)
 
 	err = bridge.Connect(maxRetry, make(chan struct{}))
@@ -164,7 +170,7 @@ func TestOFctrlFlow(t *testing.T) {
 		}
 	}()
 
-	bridge := binding.NewOFBridge(br)
+	bridge := newOFBridge(br)
 	table1 := bridge.CreateTable(1, 2, binding.TableMissActionNext)
 	table2 := bridge.CreateTable(2, 3, binding.TableMissActionNext)
 
@@ -235,7 +241,7 @@ func TestTransactions(t *testing.T) {
 		require.Nil(t, err, fmt.Sprintf("error while deleting OVS bridge: %v", err))
 	}()
 
-	bridge := binding.NewOFBridge(br)
+	bridge := newOFBridge(br)
 	table = bridge.CreateTable(2, 3, binding.TableMissActionNext)
 
 	err = bridge.Connect(maxRetry, make(chan struct{}))
@@ -292,7 +298,7 @@ func TestBundleErrorWhenOVSRestart(t *testing.T) {
 		require.Nil(t, err, fmt.Sprintf("error while deleting OVS bridge: %v", err))
 	}()
 
-	bridge := binding.NewOFBridge(br)
+	bridge := newOFBridge(br)
 	table = bridge.CreateTable(2, 3, binding.TableMissActionNext)
 
 	err = bridge.Connect(maxRetry, make(chan struct{}))
@@ -376,7 +382,7 @@ func TestReconnectOFSwitch(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 	defer DeleteOVSBridge(br)
 
-	bridge := binding.NewOFBridge(br)
+	bridge := newOFBridge(br)
 	reconnectCh := make(chan struct{})
 	var connectCount int
 	go func() {

--- a/test/integration/ovs/openflow_test_utils.go
+++ b/test/integration/ovs/openflow_test_utils.go
@@ -22,13 +22,8 @@ import (
 )
 
 func PrepareOVSBridge(brName string) error {
-	cmdStr := fmt.Sprintf("ovs-vsctl --may-exist add-br %s", brName)
+	cmdStr := fmt.Sprintf("ovs-vsctl --may-exist add-br %s -- set Bridge %s protocols=OpenFlow10,OpenFlow13", brName, brName)
 	err := exec.Command("/bin/sh", "-c", cmdStr).Run()
-	if err != nil {
-		return err
-	}
-	cmdStr = fmt.Sprintf("ovs-vsctl set Bridge %s protocols='OpenFlow10,OpenFlow13'", brName)
-	err = exec.Command("/bin/sh", "-c", cmdStr).Run()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
On windows platform, ovs bridge listens on a named pipe for OF connection
by default. This patch:
- Change the connection to ovs from UDS to named pipe on windows.
- Add "ovsRunDir" param in config file to specify the OVS runtime dir.

Signed-off-by: Rui Cao <rcao@vmware.com>