### PR TITLE
Fix deny-all egress NetworkPolicy case

### DIFF
--- a/pkg/agent/controller/networkpolicy/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/reconciler_test.go
@@ -309,6 +309,26 @@ func TestReconcilerReconcile(t *testing.T) {
 			false,
 		},
 		{
+			"ingress-rule-deny-all",
+			&CompletedRule{
+				rule:          &rule{ID: "ingress-rule", Direction: v1beta1.DirectionIn},
+				FromAddresses: nil,
+				ToAddresses:   nil,
+				Pods:          appliedToGroup1,
+			},
+			[]*types.PolicyRule{
+				{
+					Direction:  v1beta1.DirectionIn,
+					From:       []types.Address{},
+					ExceptFrom: nil,
+					To:         ofPortsToOFAddresses(sets.NewInt32(1)),
+					ExceptTo:   nil,
+					Service:    nil,
+				},
+			},
+			false,
+		},
+		{
 			"egress-rule",
 			&CompletedRule{
 				rule:          &rule{ID: "egress-rule", Direction: v1beta1.DirectionOut},
@@ -355,6 +375,29 @@ func TestReconcilerReconcile(t *testing.T) {
 						openflow.NewIPNetAddress(*ipNet4),
 					},
 					Service: nil,
+				},
+			},
+			false,
+		},
+		{
+			"egress-rule-deny-all",
+			&CompletedRule{
+				rule: &rule{
+					ID:        "egress-rule",
+					Direction: v1beta1.DirectionOut,
+				},
+				FromAddresses: nil,
+				ToAddresses:   nil,
+				Pods:          appliedToGroup1,
+			},
+			[]*types.PolicyRule{
+				{
+					Direction:  v1beta1.DirectionOut,
+					From:       ipsToOFAddresses(sets.NewString("2.2.2.2")),
+					ExceptFrom: nil,
+					To:         []types.Address{},
+					ExceptTo:   nil,
+					Service:    nil,
 				},
 			},
 			false,
@@ -470,6 +513,24 @@ func TestReconcilerUpdate(t *testing.T) {
 			ipsToOFAddresses(sets.NewString("1.1.1.2")),
 			ipsToOFAddresses(sets.NewString("2.2.2.2")),
 			ipsToOFAddresses(sets.NewString("1.1.1.1")),
+			false,
+		},
+		{
+			"updating-egress-rule-deny-all",
+			&CompletedRule{
+				rule:        &rule{ID: "egress-rule", Direction: v1beta1.DirectionOut},
+				ToAddresses: nil,
+				Pods:        appliedToGroup1,
+			},
+			&CompletedRule{
+				rule:        &rule{ID: "egress-rule", Direction: v1beta1.DirectionOut},
+				ToAddresses: nil,
+				Pods:        appliedToGroup2,
+			},
+			ipsToOFAddresses(sets.NewString("3.3.3.3")),
+			[]types.Address{},
+			ipsToOFAddresses(sets.NewString("2.2.2.2")),
+			[]types.Address{},
 			false,
 		},
 	}

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -121,3 +121,54 @@ func TestDifferentNamedPorts(t *testing.T) {
 		t.Fatalf("Pod %s should not be able to connect %s:%d, but was able to connect", client1Name, server1IP, server1Port)
 	}
 }
+
+func TestDefaultDenyEgressPolicy(t *testing.T) {
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	serverName := randName("test-server-")
+	serverPort := 80
+	if err = data.createServerPod(serverName, "http", serverPort); err != nil {
+		t.Fatalf("Error when creating server pod: %v", err)
+	}
+	defer deletePodWrapper(t, data, serverName)
+	serverIP, err := data.podWaitForIP(defaultTimeout, serverName)
+	if err != nil {
+		t.Fatalf("Error when waiting for IP for Pod '%s': %v", serverName, err)
+	}
+
+	clientName := randName("test-client-")
+	if err := data.createBusyboxPod(clientName); err != nil {
+		t.Fatalf("Error when creating busybox test Pod: %v", err)
+	}
+	defer deletePodWrapper(t, data, clientName)
+	if _, err := data.podWaitForIP(defaultTimeout, clientName); err != nil {
+		t.Fatalf("Error when waiting for IP for Pod '%s': %v", clientName, err)
+	}
+
+	if err = data.runNetcatCommandFromTestPod(clientName, serverIP, serverPort); err != nil {
+		t.Fatalf("Pod %s should be able to connect %s:%d, but was not able to connect", clientName, serverIP, serverPort)
+	}
+
+	spec := &networkingv1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{},
+		PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+		Egress:      []networkingv1.NetworkPolicyEgressRule{},
+	}
+	np, err := data.createNetworkPolicy("test-networkpolicy-deny-all-egress", spec)
+	if err != nil {
+		t.Fatalf("Error when creating network policy: %v", err)
+	}
+	defer func() {
+		if err = data.deleteNetworkpolicy(np); err != nil {
+			t.Fatalf("Error when deleting network policy: %v", err)
+		}
+	}()
+
+	if err = data.runNetcatCommandFromTestPod(clientName, serverIP, serverPort); err == nil {
+		t.Fatalf("Pod %s should not be able to connect %s:%d, but was able to connect", clientName, serverIP, serverPort)
+	}
+}


### PR DESCRIPTION
For egress policy, if there are no "ToAddresses" and "IPBlocks", there
were no PolicyRules created, which caused the Pods not being isolated.

We must ensure there is at least one PolicyRule, this patch creates a
PolicyRule with the original services if it doesn't exist. If there are
IPBlocks or Pods that cannot resolve any named port, they will share
this PolicyRule.

The upstream test has only deny-all ingress case but not egress one,
a deny-all egress test is added to antrea e2e test.

Fixes #574