### PR TITLE
Antrea Jenkins CI bugfix: ctr command and concurrenct build

### DIFF
--- a/ci/jenkins/jobs/job-templates.yaml
+++ b/ci/jenkins/jobs/job-templates.yaml
@@ -4,7 +4,7 @@
     block-downstream: false
     block-upstream: false
     builders: '{builders}'
-    concurrent: true
+    concurrent: false
     description: '{description}'
     project-type: freestyle
     properties:
@@ -15,12 +15,6 @@
         num-to-keep: 30
     - github:
         url: 'https://github.com/{org_repo}'
-    - throttle:
-        max-per-node: 1
-        max-total: 0
-        categories: '{throttle_concurrent_builds_category}'
-        option: category
-        enabled: '{throttle_concurrent_builds_enabled}'
     publishers: '{publishers}'
     scm:
     - git:
@@ -71,12 +65,6 @@
         num-to-keep: 30
     - github:
         url: 'https://github.com/{org_repo}'
-    - throttle:
-        max-per-node: 1
-        max-total: 0
-        categories: '{throttle_concurrent_builds_category}'
-        option: category
-        enabled: '{throttle_concurrent_builds_enabled}'
     publishers: '{publishers}'
     scm:
     - git:

--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -196,8 +196,7 @@
 
           kubectl get nodes -o wide --no-headers=true | awk '{print $6}' | while read IP; do
             rsync -avr --progress --inplace -e "ssh -o StrictHostKeyChecking=no -i jenkins/key/antrea-ci-key" antrea-ubuntu.tar capv@${IP}:/home/capv/antrea-ubuntu.tar
-            ssh -o StrictHostKeyChecking=no -i jenkins/key/antrea-ci-key -n capv@${IP} "sudo ctr -n=k8s.io images tag antrea/antrea-ubuntu:${DOCKER_IMG_VERSION} antrea/antrea-ubuntu"
-            ssh -o StrictHostKeyChecking=no -i jenkins/key/antrea-ci-key -n capv@${IP} "sudo crictl images | grep 'antrea-ubuntu' | awk '{print \$3}' | xargs -r crictl rmi ; sudo ctr -n=k8s.io images import /home/capv/antrea-ubuntu.tar ; sudo crictl images | grep '<none>' | awk '{print \$3}' | xargs -r crictl rmi" || true
+            ssh -o StrictHostKeyChecking=no -i jenkins/key/antrea-ci-key -n capv@${IP} "sudo crictl images | grep 'antrea-ubuntu' | awk '{print \$3}' | xargs -r crictl rmi ; sudo ctr -n=k8s.io images import /home/capv/antrea-ubuntu.tar ; sudo ctr -n=k8s.io images tag docker.io/antrea/antrea-ubuntu:${DOCKER_IMG_VERSION} docker.io/antrea/antrea-ubuntu:latest ; sudo crictl images | grep '<none>' | awk '{print \$3}' | xargs -r crictl rmi" || true
           done
 
 - builder:

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -49,8 +49,6 @@
           - nobody123_nobody123_
           only_trigger_phrase: false
           trigger_permit_all: true
-          throttle_concurrent_builds_category:
-          throttle_concurrent_builds_enabled: 'false'
           status_context: should_disappear # this value doesn't matter.
           status_url: null
           success_status: --none--
@@ -66,7 +64,7 @@
           publishers: []
       - '{name}-{test_name}-job-validator':
           test_name: jenkins-job-validator
-          node: null
+          node: 'antrea-e2e-test'
           description: 'This is for validating jenkins jobs code.'
           builders:
             - builder-job-validator
@@ -74,11 +72,10 @@
           allow_whitelist_orgs_as_admins: false
           admin_list: []
           org_list: []
-          white_list: []
+          white_list:
+          - nobody123_nobody123_
           only_trigger_phrase: false
           trigger_permit_all: true
-          throttle_concurrent_builds_category:
-          throttle_concurrent_builds_enabled: 'false'
           status_context: jenkins-jobs-validator
           status_url: null
           success_status: Validator passed.
@@ -103,8 +100,6 @@
           white_list: []
           only_trigger_phrase: false
           trigger_permit_all: true
-          throttle_concurrent_builds_category:
-          throttle_concurrent_builds_enabled: 'false'
           status_context: jenkins-e2e
           status_url: --none--
           success_status: Pending test. Mark as failure. Add comment /test-e2e to trigger.
