### PR TITLE
[Windows] Prepare ovs bridge

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -97,7 +97,10 @@ func (i *Initializer) setupOVSBridge() error {
 		klog.Error("Failed to create OVS bridge: ", err)
 		return err
 	}
-	i.nodeConfig.BridgeName = i.ovsBridgeClient.GetBridgeName()
+
+	if err := i.prepareOVSBridge(); err != nil {
+		return err
+	}
 
 	// Initialize interface cache
 	if err := i.initInterfaceStore(); err != nil {
@@ -107,7 +110,6 @@ func (i *Initializer) setupOVSBridge() error {
 	if err := i.setupDefaultTunnelInterface(config.DefaultTunPortName); err != nil {
 		return err
 	}
-
 	// Setup host gateway interface
 	err := i.setupGatewayInterface()
 	if err != nil {
@@ -127,6 +129,7 @@ func (i *Initializer) initInterfaceStore() error {
 	}
 
 	ifaceList := make([]*interfacestore.InterfaceConfig, 0, len(ovsPorts))
+	uplinkIfName := i.nodeConfig.UplinkNetConfig.Name
 	for index := range ovsPorts {
 		port := &ovsPorts[index]
 		ovsPort := &interfacestore.OVSPortConfig{
@@ -139,6 +142,12 @@ func (i *Initializer) initInterfaceStore() error {
 				Type:          interfacestore.GatewayInterface,
 				InterfaceName: port.Name,
 				OVSPortConfig: ovsPort}
+		case port.Name == uplinkIfName:
+			intf = &interfacestore.InterfaceConfig{
+				Type:          interfacestore.UplinkInterface,
+				InterfaceName: port.Name,
+				OVSPortConfig: ovsPort,
+			}
 		case port.IFType == ovsconfig.VXLANTunnel:
 			fallthrough
 		case port.IFType == ovsconfig.GeneveTunnel:
@@ -171,7 +180,9 @@ func (i *Initializer) Initialize() error {
 	if err := i.readIPSecPSK(); err != nil {
 		return err
 	}
-
+	if err := i.prepareHostNetwork(); err != nil {
+		return err
+	}
 	if err := i.setupOVSBridge(); err != nil {
 		return err
 	}
@@ -240,6 +251,12 @@ func (i *Initializer) initOpenFlowPipeline() error {
 	ofConnCh, err := i.ofClient.Initialize(roundInfo, i.nodeConfig, i.networkConfig.TrafficEncapMode, gatewayOFPort)
 	if err != nil {
 		klog.Errorf("Failed to initialize openflow client: %v", err)
+		return err
+	}
+
+	// On windows platform, host network flows are needed for host traffic.
+	if err := i.initHostNetworkFlows(); err != nil {
+		klog.Errorf("Failed to setup openflow entires for host network: %v", err)
 		return err
 	}
 
@@ -446,7 +463,7 @@ func (i *Initializer) initNodeLocalConfig() error {
 	}
 
 	if i.networkConfig.TrafficEncapMode.IsNetworkPolicyOnly() {
-		i.nodeConfig = &config.NodeConfig{Name: nodeName, NodeIPAddr: localAddr}
+		i.nodeConfig = &config.NodeConfig{Name: nodeName, NodeIPAddr: localAddr, BridgeName: i.ovsBridgeClient.GetBridgeName(), UplinkNetConfig: new(config.AdapterNetConfig)}
 		return nil
 	}
 
@@ -462,7 +479,7 @@ func (i *Initializer) initNodeLocalConfig() error {
 		return err
 	}
 
-	i.nodeConfig = &config.NodeConfig{Name: nodeName, PodCIDR: localSubnet, NodeIPAddr: localAddr}
+	i.nodeConfig = &config.NodeConfig{Name: nodeName, PodCIDR: localSubnet, NodeIPAddr: localAddr, BridgeName: i.ovsBridgeClient.GetBridgeName(), UplinkNetConfig: new(config.AdapterNetConfig)}
 	return nil
 }
 

--- a/pkg/agent/agent_linux.go
+++ b/pkg/agent/agent_linux.go
@@ -20,3 +20,18 @@ package agent
 func (i *Initializer) setupExternalConnectivity() error {
 	return nil
 }
+
+// prepareHostNetwork returns immediately on Linux.
+func (i *Initializer) prepareHostNetwork() error {
+	return nil
+}
+
+// prepareOVSBridge returns immediately on Linux.
+func (i *Initializer) prepareOVSBridge() error {
+	return nil
+}
+
+// initHostNetworkFlows returns immediately on Linux.
+func (i *Initializer) initHostNetworkFlows() error {
+	return nil
+}

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/cniserver"
+	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
 	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 	ovsconfigtest "github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig/testing"
@@ -83,6 +84,8 @@ func TestInitstore(t *testing.T) {
 
 	store := interfacestore.NewInterfaceStore()
 	initializer := newAgentInitializer(mockOVSBridgeClient, store)
+	uplinkNetConfig := config.AdapterNetConfig{Name: "eth-antrea-test-1"}
+	initializer.nodeConfig = &config.NodeConfig{UplinkNetConfig: &uplinkNetConfig}
 
 	err := initializer.initInterfaceStore()
 	if err == nil {

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -17,7 +17,14 @@
 package agent
 
 import (
+	"strings"
+
+	"github.com/Microsoft/hcsshim"
 	"k8s.io/klog"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/config"
+	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
+	"github.com/vmware-tanzu/antrea/pkg/agent/util"
 )
 
 // setupExternalConnectivity installs OpenFlow entries to SNAT Pod traffic using Node IP, and then Pod could communicate
@@ -28,6 +35,137 @@ func (i *Initializer) setupExternalConnectivity() error {
 	// Install OpenFlow entries on the OVS to enable Pod traffic to communicate to external IP addresses.
 	if err := i.ofClient.InstallExternalFlows(nodeIP, *subnetCIDR); err != nil {
 		klog.Errorf("Failed to setup SNAT openflow entries: %v", err)
+		return err
+	}
+	return nil
+}
+
+// prepareHostNetwork creates HNS Network for containers.
+func (i *Initializer) prepareHostNetwork() error {
+	// If the HNS Network already exists, return immediately.
+	hnsNetwork, err := hcsshim.GetHNSNetworkByName(util.LocalHNSNetwork)
+	if err == nil {
+		// Save the uplink adapter name to check if the OVS uplink port has been created in prepareOVSBridge stage.
+		i.nodeConfig.UplinkNetConfig.Name = hnsNetwork.NetworkAdapterName
+		return nil
+	}
+	if _, ok := err.(hcsshim.NetworkNotFoundError); !ok {
+		return err
+	}
+	// Get uplink network configuration.
+	_, adapter, err := util.GetIPNetDeviceFromIP(i.nodeConfig.NodeIPAddr.IP)
+	if err != nil {
+		return err
+	}
+	i.nodeConfig.UplinkNetConfig.Name = adapter.Name
+	i.nodeConfig.UplinkNetConfig.MAC = adapter.HardwareAddr
+	i.nodeConfig.UplinkNetConfig.IP = i.nodeConfig.NodeIPAddr
+	i.nodeConfig.UplinkNetConfig.Index = adapter.Index
+	defaultGW, err := util.GetDefaultGatewayByInterfaceIndex(adapter.Index)
+	if err != nil {
+		return err
+	}
+	i.nodeConfig.UplinkNetConfig.Gateway = defaultGW
+	dnsServers, err := util.GetDNServersByInterfaceIndex(adapter.Index)
+	if err != nil {
+		return err
+	}
+	i.nodeConfig.UplinkNetConfig.DNSServers = dnsServers
+	// Create HNS network.
+	return util.PrepareHNSNetwork(i.nodeConfig.PodCIDR, i.nodeConfig.NodeIPAddr, adapter)
+}
+
+// prepareOVSBridge adds local port and uplink to ovs bridge.
+// This function will delete OVS bridge and HNS network created by antrea on failure.
+func (i *Initializer) prepareOVSBridge() error {
+	hnsNetwork, err := hcsshim.GetHNSNetworkByName(util.LocalHNSNetwork)
+	defer func() {
+		// prepareOVSBridge only works on windows platform. The operation has a chance to fail on the first time agent
+		// starts up when OVS bridge uplink and local inteface have not been configured. If the operation fails, the
+		// host can not communicate with external network. To make sure the agent can connect to API server in
+		// next retry, this step deletes OVS bridge and HNS network created previously which will restore the
+		// host network.
+		if err := i.ovsBridgeClient.Delete(); err != nil {
+			klog.Errorf("Failed to delete OVS bridge: %v", err)
+		}
+		if err := util.DeleteHNSNetwork(util.LocalHNSNetwork); err != nil {
+			klog.Errorf("Failed to cleanup host networking: %v", err)
+		}
+	}()
+	if err != nil {
+		return err
+	}
+
+	// Set datapathID of OVS bridge.
+	// If no datapathID configured explicitly, the reconfiguration operation will change OVS bridge datapathID
+	// and break the OpenFlow channel.
+	// The length of datapathID is 64 bits, the lower 48-bits are for a MAC address, while the upper 16-bits are
+	// implementer-defined. Antrea uses "0x0000" for the upper 16-bits.
+	datapathID := strings.Replace(hnsNetwork.SourceMac, ":", "", -1)
+	datapathID = "0000" + datapathID
+	if err = i.ovsBridgeClient.SetDatapathID(datapathID); err != nil {
+		klog.Errorf("Failed to set datapath_id %s: %v", datapathID, err)
+		return err
+	}
+
+	// Create local port.
+	brName := i.ovsBridgeClient.GetBridgeName()
+	if _, err := i.ovsBridgeClient.GetOFPort(brName); err == nil {
+		klog.Infof("OVS bridge local port %s already exists, skip the configuration", brName)
+	} else {
+		// OVS does not receive "ofport_request" param when creating local port, so here use config.AutoAssignedOFPort=0
+		// to ignore this param.
+		if _, err := i.ovsBridgeClient.CreateInternalPort(brName, config.AutoAssignedOFPort, nil); err != nil {
+			return err
+		}
+	}
+
+	// If uplink is already exists, return.
+	uplinkNetConfig := i.nodeConfig.UplinkNetConfig
+	uplink := uplinkNetConfig.Name
+	if _, err := i.ovsBridgeClient.GetOFPort(uplink); err == nil {
+		klog.Infof("Uplink %s already exists, skip the configuration", uplink)
+		return err
+	}
+	// Create uplink port.
+	uplinkPortUUId, err := i.ovsBridgeClient.CreateUplinkPort(uplink, config.UplinkOFPort, nil)
+	if err != nil {
+		klog.Errorf("Failed to add uplink port %s: %v", uplink, err)
+		return err
+	}
+	uplinkInterface := interfacestore.NewUplinkInterface(uplink)
+	uplinkInterface.OVSPortConfig = &interfacestore.OVSPortConfig{uplinkPortUUId, config.UplinkOFPort}
+	i.ifaceStore.AddInterface(uplinkInterface)
+
+	// Move network configuration of uplink interface to OVS bridge local interface.
+	// - The net configuration of uplink will be restored by OS if the attached HNS network is deleted.
+	// - When ovs-switchd is down, antrea-agent will disable OVS Extension. The OVS bridge local interface will work
+	//   like a normal interface on host and is responsible for forwarding host traffic.
+	err = util.EnableHostInterface(brName)
+	if err = util.SetAdapterMACAddress(brName, &uplinkNetConfig.MAC); err != nil {
+		return err
+	}
+	// Remove existing IP addresses to avoid a candidate error of "Instance MSFT_NetIPAddress already exists" when
+	// adding it on the adapter.
+	if err = util.RemoveIPv4AddrsFromAdapter(brName); err != nil {
+		return err
+	}
+	// TODO: Configure IPv6 Address.
+	if err = util.ConfigureInterfaceAddressWithDefaultGateway(brName, uplinkNetConfig.IP, uplinkNetConfig.Gateway); err != nil {
+		return err
+	}
+	if uplinkNetConfig.DNSServers != "" {
+		if err = util.SetAdapterDNSServers(brName, uplinkNetConfig.DNSServers); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// initHostNetworkFlows installs Openflow flows between bridge local port and uplink port to support
+// host networking. These flows are only needed on windows platform.
+func (i *Initializer) initHostNetworkFlows() error {
+	if err := i.ofClient.InstallBridgeUplinkFlows(config.UplinkOFPort, config.BridgeOFPort); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -23,6 +23,10 @@ import (
 
 const (
 	DefaultTunPortName = "tun0"
+	// Invalid ofport_request number is in range 1 to 65,279. For ofport_request number not in the range, OVS
+	// ignore the it and automatically assign a port number.
+	// Here we use an invalid port number "0" to request for automatically port allocation.
+	AutoAssignedOFPort = 0
 	DefaultTunOFPort   = 1
 	HostGatewayOFPort  = 2
 	UplinkOFPort       = 3
@@ -43,13 +47,23 @@ func (g *GatewayConfig) String() string {
 	return fmt.Sprintf("Name %s: IP %s, MAC %s", g.Name, g.IP, g.MAC)
 }
 
+type AdapterNetConfig struct {
+	Name       string
+	Index      int
+	MAC        net.HardwareAddr
+	IP         *net.IPNet
+	Gateway    string
+	DNSServers string
+}
+
 // Local Node configurations retrieved from K8s API or host networking state.
 type NodeConfig struct {
-	Name          string
-	PodCIDR       *net.IPNet
-	NodeIPAddr    *net.IPNet
-	GatewayConfig *GatewayConfig
-	BridgeName    string
+	Name            string
+	PodCIDR         *net.IPNet
+	NodeIPAddr      *net.IPNet
+	GatewayConfig   *GatewayConfig
+	BridgeName      string
+	UplinkNetConfig *AdapterNetConfig
 }
 
 func (n *NodeConfig) String() string {

--- a/pkg/agent/interfacestore/types.go
+++ b/pkg/agent/interfacestore/types.go
@@ -27,6 +27,8 @@ const (
 	GatewayInterface
 	// TunnelInterface is used to mark current interface is for tunnel port
 	TunnelInterface
+	// UplinkInterface is used to mark current interface is for uplink port
+	UplinkInterface
 )
 
 type InterfaceType uint8
@@ -116,4 +118,10 @@ func NewTunnelInterface(tunnelName string, tunnelType ovsconfig.TunnelType) *Int
 func NewIPSecTunnelInterface(interfaceName string, tunnelType ovsconfig.TunnelType, nodeName string, nodeIP net.IP, psk string) *InterfaceConfig {
 	tunnelConfig := &TunnelInterfaceConfig{Type: tunnelType, NodeName: nodeName, RemoteIP: nodeIP, PSK: psk}
 	return &InterfaceConfig{InterfaceName: interfaceName, Type: TunnelInterface, TunnelInterfaceConfig: tunnelConfig}
+}
+
+// NewUplinkInterface creates InterfaceConfig for the uplink interface.
+func NewUplinkInterface(uplinkName string) *InterfaceConfig {
+	uplinkConfig := &InterfaceConfig{InterfaceName: uplinkName, Type: UplinkInterface}
+	return uplinkConfig
 }

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -40,6 +40,10 @@ type Client interface {
 	// InstallGatewayFlows sets up flows related to an OVS gateway port, the gateway must exist.
 	InstallGatewayFlows(gatewayAddr net.IP, gatewayMAC net.HardwareAddr, gatewayOFPort uint32) error
 
+	// InstallBridgeUplinkFlows installs Openflow flows between bridge local port and uplink port to support
+	// host networking. These flows are only needed on windows platform.
+	InstallBridgeUplinkFlows(uplinkPort uint32, bridgeLocalPort uint32) error
+
 	// InstallClusterServiceCIDRFlows sets up the appropriate flows so that traffic can reach
 	// the different Services running in the Cluster. This method needs to be invoked once with
 	// the Cluster Service CIDR as a parameter.
@@ -279,6 +283,16 @@ func (c *client) InstallDefaultTunnelFlows(tunnelOFPort uint32) error {
 		return err
 	}
 	c.defaultTunnelFlows = []binding.Flow{flow}
+	return nil
+}
+
+func (c *client) InstallBridgeUplinkFlows(uplinkPort uint32, bridgeLocalPort uint32) error {
+	flows := c.hostBridgeUplinkFlows(uplinkPort, bridgeLocalPort, cookie.Default)
+	c.hostNetworkingFlows = flows
+	if err := c.flowOperations.AddAll(flows); err != nil {
+		return err
+	}
+	c.hostNetworkingFlows = flows
 	return nil
 }
 

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -217,6 +217,23 @@ func (c *client) podClassifierFlow(podOFPort uint32, category cookie.Category) b
 		Done()
 }
 
+// hostBridgeUplinkFlows generates the flows that forward traffic between bridge local port and uplink port to support
+// host communicate with outside. These flows are only needed on windows platform.
+func (c *client) hostBridgeUplinkFlows(uplinkPort uint32, bridgeLocalPort uint32, category cookie.Category) (flows []binding.Flow) {
+	classifierTable := c.pipeline[classifierTable]
+	flows = []binding.Flow{
+		classifierTable.BuildFlow(priorityLow).MatchInPort(uplinkPort).
+			Action().Output(int(bridgeLocalPort)).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+		classifierTable.BuildFlow(priorityNormal).MatchInPort(bridgeLocalPort).
+			Action().Output(int(uplinkPort)).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+	}
+	return flows
+}
+
 // connectionTrackFlows generates flows that redirect traffic to ct_zone and handle traffic according to ct_state:
 // 1) commit new connections to ct_zone(0xfff0) in the conntrackCommitTable.
 // 2) Add ct_mark on the packet if it is sent to the switch from the host gateway.

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Antrea Authors
+// Copyright 2020 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -134,6 +134,20 @@ func (m *MockClient) Initialize(arg0 types.RoundInfo, arg1 *config.NodeConfig, a
 func (mr *MockClientMockRecorder) Initialize(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockClient)(nil).Initialize), arg0, arg1, arg2, arg3)
+}
+
+// InstallBridgeUplinkFlows mocks base method
+func (m *MockClient) InstallBridgeUplinkFlows(arg0, arg1 uint32) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallBridgeUplinkFlows", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallBridgeUplinkFlows indicates an expected call of InstallBridgeUplinkFlows
+func (mr *MockClientMockRecorder) InstallBridgeUplinkFlows(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallBridgeUplinkFlows", reflect.TypeOf((*MockClient)(nil).InstallBridgeUplinkFlows), arg0, arg1)
 }
 
 // InstallClusterServiceCIDRFlows mocks base method

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -73,7 +73,7 @@ type LinkNotFound struct {
 	error
 }
 
-func newLinkNoteFoundError(name string) LinkNotFound {
+func newLinkNotFoundError(name string) LinkNotFound {
 	return LinkNotFound{
 		fmt.Errorf("link %s not found", name),
 	}

--- a/pkg/agent/util/net_linux.go
+++ b/pkg/agent/util/net_linux.go
@@ -136,7 +136,7 @@ func SetLinkUp(name string) (net.HardwareAddr, int, error) {
 	link, err := netlink.LinkByName(name)
 	if err != nil {
 		if _, ok := err.(netlink.LinkNotFoundError); ok {
-			return nil, 0, newLinkNoteFoundError(name)
+			return nil, 0, newLinkNotFoundError(name)
 		} else {
 			return nil, 0, err
 		}

--- a/pkg/ovs/ovsconfig/interfaces.go
+++ b/pkg/ovs/ovsconfig/interfaces.go
@@ -31,10 +31,12 @@ type OVSBridgeClient interface {
 	Delete() Error
 	GetExternalIDs() (map[string]string, Error)
 	SetExternalIDs(externalIDs map[string]interface{}) Error
+	SetDatapathID(datapathID string) Error
 	CreatePort(name, ifDev string, externalIDs map[string]interface{}) (string, Error)
 	CreateInternalPort(name string, ofPortRequest int32, externalIDs map[string]interface{}) (string, Error)
 	CreateTunnelPort(name string, tunnelType TunnelType, ofPortRequest int32) (string, Error)
 	CreateTunnelPortExt(name string, tunnelType TunnelType, ofPortRequest int32, remoteIP string, psk string, externalIDs map[string]interface{}) (string, Error)
+	CreateUplinkPort(name string, ofPortRequest int32, externalIDs map[string]interface{}) (string, Error)
 	DeletePort(portUUID string) Error
 	DeletePorts(portUUIDList []string) Error
 	GetOFPort(ifName string) (int32, Error)

--- a/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
+++ b/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Antrea Authors
+// Copyright 2020 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -120,6 +120,21 @@ func (m *MockOVSBridgeClient) CreateTunnelPortExt(arg0 string, arg1 ovsconfig.Tu
 func (mr *MockOVSBridgeClientMockRecorder) CreateTunnelPortExt(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTunnelPortExt", reflect.TypeOf((*MockOVSBridgeClient)(nil).CreateTunnelPortExt), arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
+// CreateUplinkPort mocks base method
+func (m *MockOVSBridgeClient) CreateUplinkPort(arg0 string, arg1 int32, arg2 map[string]interface{}) (string, ovsconfig.Error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateUplinkPort", arg0, arg1, arg2)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(ovsconfig.Error)
+	return ret0, ret1
+}
+
+// CreateUplinkPort indicates an expected call of CreateUplinkPort
+func (mr *MockOVSBridgeClientMockRecorder) CreateUplinkPort(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUplinkPort", reflect.TypeOf((*MockOVSBridgeClient)(nil).CreateUplinkPort), arg0, arg1, arg2)
 }
 
 // Delete mocks base method
@@ -251,6 +266,20 @@ func (m *MockOVSBridgeClient) GetPortList() ([]ovsconfig.OVSPortData, ovsconfig.
 func (mr *MockOVSBridgeClientMockRecorder) GetPortList() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPortList", reflect.TypeOf((*MockOVSBridgeClient)(nil).GetPortList))
+}
+
+// SetDatapathID mocks base method
+func (m *MockOVSBridgeClient) SetDatapathID(arg0 string) ovsconfig.Error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetDatapathID", arg0)
+	ret0, _ := ret[0].(ovsconfig.Error)
+	return ret0
+}
+
+// SetDatapathID indicates an expected call of SetDatapathID
+func (mr *MockOVSBridgeClientMockRecorder) SetDatapathID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDatapathID", reflect.TypeOf((*MockOVSBridgeClient)(nil).SetDatapathID), arg0)
 }
 
 // SetExternalIDs mocks base method


### PR DESCRIPTION
Depend on Wenyingd's PR: Enable Windows Pod to access external addresses #393

Add windows platform specific operations during OVS bridge preparation:

1. Set fixed datapath_id for OVS bridge to avoid Openflow channel interruption.
2. Add default internal port/interface when creating OVS bridge.
  On windows platform OVS default inteface is used to forward host traffic.
3. Move IP/MAC from uplink interface to OVS bridge.
4. Add uplink port to OVS bridge.
5. Install Openflow entries for uplink/bridge to support host networking.