### PR TITLE
Implement group-bucket control interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cenkalti/rpc2 v0.0.0-20180727162946-9642ea02d0aa // indirect
 	github.com/containernetworking/cni v0.7.1
 	github.com/containernetworking/plugins v0.8.2-0.20190724153215-ded2f1757770
-	github.com/contiv/libOpenflow v0.0.0-20200115035645-b22edc53818e
+	github.com/contiv/libOpenflow v0.0.0-20200319171453-882ba6d92cbc
 	github.com/contiv/ofnet v0.0.0-00010101000000-000000000000
 	github.com/coreos/go-iptables v0.4.1
 	github.com/davecgh/go-spew v1.1.1
@@ -52,7 +52,7 @@ require (
 )
 
 replace (
-	github.com/contiv/ofnet => github.com/wenyingd/ofnet v0.0.0-20200306115935-b1f7790fe2be
+	github.com/contiv/ofnet => github.com/wenyingd/ofnet v0.0.0-20200326015539-5862ec3fa686
 	// Octant is renamed from vmware/octant to vmware-tanzu/octant since v0.9.0.
 	// However, Octant v0.9.0 K8s API is not compatible with Antrea K8s API version.
 	// Furthermore, octant v0.8 and v0.9 do not check-in some generated code required for testing

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/containernetworking/cni v0.7.1 h1:fE3r16wpSEyaqY4Z4oFrLMmIGfBYIKpPrHK
 github.com/containernetworking/cni v0.7.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/plugins v0.8.2-0.20190724153215-ded2f1757770 h1:AuFzUXPFhLlTfxhHMGdCIr7wZOQ0J0dEZLoffU0KfRM=
 github.com/containernetworking/plugins v0.8.2-0.20190724153215-ded2f1757770/go.mod h1:AlmXjbiLJBqvZ4vxkWAqjx1CKHVEoQf0/Ugrvc6Cv70=
-github.com/contiv/libOpenflow v0.0.0-20200115035645-b22edc53818e h1:txsEaGP9x3pBu8JDH2Ygqs/Eunw3Rk8HYR2GnoWu71U=
-github.com/contiv/libOpenflow v0.0.0-20200115035645-b22edc53818e/go.mod h1:DtsPlJOByJZ+MO9YITEGUlbJ/jfh/ef0qeNyBYaeNR4=
+github.com/contiv/libOpenflow v0.0.0-20200319171453-882ba6d92cbc h1:xCk8SOFX7a5svlcuRKzJ4XqekAk+CpKQNWqPY/UXX9k=
+github.com/contiv/libOpenflow v0.0.0-20200319171453-882ba6d92cbc/go.mod h1:DtsPlJOByJZ+MO9YITEGUlbJ/jfh/ef0qeNyBYaeNR4=
 github.com/contiv/libovsdb v0.0.0-20170227191248-d0061a53e358 h1:AiA9SKyNXulsU7aAnyka3UFHYOIH00A9HvdIRnDXlg0=
 github.com/contiv/libovsdb v0.0.0-20170227191248-d0061a53e358/go.mod h1:+qKEHaNVPj+wrn5st7TEFH9wcUWCJq5ZBvVKPQwzAeg=
 github.com/coreos/bbolt v1.3.1-coreos.6 h1:uTXKg9gY70s9jMAKdfljFQcuh4e/BXOM+V+d00KFj3A=
@@ -335,8 +335,8 @@ github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYp
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/wenyingd/ofnet v0.0.0-20200306115935-b1f7790fe2be h1:T08z0KR3raKK770UxouFTS7t1ldi+Hg01lBcRtSD8bM=
-github.com/wenyingd/ofnet v0.0.0-20200306115935-b1f7790fe2be/go.mod h1:9fZ2429qI+GTHZQ9vlTk5QrasJKh3HOSqDjYw6WmzPs=
+github.com/wenyingd/ofnet v0.0.0-20200326015539-5862ec3fa686 h1:a6OxcU1iYvnisaTUHK4C1jqbawN+IFwtNF9DgeKt4dA=
+github.com/wenyingd/ofnet v0.0.0-20200326015539-5862ec3fa686/go.mod h1:kPb/y9p2i14dW8xNvRnVo2D+xhcthRQZdii5ltI0fjI=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18 h1:MPPkRncZLN9Kh4MEFmbnK4h3BD7AUmskWv2+EeZJCCs=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -19,22 +19,22 @@ import (
 	"time"
 )
 
-type protocol = string
+type Protocol string
 type TableIDType uint8
-type GroupIDType = uint32
+type GroupIDType uint32
 
 const LastTableID TableIDType = 0xff
 
-type MissActionType = uint32
+type MissActionType uint32
 type Range [2]uint32
 
 const (
-	ProtocolIP   protocol = "ip"
-	ProtocolARP  protocol = "arp"
-	ProtocolTCP  protocol = "tcp"
-	ProtocolUDP  protocol = "udp"
-	ProtocolSCTP protocol = "sctp"
-	ProtocolICMP protocol = "icmp"
+	ProtocolIP   Protocol = "ip"
+	ProtocolARP  Protocol = "arp"
+	ProtocolTCP  Protocol = "tcp"
+	ProtocolUDP  Protocol = "udp"
+	ProtocolSCTP Protocol = "sctp"
+	ProtocolICMP Protocol = "icmp"
 )
 
 const (
@@ -152,7 +152,7 @@ type Action interface {
 }
 
 type FlowBuilder interface {
-	MatchProtocol(name protocol) FlowBuilder
+	MatchProtocol(name Protocol) FlowBuilder
 	MatchReg(regID int, data uint32) FlowBuilder
 	MatchRegRange(regID int, data uint32, rng Range) FlowBuilder
 	MatchInPort(inPort uint32) FlowBuilder

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -25,7 +25,7 @@ type GroupIDType = uint32
 
 const LastTableID TableIDType = 0xff
 
-type MissActionType uint32
+type MissActionType = uint32
 type Range [2]uint32
 
 const (
@@ -63,7 +63,6 @@ type Bridge interface {
 	DeleteTable(id TableIDType) bool
 	CreateGroup(id GroupIDType) Group
 	DeleteGroup(id GroupIDType) bool
-	// Conn
 	DumpTableStatus() []TableStatus
 	// DumpFlows queries the Openflow entries from OFSwitch. The filter of the query is Openflow cookieID; the result is
 	// a map from flow cookieID to FlowStates.

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -21,6 +21,7 @@ import (
 
 type protocol = string
 type TableIDType uint8
+type GroupIDType = uint32
 
 const LastTableID TableIDType = 0xff
 
@@ -60,6 +61,9 @@ const (
 type Bridge interface {
 	CreateTable(id, next TableIDType, missAction MissActionType) Table
 	DeleteTable(id TableIDType) bool
+	CreateGroup(id GroupIDType) Group
+	DeleteGroup(id GroupIDType) bool
+	// Conn
 	DumpTableStatus() []TableStatus
 	// DumpFlows queries the Openflow entries from OFSwitch. The filter of the query is Openflow cookieID; the result is
 	// a map from flow cookieID to FlowStates.
@@ -93,17 +97,30 @@ type Table interface {
 	GetNext() TableIDType
 }
 
-type Flow interface {
+type EntryType string
+
+const (
+	FlowEntry  EntryType = "FlowEntry"
+	GroupEntry EntryType = "GroupEntry"
+)
+
+type Entry interface {
 	Add() error
 	Modify() error
 	Delete() error
+	Type() EntryType
+	KeyString() string
+	// Reset ensures that the entry is "correct" and that the Add /
+	// Modify / Delete methods can be called on this object. This method
+	// should be called if a reconnection event happened.
+	Reset()
+}
+
+type Flow interface {
+	Entry
 	MatchString() string
 	// CopyToBuilder returns a new FlowBuilder that copies the matches of the Flow, but does not copy the actions.
 	CopyToBuilder() FlowBuilder
-	// Reset ensures that the ofFlow object is "correct" and that the Add /
-	// Modify / Delete methods can be called on this object. This method
-	// should be called if a reconnection event happenened.
-	Reset()
 }
 
 type Action interface {
@@ -132,6 +149,7 @@ type Action interface {
 	DecTTL() FlowBuilder
 	Normal() FlowBuilder
 	Conjunction(conjID uint32, clauseID uint8, nClause uint8) FlowBuilder
+	Group(id GroupIDType) FlowBuilder
 }
 
 type FlowBuilder interface {
@@ -164,6 +182,19 @@ type FlowBuilder interface {
 	Cookie(cookieID uint64) FlowBuilder
 	Action() Action
 	Done() Flow
+}
+
+type Group interface {
+	Entry
+	Bucket() BucketBuilder
+}
+
+type BucketBuilder interface {
+	Weight(val uint16) BucketBuilder
+	LoadReg(regID int, data uint32) BucketBuilder
+	LoadRegRange(regID int, data uint32, rng Range) BucketBuilder
+	ResubmitToTable(tableID TableIDType) BucketBuilder
+	Done() Group
 }
 
 type CTAction interface {

--- a/pkg/ovs/openflow/ofctrl_action.go
+++ b/pkg/ovs/openflow/ofctrl_action.go
@@ -277,10 +277,10 @@ func (a *ofFlowAction) Conjunction(conjID uint32, clauseID uint8, nClause uint8)
 }
 
 // Group is an action to forward packets to groups to do load-balance.
-func (a *ofFlowAction) Group(id uint32) FlowBuilder {
+func (a *ofFlowAction) Group(id GroupIDType) FlowBuilder {
 	group := &ofctrl.Group{
 		Switch: a.builder.Flow.Table.Switch,
-		ID:     id,
+		ID:     uint32(id),
 	}
 	a.builder.ofFlow.lastAction = group
 	return a.builder

--- a/pkg/ovs/openflow/ofctrl_action.go
+++ b/pkg/ovs/openflow/ofctrl_action.go
@@ -246,17 +246,14 @@ func (a *ofFlowAction) MoveRange(fromField, toField string, fromRange, toRange R
 
 // Resubmit is an action to resubmit packet to the specified table with the port as new in_port. If port is empty string,
 // the in_port field is not changed.
-func (a *ofFlowAction) Resubmit(ofPort uint16, table TableIDType) FlowBuilder {
-	ofTableID := uint8(table)
-	resubmit := ofctrl.NewResubmit(&ofPort, &ofTableID)
-	a.builder.ofFlow.lastAction = resubmit
+func (a *ofFlowAction) Resubmit(ofPort uint16, tableID TableIDType) FlowBuilder {
+	a.builder.ofFlow.Resubmit(ofPort, uint8(tableID))
 	return a.builder
 }
 
 func (a *ofFlowAction) ResubmitToTable(table TableIDType) FlowBuilder {
 	ofTableID := uint8(table)
-	resubmit := ofctrl.NewResubmit(nil, &ofTableID)
-	a.builder.ofFlow.lastAction = resubmit
+	a.builder.ofFlow.Resubmit(openflow13.OFPP_IN_PORT, ofTableID)
 	return a.builder
 }
 
@@ -276,6 +273,16 @@ func (a *ofFlowAction) Normal() FlowBuilder {
 // Conjunction is an action to add new conjunction configuration to conjunctive match flow.
 func (a *ofFlowAction) Conjunction(conjID uint32, clauseID uint8, nClause uint8) FlowBuilder {
 	a.builder.ofFlow.AddConjunction(conjID, clauseID, nClause)
+	return a.builder
+}
+
+// Group is an action to forward packets to groups to do load-balance.
+func (a *ofFlowAction) Group(id uint32) FlowBuilder {
+	group := &ofctrl.Group{
+		Switch: a.builder.Flow.Table.Switch,
+		ID:     id,
+	}
+	a.builder.ofFlow.lastAction = group
 	return a.builder
 }
 

--- a/pkg/ovs/openflow/ofctrl_bridge.go
+++ b/pkg/ovs/openflow/ofctrl_bridge.go
@@ -304,7 +304,6 @@ func (b *OFBridge) IsConnected() bool {
 	return b.ofSwitch.IsReady()
 }
 
-// TODO: @wenying, handle group also
 func (b *OFBridge) AddFlowsInBundle(addflows []Flow, modFlows []Flow, delFlows []Flow) error {
 	// If no Openflow entries are requested to be added or modified or deleted on the OVS bridge, return immediately.
 	if len(addflows) == 0 && len(modFlows) == 0 && len(delFlows) == 0 {

--- a/pkg/ovs/openflow/ofctrl_bridge.go
+++ b/pkg/ovs/openflow/ofctrl_bridge.go
@@ -132,16 +132,16 @@ type OFBridge struct {
 }
 
 func (b *OFBridge) CreateGroup(id GroupIDType) Group {
-	ofctrlGroup, err := b.ofSwitch.NewGroup(id, ofctrl.GroupSelect)
+	ofctrlGroup, err := b.ofSwitch.NewGroup(uint32(id), ofctrl.GroupSelect)
 	if err != nil {
-		ofctrlGroup = b.ofSwitch.GetGroup(id)
+		ofctrlGroup = b.ofSwitch.GetGroup(uint32(id))
 	}
 	g := &ofGroup{bridge: b, ofctrl: ofctrlGroup}
 	return g
 }
 
 func (b *OFBridge) DeleteGroup(id GroupIDType) bool {
-	err := b.ofSwitch.DeleteGroup(id)
+	err := b.ofSwitch.DeleteGroup(uint32(id))
 	if err != nil {
 		return false
 	}

--- a/pkg/ovs/openflow/ofctrl_builder.go
+++ b/pkg/ovs/openflow/ofctrl_builder.go
@@ -265,8 +265,8 @@ func (b *ofFlowBuilder) MatchConjID(value uint32) FlowBuilder {
 }
 
 // MatchProtocol adds match condition for matching protocol type.
-func (b *ofFlowBuilder) MatchProtocol(protocol protocol) FlowBuilder {
-	switch strings.ToLower(protocol) {
+func (b *ofFlowBuilder) MatchProtocol(protocol Protocol) FlowBuilder {
+	switch protocol {
 	case ProtocolIP:
 		b.Match.Ethertype = 0x0800
 	case ProtocolARP:

--- a/pkg/ovs/openflow/ofctrl_flow.go
+++ b/pkg/ovs/openflow/ofctrl_flow.go
@@ -66,6 +66,14 @@ func (f *ofFlow) Delete() error {
 	return nil
 }
 
+func (f *ofFlow) Type() EntryType {
+	return FlowEntry
+}
+
+func (f *ofFlow) KeyString() string {
+	return f.MatchString()
+}
+
 func (f *ofFlow) MatchString() string {
 	repr := fmt.Sprintf("table=%d,priority=%d", f.table.GetID(), f.Flow.Match.Priority)
 	if f.protocol != "" {

--- a/pkg/ovs/openflow/ofctrl_flow.go
+++ b/pkg/ovs/openflow/ofctrl_flow.go
@@ -21,7 +21,7 @@ type ofFlow struct {
 	// matchers is string slice, it is used to generate a readable match string of the Flow.
 	matchers []string
 	// protocol adds a readable protocol type in the match string of ofFlow.
-	protocol protocol
+	protocol Protocol
 	// ctStateString is a temporary variable for the readable ct_state configuration. Its value is changed when the client
 	// updates the matching condition of "ct_states". When FlowBuilder.Done is called, its value is added into the matchers.
 	ctStateString string

--- a/pkg/ovs/openflow/ofctrl_group.go
+++ b/pkg/ovs/openflow/ofctrl_group.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/contiv/libOpenflow/openflow13"
-
 	"github.com/contiv/ofnet/ofctrl"
 )
 
@@ -49,7 +48,7 @@ func (g *ofGroup) Type() EntryType {
 }
 
 func (g *ofGroup) KeyString() string {
-	return fmt.Sprintf("group_id:%d,bucket_num:%d", g.ofctrl.ID, len(g.ofctrl.Buckets))
+	return fmt.Sprintf("group_id:%d", g.ofctrl.ID)
 }
 
 func (g *ofGroup) Bucket() BucketBuilder {

--- a/pkg/ovs/openflow/ofctrl_group.go
+++ b/pkg/ovs/openflow/ofctrl_group.go
@@ -22,9 +22,8 @@ import (
 )
 
 type ofGroup struct {
-	ofctrl  *ofctrl.Group
-	bridge  *OFBridge
-	builder *ofGroup
+	ofctrl *ofctrl.Group
+	bridge *OFBridge
 }
 
 func (g *ofGroup) Reset() {

--- a/pkg/ovs/openflow/ofctrl_group.go
+++ b/pkg/ovs/openflow/ofctrl_group.go
@@ -1,0 +1,95 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openflow
+
+import (
+	"fmt"
+
+	"github.com/contiv/libOpenflow/openflow13"
+
+	"github.com/contiv/ofnet/ofctrl"
+)
+
+type ofGroup struct {
+	ofctrl  *ofctrl.Group
+	bridge  *OFBridge
+	builder *ofGroup
+}
+
+func (g *ofGroup) Reset() {
+	g.ofctrl.Switch = g.bridge.ofSwitch
+}
+
+func (g *ofGroup) Add() error {
+	return g.ofctrl.Install()
+}
+
+func (g *ofGroup) Modify() error {
+	return g.ofctrl.Install()
+}
+
+func (g *ofGroup) Delete() error {
+	return g.ofctrl.Delete()
+}
+
+func (g *ofGroup) Type() EntryType {
+	return GroupEntry
+}
+
+func (g *ofGroup) KeyString() string {
+	return fmt.Sprintf("group_id:%d,bucket_num:%d", g.ofctrl.ID, len(g.ofctrl.Buckets))
+}
+
+func (g *ofGroup) Bucket() BucketBuilder {
+	return &bucketBuilder{
+		group:  g,
+		bucket: openflow13.NewBucket(),
+	}
+}
+
+type bucketBuilder struct {
+	group  *ofGroup
+	bucket *openflow13.Bucket
+}
+
+// LoadRegRange is an action to Load data to the target register at range[0..31].
+func (b *bucketBuilder) LoadReg(regID int, data uint32) BucketBuilder {
+	return b.LoadRegRange(regID, data, Range{0, 31})
+}
+
+// LoadRegRange is an action to Load data to the target register at specified range.
+func (b *bucketBuilder) LoadRegRange(regID int, data uint32, rng Range) BucketBuilder {
+	reg := fmt.Sprintf("%s%d", NxmFieldReg, regID)
+	regField, _ := openflow13.FindFieldHeaderByName(reg, true)
+	b.bucket.AddAction(openflow13.NewNXActionRegLoad(rng.ToNXRange().ToOfsBits(), regField, uint64(data)))
+	return b
+}
+
+// ResubmitToTable is an action to resubmit packet to the specified table when the bucket is selected.
+func (b *bucketBuilder) ResubmitToTable(tableID TableIDType) BucketBuilder {
+	b.bucket.AddAction(openflow13.NewNXActionResubmitTableAction(openflow13.OFPP_IN_PORT, uint8(tableID)))
+	return b
+}
+
+// Weight sets the weight of a bucket.
+func (b *bucketBuilder) Weight(val uint16) BucketBuilder {
+	b.bucket.Weight = val
+	return b
+}
+
+func (b *bucketBuilder) Done() Group {
+	b.group.ofctrl.AddBuckets(b.bucket)
+	return b.group
+}

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -78,7 +78,7 @@ func (mr *MockBridgeMockRecorder) Connect(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // CreateGroup mocks base method
-func (m *MockBridge) CreateGroup(arg0 uint32) openflow.Group {
+func (m *MockBridge) CreateGroup(arg0 openflow.GroupIDType) openflow.Group {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateGroup", arg0)
 	ret0, _ := ret[0].(openflow.Group)
@@ -92,7 +92,7 @@ func (mr *MockBridgeMockRecorder) CreateGroup(arg0 interface{}) *gomock.Call {
 }
 
 // CreateTable mocks base method
-func (m *MockBridge) CreateTable(arg0, arg1 openflow.TableIDType, arg2 uint32) openflow.Table {
+func (m *MockBridge) CreateTable(arg0, arg1 openflow.TableIDType, arg2 openflow.MissActionType) openflow.Table {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTable", arg0, arg1, arg2)
 	ret0, _ := ret[0].(openflow.Table)
@@ -120,7 +120,7 @@ func (mr *MockBridgeMockRecorder) DeleteFlowsByCookie(arg0, arg1 interface{}) *g
 }
 
 // DeleteGroup mocks base method
-func (m *MockBridge) DeleteGroup(arg0 uint32) bool {
+func (m *MockBridge) DeleteGroup(arg0 openflow.GroupIDType) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteGroup", arg0)
 	ret0, _ := ret[0].(bool)
@@ -255,10 +255,10 @@ func (mr *MockTableMockRecorder) GetID() *gomock.Call {
 }
 
 // GetMissAction mocks base method
-func (m *MockTable) GetMissAction() uint32 {
+func (m *MockTable) GetMissAction() openflow.MissActionType {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMissAction")
-	ret0, _ := ret[0].(uint32)
+	ret0, _ := ret[0].(openflow.MissActionType)
 	return ret0
 }
 
@@ -509,7 +509,7 @@ func (mr *MockActionMockRecorder) Drop() *gomock.Call {
 }
 
 // Group mocks base method
-func (m *MockAction) Group(arg0 uint32) openflow.FlowBuilder {
+func (m *MockAction) Group(arg0 openflow.GroupIDType) openflow.FlowBuilder {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Group", arg0)
 	ret0, _ := ret[0].(openflow.FlowBuilder)
@@ -1120,7 +1120,7 @@ func (mr *MockFlowBuilderMockRecorder) MatchInPort(arg0 interface{}) *gomock.Cal
 }
 
 // MatchProtocol mocks base method
-func (m *MockFlowBuilder) MatchProtocol(arg0 string) openflow.FlowBuilder {
+func (m *MockFlowBuilder) MatchProtocol(arg0 openflow.Protocol) openflow.FlowBuilder {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MatchProtocol", arg0)
 	ret0, _ := ret[0].(openflow.FlowBuilder)

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -92,7 +92,7 @@ func (mr *MockBridgeMockRecorder) CreateGroup(arg0 interface{}) *gomock.Call {
 }
 
 // CreateTable mocks base method
-func (m *MockBridge) CreateTable(arg0, arg1 openflow.TableIDType, arg2 openflow.MissActionType) openflow.Table {
+func (m *MockBridge) CreateTable(arg0, arg1 openflow.TableIDType, arg2 uint32) openflow.Table {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTable", arg0, arg1, arg2)
 	ret0, _ := ret[0].(openflow.Table)
@@ -255,10 +255,10 @@ func (mr *MockTableMockRecorder) GetID() *gomock.Call {
 }
 
 // GetMissAction mocks base method
-func (m *MockTable) GetMissAction() openflow.MissActionType {
+func (m *MockTable) GetMissAction() uint32 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMissAction")
-	ret0, _ := ret[0].(openflow.MissActionType)
+	ret0, _ := ret[0].(uint32)
 	return ret0
 }
 

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -77,6 +77,20 @@ func (mr *MockBridgeMockRecorder) Connect(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Connect", reflect.TypeOf((*MockBridge)(nil).Connect), arg0, arg1)
 }
 
+// CreateGroup mocks base method
+func (m *MockBridge) CreateGroup(arg0 uint32) openflow.Group {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateGroup", arg0)
+	ret0, _ := ret[0].(openflow.Group)
+	return ret0
+}
+
+// CreateGroup indicates an expected call of CreateGroup
+func (mr *MockBridgeMockRecorder) CreateGroup(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGroup", reflect.TypeOf((*MockBridge)(nil).CreateGroup), arg0)
+}
+
 // CreateTable mocks base method
 func (m *MockBridge) CreateTable(arg0, arg1 openflow.TableIDType, arg2 openflow.MissActionType) openflow.Table {
 	m.ctrl.T.Helper()
@@ -103,6 +117,20 @@ func (m *MockBridge) DeleteFlowsByCookie(arg0, arg1 uint64) error {
 func (mr *MockBridgeMockRecorder) DeleteFlowsByCookie(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFlowsByCookie", reflect.TypeOf((*MockBridge)(nil).DeleteFlowsByCookie), arg0, arg1)
+}
+
+// DeleteGroup mocks base method
+func (m *MockBridge) DeleteGroup(arg0 uint32) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteGroup", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// DeleteGroup indicates an expected call of DeleteGroup
+func (mr *MockBridgeMockRecorder) DeleteGroup(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGroup", reflect.TypeOf((*MockBridge)(nil).DeleteGroup), arg0)
 }
 
 // DeleteTable mocks base method
@@ -333,6 +361,20 @@ func (mr *MockFlowMockRecorder) Delete() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockFlow)(nil).Delete))
 }
 
+// KeyString mocks base method
+func (m *MockFlow) KeyString() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "KeyString")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// KeyString indicates an expected call of KeyString
+func (mr *MockFlowMockRecorder) KeyString() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KeyString", reflect.TypeOf((*MockFlow)(nil).KeyString))
+}
+
 // MatchString mocks base method
 func (m *MockFlow) MatchString() string {
 	m.ctrl.T.Helper()
@@ -371,6 +413,20 @@ func (m *MockFlow) Reset() {
 func (mr *MockFlowMockRecorder) Reset() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockFlow)(nil).Reset))
+}
+
+// Type mocks base method
+func (m *MockFlow) Type() openflow.EntryType {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Type")
+	ret0, _ := ret[0].(openflow.EntryType)
+	return ret0
+}
+
+// Type indicates an expected call of Type
+func (mr *MockFlowMockRecorder) Type() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockFlow)(nil).Type))
 }
 
 // MockAction is a mock of Action interface
@@ -450,6 +506,20 @@ func (m *MockAction) Drop() openflow.FlowBuilder {
 func (mr *MockActionMockRecorder) Drop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Drop", reflect.TypeOf((*MockAction)(nil).Drop))
+}
+
+// Group mocks base method
+func (m *MockAction) Group(arg0 uint32) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Group", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// Group indicates an expected call of Group
+func (mr *MockActionMockRecorder) Group(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Group", reflect.TypeOf((*MockAction)(nil).Group), arg0)
 }
 
 // LoadARPOperation mocks base method

--- a/test/integration/ovs/openflow_test_utils.go
+++ b/test/integration/ovs/openflow_test_utils.go
@@ -116,7 +116,6 @@ func OfctlDumpGroups(brName string, args ...string) ([][]string, error) {
 		elems := strings.Split(rawGroupItem, ",bucket=")
 		groupList = append(groupList, elems)
 	}
-	//fmt.Printf("group dumps: %v\n", groupList)
 	return groupList, nil
 }
 

--- a/test/integration/ovs/openflow_test_utils.go
+++ b/test/integration/ovs/openflow_test_utils.go
@@ -103,6 +103,23 @@ func OfctlDumpFlows(brName string, args ...string) ([]string, error) {
 	return flowList, nil
 }
 
+func OfctlDumpGroups(brName string, args ...string) ([][]string, error) {
+	groupsDump, err := runOfctlCmd("dump-groups", brName, args...)
+	if err != nil {
+		return nil, err
+	}
+	groupsDumpStr := strings.TrimSpace(string(groupsDump))
+	rawGroupItems := strings.Split(groupsDumpStr, "\n")[1:]
+	var groupList [][]string
+	for _, rawGroupItem := range rawGroupItems {
+		rawGroupItem = strings.TrimSpace(rawGroupItem)
+		elems := strings.Split(rawGroupItem, ",bucket=")
+		groupList = append(groupList, elems)
+	}
+	//fmt.Printf("group dumps: %v\n", groupList)
+	return groupList, nil
+}
+
 func OfctlDumpTableFlows(brName string, table uint8) ([]string, error) {
 	return OfctlDumpFlows(brName, fmt.Sprintf("table=%d", table))
 }


### PR DESCRIPTION
- Implemented group&bucket control interface
- Made Flow and Group interfaces as Entry
- Updated Ofnet and libopenflow deps to support group message
- Changed type alias in interfaces.go to type declaration
- Implemented multiple resubmit action
- Updated mocks

TODO: @wenyingd will base on this commit to implement group installation by bundle

Signed-off-by: Weiqiang TANG <weiqiangt@vmware.com>