@@ -129,9 +124,6 @@
           white_list: '{antrea_white_list}'
           only_trigger_phrase: true
           trigger_permit_all: false
-          throttle_concurrent_builds_category:
-            - e2e-lock-per-testbed
-          throttle_concurrent_builds_enabled: 'true'
           status_context: jenkins-e2e
           status_url: null
           success_status: Build finished.
@@ -159,15 +151,11 @@
           builders: []
           allow_whitelist_orgs_as_admins: true
           admin_list: '{antrea_admin_list}'
-          org_list: []
-          white_list: []
-          only_trigger_phrase: true
           org_list: '{antrea_org_list}'
+          white_list: '{antrea_white_list}'
+          only_trigger_phrase: true
           trigger_permit_all: false
           trigger_phrase: .*/skip-(e2e|all).*
-          white_list: '{antrea_white_list}'
-          throttle_concurrent_builds_category:
-          throttle_concurrent_builds_enabled: 'false'
           status_context: jenkins-e2e
           status_url: --none--
           success_status: Skipped test. Mark as succeeded.
@@ -190,8 +178,6 @@
           white_list: []
           only_trigger_phrase: false
           trigger_permit_all: true
-          throttle_concurrent_builds_category:
-          throttle_concurrent_builds_enabled: 'false'
           status_context: jenkins-conformance
           status_url: --none--
           success_status: Pending test. Mark as failure. Add comment /test-conformance to trigger.
@@ -218,9 +204,6 @@
           white_list: '{antrea_white_list}'
           only_trigger_phrase: true
           trigger_permit_all: false
-          throttle_concurrent_builds_category:
-            - e2e-lock-per-testbed
-          throttle_concurrent_builds_enabled: 'true'
           status_context: jenkins-conformance
           status_url: null
           success_status: Build finished.
@@ -248,15 +231,11 @@
           builders: []
           allow_whitelist_orgs_as_admins: true
           admin_list: '{antrea_admin_list}'
-          org_list: []
-          white_list: []
-          only_trigger_phrase: true
           org_list: '{antrea_org_list}'
+          white_list: '{antrea_white_list}'
+          only_trigger_phrase: true
           trigger_permit_all: false
           trigger_phrase: .*/skip-(conformance|all).*
-          white_list: '{antrea_white_list}'
-          throttle_concurrent_builds_category:
-          throttle_concurrent_builds_enabled: 'false'
           status_context: jenkins-conformance
           status_url: --none--
           success_status: Skipped test. Mark as succeeded.
@@ -279,8 +258,6 @@
           white_list: []
           only_trigger_phrase: false
           trigger_permit_all: true
-          throttle_concurrent_builds_category:
-          throttle_concurrent_builds_enabled: 'false'
           status_context: jenkins-networkpolicy
           status_url: --none--
           success_status: Pending test. Mark as failure. Add comment /test-networkpolicy to trigger.
@@ -307,9 +284,6 @@
           white_list: '{antrea_white_list}'
           only_trigger_phrase: true
           trigger_permit_all: false
-          throttle_concurrent_builds_category:
-            - e2e-lock-per-testbed
-          throttle_concurrent_builds_enabled: 'true'
           status_context: jenkins-networkpolicy
           status_url: null
           success_status: Build finished.
@@ -337,15 +311,11 @@
           builders: []
           allow_whitelist_orgs_as_admins: true
           admin_list: '{antrea_admin_list}'
-          org_list: []
-          white_list: []
-          only_trigger_phrase: true
           org_list: '{antrea_org_list}'
+          white_list: '{antrea_white_list}'
+          only_trigger_phrase: true
           trigger_permit_all: false
           trigger_phrase: .*/skip-(networkpolicy|all).*
-          white_list: '{antrea_white_list}'
-          throttle_concurrent_builds_category:
-          throttle_concurrent_builds_enabled: 'false'
           status_context: jenkins-networkpolicy
           status_url: --none--
           success_status: Skipped test. Mark as succeeded.


### PR DESCRIPTION
* remove duplicated "white_list" in project.yaml
* move "ctr image tag" after "ctr image import" #491 491
* jenkins-job-validator runs on "antrea-e2e-testbed"
* disable concurrent build for a project
* remove "Throttle Concurrent Builds" restrict