### PR TITLE
Enable Antrea in GKE cluster for Ubuntu host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,7 @@ manifest:
 	@echo "===> Generating dev manifest for Antrea <==="
 	$(CURDIR)/hack/generate-manifest.sh --mode dev > build/yamls/antrea.yml
 	$(CURDIR)/hack/generate-manifest.sh --mode dev --ipsec > build/yamls/antrea-ipsec.yml
+	$(CURDIR)/hack/generate-manifest.sh --mode dev --cloud GKE > build/yamls/antrea-gke.yml
 	$(CURDIR)/hack/generate-manifest-octant.sh --mode dev > build/yamls/antrea-octant.yml
 
 .PHONY: octant-antrea-ubuntu

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1,0 +1,593 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app: antrea
+  name: antreaagentinfos.clusterinformation.antrea.tanzu.vmware.com
+spec:
+  group: clusterinformation.antrea.tanzu.vmware.com
+  names:
+    kind: AntreaAgentInfo
+    plural: antreaagentinfos
+    shortNames:
+    - aai
+    singular: antreaagentinfo
+  scope: Cluster
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app: antrea
+  name: antreacontrollerinfos.clusterinformation.antrea.tanzu.vmware.com
+spec:
+  group: clusterinformation.antrea.tanzu.vmware.com
+  names:
+    kind: AntreaControllerInfo
+    plural: antreacontrollerinfos
+    shortNames:
+    - aci
+    singular: antreacontrollerinfo
+  scope: Cluster
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: antrea
+  name: antctl
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: antrea
+  name: antrea-agent
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: antrea
+  name: antrea-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
+  name: antctl
+rules:
+- apiGroups:
+  - clusterinformation.antrea.tanzu.vmware.com
+  resources:
+  - antreacontrollerinfos
+  verbs:
+  - get
+- apiGroups:
+  - networking.antrea.tanzu.vmware.com
+  resources:
+  - networkpolicies
+  - appliedtogroups
+  - addressgroups
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
+  name: antrea-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - pods
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - clusterinformation.antrea.tanzu.vmware.com
+  resources:
+  - antreaagentinfos
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - networking.antrea.tanzu.vmware.com
+  resources:
+  - networkpolicies
+  - appliedtogroups
+  - addressgroups
+  verbs:
+  - get
+  - watch
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
+  name: antrea-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - pods
+  - namespaces
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - clusterinformation.antrea.tanzu.vmware.com
+  resources:
+  - antreacontrollerinfos
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - clusterinformation.antrea.tanzu.vmware.com
+  resources:
+  - antreaagentinfos
+  verbs:
+  - list
+  - delete
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: antrea
+  name: antrea-controller-authentication-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: antrea-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: antrea
+  name: antctl
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: antctl
+subjects:
+- kind: ServiceAccount
+  name: antctl
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: antrea
+  name: antrea-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: antrea-agent
+subjects:
+- kind: ServiceAccount
+  name: antrea-agent
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: antrea
+  name: antrea-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: antrea-controller
+subjects:
+- kind: ServiceAccount
+  name: antrea-controller
+  namespace: kube-system
+---
+apiVersion: v1
+data:
+  antrea-agent.conf: |
+    # Name of the OpenVSwitch bridge antrea-agent will create and use.
+    # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
+    #ovsBridge: br-int
+
+    # Datapath type to use for the OpenVSwitch bridge created by Antrea. Supported values are:
+    # - system
+    # - netdev
+    # 'system' is the default value and corresponds to the kernel datapath. Use 'netdev' to run
+    # OVS in userspace mode. Userspace mode requires the tun device driver to be available.
+    #ovsDatapathType: system
+
+    # Name of the interface antrea-agent will create and use for host <--> pod communication.
+    # Make sure it doesn't conflict with your existing interfaces.
+    #hostGateway: gw0
+
+    # Encapsulation mode for communication between Pods across Nodes, supported values:
+    # - vxlan (default)
+    # - geneve
+    # - gre
+    # - stt
+    #tunnelType: vxlan
+
+    # Default MTU to use for the host gateway interface and the network interface of each Pod. If
+    # omitted, antrea-agent will default this value to 1450 to accomodate for tunnel encapsulate
+    # overhead.
+    #defaultMTU: 1450
+
+    # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
+    # for the GRE tunnel type.
+    #enableIPSecTunnel: false
+
+    # CIDR Range for services in cluster. It's required to support egress network policy, should
+    # be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
+    #serviceCIDR: 10.96.0.0/12
+
+    # Determines how traffic is encapsulated. It has the following options
+    # encap(default): Inter-node Pod traffic is always encapsulated and Pod to outbound traffic is masqueraded.
+    # noEncap: Inter-node Pod traffic is not encapsulated, but Pod to outbound traffic is masqueraded.
+    #          Underlying network must be capable of supporting Pod traffic across IP subnet.
+    # hybrid: noEncap if worker Nodes on same subnet, otherwise encap.
+    trafficEncapMode: noEncap
+  antrea-cni.conf: |
+    {
+        "cniVersion":"0.3.0",
+        "name": "antrea",
+        "type": "antrea",
+        "ipam": {
+            "type": "host-local"
+        }
+    }
+  antrea-controller.conf: ""
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    app: antrea
+  name: antrea-config-92ff6c9m4d
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: antrea
+  name: antrea
+  namespace: kube-system
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app: antrea
+    component: antrea-controller
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: antrea
+    component: antrea-controller
+  name: antrea-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: antrea
+      component: antrea-controller
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: antrea
+        component: antrea-controller
+    spec:
+      containers:
+      - args:
+        - --config
+        - /etc/antrea/antrea-controller.conf
+        command:
+        - antrea-controller
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: antrea/antrea-ubuntu:latest
+        imagePullPolicy: IfNotPresent
+        name: antrea-controller
+        ports:
+        - containerPort: 443
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            host: 127.0.0.1
+            path: /healthz
+            port: 443
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+        volumeMounts:
+        - mountPath: /etc/antrea/antrea-controller.conf
+          name: antrea-config
+          readOnly: true
+          subPath: antrea-controller.conf
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      serviceAccountName: antrea-controller
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      volumes:
+      - configMap:
+          name: antrea-config-92ff6c9m4d
+        name: antrea-config
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    app: antrea
+  name: v1beta1.networking.antrea.tanzu.vmware.com
+spec:
+  group: networking.antrea.tanzu.vmware.com
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: antrea
+    namespace: kube-system
+  version: v1beta1
+  versionPriority: 100
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: antrea
+    component: antrea-agent
+  name: antrea-agent
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: antrea
+      component: antrea-agent
+  template:
+    metadata:
+      labels:
+        app: antrea
+        component: antrea-agent
+    spec:
+      containers:
+      - args:
+        - --config
+        - /etc/antrea/antrea-agent.conf
+        command:
+        - antrea-agent
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: antrea/antrea-ubuntu:latest
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - container_liveness_probe agent
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+        name: antrea-agent
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            host: 127.0.0.1
+            path: /healthz
+            port: 10443
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/antrea/antrea-agent.conf
+          name: antrea-config
+          readOnly: true
+          subPath: antrea-agent.conf
+        - mountPath: /var/run/antrea
+          name: host-var-run-antrea
+        - mountPath: /var/run/openvswitch
+          name: host-var-run-antrea
+          subPath: openvswitch
+        - mountPath: /var/lib/cni
+          name: host-var-run-antrea
+          subPath: cni
+        - mountPath: /host/proc
+          name: host-proc
+          readOnly: true
+        - mountPath: /host/var/run/netns
+          mountPropagation: HostToContainer
+          name: host-var-run-netns
+          readOnly: true
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+      - command:
+        - start_ovs
+        image: antrea/antrea-ubuntu:latest
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - timeout 5 container_liveness_probe ovs
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        name: antrea-ovs
+        securityContext:
+          capabilities:
+            add:
+            - SYS_NICE
+            - NET_ADMIN
+            - SYS_ADMIN
+            - IPC_LOCK
+        volumeMounts:
+        - mountPath: /var/run/openvswitch
+          name: host-var-run-antrea
+          subPath: openvswitch
+        - mountPath: /var/log/openvswitch
+          name: host-var-log-antrea
+          subPath: openvswitch
+      hostNetwork: true
+      initContainers:
+      - command:
+        - install_cni
+        image: antrea/antrea-ubuntu:latest
+        imagePullPolicy: IfNotPresent
+        name: install-cni
+        securityContext:
+          capabilities:
+            add:
+            - SYS_MODULE
+        volumeMounts:
+        - mountPath: /etc/antrea/antrea-cni.conf
+          name: antrea-config
+          readOnly: true
+          subPath: antrea-cni.conf
+        - mountPath: /host/etc/cni/net.d
+          name: host-cni-conf
+        - mountPath: /host/opt/cni/bin
+          name: host-cni-bin
+        - mountPath: /lib/modules
+          name: host-lib-modules
+          readOnly: true
+        - mountPath: /sbin/depmod
+          name: host-depmod
+          readOnly: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      priorityClassName: system-node-critical
+      serviceAccountName: antrea-agent
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+      volumes:
+      - configMap:
+          name: antrea-config-92ff6c9m4d
+        name: antrea-config
+      - hostPath:
+          path: /etc/cni/net.d
+        name: host-cni-conf
+      - hostPath:
+          path: /home/kubernetes/bin
+        name: host-cni-bin
+      - hostPath:
+          path: /proc
+        name: host-proc
+      - hostPath:
+          path: /var/run/netns
+        name: host-var-run-netns
+      - hostPath:
+          path: /var/run/antrea
+          type: DirectoryOrCreate
+        name: host-var-run-antrea
+      - hostPath:
+          path: /var/log/antrea
+          type: DirectoryOrCreate
+        name: host-var-log-antrea
+      - hostPath:
+          path: /lib/modules
+        name: host-lib-modules
+      - hostPath:
+          path: /sbin/depmod
+        name: host-depmod
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: xtables-lock
+  updateStrategy:
+    type: RollingUpdate

