### PR TITLE
Hide output when resetting changes introduced by YEAR

### DIFF
--- a/hack/update-codegen-dockerized.sh
+++ b/hack/update-codegen-dockerized.sh
@@ -87,6 +87,8 @@ $GOPATH/bin/go-to-protobuf \
 # Clean up vendor directory.
 rm -rf vendor
 
+set +x
+
 echo "=== Start resetting changes introduced by YEAR ==="
 git diff  --numstat | awk '$1 == "1" && $2 == "1" {print $3}' | while read file; do
   if [[ "$(git diff ${file})" == *"-// Copyright "*" Antrea Authors"* ]]; then
@@ -94,4 +96,3 @@ git diff  --numstat | awk '$1 == "1" && $2 == "1" {print $3}' | while read file;
     echo "=== ${file} is reset ==="
   fi
 done
-


### PR DESCRIPTION
Such detailed output is unnecessary. Just tell if this file is reset or not is enough.
e.g.
```
+ read file
++ git diff pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
+ [[ diff --git a/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go b/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
index cd52701..588e471 100644
--- a/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
+++ b/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Antrea Authors
+// Copyright 2020 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License. == *\-\/\/\ \C\o\p\y\r\i\g\h\t\ *\ \A\n\t\r\e\a\ \A\u\t\h\o\r\s* ]]
+ git checkout HEAD -- pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
+ echo '=== pkg/ovs/ovsconfig/testing/mock_ovsconfig.go is reset ==='
+ read file
=== pkg/ovs/ovsconfig/testing/mock_ovsconfig.go is reset ===
```