### PR TITLE
Update datapath type if bridge br-int exists

### DIFF
--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -105,8 +105,8 @@ func (br *OVSBridge) Create() Error {
 		return err
 	} else if exists {
 		klog.Info("Bridge exists: ", br.uuid)
-		// Update OpenFlow protocol versions on existent bridge.
-		if err := br.updateProtocols(); err != nil {
+		// Update OpenFlow protocol versions and datapath type on existent bridge.
+		if err := br.updateBridgeConfiguration(); err != nil {
 			return err
 		}
 	} else if err = br.create(); err != nil {
@@ -139,7 +139,7 @@ func (br *OVSBridge) lookupByName() (bool, Error) {
 	return true, nil
 }
 
-func (br *OVSBridge) updateProtocols() Error {
+func (br *OVSBridge) updateBridgeConfiguration() Error {
 	tx := br.ovsdb.Transaction(openvSwitchSchema)
 	// Use Openflow protocol version 1.0 and 1.3.
 	tx.Update(dbtransaction.Update{
@@ -148,6 +148,7 @@ func (br *OVSBridge) updateProtocols() Error {
 		Row: map[string]interface{}{
 			"protocols": makeOVSDBSetFromList([]string{openflowProtoVersion10,
 				openflowProtoVersion13}),
+			"datapath_type": br.datapathType,
 		},
 	})
 	_, err, temporary := tx.Commit()


### PR DESCRIPTION
Doing this without checking if datapath_type is different from datapath
type in given manifest like openflow protocol.

Tested by deleting antrea (with system datapath type) and redeploying
antrea with new manifest file that has netdev datapath type and added
changes to deploy tun device driver.
Antrea agent comes up with new datapath type with out any issues.
Changed to system datapath type again.

Fixes #152