### PR TITLE
Add table output formats for antctl get commands

### DIFF
--- a/pkg/antctl/command_definition.go
+++ b/pkg/antctl/command_definition.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -29,6 +30,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog"
+
+	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/common"
 )
 
 type formatterType string
@@ -37,6 +40,10 @@ const (
 	jsonFormatter  formatterType = "json"
 	yamlFormatter  formatterType = "yaml"
 	tableFormatter formatterType = "table"
+)
+
+const (
+	maxTableOutputColumnLength int = 50
 )
 
 // commandGroup is used to group commands, it could be specified in commandDefinition.
@@ -320,6 +327,85 @@ func respTransformer(obj interface{}) (interface{}, error) {
 	return target, nil
 }
 
+// tableOutputForGetCommands formats the table output for "get" commands.
+func (cd *commandDefinition) tableOutputForGetCommands(obj interface{}, writer io.Writer) error {
+	var list []common.TableOutput
+	if reflect.TypeOf(obj).Kind() == reflect.Slice {
+		s := reflect.ValueOf(obj)
+		if s.Len() == 0 || s.Index(0).Interface() == nil {
+			var buffer bytes.Buffer
+			buffer.WriteString("\n")
+			if _, err := io.Copy(writer, &buffer); err != nil {
+				return fmt.Errorf("error when copy output into writer: %w", err)
+			}
+			return nil
+		}
+		if _, ok := s.Index(0).Interface().(common.TableOutput); !ok {
+			return cd.tableOutput(obj, writer)
+		}
+		for i := 0; i < s.Len(); i++ {
+			ele := s.Index(i)
+			list = append(list, ele.Interface().(common.TableOutput))
+		}
+	} else {
+		ele, ok := obj.(common.TableOutput)
+		if !ok {
+			return cd.tableOutput(obj, writer)
+		}
+		list = []common.TableOutput{ele}
+	}
+
+	// Get the elements and headers of table.
+	args := list[0].GetTableHeader()
+	rows := make([][]string, len(list)+1)
+	rows[0] = list[0].GetTableHeader()
+	for i, element := range list {
+		rows[i+1] = element.GetTableRow(maxTableOutputColumnLength)
+	}
+	body := rows[1:]
+	sort.Slice(body, func(i, j int) bool {
+		return body[i][0] < body[j][0]
+	})
+
+	widths := make([]int, len(args))
+	// Get the width of every column.
+	for j := 0; j < len(args); j++ {
+		width := len(rows[0][j])
+		for i := 1; i < len(list)+1; i++ {
+			if len(rows[i][j]) == 0 {
+				rows[i][j] = "<NONE>"
+			}
+			if width < len(rows[i][j]) {
+				width = len(rows[i][j])
+			}
+		}
+		widths[j] = width
+		if j != 0 {
+			widths[j]++
+		}
+	}
+
+	// Construct the table.
+	var buffer bytes.Buffer
+	for i := 0; i < len(list)+1; i++ {
+		for j := 0; j < len(args); j++ {
+			val := ""
+			if j != 0 {
+				val = " " + val
+			}
+			val += rows[i][j]
+			val += strings.Repeat(" ", widths[j]-len(val))
+			buffer.WriteString(val)
+		}
+		buffer.WriteString("\n")
+	}
+	if _, err := io.Copy(writer, &buffer); err != nil {
+		return fmt.Errorf("error when copy output into writer: %w", err)
+	}
+
+	return nil
+}
+
 func (cd *commandDefinition) tableOutput(obj interface{}, writer io.Writer) error {
 	target, err := respTransformer(obj)
 	if err != nil {
@@ -422,7 +508,11 @@ func (cd *commandDefinition) output(resp io.Reader, writer io.Writer, ft formatt
 	case yamlFormatter:
 		return cd.yamlOutput(obj, writer)
 	case tableFormatter:
-		return cd.tableOutput(obj, writer)
+		if cd.commandGroup == get {
+			return cd.tableOutputForGetCommands(obj, writer)
+		} else {
+			return cd.tableOutput(obj, writer)
+		}
 	default:
 		return fmt.Errorf("unsupport format type: %v", ft)
 	}

--- a/pkg/antctl/command_definition_test.go
+++ b/pkg/antctl/command_definition_test.go
@@ -17,6 +17,7 @@ package antctl
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"reflect"
 	"strings"
@@ -24,10 +25,140 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/addressgroup"
+	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/appliedtogroup"
+	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/common"
+	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/networkpolicy"
+	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/rule"
+	networkingv1beta1 "github.com/vmware-tanzu/antrea/pkg/apis/networking/v1beta1"
 )
 
 type Foobar struct {
 	Foo string
+}
+
+func TestCommandList_tableOutputForGetCommands(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		rawResponseData interface{}
+		expected        string
+	}{
+		{
+			name:            "StructureData-NonTableOutput-Single",
+			rawResponseData: Foobar{Foo: "foo"},
+			expected: `Foo            
+foo            
+`,
+		},
+		{
+			name: "StructureData-NonTableOutput-List",
+			rawResponseData: []Foobar{
+				{Foo: "foo1"},
+				{Foo: "foo2"},
+			},
+			expected: `Foo            
+foo1           
+foo2           
+`,
+		},
+		{
+			name: "StructureData-NetworkPolicy-List-HasSummary-RandomFieldOrder",
+			rawResponseData: []networkpolicy.Response{
+				{
+					Name:            "GroupName2",
+					AppliedToGroups: []string{"32ef631b-6817-5a18-86eb-93f4abf0467c", "c4c59cfe-9160-5de5-a85b-01a58d11963e"},
+					Rules: []rule.Response{
+						{
+							Direction: "In",
+							Services:  nil,
+						},
+					},
+				},
+				{
+					Rules: []rule.Response{
+						{
+							Direction: "In",
+							Services:  nil,
+						},
+						{
+							Direction: "In",
+							Services:  nil,
+						},
+					},
+					AppliedToGroups: []string{"32ef631b-6817-5a18-86eb-93f4abf0467c"},
+					Name:            "GroupName1",
+				},
+			},
+			expected: `NAME       APPLIED-TO                                       RULES
+GroupName1 32ef631b-6817-5a18-86eb-93f4abf0467c             2    
+GroupName2 32ef631b-6817-5a18-86eb-93f4abf0467c + 1 more... 1    
+`,
+		},
+		{
+			name: "StructureData-AddressGroup-List-HasSummary-HasEmpty",
+			rawResponseData: []addressgroup.Response{
+				{
+					Name: "GroupName1",
+					Pods: []common.GroupMemberPod{
+						{IP: "127.0.0.1"}, {IP: "192.168.0.1"}, {IP: "127.0.0.2"},
+						{IP: "127.0.0.3"}, {IP: "10.0.0.3"}, {IP: "127.0.0.5"}, {IP: "127.0.0.6"},
+					},
+				},
+				{
+					Name: "GroupName2",
+					Pods: []common.GroupMemberPod{},
+				},
+			},
+			expected: `NAME       POD-IPS                                           
+GroupName1 10.0.0.3,127.0.0.1,127.0.0.2,127.0.0.3 + 2 more...
+GroupName2 <NONE>                                            
+`,
+		},
+		{
+			name: "StructureData-AppliedToGroup-Single-NoSummary",
+			rawResponseData: appliedtogroup.Response{
+				Name: "GroupName",
+				Pods: []common.GroupMemberPod{
+					{Pod: &networkingv1beta1.PodReference{
+						Name:      "nginx-6db489d4b7-324rc",
+						Namespace: "PodNamespace",
+					}},
+					{Pod: &networkingv1beta1.PodReference{
+						Name:      "nginx-6db489d4b7-vgv7v",
+						Namespace: "PodNamespace",
+					}},
+				},
+			},
+			expected: `NAME      PODS                                           
+GroupName PodNamespace/nginx-6db489d4b7-324rc + 1 more...
+`,
+		},
+		{
+			name:            "StructureData-NetworkPolicy-List-EmptyRespCase",
+			rawResponseData: []networkpolicy.Response{},
+			expected:        "\n",
+		},
+		{
+			name: "StructureData-AppliedToGroup-Single-EmptyRespCase",
+			rawResponseData: appliedtogroup.Response{
+				Name: "GroupName",
+				Pods: []common.GroupMemberPod{},
+			},
+			expected: `NAME      PODS  
+GroupName <NONE>
+`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opt := &commandDefinition{}
+			var outputBuf bytes.Buffer
+			err := opt.tableOutputForGetCommands(tc.rawResponseData, &outputBuf)
+			fmt.Println(outputBuf.String())
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expected, outputBuf.String())
+		})
+	}
 }
 
 // TestFormat ensures the formatter and AddonTransform works as expected.

