### PR TITLE
Use apiserver built-in version API for antctl version

### DIFF
--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -70,9 +70,12 @@ metadata:
   name: antctl
 rules:
 - apiGroups:
-  - clusterinformation.antrea.tanzu.vmware.com
+  - ""
+  resourceNames:
+  - antrea
+  - 'https:antrea:'
   resources:
-  - antreacontrollerinfos
+  - services/proxy
   verbs:
   - get
 - apiGroups:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -70,9 +70,12 @@ metadata:
   name: antctl
 rules:
 - apiGroups:
-  - clusterinformation.antrea.tanzu.vmware.com
+  - ""
+  resourceNames:
+  - antrea
+  - 'https:antrea:'
   resources:
-  - antreacontrollerinfos
+  - services/proxy
   verbs:
   - get
 - apiGroups:

--- a/build/yamls/base/antctl.yml
+++ b/build/yamls/base/antctl.yml
@@ -11,9 +11,12 @@ metadata:
   name: antctl
 rules:
   - apiGroups:
-      - clusterinformation.antrea.tanzu.vmware.com
+      - ""
+    resourceNames:
+      - "antrea"
+      - "https:antrea:"
     resources:
-      - antreacontrollerinfos
+      - services/proxy
     verbs:
       - get
   - apiGroups:

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -134,6 +134,8 @@ func createAPIServerConfig(kubeconfig string,
 		return nil, err
 	}
 
+	serverConfig.Version = version.GetVersionInfo()
+
 	serverConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(openapi.GetOpenAPIDefinitions, genericopenapi.NewDefinitionNamer(apiserver.Scheme))
 	serverConfig.OpenAPIConfig.Info.Title = "Antrea"
 

--- a/hack/update-codegen-dockerized.sh
+++ b/hack/update-codegen-dockerized.sh
@@ -45,7 +45,7 @@ $GOPATH/bin/conversion-gen  \
 
 $GOPATH/bin/openapi-gen  \
   --input-dirs "${ANTREA_PKG}/pkg/apis/networking/v1beta1" \
-  --input-dirs "k8s.io/apimachinery/pkg/apis/meta/v1,k8s.io/apimachinery/pkg/runtime,k8s.io/apimachinery/pkg/util/intstr" \
+  --input-dirs "k8s.io/apimachinery/pkg/apis/meta/v1,k8s.io/apimachinery/pkg/runtime,k8s.io/apimachinery/pkg/util/intstr,k8s.io/apimachinery/pkg/version" \
   --output-package "${ANTREA_PKG}/pkg/apiserver/openapi" \
   -O zz_generated.openapi \
   --go-header-file hack/boilerplate/license_header.go.txt

--- a/pkg/agent/apiserver/apiserver.go
+++ b/pkg/agent/apiserver/apiserver.go
@@ -20,7 +20,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	k8sversion "k8s.io/apimachinery/pkg/version"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 
@@ -29,7 +28,7 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver/handlers/appliedtogroup"
 	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver/handlers/networkpolicy"
 	"github.com/vmware-tanzu/antrea/pkg/monitor"
