### PR TITLE
Update beta.kubernetes.io/os to kubernetes.io/os

### DIFF
--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -388,7 +388,7 @@ spec:
           subPath: antrea-controller.conf
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: antrea-controller
       tolerations:
@@ -588,7 +588,7 @@ spec:
           name: host-depmod
           readOnly: true
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: system-node-critical
       serviceAccountName: antrea-agent
       tolerations:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -379,7 +379,7 @@ spec:
           subPath: antrea-controller.conf
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: antrea-controller
       tolerations:
@@ -547,7 +547,7 @@ spec:
           name: host-depmod
           readOnly: true
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: system-node-critical
       serviceAccountName: antrea-agent
       tolerations:

--- a/build/yamls/base/agent.yml
+++ b/build/yamls/base/agent.yml
@@ -26,10 +26,7 @@ spec:
         - effect: NoSchedule
           operator: Exists
       nodeSelector:
-        # Note: beta.kubernetes.io/os is targeted for removal in K8s v1.18, if running Antrea with 1.18
-        # or higher uncomment the following line and remove beta.kubernetes.io/os.
-        #kubernetes.io/os: linux
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       serviceAccountName: antrea-agent
       initContainers:
         - name: install-cni

--- a/build/yamls/base/controller.yml
+++ b/build/yamls/base/controller.yml
@@ -44,10 +44,7 @@ spec:
         component: antrea-controller
     spec:
       nodeSelector:
-        # Note: beta.kubernetes.io/os is targeted for removal in K8s v1.18, if running Antrea with 1.18
-        # or higher uncomment the following line and remove beta.kubernetes.io/os.
-        #kubernetes.io/os: linux
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       priorityClassName: system-cluster-critical
       tolerations:


### PR DESCRIPTION
Starting with K8s 1.18, beta.kubernetes.io/os is removed.
kubernetes.io/os is supported from K8s 1.14.

Fixes #361