### PR TITLE
Build multi-architecture Antrea image

### DIFF
--- a/.github/workflows/build_tag_multiarch.yml
+++ b/.github/workflows/build_tag_multiarch.yml
@@ -1,0 +1,32 @@
+name: Build and push a multi-architecture release image
+
+on:
+  push:
+    tags:
+      - v*
+
+env:
+  OVS_VERSION: 2.13.0
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: crazy-max/ghaction-docker-buildx@v1
+      with:
+        version: latest
+    - name: Show available platforms
+      run: echo ${{ steps.buildx.outputs.platforms }}
+    - name: Run Buildx
+      env:
+        PLATFORMS: "linux/amd64,linux/arm/v7,linux/arm64"
+        NAME: antrea/antrea-ubuntu-multiarch
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      run: |
+        cd build/images/ovs && docker buildx build -t antrea/openvswitch:$OVS_VERSION --platform $PLATFORMS --build-arg OVS_VERSION=$OVS_VERSION . && cd -
+        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        docker buildx build -t $NAME --platform $PLATFORMS --push -f build/images/Dockerfile.build.ubuntu .

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -145,8 +145,14 @@ func TestInitialize(t *testing.T) {
 		// verify ip rules
 		expIPRulesStr := ""
 		if tc.expIPRule {
-			expIPRulesStr = fmt.Sprintf("%d: from all fwmark %#x iif %s lookup %s", route.AntreaIPRulePriority, route.RtTblSelectorValue,
-				gwName, svcTblName)
+			expIPRulesStr = fmt.Sprintf(
+				"%d: from all fwmark %#x/%#x iif %s lookup %s",
+				route.AntreaIPRulePriority,
+				route.RtTblSelectorValue,
+				route.RtTblSelectorMask,
+				gwName,
+				svcTblName,
+			)
 			expIPRulesStr = strings.Join(strings.Fields(expIPRulesStr), "")
 		}
 		ipRule, _ := ExecOutputTrim(fmt.Sprintf("ip rule | grep %x", route.RtTblSelectorValue))


### PR DESCRIPTION
Use a Github workflow to build an Antrea docker image supporting
multiple architectures (amd64, arm64, arm/v7).

The build takes about 3 hours because of CPU emulation, so we only do it
when a new tag is pushed to the Github repo. Note that parallelizing the
builds for the different architectures adds a lot of complexity for
minimal gains (build still takes more than 2 hours).

We use a separate Docker image name (antrea/antrea-ubuntu-multiarch)
since this is still fairly experimental.

Unfortunately, there is no easy way to test the arm images using public
CI tools at this stage. See issue #450 for more details.