### PR TITLE
Improve antrea-controller NetworkPolicy computation performance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,4 +59,11 @@ replace (
 	// (mocks), which breaks "go mod". This has been fixed in master.
 	// Will remove this and upgrade Octant version after finding another compatible Octant release.
 	github.com/vmware/octant => github.com/antoninbas/octant v0.8.1-0.20191116223915-811df1acc59f
+	// fake.NewSimpleClientset is quite slow when it's initialized with massive objects due to
+	// https://github.com/kubernetes/kubernetes/issues/89574. It takes more than tens of minutes to
+	// init a fake client with 200k objects, which makes it hard to run the NetworkPolicy scale test.
+	// There is an optimization https://github.com/kubernetes/kubernetes/pull/89575 but will only be
+	// available from 1.18.1 and later releases. Use this commit before Antrea bumps up its K8s
+	// dependency version.
+	k8s.io/client-go => github.com/tnqn/client-go v0.0.0-20200330154227-d0a165c8fbd8
 )

--- a/go.sum
+++ b/go.sum
@@ -326,6 +326,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8 h1:ndzgwNDnKIqyCvHTXaCqh9KlOWKvBry6nuXMJmonVsE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/tnqn/client-go v0.0.0-20200330154227-d0a165c8fbd8 h1:0Pc3KeaI8bRWtQLG3QJDvF7y+5QgtIEXTX/CML2Q5K4=
+github.com/tnqn/client-go v0.0.0-20200330154227-d0a165c8fbd8/go.mod h1:E95RaSlHr79aHaX0aGSwcPNfygDiPKOVXdmivCIZT0k=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
@@ -481,8 +483,6 @@ k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719 h1:uV4S5IB5g4Nvi+TBVNf3e9
 k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719/go.mod h1:I4A+glKBHiTgiEjQiCCQfCAIcIMFGt291SmsvcrFzJA=
 k8s.io/apiserver v0.0.0-20190620085212-47dc9a115b18 h1:+C0wd/HnjyZ2I0SPqAy1cqfPoPxwZ0hUiNwj/EGTe6c=
 k8s.io/apiserver v0.0.0-20190620085212-47dc9a115b18/go.mod h1:Hc9PbFVOsMigd7B7OiY/6bIRkR8y31eIKsr1D+JtKg4=
-k8s.io/client-go v0.0.0-20190620085101-78d2af792bab h1:E8Fecph0qbNsAbijJJQryKu4Oi9QTp5cVpjTE+nqg6g=
-k8s.io/client-go v0.0.0-20190620085101-78d2af792bab/go.mod h1:E95RaSlHr79aHaX0aGSwcPNfygDiPKOVXdmivCIZT0k=
 k8s.io/component-base v0.0.0-20190620085130-185d68e6e6ea h1:CAN9Jo6bb5+mp3s1/1w8TbaWIxYK1WGQwwYvlacSet4=
 k8s.io/component-base v0.0.0-20190620085130-185d68e6e6ea/go.mod h1:VLedAFwENz2swOjm0zmUXpAP2mV55c49xgaOzPBI/QQ=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=

