### PR TITLE
Do not use Github API to check tag

### DIFF
--- a/ci/kind/test-upgrade-antrea.sh
+++ b/ci/kind/test-upgrade-antrea.sh
@@ -60,9 +60,7 @@ esac
 done
 
 rc=0
-# adding retry since there seems to be some transient failures when this is run
-# in CI as part of a Github workflow.
-curl -s --retry 5 --retry-delay 1 https://api.github.com/repos/vmware-tanzu/antrea/releases/tags/$FROM_TAG | grep -q tag_name || rc=$?
+git ls-remote --heads --tags https://github.com/vmware-tanzu/antrea.git | grep -q "refs/tags/$FROM_TAG" || rc=$?
 if [ $rc -ne 0 ]; then
     echoerr "$FROM_TAG is not a valid Antrea tag"
     exit 1


### PR DESCRIPTION
There seems to be some rate limiting which creates issues when running
an unauthenticated request as part of a Github workflow.
https://developer.github.com/v3/#rate-limiting

Furthermore, using "grep -q" with "curl" sometimes lead to the "(23)
Failed writing body" error being displayed when grep closes the pipe
early. Not sure exactly why since we run curl in silent mode, but I have
seen it in the workflow logs.
https://github.com/vmware-tanzu/antrea/runs/532409948