### PR TITLE
Add e2e test for upgrade scenario

### DIFF
--- a/.github/workflows/kind-upgrade.yml
+++ b/.github/workflows/kind-upgrade.yml
@@ -1,0 +1,102 @@
+name: Antrea upgrade
+on:
+  pull_request:
+    branches:
+    - master
+    - release-*
+  push:
+    branches:
+    - master
+    - release-*
+jobs:
+  build-antrea-image:
+    name: Build Antrea image to be used for Kind upgrade test
+    runs-on: [ubuntu-18.04]
+    steps:
+    - uses: actions/checkout@v2
+    - run: make
+    - name: Save Antrea image to tarball
+      run:  docker save -o antrea-ubuntu.tar antrea/antrea-ubuntu:latest
+    - name: Upload Antrea image for subsequent jobs
+      uses: actions/upload-artifact@v1
+      with:
+        name: antrea-ubuntu
+        path: antrea-ubuntu.tar
+
+  from-v0_3_0:
+    name: Upgrade from Antrea v0.3.0
+    needs: build-antrea-image
+    runs-on: [ubuntu-18.04]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - name: Download Antrea image from previous job
+      uses: actions/download-artifact@v1
+      with:
+        name: antrea-ubuntu
+    - name: Load Antrea image
+      run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
+    - name: Install Kind
+      env:
+        KIND_VERSION: v0.7.0
+      run: |
+        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
+        chmod +x ./kind
+        sudo mv kind /usr/local/bin
+    - name: Run test
+      run: |
+        ./ci/kind/test-upgrade-antrea.sh --from-tag v0.3.0
+
+  from-v0_4_0: # TODO: define an action to avoid repetiion?
+    name: Upgrade from Antrea v0.4.0
+    needs: build-antrea-image
+    runs-on: [ubuntu-18.04]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - name: Download Antrea image from previous job
+      uses: actions/download-artifact@v1
+      with:
+        name: antrea-ubuntu
+    - name: Load Antrea image
+      run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
+    - name: Install Kind
+      env:
+        KIND_VERSION: v0.7.0
+      run: |
+        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
+        chmod +x ./kind
+        sudo mv kind /usr/local/bin
+    - name: Run test
+      run: |
+        ./ci/kind/test-upgrade-antrea.sh --from-tag v0.4.0
+
+  from-v0_4_1:
+    name: Upgrade from Antrea v0.4.1
+    needs: build-antrea-image
+    runs-on: [ubuntu-18.04]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - name: Download Antrea image from previous job
+      uses: actions/download-artifact@v1
+      with:
+        name: antrea-ubuntu
+    - name: Load Antrea image
+      run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
+    - name: Install Kind
+      env:
+        KIND_VERSION: v0.7.0
+      run: |
+        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
+        chmod +x ./kind
+        sudo mv kind /usr/local/bin
+    - name: Run test
+      run: |
+        ./ci/kind/test-upgrade-antrea.sh --from-tag v0.4.1

--- a/ci/kind/test-upgrade-antrea.sh
+++ b/ci/kind/test-upgrade-antrea.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+FROM_TAG=
+
+_usage="Usage: $0 --from-tag <TAG>
+Perform some basic tests to make sure that Antrea can be upgraded from <TAG> to the current checked-out version.
+        --from-tag            Upgrade from this version of Antrea (pulled from upstream Antrea) to the current version.
+        --help, -h            Print this message and exit
+"
+
+function print_usage {
+    echoerr "$_usage"
+}
+
+function print_help {
+    echoerr "Try '$0 --help' for more information."
+}
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR=$THIS_DIR/../..
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    --from-tag)
+    FROM_TAG="$2"
+    shift 2
+    ;;
+    -h|--help)
+    print_usage
+    exit 0
+    ;;
+    *)    # unknown option
+    echoerr "Unknown option $1"
+    exit 1
+    ;;
+esac
+done
+
+rc=0
+# adding retry since there seems to be some transient failures when this is run
+# in CI as part of a Github workflow.
+curl -s --retry 5 --retry-delay 1 https://api.github.com/repos/vmware-tanzu/antrea/releases/tags/$FROM_TAG | grep -q tag_name || rc=$?
+if [ $rc -ne 0 ]; then
+    echoerr "$FROM_TAG is not a valid Antrea tag"
+    exit 1
+fi
+
+DOCKER_IMAGES=("busybox" "antrea/antrea-ubuntu:$FROM_TAG")
+
+for img in "${DOCKER_IMAGES[@]}"; do
+    echo "Pulling $img"
+    docker pull $img > /dev/null
+done
+
+DOCKER_IMAGES+=("antrea/antrea-ubuntu:latest")
+
+echo "Creating Kind cluster"
+IMAGES="${DOCKER_IMAGES[@]}"
+$THIS_DIR/kind-setup.sh create kind --antrea-cni false --images "$IMAGES"
+
+TMP_ANTREA_DIR=$(mktemp -d)
+git clone --branch $FROM_TAG --depth 1 https://github.com/vmware-tanzu/antrea.git $TMP_ANTREA_DIR
+pushd $TMP_ANTREA_DIR > /dev/null
+export IMG_NAME=antrea/antrea-ubuntu
+export IMG_TAG=$FROM_TAG
+./hack/generate-manifest.sh --mode release --kind | kubectl apply -f -
+./hack/generate-manifest.sh --mode release --kind | docker exec -i kind-control-plane dd of=/root/antrea.yml
+popd
+rm -rf $TMP_DIR
+
+$ROOT_DIR/hack/generate-manifest.sh --kind | docker exec -i kind-control-plane dd of=/root/antrea-new.yml
+
+rc=0
+go test -v -run=TestUpgrade github.com/vmware-tanzu/antrea/test/e2e -provider=kind -upgrade.toYML=antrea-new.yml || rc=$?
+
+$THIS_DIR/kind-setup.sh destroy kind
+
+exit $rc

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -59,15 +59,7 @@ func (data *TestData) runPingMesh(t *testing.T, podNames []string) {
 	}
 }
 
