### PR TITLE
[Netpol] Sleep between successive tests

### DIFF
--- a/hack/netpol/pkg/utils/k8s_util.go
+++ b/hack/netpol/pkg/utils/k8s_util.go
@@ -108,11 +108,11 @@ func (k *Kubernetes) Probe(ns1, pod1, ns2, pod2 string, port int) (bool, error) 
 	}
 	// HACK: inferring container name as c80, c81, etc, for simplicity.
 	containerName := fmt.Sprintf("c%v", port)
-	log.Infof("Running: kubectl exec %s -c %s -n %s -- %s", fromPod.Name, containerName, fromPod.Namespace, strings.Join(cmd, " "))
+	log.Tracef("Running: kubectl exec %s -c %s -n %s -- %s", fromPod.Name, containerName, fromPod.Namespace, strings.Join(cmd, " "))
 	stdout, stderr, err := k.ExecuteRemoteCommand(fromPod, containerName, cmd)
 	if err != nil {
-		// log this error as debug since may be an expected failure
-		log.Debugf("%s/%s -> %s/%s: error when running command: err - %v /// stdout - %s /// stderr - %s", ns1, pod1, ns2, pod2, err, stdout, stderr)
+		// log this error as trace since may be an expected failure
+		log.Tracef("%s/%s -> %s/%s: error when running command: err - %v /// stdout - %s /// stderr - %s", ns1, pod1, ns2, pod2, err, stdout, stderr)
 		// do not return an error
 		return false, nil
 	}


### PR DESCRIPTION
Because the same Pods are re-used to validate NetworkPolicy
implementation, there is virtually no delay between successive
tests. This means that Antrea does not always have time to properly
clean-up stale NetworkPolicies and a test can fail because of the
NetworkPolicy from the previous test. By adding a short delay (2s) every
time we update or delete a NetworkPolicy, we can bypass the issue. This
change only increases testing time by < 20% (3min -> 3min30).

This commit also changes the verbosity of some log messages to "TRACE"
to make the logs easier to navigate.

Fixes #544