### PR TITLE
Support kind provider e2e tests with arbitrary cluster name:

### DIFF
--- a/ci/kind/kind-setup.sh
+++ b/ci/kind/kind-setup.sh
@@ -204,6 +204,13 @@ function create {
     exit 1
   fi
 
+  # Having a simple validation check for now.
+  # TODO: Making this comprehensive check confirming with rfc1035/rfc1123
+  if [[ "$CLUSTER_NAME" =~ [^a-z0-9-] ]]; then
+     echoerr "Invalid string. Conform to rfc1035/rfc1123"
+     exit 1
+  fi
+
   set +e
   kind get clusters | grep $CLUSTER_NAME > /dev/null 2>&1
   if [[ $? -eq 0 ]]; then
@@ -237,7 +244,7 @@ spec:
   template:
     spec:
       nodeSelector:
-        kubernetes.io/hostname: kind-control-plane
+        kubernetes.io/hostname: $CLUSTER_NAME-control-plane
 EOF
 )
   kubectl patch deployment coredns -p "$patch" -n kube-system

--- a/test/e2e/providers/exec/docker.go
+++ b/test/e2e/providers/exec/docker.go
@@ -59,3 +59,36 @@ func RunDockerExecCommand(container string, cmd string, workdir string) (
 	// command is successful
 	return 0, string(stdoutBytes), string(stderrBytes), nil
 }
+
+// RunDockerPsFilterCommand runs the provided command on the specified host using "docker ps filter". Returns
+// the exit code of the command, along with the contents of stdout and stderr as strings.
+func RunDockerPsFilterCommand(filter string) (
+	code int, stdout string, stderr string, err error,
+) {
+	args := []string{"ps", "--filter", filter}
+	dockerCmd := exec.Command("docker", args...)
+	stdoutPipe, err := dockerCmd.StdoutPipe()
+	if err != nil {
+		return 0, "", "", fmt.Errorf("error when connecting to stdout: %v", err)
+	}
+	stderrPipe, err := dockerCmd.StderrPipe()
+	if err != nil {
+		return 0, "", "", fmt.Errorf("error when connecting to stderr: %v", err)
+	}
+	if err := dockerCmd.Start(); err != nil {
+		return 0, "", "", fmt.Errorf("error when starting command: %v", err)
+	}
+
+	stdoutBytes, _ := ioutil.ReadAll(stdoutPipe)
+	stderrBytes, _ := ioutil.ReadAll(stderrPipe)
+
+	if err := dockerCmd.Wait(); err != nil {
+		if e, ok := err.(*exec.ExitError); ok {
+			return e.ExitCode(), string(stdoutBytes), string(stderrBytes), nil
+		}
+		return 0, "", "", err
+	}
+
+	// command is successful
+	return 0, string(stdoutBytes), string(stderrBytes), nil
+}


### PR DESCRIPTION
For e2e tests, kind provider only supports only the default master node name ("kind-control-plane").
Fixed to run the e2e tests for any master node name, which was created from user given cluster name.

In addition, https://github.com/vmware-tanzu/antrea/blob/master/ci/kind/kind-setup.sh accepts any type of a cluster name. We should probably restrict naming convention to rfc1035/rfc1123. Otherwise, we do not align with kubernetes naming convention and following command breaks.
go test -v github.com/vmware-tanzu/antrea/test/e2e -provider=kind

Testing: Tested with cluster names such as stati_kind, statiKind, stati-kind, stati-kind01 etc.