-// TestPodConnectivitySameNode checks that Pods running on the same Node can reach each other, by
-// creating multiple Pods on the same Node and having them ping each other.
-func TestPodConnectivitySameNode(t *testing.T) {
-	data, err := setupTest(t)
-	if err != nil {
-		t.Fatalf("Error when setting up test: %v", err)
-	}
-	defer teardownTest(t, data)
-
+func (data *TestData) testPodConnectivitySameNode(t *testing.T) {
 	numPods := 2 // can be increased
 	podNames := make([]string, numPods)
 	for idx := range podNames {
@@ -84,6 +76,18 @@ func TestPodConnectivitySameNode(t *testing.T) {
 	}
 
 	data.runPingMesh(t, podNames)
+}
+
+// TestPodConnectivitySameNode checks that Pods running on the same Node can reach each other, by
+// creating multiple Pods on the same Node and having them ping each other.
+func TestPodConnectivitySameNode(t *testing.T) {
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	data.testPodConnectivitySameNode(t)
 }
 
 // createPodsOnDifferentNodes creates numPods busybox test Pods and assign them to all the different

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -1,0 +1,102 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"flag"
+	"testing"
+)
+
+var (
+	upgradeToYML = flag.String("upgrade.toYML", "", "Path to new Antrea manifest (on master Node)")
+	pruneAll     = flag.Bool("upgrade.pruneAll", false, "Prune all Antrea resources when upgrading")
+)
+
+func skipIfNotUpgradeTest(t *testing.T) {
+	if *upgradeToYML == "" {
+		t.Skipf("Skipping test as we are not testing for upgrade")
+	}
+}
+
+// TestUpgrade tests that some basic functionalities are not broken when
+// upgrading from one version of Antrea to another. At the moment it checks
+// that:
+//  * connectivity (intra and inter Node) is not broken
+//  * namespaces can be deleted
+//  * Pod deletion leads to correct resource cleanup
+// To run the test, provide the -upgrade.toYML flag.
+func TestUpgrade(t *testing.T) {
+	skipIfNotUpgradeTest(t)
+	skipIfNumNodesLessThan(t, 2)
+
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	nodeName := nodeName(0)
+	podName := randName("test-pod-")
+
+	t.Logf("Creating a busybox test Pod on '%s'", nodeName)
+	if err := data.createBusyboxPodOnNode(podName, nodeName); err != nil {
+		t.Fatalf("Error when creating busybox test Pod: %v", err)
+	}
+	if err := data.podWaitForRunning(defaultTimeout, podName); err != nil {
+		t.Fatalf("Error when waiting for Pod '%s' to be in the Running state", podName)
+	}
+
+	namespace := randName("test-namespace-")
+
+	t.Logf("Creating namespace '%s'", namespace)
+	if err := data.createNamespace(namespace); err != nil {
+		t.Fatalf("Error when creating namespace '%s'", namespace)
+	}
+	defer data.deleteNamespace(namespace, defaultTimeout)
+
+	data.testPodConnectivitySameNode(t)
+	data.testPodConnectivityDifferentNodes(t)
+
+	if t.Failed() {
+		t.FailNow()
+	}
+
+	t.Logf("Upgrading YAML to %s", *upgradeToYML)
+	var extraOptions string
+	if *pruneAll {
+		extraOptions = "--prune -l app=antrea --prune-whitelist=apiregistration.k8s.io/v1/APIService"
+	}
+	data.deployAntreaCommon(*upgradeToYML, extraOptions)
+	t.Logf("Waiting for all Antrea DaemonSet Pods")
+	if err := data.waitForAntreaDaemonSetPods(defaultTimeout); err != nil {
+		t.Fatalf("Error when restarting Antrea: %v", err)
+	}
+	// Restart CoreDNS Pods to avoid issues caused by disrupting the datapath (when restarting
+	// Antrea Agent Pods).
+	t.Logf("Restarting CoreDNS Pods")
+	if err := data.restartCoreDNSPods(defaultTimeout); err != nil {
+		t.Fatalf("Error when restarting CoreDNS Pods: %v", err)
+	}
+
+	data.testPodConnectivitySameNode(t)
+	data.testPodConnectivityDifferentNodes(t)
+
+	t.Logf("Deleting namespace '%s'", namespace)
+	if err := data.deleteNamespace(namespace, defaultTimeout); err != nil {
+		t.Errorf("Namespace deletion failed: %v", err)
+	}
+
+	data.testDeletePod(t, podName, nodeName)
+}


### PR DESCRIPTION
The new Go test (TestUpgrade) is meant to be run through the wrapper
script ./ci/kind/test-upgrade-antrea.sh.

At the moment we test upgrade from versions 0.3.0, 0.4.0 and 0.4.1 as
part of CI, but we can modify that set as we go through Antrea
releases. We also run the test for every PR against master, which may be
a bit excessive.

Fixes #511