### PR TITLE
Change antctl commands to follow K8s resource naming convention

### DIFF
--- a/pkg/agent/apiserver/handlers/agentinfo/handler.go
+++ b/pkg/agent/apiserver/handlers/agentinfo/handler.go
@@ -25,7 +25,7 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/monitor"
 )
 
-// AntreaAgentInfoResponse is the struct for the response of agent-info command.
+// AntreaAgentInfoResponse is the struct for the response of agentinfo command.
 // It includes all fields except meta info from v1beta1.AntreaAgentInfo struct.
 type AntreaAgentInfoResponse struct {
 	Version                     string                              `json:"version,omitempty"`                     // Antrea binary version
@@ -38,7 +38,7 @@ type AntreaAgentInfoResponse struct {
 	AgentConditions             []v1beta1.AgentCondition            `json:"agentConditions,omitempty"`             // Agent condition contains types like AgentHealthy
 }
 
-// HandleFunc returns the function which can handle queries issued by agent-info commands.
+// HandleFunc returns the function which can handle queries issued by agentinfo commands.
 // The handler function populates Antrea agent information to the response.
 func HandleFunc(aq monitor.AgentQuerier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/agent/apiserver/handlers/podinterface/handler.go
+++ b/pkg/agent/apiserver/handlers/podinterface/handler.go
@@ -24,7 +24,7 @@ import (
 
 // Response describes the response struct of pod-interface command.
 type Response struct {
-	PodName       string `json:"name,omitempty" yaml:"name,omitempty" antctl:"name,The name of the pod"`
+	PodName       string `json:"name,omitempty" yaml:"name,omitempty" antctl:"name,Name of the Pod"`
 	PodNamespace  string `json:"podNamespace,omitempty" yaml:"podNamespace,omitempty"`
 	InterfaceName string `json:"interfaceName,omitempty" yaml:"interfaceName,omitempty"`
 	IP            string `json:"ip,omitempty" yaml:"ip,omitempty"`

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -55,7 +55,7 @@ var CommandList = &commandList{
 			transformedResponse: reflect.TypeOf(version.Response{}),
 		},
 		{
-			use:          "network-policy",
+			use:          "networkpolicy",
 			short:        "Print network policies",
 			long:         "Print network policies in ${component}",
 			commandGroup: get,
@@ -81,9 +81,9 @@ var CommandList = &commandList{
 			transformedResponse: reflect.TypeOf(networkpolicy.Response{}),
 		},
 		{
-			use:          "applied-to-group",
-			short:        "Print applied-to-groups",
-			long:         "Print applied-to-groups in ${component}",
+			use:          "appliedtogroup",
+			short:        "Print appliedto groups",
+			long:         "Print appliedto groups in ${component}",
 			commandGroup: get,
 			controllerEndpoint: &endpoint{
 				resourceEndpoint: &resourceEndpoint{
@@ -107,7 +107,7 @@ var CommandList = &commandList{
 			transformedResponse: reflect.TypeOf(appliedtogroup.Response{}),
 		},
 		{
-			use:          "address-group",
+			use:          "addressgroup",
 			short:        "Print address groups",
 			long:         "Print address groups in ${component}",
 			commandGroup: get,
@@ -133,7 +133,7 @@ var CommandList = &commandList{
 			transformedResponse: reflect.TypeOf(addressgroup.Response{}),
 		},
 		{
-			use:   "controller-info",
+			use:   "controllerinfo",
 			short: "Print Antrea controller's basic information",
 			long:  "Print Antrea controller's basic information including version, deployment, NetworkPolicy controller, ControllerConditions, etc.",
 			controllerEndpoint: &endpoint{
@@ -147,7 +147,7 @@ var CommandList = &commandList{
 			transformedResponse: reflect.TypeOf(controllerinfo.Response{}),
 		},
 		{
-			use:   "agent-info",
+			use:   "agentinfo",
 			short: "Print agent's basic information",
 			long:  "Print agent's basic information including version, deployment, Node subnet, OVS info, AgentConditions, etc.",
 			agentEndpoint: &endpoint{
@@ -160,29 +160,29 @@ var CommandList = &commandList{
 			transformedResponse: reflect.TypeOf(agentinfo.AntreaAgentInfoResponse{}),
 		},
 		{
-			use:   "pod-interface",
-			short: "Print Pod's basic interface information",
+			use:   "podinterface",
+			short: "Print Pod's network interface information",
 			long:  "Print information about the network interface(s) created by the Antrea agent for the specified Pod.",
 			example: `  Get a pod-interface
-  $ antctl get pod-interface pod0 -n ns0
-  Get the list of pod-interfaces in a namespace
-  $ antctl get pod-interface -n ns0
-  Get the list of pod-interfaces whose names match in all namespaces
-  $ antctl get pod-interface pod0
-  Get the list of pod-interfaces in all namespaces
-  $ antctl get pod-interface`,
+  $ antctl get podinterface pod1 -n ns1
+  Get the list of podinterfaces in a Namespace
+  $ antctl get podinterface -n ns1
+  Get the list of podinterfaces whose names match in all Namespaces
+  $ antctl get podinterface pod1
+  Get the list of podinterfaces in all Namespaces
+  $ antctl get podinterface`,
 			agentEndpoint: &endpoint{
 				nonResourceEndpoint: &nonResourceEndpoint{
 					path: "/podinterfaces",
 					params: []flagInfo{
 						{
 							name:  "name",
-							usage: "Retrieve Pod interface by name. If present, make sure namespace is provided.",
+							usage: "Retrieve Pod interface by name. If present, Namespace must be provided.",
 							arg:   true,
 						},
 						{
 							name:      "namespace",
-							usage:     "Get all Pod interfaces from specific Namespace",
+							usage:     "Get Pod interfaces from specific Namespace",
 							shorthand: "n",
 						},
 					},


### PR DESCRIPTION
For example: controller-info -> controllerinfo, network-policy ->
networkpolicy, applied-to-group -> appliedtogroup.