### PR TITLE
[Netpol] Use parallel probes to verify reachability matrix

### DIFF
--- a/hack/netpol/README.md
+++ b/hack/netpol/README.md
@@ -108,6 +108,7 @@ Now, look at the results of the network policy probe:
 ```
 kubectl logs -n kube-system job.batch/netpol
 ```
+(or add `-f` to stream the logs while the tests are running)
  
 ## Developers
 

--- a/hack/netpol/images/netpol-test/Dockerfile
+++ b/hack/netpol/images/netpol-test/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:rc-alpine3.10
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
-LABEL description="A Docker image based on Alpine with pyhton and wget"
+LABEL description="A Docker image based on Alpine used for netpol tests"
 
-RUN apk add --no-cache ca-certificates wget && update-ca-certificates
+# TODO: remove wget and python, these are no longer needed. We keep them for now
+# to avoid breaking CI tests.
+RUN apk add --no-cache ca-certificates wget nmap-ncat && update-ca-certificates

--- a/hack/netpol/images/netpol-test/README.md
+++ b/hack/netpol/images/netpol-test/README.md
@@ -1,6 +1,7 @@
 # images/perftool
 
-This Docker image is a very lightweight Alpine which includes python and wget.
+This Docker image is a very lightweight Alpine image which includes
+[ncat](https://nmap.org/ncat/).
 
 If you need to build a new version of the image and push it to Dockerhub, you
 can run the following from this directory:

--- a/hack/netpol/pkg/utils/reachability.go
+++ b/hack/netpol/pkg/utils/reachability.go
@@ -13,6 +13,10 @@ func NewPod(namespace string, podName string) Pod {
 	return Pod(fmt.Sprintf("%s/%s", namespace, podName))
 }
 
+func (pod Pod) String() string {
+	return string(pod)
+}
+
 func (pod Pod) split() (string, string) {
 	pieces := strings.Split(string(pod), "/")
 	if len(pieces) != 2 {

--- a/hack/netpol/test-kind.sh
+++ b/hack/netpol/test-kind.sh
@@ -29,7 +29,7 @@ kubectl create -f $THIS_DIR/install-latest.yml
 
 echo "===> Waiting for netpol Job to complete. This can take a while... <==="
 
-kubectl wait --for=condition=complete --timeout=$WAIT_TIMEOUT -n kube-system $JOB_NAME
+time kubectl wait --for=condition=complete --timeout=$WAIT_TIMEOUT -n kube-system $JOB_NAME
 
 echo "===> Checking netpol results <==="
 


### PR DESCRIPTION
This speeds up the time required to run the tests considerably (from 9
minutes to less than 4 minutes). We currently create a goroutine for
each probe, but that may become an issue if the reachability matrix
becomes too large.

We also update the netpol-test image to use ncat (from the nmap
package) instead of the Python SimpleHTTPServer. The Python server
cannot handle concurrent connections which caused the tests to be
flaky. By using ncat, we also make it possible to write network policy
tests for the SCTP protocol.

Fixes #487 