--- a/build/yamls/antrea-node-init.yml
+++ b/build/yamls/antrea-node-init.yml
@@ -1,0 +1,42 @@
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: antrea-node-init
+  namespace: kube-system
+  labels:
+    app: antrea-node-init
+spec:
+  template:
+    metadata:
+      labels:
+        app: antrea-node-init
+    spec:
+      hostPID: true
+      hostNetwork: true
+      containers:
+        - name: node-init
+          image: gcr.io/google-containers/startup-script:v1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          env:
+          - name: STARTUP_SCRIPT
+            value: |
+              #! /bin/bash
+
+              set -o errexit
+              set -o pipefail
+              set -o nounset
+
+              echo "Changing kubelet configuration to --network-plugin=cni --cni-bin-dir=/home/kubernetes/bin"
+              mkdir -p /home/kubernetes/bin
+              sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir=/home/kubernetes/bin:g" /etc/default/kubelet
+              echo "Restarting kubelet..."
+              systemctl restart kubelet
+
+              if ip link show cbr0; then
+                      echo "Detected cbr0 bridge. Deleting interface..."
+                      ip link del cbr0
+              fi
+
+              echo "Node initialization complete"

--- a/build/yamls/patches/gke/cniPath.yml
+++ b/build/yamls/patches/gke/cniPath.yml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: antrea
+    component: antrea-agent
+  name: antrea-agent
+spec:
+  template:
+    spec:
+      volumes:
+      - hostPath:
+          path: /home/kubernetes/bin
+        name: host-cni-bin

