### PR TITLE
Run linters on netpol Go code as part of CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,6 +42,21 @@ jobs:
       run: make golangci
 
 
+  golangci-lint-netpol-tmp:
+    name: Golangci-lint for netpol code
+    runs-on: [ubuntu-18.04]
+    steps:
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - name: Check-out code
+      uses: actions/checkout@v2
+    - name: Run golangci-lint
+      working-directory: hack/netpol
+      run: make golangci
+
+
   bin:
     name: Build Antrea binaries
     runs-on: [ubuntu-18.04]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,11 @@ To develop locally, you can follow these steps:
  3. To build all Go files and install them under `bin`, run `make bin`
  4. To run all Go unit tests, run `make test-unit`
 
+### CI testing
+
+For more information about the tests we run as part of CI, please refer to
+[ci/README.md](ci/README.md).
+
 ### Running the end-to-end tests
 
 In addition to the unit tests, we provide a suite of end-to-end tests, which

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ endif
 build: build-ubuntu
 
 .PHONY: test
-test: test-fmt
+test: golangci
 test: build
 test: docker-test-unit
 test: docker-test-integration
@@ -125,11 +125,6 @@ tidy:
 	@echo "SOME TESTS WILL FAIL IF NOT RUN AS ROOT!"
 	$(GO) test github.com/vmware-tanzu/antrea/test/integration/...
 
-test-fmt:
-	@echo
-	@echo "===> Checking format of Go files <==="
-	@test -z "$$(gofmt -s -l -d $(GO_FILES) | tee /dev/stderr)"
-
 test-tidy:
 	@echo
 	@echo "===> Checking go.mod tidiness <==="
@@ -148,6 +143,10 @@ fmt:
 .PHONY: golangci
 golangci: .golangci-bin
 	@GOOS=linux .golangci-bin/golangci-lint run -c .golangci.yml
+
+.PHONY: golangci-fix
+golangci-fix: .golangci-bin
+	@GOOS=linux .golangci-bin/golangci-lint run -c .golangci.yml --fix
 
 .PHONY: lint
 lint: .golangci-bin

--- a/ci/README.md
+++ b/ci/README.md
@@ -8,3 +8,23 @@ see [here](jenkins/README.md).
 File [k8s-conformance-image-version](k8s-conformance-image-version) stores the
 version number of the K8s conformance container image we currently use to run
 tests.
