### PR TITLE
Set table output as the default output for  commands

### DIFF
--- a/pkg/agent/apiserver/handlers/podinterface/handler.go
+++ b/pkg/agent/apiserver/handlers/podinterface/handler.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
+	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/common"
 	"github.com/vmware-tanzu/antrea/pkg/monitor"
 )
 
@@ -71,4 +72,21 @@ func HandleFunc(aq monitor.AgentQuerier) http.HandlerFunc {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 	}
+}
+
+var _ common.TableOutput = new(Response)
+
+func (r Response) GetTableHeader() []string {
+	return []string{"NAMESPACE", "NAME", "INTERFACE-NAME", "IP", "MAC", "PORT-UUID", "OF-PORT", "CONTAINER-ID"}
+}
+
+func (r Response) GetContainerIDStr() string {
+	if len(r.ContainerID) > 12 {
+		return r.ContainerID[0:11]
+	}
+	return r.ContainerID
+}
+
+func (r Response) GetTableRow(maxColumnLength int) []string {
+	return []string{r.PodNamespace, r.PodName, r.InterfaceName, r.IP, r.MAC, r.PortUUID, common.Int32ToString(r.OFPort), r.GetContainerIDStr()}
 }

--- a/pkg/antctl/command_definition.go
+++ b/pkg/antctl/command_definition.go
@@ -607,7 +607,11 @@ func (cd *commandDefinition) applyFlagsToCommand(cmd *cobra.Command) {
 	if !hasFlag {
 		cmd.Args = cobra.NoArgs
 	}
-	cmd.Flags().StringP("output", "o", "json", "output format: json|yaml|table")
+	if cd.commandGroup == get {
+		cmd.Flags().StringP("output", "o", "table", "output format: json|yaml|table")
+	} else {
+		cmd.Flags().StringP("output", "o", "json", "output format: json|yaml|table")
+	}
 }
 
 // applyExampleToCommand generates examples according to the commandDefinition.

--- a/pkg/antctl/transform/addressgroup/transform.go
+++ b/pkg/antctl/transform/addressgroup/transform.go
@@ -62,14 +62,14 @@ func (r Response) GetTableHeader() []string {
 	return []string{"NAME", "POD-IPS"}
 }
 