--- a/pkg/controller/networkpolicy/networkpolicy_controller_perf_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_perf_test.go
@@ -1,0 +1,278 @@
+// +build !race
+
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy
+
+import (
+	"context"
+	"fmt"
+	goruntime "runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+/*
+TestInitXLargeScaleWithSmallNamespaces tests the execution time and the memory usage of computing a scale
+of 25k Namespaces, 75k NetworkPolicies, 100k Pods. The reference value is:
+
+NAMESPACES   PODS    NETWORK-POLICIES    TIME(s)    MEMORY(M)    EXECUTIONS    EVENTS(ag, atg, np)
+25000        100000  75000               6.10       1626         519853        208503 166707 208503
+25000        100000  75000               5.84       1522         585696        225480 182641 225480
+25000        100000  75000               6.42       1708         507003        206149 163293 206149
+
+The metrics are not accurate under the race detector, and will be skipped when testing with "-race".
+*/
+func TestInitXLargeScaleWithSmallNamespaces(t *testing.T) {
+	getObjects := func() ([]*v1.Namespace, []*networkingv1.NetworkPolicy, []*v1.Pod) {
+		namespace := rand.String(8)
+		namespaces := []*v1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: namespace, Labels: map[string]string{"app": namespace}},
+			},
+		}
+		networkPolicies := []*networkingv1.NetworkPolicy{
+			{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "default-deny-all", UID: types.UID(uuid.New().String())},
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{},
+					PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "np-1", UID: types.UID(uuid.New().String())},
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app-1": "scale-1"}},
+					PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+					Ingress: []networkingv1.NetworkPolicyIngressRule{
+						{
+							From: []networkingv1.NetworkPolicyPeer{
+								{
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"app-1": "scale-1"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "np-2", UID: types.UID(uuid.New().String())},
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app-2": "scale-2"}},
+					PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+					Ingress: []networkingv1.NetworkPolicyIngressRule{
+						{
+							From: []networkingv1.NetworkPolicyPeer{
+								{
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"app-2": "scale-2"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		pods := []*v1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod1", UID: types.UID(uuid.New().String()), Labels: map[string]string{"app-1": "scale-1"}},
+				Spec:       v1.PodSpec{NodeName: getRandomNodeName()},
+				Status:     v1.PodStatus{PodIP: getRandomIP()},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod2", UID: types.UID(uuid.New().String()), Labels: map[string]string{"app-1": "scale-1"}},
+				Spec:       v1.PodSpec{NodeName: getRandomNodeName()},
+				Status:     v1.PodStatus{PodIP: getRandomIP()},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod3", UID: types.UID(uuid.New().String()), Labels: map[string]string{"app-2": "scale-2"}},
+				Spec:       v1.PodSpec{NodeName: getRandomNodeName()},
+				Status:     v1.PodStatus{PodIP: getRandomIP()},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod4", UID: types.UID(uuid.New().String()), Labels: map[string]string{"app-2": "scale-2"}},
+				Spec:       v1.PodSpec{NodeName: getRandomNodeName()},
+				Status:     v1.PodStatus{PodIP: getRandomIP()},
+			},
+		}
+		return namespaces, networkPolicies, pods
+	}
+	namespaces, networkPolicies, pods := getXObjects(25000, getObjects)
+	testComputeNetworkPolicy(t, 10*time.Second, namespaces, networkPolicies, pods)
+}
+
+func testComputeNetworkPolicy(t *testing.T, maxExecutionTime time.Duration, namespaces []*v1.Namespace, networkPolicies []*networkingv1.NetworkPolicy, pods []*v1.Pod) {
+	objs := make([]runtime.Object, 0, len(namespaces)+len(networkPolicies)+len(pods))
+	for i := range namespaces {
+		objs = append(objs, namespaces[i])
+	}
+	for i := range networkPolicies {
+		objs = append(objs, networkPolicies[i])
+	}
+	for i := range pods {
+		objs = append(objs, pods[i])
+	}
+
+	_, c := newController(objs...)
+	c.heartbeatCh = make(chan heartbeat, 1000)
+
+	stopCh := make(chan struct{})
+
+	// executionMetric is used to count the executions of each routine and to record the last execution time.
+	type executionMetric struct {
+		executions    int
+		lastExecution time.Time
+	}
+	executionMetrics := map[string]*executionMetric{}
+
+	// If we don't receive any heartbeat from NetworkPolicyController for 3 seconds, it means all computation
+	// finished 3 seconds ago.
+	idleTimeout := 3 * time.Second
+	timer := time.NewTimer(idleTimeout)
+	go func() {
+		for {
+			timer.Reset(idleTimeout)
+			select {
+			case heartbeat := <-c.heartbeatCh:
+				m, ok := executionMetrics[heartbeat.name]
+				if !ok {
+					m = &executionMetric{}
+					executionMetrics[heartbeat.name] = m
+				}
+				m.executions++
+				m.lastExecution = heartbeat.timestamp
+			case <-timer.C:
+				// Send the stop signal if we don't receive any heartbeat for 3 seconds.
+				close(stopCh)
+				return
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+
+	// Stat how many events we will get during the computation.
+	var addressGroupEvents, appliedToGroupEvents, networkPolicyEvents int32
+	wg.Add(1)
+	go func() {
+		statEvents(c, &addressGroupEvents, &appliedToGroupEvents, &networkPolicyEvents, stopCh)
+		wg.Done()
+	}()
+
+	// Stat the maximum heap allocation.
+	var maxAlloc uint64
+	wg.Add(1)
+	go func() {
+		statMaxMemAlloc(&maxAlloc, 500*time.Millisecond, stopCh)
+		wg.Done()
+	}()
+
+	// Everything is ready, now start timing.
+	start := time.Now()
+	c.informerFactory.Start(stopCh)
+	go c.Run(stopCh)
+
+	// Block until all computation is done.
+	<-stopCh
+	// Minus the idle time to get the actual execution time.
+	executionTime := time.Since(start) - idleTimeout
+	if executionTime > maxExecutionTime {
+		t.Errorf("The actual execution time %v is greater than the maximum value %v", executionTime, maxExecutionTime)
+	}
+	totalExecution := 0
+	for name, m := range executionMetrics {
+		t.Logf("Execution metrics of %s, executions: %d, duration: %v", name, m.executions, m.lastExecution.Sub(start))
+		totalExecution += m.executions
+	}
+
+	// Block until all statistics are done.
+	wg.Wait()
+
+	t.Logf(`Summary metrics:
+NAMESPACES   PODS    NETWORK-POLICIES    TIME(s)    MEMORY(M)    EXECUTIONS    EVENTS(ag, atg, np)
+%-12d %-7d %-19d %-10.2f %-12d %-13d %d %d %d
+`, len(namespaces), len(pods), len(networkPolicies), float64(executionTime)/float64(time.Second), maxAlloc/1024/1024, totalExecution, networkPolicyEvents, appliedToGroupEvents, networkPolicyEvents)
+}
+
+func statEvents(c *networkPolicyController, addressGroupEvents, appliedToGroupEvents, networkPolicyEvents *int32, stopCh chan struct{}) {
+	addressGroupWatcher, _ := c.addressGroupStore.Watch(context.Background(), "", labels.Everything(), fields.Everything())
+	appliedToGroupWatcher, _ := c.appliedToGroupStore.Watch(context.Background(), "", labels.Everything(), fields.Everything())
+	networkPolicyWatcher, _ := c.internalNetworkPolicyStore.Watch(context.Background(), "", labels.Everything(), fields.Everything())
+	for {
+		select {
+		case <-addressGroupWatcher.ResultChan():
+			*addressGroupEvents++
+		case <-appliedToGroupWatcher.ResultChan():
+			*appliedToGroupEvents++
+		case <-networkPolicyWatcher.ResultChan():
+			*networkPolicyEvents++
+		case <-stopCh:
+			return
+		}
+	}
+}
+
+func statMaxMemAlloc(maxAlloc *uint64, interval time.Duration, stopCh chan struct{}) {
+	var memStats goruntime.MemStats
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			goruntime.ReadMemStats(&memStats)
+			if memStats.Alloc > *maxAlloc {
+				*maxAlloc = memStats.Alloc
+			}
+		case <-stopCh:
+			return
+		}
+	}
+}
+
+func getRandomIP() string {
+	return fmt.Sprintf("%d.%d.%d.%d", rand.Intn(256), rand.Intn(256), rand.Intn(256), rand.Intn(256))
+}
+
+func getRandomNodeName() string {
+	return fmt.Sprintf("Node-%d", rand.Intn(1000))
+}
+
+// getXObjects calls the provided getObjectsFunc x times and aggregate the objects.
+func getXObjects(x int, getObjectsFunc func() ([]*v1.Namespace, []*networkingv1.NetworkPolicy, []*v1.Pod)) ([]*v1.Namespace, []*networkingv1.NetworkPolicy, []*v1.Pod) {
+	var namespaces []*v1.Namespace
+	var networkPolicies []*networkingv1.NetworkPolicy
+	var pods []*v1.Pod
+	for i := 0; i < x; i++ {
+		newNamespaces, newNetworkPolicies, newPods := getObjectsFunc()
+		namespaces = append(namespaces, newNamespaces...)
+		networkPolicies = append(networkPolicies, newNetworkPolicies...)
+		pods = append(pods, newPods...)
+	}
+	return namespaces, networkPolicies, pods
+}

--- a/pkg/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_test.go
@@ -53,10 +53,11 @@ type networkPolicyController struct {
 	appliedToGroupStore        storage.Interface
 	addressGroupStore          storage.Interface
 	internalNetworkPolicyStore storage.Interface
+	informerFactory            informers.SharedInformerFactory
 }
 
-func newController() (*fake.Clientset, *networkPolicyController) {
-	client := newClientset()
+func newController(objects ...runtime.Object) (*fake.Clientset, *networkPolicyController) {
+	client := newClientset(objects...)
 	informerFactory := informers.NewSharedInformerFactory(client, informerDefaultResync)
 	appliedToGroupStore := store.NewAppliedToGroupStore()
 	addressGroupStore := store.NewAddressGroupStore()
@@ -73,11 +74,12 @@ func newController() (*fake.Clientset, *networkPolicyController) {
 		appliedToGroupStore,
 		addressGroupStore,
 		internalNetworkPolicyStore,
+		informerFactory,
 	}
 }
 
-func newClientset() *fake.Clientset {
-	client := fake.NewSimpleClientset()
+func newClientset(objects ...runtime.Object) *fake.Clientset {
+	client := fake.NewSimpleClientset(objects...)
 
 	client.PrependReactor("create", "networkpolicies", k8stesting.ReactionFunc(func(action k8stesting.Action) (bool, runtime.Object, error) {
 		np := action.(k8stesting.CreateAction).GetObject().(*networkingv1.NetworkPolicy)

--- a/pkg/controller/networkpolicy/store/addressgroup.go
+++ b/pkg/controller/networkpolicy/store/addressgroup.go
@@ -152,5 +152,15 @@ func AddressGroupKeyFunc(obj interface{}) (string, error) {
 
 // NewAddressGroupStore creates a store of AddressGroup.
 func NewAddressGroupStore() storage.Interface {
-	return ram.NewStore(AddressGroupKeyFunc, cache.Indexers{}, genAddressGroupEvent, keyAndSpanSelectFunc)
+	indexers := cache.Indexers{
+		cache.NamespaceIndex: func(obj interface{}) ([]string, error) {
+			ag, ok := obj.(*types.AddressGroup)
+			if !ok {
+				return []string{}, nil
+			}
+			// ag.Selector.Namespace == "" means it's a cluster scoped group, we index it as it is.
+			return []string{ag.Selector.Namespace}, nil
+		},
+	}
+	return ram.NewStore(AddressGroupKeyFunc, indexers, genAddressGroupEvent, keyAndSpanSelectFunc)
 }

--- a/pkg/controller/networkpolicy/store/appliedtogroup.go
+++ b/pkg/controller/networkpolicy/store/appliedtogroup.go
@@ -165,5 +165,14 @@ func AppliedToGroupKeyFunc(obj interface{}) (string, error) {
 
 // NewAppliedToGroupStore creates a store of AppliedToGroup.
 func NewAppliedToGroupStore() storage.Interface {
-	return ram.NewStore(AppliedToGroupKeyFunc, cache.Indexers{}, genAppliedToGroupEvent, keyAndSpanSelectFunc)
+	indexers := cache.Indexers{
+		cache.NamespaceIndex: func(obj interface{}) ([]string, error) {
+			atg, ok := obj.(*types.AppliedToGroup)
+			if !ok {
+				return []string{}, nil
+			}
+			return []string{atg.Selector.Namespace}, nil
+		},
+	}
+	return ram.NewStore(AppliedToGroupKeyFunc, indexers, genAppliedToGroupEvent, keyAndSpanSelectFunc)
 }


### PR DESCRIPTION
In a scale of 25k Namespaces, 100k Pods, 75k NetworkPolicies, It took ~20 minutes to finish the initial computation, which could leave the cluster in a degraded state for a long time once antrea-controller is restarted.

It's profiled that the bottleneck is the Pod event handlers: addPod. For instance, in the above scale, addNetworkPolicy can finish all tasks in 9.42s, addNamespace can finish in 910ms, but addPod needs 17min. So it is actually addPod keeping producing new tasks for the workers to process. It's slow because addPod listed all AddressGroups and AppliedToGroups and checked whether they could be affected by this pod, leading to O(N * M) time complexity, where N is number of pods, M is number of groups. Further more, as multiple Pods can affect same AddressGroups or AppliedToGroups, if it produces very slow but the workers consumes very fast, there would be many repeated computation, for instance: podA added -> sync groupM -> podB added -> sync groupM -> podC added -> sync groupM, where groupM is synced 3 times, wasting CPU a lot, making the whole processing worse.

Given the fact that a Pod can only possibly affect AddressGroups and AppliedToGroups that are namespace scoped and targeting for this namespace, and that are cluster scoped. This patch builds a namespace index for AddressGroups and AppliedToGroups. When it processes a Pod added event, it no longer lists all groups but get a small portion of groups by index, ideally the while time complexity is reduced to O(N), so it is able to produce all tasks for workers very fast. Besides, the workers will only process each group once or a few times.

With this optimization, the execution time of the above scale is reduced from ~20 minutes to 6 seconds.

The patch also adds a performance test with a large scale fake input to measure the metrics automatically.

For #284