-	antreaversion "github.com/vmware-tanzu/antrea/pkg/version"
+	"github.com/vmware-tanzu/antrea/pkg/version"
 )
 
 const (
@@ -84,15 +83,8 @@ func newConfig() (*genericapiserver.CompletedConfig, error) {
 	if err := secureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
-	v := antreaversion.GetVersion()
 	serverCfg := genericapiserver.NewConfig(codecs)
-	serverCfg.Version = &k8sversion.Info{
-		Major:        fmt.Sprint(v.Major),
-		Minor:        fmt.Sprint(v.Minor),
-		GitVersion:   v.String(),
-		GitTreeState: antreaversion.GitTreeState,
-		GitCommit:    antreaversion.GetGitSHA(),
-	}
+	serverCfg.Version = version.GetVersionInfo()
 	if err := secureServing.ApplyTo(&serverCfg.SecureServing, &serverCfg.LoopbackClientConfig); err != nil {
 		return nil, err
 	}

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -25,7 +25,6 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/appliedtogroup"
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/networkpolicy"
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/version"
-	clusterinfov1beta1 "github.com/vmware-tanzu/antrea/pkg/apis/clusterinformation/v1beta1"
 	networkingv1beta1 "github.com/vmware-tanzu/antrea/pkg/apis/networking/v1beta1"
 	"github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned/scheme"
 )
@@ -40,21 +39,16 @@ var CommandList = &commandList{
 			long:         "Print version information of the antctl and the ${component}",
 			commandGroup: flat,
 			controllerEndpoint: &endpoint{
-				resourceEndpoint: &resourceEndpoint{
-					resourceName: "antrea-controller",
-					groupVersionResource: &schema.GroupVersionResource{
-						Group:    clusterinfov1beta1.SchemeGroupVersion.Group,
-						Version:  clusterinfov1beta1.SchemeGroupVersion.Version,
-						Resource: "antreacontrollerinfos",
-					},
+				nonResourceEndpoint: &nonResourceEndpoint{
+					path: "/version",
 				},
-				addonTransform: version.ControllerTransform,
+				addonTransform: version.Transform,
 			},
 			agentEndpoint: &endpoint{
 				nonResourceEndpoint: &nonResourceEndpoint{
 					path: "/version",
 				},
-				addonTransform: version.AgentTransform,
+				addonTransform: version.Transform,
 			},
 			transformedResponse: reflect.TypeOf(version.Response{}),
 		},

--- a/pkg/apiserver/openapi/zz_generated.openapi.go
+++ b/pkg/apiserver/openapi/zz_generated.openapi.go
@@ -98,6 +98,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"k8s.io/apimachinery/pkg/runtime.TypeMeta":                                       schema_k8sio_apimachinery_pkg_runtime_TypeMeta(ref),
 		"k8s.io/apimachinery/pkg/runtime.Unknown":                                        schema_k8sio_apimachinery_pkg_runtime_Unknown(ref),
 		"k8s.io/apimachinery/pkg/util/intstr.IntOrString":                                schema_apimachinery_pkg_util_intstr_IntOrString(ref),
+		"k8s.io/apimachinery/pkg/version.Info":                                           schema_k8sio_apimachinery_pkg_version_Info(ref),
 	}
 }
 
@@ -3027,6 +3028,74 @@ func schema_apimachinery_pkg_util_intstr_IntOrString(ref common.ReferenceCallbac
 				Description: "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
 				Type:        intstr.IntOrString{}.OpenAPISchemaType(),
 				Format:      intstr.IntOrString{}.OpenAPISchemaFormat(),
+			},
+		},
+	}
+}
+
+func schema_k8sio_apimachinery_pkg_version_Info(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Info contains versioning information. how we'll want to distribute that information.",
+				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"major": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"minor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"gitVersion": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"gitCommit": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"gitTreeState": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"buildDate": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"goVersion": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"compiler": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"platform": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+				},
+				Required: []string{"major", "minor", "gitVersion", "gitCommit", "gitTreeState", "buildDate", "goVersion", "compiler", "platform"},
 			},
 		},
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,6 +19,7 @@ import (
 	"runtime"
 
 	"github.com/blang/semver"
+	"k8s.io/apimachinery/pkg/version"
 )
 
 // These variables are set at build-time.
@@ -35,9 +36,15 @@ var (
 	ReleaseStatus = "unreleased"
 )
 
-func GetVersion() semver.Version {
+func GetVersionInfo() *version.Info {
 	v, _ := semver.Parse(Version[1:])
-	return v
+	return &version.Info{
+		Major:        fmt.Sprint(v.Major),
+		Minor:        fmt.Sprint(v.Minor),
+		GitVersion:   v.String(),
+		GitTreeState: GitTreeState,
+		GitCommit:    GetGitSHA(),
+	}
 }
 
 func GetGitSHA() string {


### PR DESCRIPTION
The PR makes antrea-controller use apiserver built-in version API to
serve version query. To access antrea's nonGoRestful API which cannot be
registered as APIService, it uses K8s apiserver service proxy, which can
also be used to access antrea-controller's other nonGoRestful APIs.

It unifies how version command is implemented for antrea-agent and
antrea-controller on both client and server side.