### PR TITLE
Ignore image prune operation error

### DIFF
--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -181,7 +181,7 @@
           docker images | grep 'antrea-ubuntu' | awk '{print $3}' | xargs -r docker rmi || true
           # Clean up dangling images generated in previous builds. Recent ones must be excluded
           # because they might be being used in other builds running simultaneously.
-          docker image prune -f --filter "until=1h"
+          docker image prune -f --filter "until=1h" || true
           VERSION="$JOB_NAME-$BUILD_NUMBER" make
 
           sed -i "s|#serviceCIDR: 10.96.0.0/12|serviceCIDR: 100.64.0.0/13|g" build/yamls/antrea.yml


### PR DESCRIPTION
The image prune operation cannot be executed in parallel. It could fail
when another build is doing it and terminate the build, ignore the
failure as dangling images will be cleaned up by another build or
following builds anyway.