-func (r Response) GetTableRow(maxColumnLength int) []string {
-	row := []string{r.Name}
-
+func (r Response) GetPodNames(maxColumnLength int) string {
 	list := make([]string, len(r.Pods))
 	for i, pod := range r.Pods {
 		list[i] = pod.IP
 	}
-	row = append(row, common.GenerateTableElementWithSummary(list, maxColumnLength))
+	return common.GenerateTableElementWithSummary(list, maxColumnLength)
+}
 
-	return row
+func (r Response) GetTableRow(maxColumnLength int) []string {
+	return []string{r.Name, r.GetPodNames(maxColumnLength)}
 }

--- a/pkg/antctl/transform/appliedtogroup/transform.go
+++ b/pkg/antctl/transform/appliedtogroup/transform.go
@@ -62,14 +62,14 @@ func (r Response) GetTableHeader() []string {
 	return []string{"NAME", "PODS"}
 }
 
-func (r Response) GetTableRow(maxColumnLength int) []string {
-	row := []string{r.Name}
-
+func (r Response) GetPodNames(maxColumnLength int) string {
 	list := make([]string, len(r.Pods))
 	for i, pod := range r.Pods {
 		list[i] = pod.Pod.Namespace + "/" + pod.Pod.Name
 	}
-	row = append(row, common.GenerateTableElementWithSummary(list, maxColumnLength))
+	return common.GenerateTableElementWithSummary(list, maxColumnLength)
+}
 
-	return row
+func (r Response) GetTableRow(maxColumnLength int) []string {
+	return []string{r.Name, r.GetPodNames(maxColumnLength)}
 }

--- a/pkg/antctl/transform/common/transform.go
+++ b/pkg/antctl/transform/common/transform.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"strconv"
 
 	networkingv1beta1 "github.com/vmware-tanzu/antrea/pkg/apis/networking/v1beta1"
 )
@@ -41,6 +42,10 @@ func GroupMemberPodTransform(pod networkingv1beta1.GroupMemberPod) GroupMemberPo
 type TableOutput interface {
 	GetTableHeader() []string
 	GetTableRow(maxColumnLength int) []string
+}
+
+func Int32ToString(val int32) string {
+	return strconv.Itoa(int(val))
 }
 
 func GenerateTableElementWithSummary(list []string, maxColumnLength int) string {

--- a/pkg/antctl/transform/networkpolicy/transform.go
+++ b/pkg/antctl/transform/networkpolicy/transform.go
@@ -70,8 +70,5 @@ func (r Response) GetTableHeader() []string {
 }
 
 func (r Response) GetTableRow(maxColumnLength int) []string {
-	row := []string{r.Name}
-	row = append(row, common.GenerateTableElementWithSummary(r.AppliedToGroups, maxColumnLength))
-	row = append(row, strconv.Itoa(len(r.Rules)))
-	return row
+	return []string{r.Name, common.GenerateTableElementWithSummary(r.AppliedToGroups, maxColumnLength), strconv.Itoa(len(r.Rules))}
 }


### PR DESCRIPTION
- Set table output as the default output for  commands
- Apply the table output format to `antctl get podinterface`, `antctl get controllerinfo`, `antctl get agentinfo` commands

This is a follow-up of #477 .

FIxes #541 


Before:
```shell
$ antctl get podinterface
{
  "name": "nginx-6db489d4b7-vgv7v",
  "InterfaceName": "patch-de-17bf25",
  "IP": "192.168.2.7",
  "MAC": "36:44:77:45:ee:55",
  "PortUUID": "e2bc4318-5cda-4be9-ab61-8ff748db7320",
  "OFPort": 80,
  "ContainerID": "58e4aba280fe1696a647aa0f928071a3bfb25a9da21937dcdc05200fce39ca20",
  "PodNamespace": "default"
}

$ antctl get controllerinfo
{
    "version": "v0.4.0", 
    "podRef": {
        "kind": "Pod", 
        "namespace": "kube-system", 
        "name": "antrea-controller-55b9bcd59f-h9ll4"
    }, 
    "nodeRef": {
        "kind": "Node", 
        "name": "node-master"
    }, 
    "serviceRef": {
        "kind": "Service", 
        "name": "antrea"
    }, 
    "networkPolicyControllerInfo": {
        "networkPolicyNum": 1, 
        "addressGroupNum": 1, 
        "appliedToGroupNum": 2
    }, 
    "connectedAgentNum": 2, 
    "controllerConditions": [
        {
            "type": "ControllerHealthy", 
            "status": "True", 
            "lastHeartbeatTime": "2020-03-22T05:41:46Z"
        }
    ]
}

$ antctl get agentinfo
{
  "version": "v0.4.0",
  "podRef": {
    "kind": "Pod",
    "namespace": "kube-system",
    "name": "antrea-agent-0"
  },
  "nodeRef": {
    "kind": "Node",
    "name": "node-worker"
  },
  "nodeSubnet": [
    "192.168.1.0/24",
    "192.168.1.1/24"
  ],
  "ovsInfo": {
    "version": "1.0",
    "bridgeName": "br-int",
    "flowTable": {
      "0": 5,
      "10": 7,
    }
  },
  "networkPolicyControllerInfo": {
    "NetworkPolicyNum":  1,
    "AddressGroupNum":   1,
    "AppliedToGroupNum": 2,
  },
  "localPodNum": 3,
  "agentConditions": [
    {
      "type": "AgentHealthy",
      "status": "True",
      "lastHeartbeatTime": "2020-03-24T11:25:20Z"
    },
  ]
}
```

After:
```shell
$ antctl get podinterface
NAMESPACE NAME                   INTERFACE-NAME IP        MAC               PORT-UUID OF-PORT CONTAINER-ID
default   nginx-6db489d4b7-vgv7v Interface      127.0.0.1 07-16-76-00-02-86 portuuid0 80      dve7a2d6c22 
default   nginx-32b489d4b7-vgv7v Interface2     127.0.0.2 07-16-76-00-02-87 portuuid1 35572   uci2ucsd6dx 

$ antctl get controllerinfo
POD                                            NODE        STATUS  NETWORK-POLICIES ADDRESS-GROUPS APPLIED-TO-GROUPS CONNECTED-AGENTS
kube-system/antrea-controller-55b9bcd59f-h9ll4 node-master Healthy 1                1              2                 2               

$ antctl get agentinfo
POD                        NODE        STATUS  NODE-SUBNET                   NETWORK-POLICIES ADDRESS-GROUPS APPLIED-TO-GROUPS LOCAL-PODS
kube-system/antrea-agent-0 node-worker Healthy 192.168.1.0/24,192.168.1.1/24 1                1              2                 3         
    

```