### PR TITLE
Fix antctl segment fault when kubeconfig cannot be resolved

### DIFF
--- a/pkg/antctl/client.go
+++ b/pkg/antctl/client.go
@@ -58,7 +58,9 @@ func (c *client) resolveKubeconfig(opt *requestOption) (*rest.Config, error) {
 	var kubeconfig *rest.Config
 	if _, err = os.Stat(opt.kubeconfig); opt.kubeconfig == clientcmd.RecommendedHomeFile && os.IsNotExist(err) {
 		kubeconfig, err = rest.InClusterConfig()
-		err = nil
+		if err != nil {
+			err = fmt.Errorf("Unable to resolve in-cluster configuration: %v. Please specify the kubeconfig file", err)
+		}
 	} else {
 		kubeconfig, err = clientcmd.BuildConfigFromFlags("", opt.kubeconfig)
 	}


### PR DESCRIPTION
Return an error when failed to load in-cluster config, when kubeconfig
file is not specified, and the default path does not exist.

Segment fault is like the following:
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x1243750]

goroutine 1 [running]:
github.com/vmware-tanzu/antrea/pkg/antctl.(*client).resolveKubeconfig(0xc000098a80, 0xc000559c80, 0x15, 0x76, 0x0)
        /home/shenj/github/antrea/pkg/antctl/client.go:68 +0x120
github.com/vmware-tanzu/antrea/pkg/antctl.(*client).resourceRequest(0xc000098a80, 0x2114ae0, 0xc000559c80, 0x1443cc0, 0x214d3a0, 0x0, 0x0)
        /home/shenj/github/antrea/pkg/antctl/client.go:118 +0x50
github.com/vmware-tanzu/antrea/pkg/antctl.(*client).request(0xc000098a80, 0xc000559c80, 0x7, 0x0, 0x0, 0x0)
        /home/shenj/github/antrea/pkg/antctl/client.go:80 +0x78
github.com/vmware-tanzu/antrea/pkg/antctl.(*commandDefinition).newCommandRunE.func1(0xc000326a00, 0x214c088, 0x0, 0x0, 0x0, 0x0)
        /home/shenj/github/antrea/pkg/antctl/command_definition.go:576 +0x396
github.com/spf13/cobra.(*Command).execute(0xc000326a00, 0x214c088, 0x0, 0x0, 0xc000326a00, 0x214c088)
        /home/shenj/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:826 +0x460
github.com/spf13/cobra.(*Command).ExecuteC(0x212f720, 0x212f720, 0x0, 0xc000559f50)
        /home/shenj/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
        /home/shenj/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
        /home/shenj/github/antrea/cmd/antctl/main.go:49 +0x78