### PR TITLE
Fix typo in register

### DIFF
--- a/pkg/apis/networking/v1beta1/register.go
+++ b/pkg/apis/networking/v1beta1/register.go
@@ -30,7 +30,7 @@ var (
 	AppliedToGroupVersionResource = schema.GroupVersionResource{
 		Group:    SchemeGroupVersion.Group,
 		Version:  SchemeGroupVersion.Version,
-		Resource: "applitedtogroups"}
+		Resource: "appliedtogroups"}
 	AddressGroupVersionResource = schema.GroupVersionResource{
 		Group:    SchemeGroupVersion.Group,
 		Version:  SchemeGroupVersion.Version,


### PR DESCRIPTION
It leads to `antctl get appliedtogroup` failing.