--- a/pkg/antctl/transform/addressgroup/transform.go
+++ b/pkg/antctl/transform/addressgroup/transform.go
@@ -55,3 +55,21 @@ func Transform(reader io.Reader, single bool) (interface{}, error) {
 		listTransform,
 	)(reader, single)
 }
+
+var _ common.TableOutput = new(Response)
+
+func (r Response) GetTableHeader() []string {
+	return []string{"NAME", "POD-IPS"}
+}
+
+func (r Response) GetTableRow(maxColumnLength int) []string {
+	row := []string{r.Name}
+
+	list := make([]string, len(r.Pods))
+	for i, pod := range r.Pods {
+		list[i] = pod.IP
+	}
+	row = append(row, common.GenerateTableElementWithSummary(list, maxColumnLength))
+
+	return row
+}

--- a/pkg/antctl/transform/appliedtogroup/transform.go
+++ b/pkg/antctl/transform/appliedtogroup/transform.go
@@ -55,3 +55,21 @@ func Transform(reader io.Reader, single bool) (interface{}, error) {
 		listTransform,
 	)(reader, single)
 }
+
+var _ common.TableOutput = new(Response)
+
+func (r Response) GetTableHeader() []string {
+	return []string{"NAME", "PODS"}
+}
+
+func (r Response) GetTableRow(maxColumnLength int) []string {
+	row := []string{r.Name}
+
+	list := make([]string, len(r.Pods))
+	for i, pod := range r.Pods {
+		list[i] = pod.Pod.Namespace + "/" + pod.Pod.Name
+	}
+	row = append(row, common.GenerateTableElementWithSummary(list, maxColumnLength))
+
+	return row
+}

