### PR TITLE
Refactor antctl error message

### DIFF
--- a/pkg/antctl/client.go
+++ b/pkg/antctl/client.go
@@ -105,7 +105,7 @@ func (c *client) nonResourceRequest(e *nonResourceEndpoint, opt *requestOption) 
 	getter := restClient.Get().RequestURI(u.RequestURI()).Timeout(opt.timeout)
 	result := getter.Do()
 	if result.Error() != nil {
-		return nil, fmt.Errorf("error when requesting %s: %w", getter.URL(), result.Error())
+		return nil, generateMessage(opt, result)
 	}
 	raw, err := result.Raw()
 	if err != nil {
@@ -147,7 +147,7 @@ func (c *client) resourceRequest(e *resourceEndpoint, opt *requestOption) (io.Re
 	}
 	result := resGetter.Do()
 	if result.Error() != nil {
-		return nil, fmt.Errorf("error when requesting %s: %w", resGetter.URL(), result.Error())
+		return nil, generateMessage(opt, result)
 	}
 	raw, err := result.Raw()
 	if err != nil {

--- a/pkg/antctl/command_list.go
+++ b/pkg/antctl/command_list.go
@@ -56,6 +56,7 @@ func (cl *commandList) ApplyToRootCommand(root *cobra.Command) {
 		klog.Infof("Added command %s", def.use)
 	}
 	cl.applyPersistentFlagsToRoot(root)
+	root.SilenceUsage = true
 	root.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		enableVerbose, err := root.PersistentFlags().GetBool("verbose")
 		if err != nil {

--- a/pkg/antctl/command_message.go
+++ b/pkg/antctl/command_message.go
@@ -1,0 +1,42 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package antctl
+
+import (
+	"fmt"
+	"net/http"
+
+	"k8s.io/client-go/rest"
+)
+
+func generateMessage(opt *requestOption, result rest.Result) error {
+	var code int
+	_ = result.StatusCode(&code)
+	if errMsg := generate(opt.commandDefinition, opt.args, code); errMsg != nil {
+		return errMsg
+	}
+	return result.Error()
+}
+
+func generate(cd *commandDefinition, args map[string]string, code int) error {
+	switch code {
+	case http.StatusNotFound:
+		return fmt.Errorf("NotFound: %s \"%s\" not found", cd.use, args["name"])
+	case http.StatusInternalServerError:
+		return fmt.Errorf("InternalServerError: Encoding response failed for %s", cd.use)
+	default:
+		return fmt.Errorf("Unknown error")
+	}
+}

--- a/pkg/antctl/command_message_test.go
+++ b/pkg/antctl/command_message_test.go
@@ -1,0 +1,59 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package antctl
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerate(t *testing.T) {
+	for _, tc := range []struct {
+		cd       *commandDefinition
+		args     map[string]string
+		code     int
+		expected string
+	}{
+		{
+			cd: &commandDefinition{
+				use: "foo",
+			},
+			args: map[string]string{
+				"name": "bar",
+			},
+			code:     http.StatusNotFound,
+			expected: "NotFound: foo \"bar\" not found",
+		},
+		{
+			cd: &commandDefinition{
+				use: "foo",
+			},
+			args:     map[string]string{},
+			code:     http.StatusInternalServerError,
+			expected: "InternalServerError: Encoding response failed for foo",
+		},
+		{
+			cd:       &commandDefinition{},
+			args:     map[string]string{},
+			code:     http.StatusOK,
+			expected: "Unknown error",
+		},
+	} {
+		generated := generate(tc.cd, tc.args, tc.code)
+		assert.Equal(t, tc.expected, generated.Error())
+	}
+}


### PR DESCRIPTION
issue #506 

Turn error message into a more friendly one:
Error: NotFound: resource "resouce name" not found