+
+## Go linters
+
+As part of CI, we run the following linters via
+[golangci-lint](https://github.com/golangci/golangci-lint):
+ * `misspell` - Finds commonly misspelled English words in comments.
+ * `gofmt` - Gofmt checks whether code was gofmt-ed.
+ * `deadcode` - Finds unused code.
+
+You can run the linters locally with `make golangci` from the root of the
+repository. Some issues can be fixed automatically for you if you run `make
+golangci-fix`.
+
+See our [golangci-lint configuration file](/.golangci.yml) for more details.
+
+You can also run the `golint` linter with `make lint` to see suggestions about
+how to improve your code, and we encourage you to do so when submitting a
+patch. The reason why we do not run this linter by default in CI is that, unlike
+`gofmt`, it is not considered [trustworthy enough for its suggestions to be
+enforced automatically](https://github.com/golang/lint#purpose).

--- a/hack/netpol/.golangci.yml
+++ b/hack/netpol/.golangci.yml
@@ -1,4 +1,4 @@
-# golangci-lint configuration used to run golint only (with all warnings enabled)
+# golangci-lint configuration used for CI
 run:
   tests: true
   timeout: 5m
@@ -6,10 +6,9 @@ run:
     - ".*\\.pb\\.go"
   skip-dirs-use-default: true
 
-issues:
-  exclude-use-default: false
-
 linters:
   disable-all: true
   enable:
-    - golint
+    - misspell
+    - gofmt
+    - deadcode

--- a/hack/netpol/Makefile
+++ b/hack/netpol/Makefile
@@ -20,3 +20,15 @@ push: build
 .PHONY: push-release
 push-release: build
 	docker push antrea/netpol:$(VERSION)
+
+.golangci-bin:
+	@echo "===> Installing Golangci-lint <==="
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $@ v1.21.0
+
+.PHONY: golangci
+golangci: .golangci-bin
+	@GOOS=linux .golangci-bin/golangci-lint run -c .golangci.yml
+
+.PHONY: golangci-fix
+golangci-fix: .golangci-bin
+	@GOOS=linux .golangci-bin/golangci-lint run -c .golangci.yml --fix

--- a/hack/netpol/pkg/main/main.go
+++ b/hack/netpol/pkg/main/main.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/vmware-tanzu/antrea/hack/netpol/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
 )
 
@@ -246,8 +245,8 @@ CIDR tests.... todo
 	ginkgo.It("should deny ingress access to updated pod [Feature:NetworkPolicy]", func() {
 	ginkgo.It("should stop enforcing policies after they are deleted [Feature:NetworkPolicy]", func() {
 **/
+/* TODO rewrite this using steps
 func testMultipleUpdates() {
-	/* TODO rewrite this using steps
 	func() {
 		builder := &NetworkPolicySpecBuilder{}
 		builder = builder.SetName("x", "deny-all").SetPodSelector(map[string]string{"pod": "a"})
@@ -309,7 +308,7 @@ func testMultipleUpdates() {
 	}()
 
 	// NOTE THIS TEST IS COPIED FROM THE ABOVE TEST, only delta being that we
-	// dont have the udpated=true annotation above.
+	// dont have the updated=true annotation above.
 	func() {
 		k8s.CreateOrUpdateDeployment("z", "zb", 1,
 			map[string]string{
@@ -328,8 +327,8 @@ func testMultipleUpdates() {
 
 		reachability1.PrintSummary(true, true, true)
 	}()
-	*/
 }
+*/
 
 /**
 ginkgo.It("should enforce multiple egress policies with egress allow-all policy taking precedence [Feature:NetworkPolicy]", func() {
@@ -769,93 +768,93 @@ func testEnforcePodOrNSSelector() []*TestStep {
 }
 
 // testNamespaceSelectorMatchExpressions should enforce policy based on NamespaceSelector with MatchExpressions[Feature:NetworkPolicy]
-func testNamespaceSelectorMatchExpressions() []*TestStep {
-	builder := &NetworkPolicySpecBuilder{}
-	selector := []metav1.LabelSelectorRequirement{{
-		Key:      "ns",
-		Operator: metav1.LabelSelectorOpIn,
-		Values:   []string{"y"},
-	}}
-	builder = builder.SetName("x", "allow-a-via-ns-selector").SetPodSelector(map[string]string{"pod": "a"})
-	builder.SetTypeIngress().AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, &selector, nil)
+// func testNamespaceSelectorMatchExpressions() []*TestStep {
+// 	builder := &NetworkPolicySpecBuilder{}
+// 	selector := []metav1.LabelSelectorRequirement{{
+// 		Key:      "ns",
+// 		Operator: metav1.LabelSelectorOpIn,
+// 		Values:   []string{"y"},
+// 	}}
+// 	builder = builder.SetName("x", "allow-a-via-ns-selector").SetPodSelector(map[string]string{"pod": "a"})
+// 	builder.SetTypeIngress().AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, &selector, nil)
 
-	reachability := func() *Reachability {
-		reachability := NewReachability(allPods, true)
-		reachability.ExpectAllIngress(Pod("x/a"), false)
-		reachability.Expect(Pod("y/a"), Pod("x/a"), true)
-		reachability.Expect(Pod("y/b"), Pod("x/a"), true)
-		reachability.Expect(Pod("y/c"), Pod("x/a"), true)
-		reachability.Expect(Pod("x/a"), Pod("x/a"), true)
-		return reachability
-	}
+// 	reachability := func() *Reachability {
+// 		reachability := NewReachability(allPods, true)
+// 		reachability.ExpectAllIngress(Pod("x/a"), false)
+// 		reachability.Expect(Pod("y/a"), Pod("x/a"), true)
+// 		reachability.Expect(Pod("y/b"), Pod("x/a"), true)
+// 		reachability.Expect(Pod("y/c"), Pod("x/a"), true)
+// 		reachability.Expect(Pod("x/a"), Pod("x/a"), true)
+// 		return reachability
+// 	}
 
-	return []*TestStep{
-		{
-			"Port 80",
-			reachability(),
-			builder.Get(),
-			80,
-			0,
-		},
-	}
-}
+// 	return []*TestStep{
+// 		{
+// 			"Port 80",
+// 			reachability(),
+// 			builder.Get(),
+// 			80,
+// 			0,
+// 		},
+// 	}
+// }
 
 // testPodSelectorMatchExpressions should enforce policy based on PodSelector with MatchExpressions[Feature:NetworkPolicy]
-func testPodSelectorMatchExpressions() []*TestStep {
-	builder := &NetworkPolicySpecBuilder{}
-	selector := []metav1.LabelSelectorRequirement{{
-		Key:      "pod",
-		Operator: metav1.LabelSelectorOpIn,
-		Values:   []string{"b"},
-	}}
-	builder = builder.SetName("x", "allow-client-b-via-pod-selector").SetPodSelector(map[string]string{"pod": "a"})
-	builder.SetTypeIngress().AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, &selector, nil)
+// func testPodSelectorMatchExpressions() []*TestStep {
+// 	builder := &NetworkPolicySpecBuilder{}
+// 	selector := []metav1.LabelSelectorRequirement{{
+// 		Key:      "pod",
+// 		Operator: metav1.LabelSelectorOpIn,
+// 		Values:   []string{"b"},
+// 	}}
+// 	builder = builder.SetName("x", "allow-client-b-via-pod-selector").SetPodSelector(map[string]string{"pod": "a"})
+// 	builder.SetTypeIngress().AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, &selector, nil)
 
-	reachability := func() *Reachability {
-		reachability := NewReachability(allPods, true)
-		reachability.ExpectAllIngress(Pod("x/a"), false)
+// 	reachability := func() *Reachability {
+// 		reachability := NewReachability(allPods, true)
+// 		reachability.ExpectAllIngress(Pod("x/a"), false)
 
-		reachability.Expect(Pod("x/b"), Pod("x/a"), true)
-		reachability.Expect(Pod("x/a"), Pod("x/a"), true)
-		return reachability
-	}
+// 		reachability.Expect(Pod("x/b"), Pod("x/a"), true)
+// 		reachability.Expect(Pod("x/a"), Pod("x/a"), true)
+// 		return reachability
+// 	}
 
-	return []*TestStep{
-		{
-			"Port 80",
-			reachability(),
-			builder.Get(),
-			80,
-			0,
-		},
-	}
-}
+// 	return []*TestStep{
+// 		{
+// 			"Port 80",
+// 			reachability(),
+// 			builder.Get(),
+// 			80,
+// 			0,
+// 		},
+// 	}
+// }
 
 // TODO: Find the matching upstream test
-func testIntraNamespaceTrafficOnly() []*TestStep {
-	builder := &NetworkPolicySpecBuilder{}
-	builder = builder.SetName("x", "allow-client-b-via-pod-selector").SetPodSelector(map[string]string{"pod": "a"})
-	builder.SetTypeIngress().AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"ns": "y"}, nil, nil)
+// func testIntraNamespaceTrafficOnly() []*TestStep {
+// 	builder := &NetworkPolicySpecBuilder{}
+// 	builder = builder.SetName("x", "allow-client-b-via-pod-selector").SetPodSelector(map[string]string{"pod": "a"})
+// 	builder.SetTypeIngress().AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"ns": "y"}, nil, nil)
 
-	reachability := func() *Reachability {
-		reachability := NewReachability(allPods, true)
-		reachability.ExpectAllIngress(Pod("x/a"), false)
-		reachability.Expect(Pod("y/a"), Pod("x/a"), true)
-		reachability.Expect(Pod("y/b"), Pod("x/a"), true)
-		reachability.Expect(Pod("y/c"), Pod("x/a"), true)
-		return reachability
-	}
+// 	reachability := func() *Reachability {
+// 		reachability := NewReachability(allPods, true)
+// 		reachability.ExpectAllIngress(Pod("x/a"), false)
+// 		reachability.Expect(Pod("y/a"), Pod("x/a"), true)
+// 		reachability.Expect(Pod("y/b"), Pod("x/a"), true)
+// 		reachability.Expect(Pod("y/c"), Pod("x/a"), true)
+// 		return reachability
+// 	}
 
-	return []*TestStep{
-		{
-			"Port 80",
-			reachability(),
-			builder.Get(),
-			80,
-			0,
-		},
-	}
-}
+// 	return []*TestStep{
+// 		{
+// 			"Port 80",
+// 			reachability(),
+// 			builder.Get(),
+// 			80,
+// 			0,
+// 		},
+// 	}
+// }
 
 // testInnerNamespaceTraffic should enforce policy to allow traffic from pods within server namespace, based on PodSelector [Feature:NetworkPolicy]
 // note : network policies are applied to a namespace by default, meaning that you need a specific policy to select pods in external namespaces.

--- a/hack/netpol/pkg/utils/networkpolicyspecbuilder.go
+++ b/hack/netpol/pkg/utils/networkpolicyspecbuilder.go
@@ -95,7 +95,7 @@ func (n *NetworkPolicySpecBuilder) AddIngress(protoc v1.Protocol, port *int, por
 		fmt.Println("port not nil")
 		ports = []networkingv1.NetworkPolicyPort{
 			{
-				Port: &intstr.IntOrString{IntVal: int32(*port)},
+				Port:     &intstr.IntOrString{IntVal: int32(*port)},
 				Protocol: &protoc,
 			},
 		}
@@ -104,7 +104,7 @@ func (n *NetworkPolicySpecBuilder) AddIngress(protoc v1.Protocol, port *int, por
 		fmt.Println("portName not nil")
 		ports = []networkingv1.NetworkPolicyPort{
 			{
-				Port: &intstr.IntOrString{Type: intstr.String, StrVal: *portName},
+				Port:     &intstr.IntOrString{Type: intstr.String, StrVal: *portName},
 				Protocol: &protoc,
 			},
 		}

--- a/hack/netpol/pkg/utils/utils_test.go
+++ b/hack/netpol/pkg/utils/utils_test.go
@@ -24,7 +24,7 @@ func TestNetworkPolicyBuilder(t *testing.T) {
 	if *policy1.Spec.Ingress[0].Ports[0].Protocol != v1.ProtocolUDP {
 		t.Error("Protocol mismatched")
 	}
-	if policy1.Spec.Ingress[0].Ports[0].Port.IntVal !=  80 {
+	if policy1.Spec.Ingress[0].Ports[0].Port.IntVal != 80 {
 		t.Error("ingress rule port value should be 80")
 	}
 
@@ -37,7 +37,7 @@ func TestNetworkPolicyBuilder(t *testing.T) {
 	if *policy1.Spec.Egress[0].Ports[0].Protocol != v1.ProtocolUDP {
 		t.Error("Protocol mismatched")
 	}
-	if policy1.Spec.Egress[0].Ports[0].Port.IntVal !=  80 {
+	if policy1.Spec.Egress[0].Ports[0].Port.IntVal != 80 {
 		t.Error("ingress rule port value should be 80")
 	}
 }


### PR DESCRIPTION
We also remove the `test-fmt` target since it has been replaced by
`golangci`. It is still possible to use `make fmt` to apply `gofmt`
changes on the entire code base.

Because `golangci-lint` can only be used in the scope of a single module
(apparently), we need a separate `golangci` make target in
hack/netpol. This is probably better anyway as it helps keep the Antrea
core code and the netpol code separate, which is why they are different
modules in the first place.