### PR TITLE
Check whether an object matches the watcher before generating init event

### DIFF
--- a/pkg/apiserver/storage/interfaces.go
+++ b/pkg/apiserver/storage/interfaces.go
@@ -44,7 +44,7 @@ type InternalEvent interface {
 	// It will be called once for all watchers that are interested in the event. Expensive computation that will repeat
 	// for all watchers should be placed in GenEventFunc as pre-process. For example, the routine that groups a list of
 	// pods by nodes is a potential candidate.
-	ToWatchEvent(selectors *Selectors) *watch.Event
+	ToWatchEvent(selectors *Selectors, isInitEvent bool) *watch.Event
 	// GetResourceVersion returns the resourceVersion of this event.
 	// The resourceVersion is used to filter out previously buffered events when watcher is started.
 	GetResourceVersion() uint64
@@ -54,6 +54,9 @@ type InternalEvent interface {
 // Only a single InternalEvent will be generated for each add/update/delete, and the InternalEvent itself should be
 // immutable during its conversion to *watch.Event.
 type GenEventFunc func(key string, prevObj, obj interface{}, resourceVersion uint64) (InternalEvent, error)
+
+// SelectFunc checks whether an object match the provided selectors.
+type SelectFunc func(selectors *Selectors, key string, obj interface{}) bool
 
 // Interface offers a common storage interface for runtime.Object.
 // It's provided for Network Policy controller to store the translated Network Policy resources, then Antrea apiserver can

--- a/pkg/apiserver/storage/ram/watch_test.go
+++ b/pkg/apiserver/storage/ram/watch_test.go
@@ -35,7 +35,7 @@ type simpleInternalEvent struct {
 	ResourceVersion uint64
 }
 
-func (e *simpleInternalEvent) ToWatchEvent(selectors *storage.Selectors) *watch.Event {
+func (e *simpleInternalEvent) ToWatchEvent(selectors *storage.Selectors, isInitEvent bool) *watch.Event {
 	return &watch.Event{
 		Type:   e.Type,
 		Object: e.Object,
@@ -50,7 +50,7 @@ func (e *simpleInternalEvent) GetResourceVersion() uint64 {
 // represents the case that the watcher is not interested in an object.
 type emptyInternalEvent struct{}
 
-func (e *emptyInternalEvent) ToWatchEvent(selectors *storage.Selectors) *watch.Event {
+func (e *emptyInternalEvent) ToWatchEvent(selectors *storage.Selectors, isInitEvent bool) *watch.Event {
 	return nil
 }
 

--- a/pkg/controller/networkpolicy/store/util.go
+++ b/pkg/controller/networkpolicy/store/util.go
@@ -15,22 +15,34 @@
 package store
 
 import (
-	"k8s.io/apimachinery/pkg/util/sets"
+	"reflect"
 
 	"github.com/vmware-tanzu/antrea/pkg/apiserver/storage"
+	"github.com/vmware-tanzu/antrea/pkg/controller/types"
 )
 
-// filter returns whether the provided selectors matches the key and/or the nodeNames.
-func filter(selectors *storage.Selectors, key string, nodeNames sets.String) bool {
+// keyAndSpanSelectFunc returns whether the provided selectors matches the key and/or the nodeNames.
+func keyAndSpanSelectFunc(selectors *storage.Selectors, key string, obj interface{}) bool {
 	// If Key is present in selectors, the provided key must match it.
 	if selectors.Key != "" && key != selectors.Key {
 		return false
 	}
 	// If nodeName is present in selectors's Field selector, the provided nodeNames must contain it.
 	if nodeName, found := selectors.Field.RequiresExactMatch("nodeName"); found {
-		if !nodeNames.Has(nodeName) {
+		if !obj.(types.Span).Has(nodeName) {
 			return false
 		}
 	}
 	return true
+}
+
+// isSelected determines if the previous and the current version of an object should be selected by the given selectors.
+func isSelected(key string, prevObj, currObj interface{}, selectors *storage.Selectors, isInitEvent bool) (bool, bool) {
+	// We have filtered out init events that we are not interested in, so the current object must be selected.
+	if isInitEvent {
+		return false, true
+	}
+	prevObjSelected := !reflect.ValueOf(prevObj).IsNil() && keyAndSpanSelectFunc(selectors, key, prevObj)
+	currObjSelected := !reflect.ValueOf(currObj).IsNil() && keyAndSpanSelectFunc(selectors, key, currObj)
+	return prevObjSelected, currObjSelected
 }

--- a/pkg/controller/types/networkpolicy.go
+++ b/pkg/controller/types/networkpolicy.go
@@ -28,6 +28,15 @@ type SpanMeta struct {
 	NodeNames sets.String
 }
 
+// Span provides methods to work with SpanMeta and objects composed of it.
+type Span interface {
+	Has(nodeName string) bool
+}
+
+func (meta *SpanMeta) Has(nodeName string) bool {
+	return meta.NodeNames.Has(nodeName)
+}
+
 // GroupSelector describes how to select pods.
 type GroupSelector struct {
 	// The normalized name is calculated from Namespace, PodSelector, and NamespaceSelector.


### PR DESCRIPTION
It's observed in scale tests that antrea-controller had memory usage
peak when agents were connecting to it, which is quite greater than the
usage after agents connected it. For example, in a scale of 100k Pods,
75k NetworkPolicies, 25k Namespaces, 1k antrea-agents, it would consume
8~9GB memory at peak and lead to OOM sometimes while it only consumed
1.3GB memory when there were no agents connection and 1.5GB after 1k
Nodes connected it.

The memory should be consumed by a process in store.Watch where it lists
all items (pointers) of a kind of resource, converts them to
InternalEvent, sends them to watchers to further process. This means
that every object will be converted once regardless of whether the
watcher is interested in it or not, while the conversion is an expensive
operation in memory usage and normally a watcher won't be interested in
most objects, for example, in the above scale each agent only cares
hundreds out of 75k NetworkPolicies by average.

This patch optimizes it by filtering the object before converting it. As
the filter is a very cheap hash query, it can save the memory and CPU
usage a lot. For example, in a local scale test with 80 Pods, 30k
NetworkPolicies, 10k Namespaces, 50 antrea-agents, it would consume
1.1 ~ 1.2GB memory at peak. With this patch, it would consume only 310~MB
at peak.

Fixes #500