### PR TITLE
Add antctl role to Controller to allow antctl to run in Controller Pod

### DIFF
--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -206,6 +206,9 @@ subjects:
 - kind: ServiceAccount
   name: antctl
   namespace: kube-system
+- kind: ServiceAccount
+  name: anntrea-controller
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -206,6 +206,9 @@ subjects:
 - kind: ServiceAccount
   name: antctl
   namespace: kube-system
+- kind: ServiceAccount
+  name: anntrea-controller
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/build/yamls/base/antctl.yml
+++ b/build/yamls/base/antctl.yml
@@ -41,3 +41,9 @@ subjects:
   - kind: ServiceAccount
     name: antctl
     namespace: kube-system
+  - kind: ServiceAccount
+    # This is to allow antctl to be executed inside the Antrea Controller Pod
+    # and authenticate with Controller API server using the Controller's
+    # ServiceAccount token.
+    name: anntrea-controller
+    namespace: kube-system


### PR DESCRIPTION
antctl uses controller ServiceAccount token to authenticate with
controller API when running inside the Antrea controller Pod. This
commit adds the antctl role to the Controller ServiceAccount, so
antctl has all permissions to call the controller APIs for the
controller commands.