### PR TITLE
Implemented plural and short names for antctl

### DIFF
--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -56,6 +56,7 @@ var CommandList = &commandList{
 		},
 		{
 			use:          "networkpolicy",
+			aliases:      []string{"networkpolicies", "netpol"},
 			short:        "Print network policies",
 			long:         "Print network policies in ${component}",
 			commandGroup: get,
@@ -82,6 +83,7 @@ var CommandList = &commandList{
 		},
 		{
 			use:          "appliedtogroup",
+			aliases:      []string{"appliedtogroups", "atg"},
 			short:        "Print appliedto groups",
 			long:         "Print appliedto groups in ${component}",
 			commandGroup: get,
@@ -108,6 +110,7 @@ var CommandList = &commandList{
 		},
 		{
 			use:          "addressgroup",
+			aliases:      []string{"addressgroups", "ag"},
 			short:        "Print address groups",
 			long:         "Print address groups in ${component}",
 			commandGroup: get,
@@ -133,9 +136,10 @@ var CommandList = &commandList{
 			transformedResponse: reflect.TypeOf(addressgroup.Response{}),
 		},
 		{
-			use:   "controllerinfo",
-			short: "Print Antrea controller's basic information",
-			long:  "Print Antrea controller's basic information including version, deployment, NetworkPolicy controller, ControllerConditions, etc.",
+			use:     "controllerinfo",
+			aliases: []string{"controllerinfos", "ci"},
+			short:   "Print Antrea controller's basic information",
+			long:    "Print Antrea controller's basic information including version, deployment, NetworkPolicy controller, ControllerConditions, etc.",
 			controllerEndpoint: &endpoint{
 				resourceEndpoint: &resourceEndpoint{
 					resourceName:         controllerinforest.ControllerInfoResourceName,
@@ -147,9 +151,10 @@ var CommandList = &commandList{
 			transformedResponse: reflect.TypeOf(controllerinfo.Response{}),
 		},
 		{
-			use:   "agentinfo",
-			short: "Print agent's basic information",
-			long:  "Print agent's basic information including version, deployment, Node subnet, OVS info, AgentConditions, etc.",
+			use:     "agentinfo",
+			aliases: []string{"agentinfos", "ai"},
+			short:   "Print agent's basic information",
+			long:    "Print agent's basic information including version, deployment, Node subnet, OVS info, AgentConditions, etc.",
 			agentEndpoint: &endpoint{
 				nonResourceEndpoint: &nonResourceEndpoint{
 					path:       "/agentinfo",
@@ -160,9 +165,10 @@ var CommandList = &commandList{
 			transformedResponse: reflect.TypeOf(agentinfo.AntreaAgentInfoResponse{}),
 		},
 		{
-			use:   "podinterface",
-			short: "Print Pod's network interface information",
-			long:  "Print information about the network interface(s) created by the Antrea agent for the specified Pod.",
+			use:     "podinterface",
+			aliases: []string{"podinterfaces", "pi"},
+			short:   "Print Pod's network interface information",
+			long:    "Print information about the network interface(s) created by the Antrea agent for the specified Pod.",
 			example: `  Get a pod-interface
   $ antctl get podinterface pod1 -n ns1
   Get the list of podinterfaces in a Namespace

--- a/pkg/antctl/command_definition.go
+++ b/pkg/antctl/command_definition.go
@@ -157,6 +157,7 @@ type flagInfo struct {
 type commandDefinition struct {
 	// Cobra related
 	use     string
+	aliases []string
 	short   string
 	long    string
 	example string // It will be filled with generated examples if it is not provided.
@@ -213,9 +214,10 @@ func (cd *commandDefinition) getEndpoint() endpointResponder {
 // appropriate RunE function for it according to the commandDefinition.
 func (cd *commandDefinition) applySubCommandToRoot(root *cobra.Command, client *client) {
 	cmd := &cobra.Command{
-		Use:   cd.use,
-		Short: cd.short,
-		Long:  cd.long,
+		Use:     cd.use,
+		Aliases: cd.aliases,
+		Short:   cd.short,
+		Long:    cd.long,
 	}
 	renderDescription(cmd)
 	cd.applyFlagsToCommand(cmd)
@@ -235,6 +237,16 @@ func (cd *commandDefinition) validate() []error {
 	var errs []error
 	if len(cd.use) == 0 {
 		errs = append(errs, fmt.Errorf("the command does not have name"))
+	}
+	existingAliases := make(map[string]bool)
+	for _, a := range cd.aliases {
+		if a == cd.use {
+			errs = append(errs, fmt.Errorf("%s: command alias is the same with use of the command", cd.use))
+		}
+		if _, ok := existingAliases[a]; ok {
+			errs = append(errs, fmt.Errorf("%s: command alias is provided twice: %s", cd.use, a))
+		}
+		existingAliases[a] = true
 	}
 	if cd.transformedResponse == nil {
 		errs = append(errs, fmt.Errorf("%s: command does not define output struct", cd.use))


### PR DESCRIPTION
Fixed #547 

Added field: aliases in commandDefinition. All commands can have aliases now.
e.g.
antctl get networkpolicy
antctl get networkpolicies
antctl get netpol
All 3 commands above return same result.

```
# antctl get networkpolicy -h
Print network policies in agent

Args:
  name  Retrieve resource by name

Usage:
  antctl get networkpolicy [name] [flags]

Aliases:
  networkpolicy, networkpolicies, netpol

Examples:
  Get a networkpolicy
  $ antctl get networkpolicy [name]
  Get the list of networkpolicy
  $ antctl get networkpolicy


Flags:
  -h, --help            help for networkpolicy
  -o, --output string   output format: json|yaml|table (default "json")

Global Flags:
  -k, --kubeconfig string   absolute path to the kubeconfig file (default "/root/.kube/config")
  -t, --timeout duration    time limit of the execution of the command
  -v, --verbose             enable verbose output
```