--- a/docs/antrea-gke.md
+++ b/docs/antrea-gke.md
@@ -1,0 +1,128 @@
+# Deploying Antrea on a GKE cluster
+
+We support running Antrea inside of GKE clusters on Ubuntu host. Antrea would operate
+in noEncap mode, in which no encapsulation is required for any kind of traffic (Intra node,
+Inter node etc) and enforcing network policies using OVS.
+
+For details on Antrea noEncap Mode, refer to this. [TODO]
+
+## GKE Prerequisites
+
+1. Install the Google Cloud SDK (gcloud). Refer to this (https://cloud.google.com/sdk/install)
+
+    ```bash
+    curl https://sdk.cloud.google.com | bash
+    ```
+
+2. Make sure you are authenticated to use the Google Cloud API
+
+    ```bash
+    export ADMIN_USER=user@email.com
+    gcloud auth login
+    ```
+
+3. Create a project or use an existing one
+
+    ```bash
+    export GKE_PROJECT=gke-clusters
+    gcloud projects create $GKE_PROJECT
+    ```
+
+## Creating the cluster
+
+You can use any method to create a GKE cluster (gcloud SDK, gcloud Console etc). The example
+given here is using the Google Cloud SDK.
+
+Note: Antrea is supported on Ubuntu hosts only for GKE cluster. Also, its must to select service
+CIDR at the time of cluster deployment.
+
+1. Create a GKE cluster
+
+    ```bash
+    export GKE_ZONE="us-west1"
+    export GKE_HOST="UBUNTU"
+    export GKE_SERVICE_CIDR="10.94.0.0/16"
+    gcloud container --project $GKE_PROJECT clusters create cluster1 --image-type $GKE_HOST \
+       --zone $GKE_ZONE --enable-ip-alias --services-ipv4-cidr $GKE_SERVICE_CIDR
+    ```
+
+2. Access your cluster
+
+    ```bash
+    kubectl get nodes
+    NAME                                      STATUS   ROLES    AGE     VERSION
+    gke-cluster1-default-pool-93d7da1c-61z4   Ready    <none>   3m11s   v1.14.10-gke.17
+    gke-cluster1-default-pool-93d7da1c-rkbm   Ready    <none>   3m9s    v1.14.10-gke.17
+    ```
+
+3. Create a cluster-admin-binding
+
+    ```bash
+    kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user user@email.com
+    ```
+
+    Note: To create clusterRoleBinding, the user must have `container.clusterRoleBindings.create` permission.
+Use this command to enable it, if the previous command fails due to permission error. Only cluster Admin can
+assign this permission.
+
+    ```bash
+    gcloud projects add-iam-policy-binding $GKE_PROJECT --member user:user@email.com --role roles/container.admin
+    ```
+
+## Deploying Antrea
+
+1. Prepare the Cluster Nodes
+
+    Deploy antrea-node-init DaemonSet to enable kubelet to operate in CNI mode.
+
+    ```bash
+    kubectl apply -f https://github.com/vmware-tanzu/antrea/releases/download/v0.5.0/antrea-node-init.yml
+    ```
+
+2. Download and Update Antrea YAML
+
+    Download a released version of Antrea deployment YAML (>=v0.5.0). Update the `serviceCIDR` config in the
+antrea-gke.yml file with GKE_SERVICE_CIDR selected at the time of deploying GKE cluster.
+
+    ```bash
+    export TAG=v0.5.0
+    curl https://github.com/vmware-tanzu/antrea/releases/download/<TAG>/antrea-gke.yml --output antrea-gke.yml
+
+    cat antrea-gke.yml
+    ...
+        # CIDR Range for services in cluster. It's required to support egress network policy, should
+        # be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
+        serviceCIDR: 10.94.0.0/16
+    ...
+    ```
+
+3. Deploy Antrea
+
+    Deploy Antrea using `kubectl apply -f antrea-gke.yml`. It will deploy single replica of Antrea controller
+and Antrea agent to every worker nodes of the GKE cluster. After a successful deployment you should be able to see
+these Pods running in your cluster:
+
+    ```bash
+    $ kubectl get pods --namespace kube-system  -l app=antrea -o wide
+    NAME                                READY   STATUS    RESTARTS   AGE   IP              NODE                                      NOMINATED NODE   READINESS GATES
+    antrea-agent-24vwr                  2/2     Running   0          46s   10.138.15.209   gke-cluster1-default-pool-93d7da1c-rkbm   <none>           <none>
+    antrea-agent-7dlcp                  2/2     Running   0          46s   10.138.15.206   gke-cluster1-default-pool-9ba12cea-wjzn   <none>           <none>
+    antrea-controller-5f9985c59-5crt6   1/1     Running   0          46s   10.138.15.209   gke-cluster1-default-pool-93d7da1c-rkbm   <none>           <none>
+    ```
+
+4. Restart remaining pods
+
+    Once Antrea is up and running, restart all pods in kube-system so they can be managed by Antrea.
+
+    ```bash
+    $ kubectl delete pods -n kube-system $(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{ print $1 }')
+    pod "event-exporter-v0.2.5-7df89f4b8f-cm5r5" deleted
+    pod "fluentd-gcp-scaler-54ccb89d5-2glmv" deleted
+    pod "heapster-gke-6dd876579c-fc7xd" deleted
+    pod "kube-dns-5877696fb4-7cfbc" deleted
+    pod "kube-dns-5877696fb4-9zdpb" deleted
+    pod "kube-dns-autoscaler-8687c64fc-h4dtg" deleted
+    pod "l7-default-backend-8f479dd9-z42mx" deleted
+    pod "metrics-server-v0.3.1-cf56c77fc-7xgvc" deleted
+    pod "stackdriver-metadata-agent-cluster-level-6d96ccfd4-5rmwh" deleted
+    ```

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -25,6 +25,7 @@ Generate a YAML manifest for Antrea using Kustomize and print it to stdout.
         --mode (dev|release)  Choose the configuration variant that you need (default is 'dev')
         --encap-mode          Traffic encapsulation mode. (default is 'encap')
         --kind                Generate a manifest appropriate for running Antrea in a Kind cluster
+        --cloud               Generate a manifest appropriate for running Antrea in Public Cloud
         --ipsec               Generate a manifest with IPSec encryption of tunnel traffic enabled
         --keep                Debug flag which will preserve the generated kustomization.yml
         --help, -h            Print this message and exit
@@ -49,6 +50,7 @@ KIND=false
 IPSEC=false
 KEEP=false
 ENCAP_MODE=""
+CLOUD=""
 
 while [[ $# -gt 0 ]]
 do
@@ -63,7 +65,10 @@ case $key in
     ENCAP_MODE="$2"
     shift 2
     ;;
-
+    --cloud)
+    CLOUD="$2"
+    shift 2
+    ;;
     --kind)
     KIND=true
     shift
@@ -144,6 +149,12 @@ if [[ $ENCAP_MODE != "" ]]; then
     sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*trafficEncapMode[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/trafficEncapMode: $ENCAP_MODE/" antrea-agent.conf
 fi
 
+if [[ $CLOUD != "" ]]; then
+    if [[ $CLOUD == "GKE" ]]; then
+        sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*trafficEncapMode[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/trafficEncapMode: noEncap/" antrea-agent.conf
+    fi
+fi
+
 # unfortunately 'kustomize edit add configmap' does not support specifying 'merge' as the behavior,
 # which is why we use a template kustomization file.
 sed -e "s/<CONF_FILE>/antrea-agent.conf/" ../../patches/kustomization.configMap.tpl.yml > kustomization.yml
@@ -166,6 +177,18 @@ if $IPSEC; then
     $KUSTOMIZE edit add patch pskEnv.yml
     BASE=../ipsec
     cd ..
+fi
+
+if [[ $CLOUD != "" ]]; then
+    if [[ $CLOUD == "GKE" ]]; then
+        mkdir gke && cd gke
+        cp ../../patches/gke/*.yml .
+        touch kustomization.yml
+        $KUSTOMIZE edit add base $BASE
+        $KUSTOMIZE edit add patch cniPath.yml
+        BASE=../gke
+        cd ..
+    fi
 fi
 
 if $KIND; then


### PR DESCRIPTION
Antrea can be enabled as a CNI operating in noEncap mode
and enforcing Network Policies in GKE cluster.

This checkin enables the support. Also added details regarding
deploying and configuring antrea in GKE cluster