### PR TITLE
Start documentation for antctl

### DIFF
--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -1,0 +1,55 @@
+# Antctl
+
+Antctl is the command-line tool for Antrea. At the moment, antctl supports
+running in two different modes:
+ * "controller mode": when run out-of-cluster or from within the Antrea
+ Controller Pod, antctl can connect to the Antrea Controller and query
+ information from it (e.g. the set of computed NetworkPolicies).
+ * "agent mode": when run from within an Antrea Agent Pod, antctl can connect to
+ the Antrea Agent and query information local to that Agent (e.g. the set of
+ computed NetworkPolicies received by that Agent from the Antrea Controller, as
+ opposed to the entire set of computed policies).
+
+## Installation
+
+The antctl binary is included in the Antrea Docker image
+(`antrea/antrea-ubuntu`) which means that there is no need to install anything
+to connect to the Antrea Agent. Simply exec into the antrea-agent container for
+the appropriate antrea-agent Pod and run `antctl`:
+```
+kubectl exec -it <antrea-agent Pod name> -n kube-system -c antrea-agent bash
+> antctl help
+```
+
+Starting with Antrea release v0.5.0, we publish the antctl binaries for
+different OS / CPU Architecture combinations. Head to the [releases
+page](https://github.com/vmware-tanzu/antrea/releases) and download the
+appropriate one for your machine. For example:
+
+On Mac & Linux:
+```
+curl -Lo ./antctl "https://github.com/vmware-tanzu/antrea/releases/download/v0.5.0/antctl-$(uname)-x86_64"
+chmod +x ./antctl
+mv ./antctl /some-dir-in-your-PATH/antctl
+antctl version
+```
+
+For Linux, we also publish binaries for Arm-based systems.
+
+On Windows:
+```
+# if you have curl / curl.exe installed (otherwise download antctl with a browser)
+curl -Lo antctl.exe https://github.com/vmware-tanzu/antrea/releases/download/v0.5.0/antctl-windows-x86_64
+Move-Item .\antctl-windows-x86_64.exe c:\some-dir-in-your-PATH\kubectl.exe
+antctl version
+```
+
+## Usage
+
+To see the list of available commands and options, run `antctl help`. The list
+will be different based on whether you are connecting to the Antrea Controller
+or Agent.
+
+When running out-of-cluster ("controller mode" only), antctl will look for your
+kubeconfig file at `$HOME/.kube/config` by default. You can select a different
+one with `--kubeconfig`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -111,3 +111,8 @@ please refer to this [guide](/docs/eks-installation.md).
 
 Antrea supports encrypting GRE tunnel traffic with IPsec. To deploy Antrea with
 IPsec encyption enabled, please refer to this [guide](/docs/ipsec-tunnel.md).
+
+### Antctl: Installation and Usage
+
+To use antctl, the Antrea command-line tool, please refer to this
+[guide](/docs/antctl.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,7 +18,7 @@
 You can inspect the logs for the `antrea-agent` and `antrea-ovs` containers in any
 `antrea-agent` Pod by running this `kubectl` command:
 ```
-kubectl logs -n kube-system <POD_NAME> -c [antrea-agent|antrea-ovs]
+kubectl logs -n kube-system <antrea-agent Pod name> -c [antrea-agent|antrea-ovs]
 ```
 
 The list of `antrea-agent` Pods, along with the node on which the Pod is scheduled,
@@ -31,7 +31,7 @@ To check the Open vSwitch logs (e.g. if the `antrea-ovs` container logs indicate
 that one of the Open vSwitch daemons generated an error), you can use `kubectl
 exec`:
 ```
-kubectl exec -n kube-system <POD_NAME> -c antrea-ovs tail /var/log/openvswitch/<DAEMON>.log
+kubectl exec -n kube-system <antrea-agent Pod name> -c antrea-ovs tail /var/log/openvswitch/<DAEMON>.log
 ```
 The Open vSwitch daemon logs for each `antrea-agent` Pod are also stored on the
 persistent storage of the corresponding node (i.e. the node on which the Pod is
@@ -118,7 +118,7 @@ container of the `antrea-agent` Pod. You can use `kubectl exec` to execute OVS
 command line tools (e.g. `ovs-vsctl`, `ovs-ofctl`) in the container, for
 example:
 ```
-kubectl exec -n kube-system <POD_NAME> -c antrea-ovs ovs-vsctl show
+kubectl exec -n kube-system <antrea-agent Pod name> -c antrea-ovs ovs-vsctl show
 ```
 
 By default the host directory `/var/run/antrea/openvswitch/` is mounted to


### PR DESCRIPTION
Add a new document under docs/ with information on how to install
(instructions valid starting with release 0.5.0) and use antctl. This is
user-facing documentation and does not include information about the
antctl implementation.

We also do not include a detailed list of commands at the moment. This
list can come later if needed (can be hard to keep up-to-date), and we
can keep adding information about specific commands in
troubleshooting.md for specific debugging scenarios.

Fixes #337