### PR TITLE
Modified CI to Run Golint and link to the report as a comment

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,6 +28,39 @@ jobs:
       run: make test-unit
 
 
+  golint:
+    name: Run golint
+    runs-on: [ubuntu-18.04]
+    steps:
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+      - name: Install golint
+        run: go get -u golang.org/x/lint/golint
+      - name: Check-out code
+        uses: actions/checkout@v2
+      - name: Run golint
+        run: |
+          GOLINT_PATH=$(go list -f {{.Target}} golang.org/x/lint/golint)
+          $GOLINT_PATH ./... | tee golint-report.txt
+      - name: Upload and Add Link to PR
+        if: github.event.pull_request != null
+        run: |
+          PULL_NUMBER=$(jq -r .pull_request.number "${{ github.event_path }}")
+          echo "Pull Request: $PULL_NUMBER"
+
+          # Upload report to https://transfer.sh (upload expires after 2 week by default)
+          DOWNLOAD_LINK_QUOTED=\"$(curl --upload-file ./golint-report.txt https://transfer.sh/golint-report.txt | sed 's|https://transfer.sh|https://transfer.sh/get|')\"
+          echo "Download Link: $DOWNLOAD_LINK_QUOTED"
+
+          # Add comment to Pull Request
+          # JQ String Interpolation used to build POST body. Ref: https://stedolan.github.io/jq/manual/#Stringinterpolation-\(foo)
+          POST_COMMENT_TARGET="https://api.github.com/repos/${{ github.repository }}/issues/${PULL_NUMBER}/comments"
+          POST_COMMENT_BODY=$(echo $DOWNLOAD_LINK_QUOTED | jq -c '{"body": "Golint report for a recent push to this PR can be [downloaded here](\(.))"}')
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d "$POST_COMMENT_BODY" "${POST_COMMENT_TARGET}"
+
+
   golangci-lint:
     name: Golangci-lint
     runs-on: [ubuntu-18.04]


### PR DESCRIPTION
Added a new job to the "Go" workflow that runs Golint on the codebase, uploads
to a public and free temporary file host (transfer.sh) and adds link to it
as a PR comment. Also added a check to skip upload for non-PR runs.

Example comment: https://github.com/theshubhamp/antrea/pull/1#issuecomment-605510412

Upload Works on Feature Branch:
https://github.com/theshubhamp/antrea/runs/542165386?check_suite_focus=true
<img width="1680" alt="Screenshot 2020-03-29 at 1 25 59 AM" src="https://user-images.githubusercontent.com/47491367/77832490-904b3800-715c-11ea-8f9c-7e9d5870ba60.png">

Upload Skipped on "master":
https://github.com/theshubhamp/antrea/runs/542167757?check_suite_focus=true
<img width="1678" alt="Screenshot 2020-03-29 at 1 25 48 AM" src="https://user-images.githubusercontent.com/47491367/77832483-7f9ac200-715c-11ea-935b-df7f546b0b66.png">
