### PR TITLE
Templates in hack/boilerplate: 2019 -> 2020

### DIFF
--- a/hack/boilerplate/license_header.go.txt
+++ b/hack/boilerplate/license_header.go.txt
@@ -1,4 +1,4 @@
-// Copyright 2019 Antrea Authors
+// Copyright YEAR Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/hack/boilerplate/license_header.raw.txt
+++ b/hack/boilerplate/license_header.raw.txt
@@ -1,4 +1,4 @@
-Copyright 2019 Antrea Authors
+Copyright YEAR Antrea Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/update-codegen-dockerized.sh
+++ b/hack/update-codegen-dockerized.sh
@@ -60,6 +60,10 @@ MOCKGEN_TARGETS=(
   "pkg/monitor AgentQuerier,ControllerQuerier"
 )
 
+# Command mockgen does not automatically replace variable YEAR with current year
+# like others do, e.g. client-gen.
+current_year=$(date +"%Y")
+sed -i "s/YEAR/${current_year}/g" hack/boilerplate/license_header.raw.txt
 for target in "${MOCKGEN_TARGETS[@]}"; do
   read -r package interfaces <<<"${target}"
   package_name=$(basename "${package}")
@@ -69,6 +73,7 @@ for target in "${MOCKGEN_TARGETS[@]}"; do
     -package=testing \
     "${ANTREA_PKG}/${package}" "${interfaces}"
 done
+git checkout HEAD -- hack/boilerplate/license_header.raw.txt
 
 # Download vendored modules to the vendor directory so it's easier to
 # specify the search path of required protobuf files.
@@ -79,4 +84,12 @@ $GOPATH/bin/go-to-protobuf \
   --go-header-file hack/boilerplate/license_header.go.txt
 # Clean up vendor directory.
 rm -rf vendor
+
+echo "=== Start resetting changes introduced by YEAR ==="
+git diff  --numstat | awk '$1 == "1" && $2 == "1" {print $3}' | while read file; do
+  if [[ "$(git diff ${file})" == *"-// Copyright "*" Antrea Authors"* ]]; then
+    git checkout HEAD -- "${file}"
+    echo "=== ${file} is reset ==="
+  fi
+done
 


### PR DESCRIPTION
Generated mock code are still using 2019.

Use YEAR to replace 2019 in header templates: license_header.raw.txt and
license_header.go.txt.
Command mockgen does not automatically replace variable YEAR with current year
like others do, e.g. client-gen.

Added check in update-codegen-dockerized.sh: reset file change if it is
introduced by year change.
1. filter changed files by 1 added line and 1 deleted line
2. check if diff result contains "Copyright YEAR Antrea Authors" line
3. reset the file if #2 returns true