### PR TITLE
Fix Antrea EKS manifest

### DIFF
--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -206,6 +206,9 @@ subjects:
 - kind: ServiceAccount
   name: antctl
   namespace: kube-system
+- kind: ServiceAccount
+  name: antrea-controller
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -207,7 +207,7 @@ subjects:
   name: antctl
   namespace: kube-system
 - kind: ServiceAccount
-  name: anntrea-controller
+  name: antrea-controller
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -207,7 +207,7 @@ subjects:
   name: antctl
   namespace: kube-system
 - kind: ServiceAccount
-  name: anntrea-controller
+  name: antrea-controller
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/build/yamls/base/antctl.yml
+++ b/build/yamls/base/antctl.yml
@@ -45,5 +45,5 @@ subjects:
     # This is to allow antctl to be executed inside the Antrea Controller Pod
     # and authenticate with Controller API server using the Controller's
     # ServiceAccount token.
-    name: anntrea-controller
+    name: antrea-controller
     namespace: kube-system


### PR DESCRIPTION
The PR adding the antrea-eks.yml manifest was merged without being
rebased first, so the new ServiceAccount used by antctl was omitted from
it.

This commit also fixes a typo in the ServiceAccount's name.
The PR adding the new ServiceAccount was merged before the PR adding the
antrea-eks.yml manifest