--- a/pkg/antctl/transform/networkpolicy/transform.go
+++ b/pkg/antctl/transform/networkpolicy/transform.go
@@ -17,8 +17,10 @@ package networkpolicy
 import (
 	"io"
 	"reflect"
+	"strconv"
 
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform"
+	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/common"
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/rule"
 	networkingv1beta1 "github.com/vmware-tanzu/antrea/pkg/apis/networking/v1beta1"
 )
@@ -59,4 +61,17 @@ func Transform(reader io.Reader, single bool) (interface{}, error) {
 		objectTransform,
 		listTransform,
 	)(reader, single)
+}
+
+var _ common.TableOutput = new(Response)
+
+func (r Response) GetTableHeader() []string {
+	return []string{"NAME", "APPLIED-TO", "RULES"}
+}
+
+func (r Response) GetTableRow(maxColumnLength int) []string {
+	row := []string{r.Name}
+	row = append(row, common.GenerateTableElementWithSummary(r.AppliedToGroups, maxColumnLength))
+	row = append(row, strconv.Itoa(len(r.Rules)))
+	return row
 }


### PR DESCRIPTION
Reformat the table output for antctl get commands.

1. Reorder the headers of the output.
2. Set a maximum length for all elements in tables with a const variable maxTableOutputColumnLength. If one line is not enough, then generate a summary.
3. Beautify the names of pods along with other fields.
4. Make table headers capitalized and meaningful.


Before:
```shell
# antctl get network-policy -o table
name                                 rules                                                                                                                                        appliedToGroups
c4c59cfe-9160-5de5-a85b-01a58d11963e [{"direction":"In","from":{"addressGroups":["32ef631b-6817-5a18-86eb-93f4abf0467c"]},"services":[{"port":"http","protocol":"TCP"}],"to":{}}] ["c4c59cfe-9160-5de5-a85b-01a58d11963e"]

# antctl get applied-to-group -o table
name                                 pods
c4c59cfe-9160-5de5-a85b-01a58d11963e [{"pod":{"name":"nginx-6db489d4b7-vgv7v","namespace":"default"}},{"pod":{"name":"nginx-6db489d4b7-bh74d","namespace":"default"}},{"pod":{"name":"nginx-6db489d4b7-m272t","namespace":"default"}}]

# antctl get address-group -o table
name                                 pods
32ef631b-6817-5a18-86eb-93f4abf0467c [{"ip":"127.0.0.1"},{"ip":"192.168.0.1"}]
```

After:
```shell
# antctl get network-policy -o table
NAME                                 APPLIED-TO                                       RULES
c4c59cfe-9160-5de5-a85b-01a58d11963e 32ef631b-6817-5a18-86eb-93f4abf0467c             2    
0044b144-8d49-4621-8cc3-9a4ddf2c35f9 32ef631b-6817-5a18-86eb-93f4abf0467c + 1 more... 1    

# antctl get applied-to-group -o table
NAME                                 PODS
c4c59cfe-9160-5de5-a85b-01a58d11963e default/nginx-6db489d4b7-vgv7v + 3 more...


# antctl get address-group -o table
NAME                                 POD-IPS
c4c59cfe-9160-5de5-a85b-01a58d11963e <NONE>
32ef631b-6817-5a18-86eb-93f4abf0467c 10.30.0.149,10.30.0.150,10.30.0.151 + 2 more...

```

Fixes #477 
