### PR TITLE
Update fields for `antctl get networkpolicy` command

### DIFF
--- a/pkg/agent/apiserver/handlers/networkpolicy/handler.go
+++ b/pkg/agent/apiserver/handlers/networkpolicy/handler.go
@@ -27,21 +27,30 @@ import (
 func HandleFunc(npq monitor.AgentNetworkPolicyInfoQuerier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		name := r.URL.Query().Get("name")
-		groups := npq.GetNetworkPolicies()
+		ns := r.URL.Query().Get("namespace")
+		if len(name) > 0 && len(ns) == 0 {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		policies := npq.GetNetworkPolicies()
+		var resp []networkingv1beta1.NetworkPolicy
+		for _, p := range policies {
+			if (len(name) == 0 || name == p.Name) && (len(ns) == 0 || ns == p.Namespace) {
+				resp = append(resp, p)
+			}
+		}
+
+		if len(name) > 0 && len(resp) == 0 {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
 		var obj interface{}
 		if len(name) > 0 {
-			for _, group := range groups {
-				if group.Name == name {
-					obj = group
-					break
-				}
-			}
-			if obj == nil {
-				w.WriteHeader(http.StatusNotFound)
-				return
-			}
+			obj = resp[0]
 		} else {
-			obj = networkingv1beta1.NetworkPolicyList{Items: groups}
+			obj = networkingv1beta1.NetworkPolicyList{Items: resp}
 		}
 		if err := json.NewEncoder(w).Encode(obj); err != nil {
 			http.Error(w, "Failed to encode response: "+err.Error(), http.StatusInternalServerError)

--- a/pkg/agent/controller/networkpolicy/cache_test.go
+++ b/pkg/agent/controller/networkpolicy/cache_test.go
@@ -282,12 +282,12 @@ func TestRuleCacheAddNetworkPolicy(t *testing.T) {
 		Services:  nil,
 	}
 	networkPolicy1 := &v1beta1.NetworkPolicy{
-		ObjectMeta:      metav1.ObjectMeta{UID: "policy1"},
+		ObjectMeta:      metav1.ObjectMeta{UID: "policy1", Namespace: "ns1", Name: "name1"},
 		Rules:           nil,
 		AppliedToGroups: []string{"appliedToGroup1"},
 	}
 	networkPolicy2 := &v1beta1.NetworkPolicy{
-		ObjectMeta:      metav1.ObjectMeta{UID: "policy2"},
+		ObjectMeta:      metav1.ObjectMeta{UID: "policy2", Namespace: "ns2", Name: "name2"},
 		Rules:           []v1beta1.NetworkPolicyRule{*networkPolicyRule1, *networkPolicyRule2},
 		AppliedToGroups: []string{"appliedToGroup1"},
 	}
@@ -351,7 +351,7 @@ func TestRuleCacheDeleteNetworkPolicy(t *testing.T) {
 			"delete-zero-rule",
 			[]*rule{rule1, rule2, rule3},
 			&v1beta1.NetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{UID: "policy0"},
+				ObjectMeta: metav1.ObjectMeta{UID: "policy0", Namespace: "ns0", Name: "name0"},
 			},
 			[]*rule{rule1, rule2, rule3},
 			sets.NewString(),
@@ -360,7 +360,7 @@ func TestRuleCacheDeleteNetworkPolicy(t *testing.T) {
 			"delete-one-rule",
 			[]*rule{rule1, rule2, rule3},
 			&v1beta1.NetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{UID: "policy1"},
+				ObjectMeta: metav1.ObjectMeta{UID: "policy1", Namespace: "ns1", Name: "name1"},
 			},
 			[]*rule{rule2, rule3},
 			sets.NewString("rule1"),
@@ -369,7 +369,7 @@ func TestRuleCacheDeleteNetworkPolicy(t *testing.T) {
 			"delete-two-rule",
 			[]*rule{rule1, rule2, rule3},
 			&v1beta1.NetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{UID: "policy2"},
+				ObjectMeta: metav1.ObjectMeta{UID: "policy2", Namespace: "ns2", Name: "name2"},
 			},
 			[]*rule{rule1},
 			sets.NewString("rule2", "rule3"),

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -55,14 +55,22 @@ var CommandList = &commandList{
 			transformedResponse: reflect.TypeOf(version.Response{}),
 		},
 		{
-			use:          "networkpolicy",
-			aliases:      []string{"networkpolicies", "netpol"},
-			short:        "Print network policies",
-			long:         "Print network policies in ${component}",
+			use:     "networkpolicy",
+			aliases: []string{"networkpolicies", "netpol"},
+			short:   "Print network policies",
+			long:    "Print network policies in ${component}. \"Namespace\" is required if \"Name\" is provided.",
+			example: `  Get a NetworkPolicy in a specific Namespace
+  $ antctl get networkpolicy access-nginx -n prod
+  Get the list of NetworkPolicies in a Namespace
+  $ antctl get networkpolicy -n prod
+  Get the list of NetworkPolicies in all Namespaces
+  $ antctl get networkpolicy`,
 			commandGroup: get,
 			controllerEndpoint: &endpoint{
 				resourceEndpoint: &resourceEndpoint{
 					groupVersionResource: &networkingv1beta1.NetworkPolicyVersionResource,
+					resourceName:         "",
+					namespaced:           true,
 				},
 				addonTransform: networkpolicy.Transform,
 			},
@@ -74,6 +82,11 @@ var CommandList = &commandList{
 							name:  "name",
 							usage: "Retrieve resource by name",
 							arg:   true,
+						},
+						{
+							name:      "namespace",
+							usage:     "Get networkpolicies from specific Namespace",
+							shorthand: "n",
 						},
 					},
 				},

--- a/pkg/antctl/command_definition_test.go
+++ b/pkg/antctl/command_definition_test.go
@@ -148,6 +148,7 @@ foo2
 			name: "StructureData-NetworkPolicy-List-HasSummary-RandomFieldOrder",
 			rawResponseData: []networkpolicy.Response{
 				{
+					NameSpace:       "Namespace1",
 					Name:            "GroupName2",
 					AppliedToGroups: []string{"32ef631b-6817-5a18-86eb-93f4abf0467c", "c4c59cfe-9160-5de5-a85b-01a58d11963e"},
 					Rules: []rule.Response{
@@ -170,11 +171,12 @@ foo2
 					},
 					AppliedToGroups: []string{"32ef631b-6817-5a18-86eb-93f4abf0467c"},
 					Name:            "GroupName1",
+					NameSpace:       "Namespace2",
 				},
 			},
-			expected: `NAME       APPLIED-TO                                       RULES
-GroupName1 32ef631b-6817-5a18-86eb-93f4abf0467c             2    
-GroupName2 32ef631b-6817-5a18-86eb-93f4abf0467c + 1 more... 1    
+			expected: `NAMESPACE  NAME       APPLIED-TO                                       RULES
+Namespace1 GroupName2 32ef631b-6817-5a18-86eb-93f4abf0467c + 1 more... 1    
+Namespace2 GroupName1 32ef631b-6817-5a18-86eb-93f4abf0467c             2    
 `,
 		},
 		{
@@ -256,8 +258,8 @@ GroupName <NONE>
 				},
 			},
 			expected: `NAMESPACE NAME                   INTERFACE-NAME IP        MAC               PORT-UUID OF-PORT CONTAINER-ID
-default   nginx-6db489d4b7-vgv7v Interface      127.0.0.1 07-16-76-00-02-86 portuuid0 80      dve7a2d6c22 
 default   nginx-32b489d4b7-vgv7v Interface2     127.0.0.2 07-16-76-00-02-87 portuuid1 35572   uci2ucsd6dx 
+default   nginx-6db489d4b7-vgv7v Interface      127.0.0.1 07-16-76-00-02-86 portuuid0 80      dve7a2d6c22 
 `,
 		},
 	} {

--- a/pkg/antctl/command_message.go
+++ b/pkg/antctl/command_message.go
@@ -36,6 +36,8 @@ func generate(cd *commandDefinition, args map[string]string, code int) error {
 		return fmt.Errorf("NotFound: %s \"%s\" not found", cd.use, args["name"])
 	case http.StatusInternalServerError:
 		return fmt.Errorf("InternalServerError: Encoding response failed for %s", cd.use)
+	case http.StatusBadRequest:
+		return fmt.Errorf("BadRequest: Please check the args for %s", cd.use)
 	default:
 		return fmt.Errorf("Unknown error")
 	}

--- a/pkg/antctl/command_message_test.go
+++ b/pkg/antctl/command_message_test.go
@@ -52,6 +52,16 @@ func TestGenerate(t *testing.T) {
 			code:     http.StatusOK,
 			expected: "Unknown error",
 		},
+		{
+			cd: &commandDefinition{
+				use: "foo",
+			},
+			args: map[string]string{
+				"name": "bar",
+			},
+			code:     http.StatusBadRequest,
+			expected: `BadRequest: Please check the args for foo`,
+		},
 	} {
 		generated := generate(tc.cd, tc.args, tc.code)
 		assert.Equal(t, tc.expected, generated.Error())

--- a/pkg/antctl/transform/networkpolicy/transform.go
+++ b/pkg/antctl/transform/networkpolicy/transform.go
@@ -26,6 +26,7 @@ import (
 )
 
 type Response struct {
+	NameSpace       string          `json:"namespace" yaml:"namespace"`
 	Name            string          `json:"name" yaml:"name"`
 	Rules           []rule.Response `json:"rules" yaml:"rules"`
 	AppliedToGroups []string        `json:"appliedToGroups" yaml:"appliedToGroups"`
@@ -38,6 +39,7 @@ func objectTransform(o interface{}) (interface{}, error) {
 		policy.AppliedToGroups = []string{}
 	}
 	return Response{
+		NameSpace:       policy.Namespace,
 		Name:            policy.Name,
 		Rules:           rules.([]rule.Response),
 		AppliedToGroups: policy.AppliedToGroups,
@@ -66,9 +68,9 @@ func Transform(reader io.Reader, single bool) (interface{}, error) {
 var _ common.TableOutput = new(Response)
 
 func (r Response) GetTableHeader() []string {
-	return []string{"NAME", "APPLIED-TO", "RULES"}
+	return []string{"NAMESPACE", "NAME", "APPLIED-TO", "RULES"}
 }
 
 func (r Response) GetTableRow(maxColumnLength int) []string {
-	return []string{r.Name, common.GenerateTableElementWithSummary(r.AppliedToGroups, maxColumnLength), strconv.Itoa(len(r.Rules))}
+	return []string{r.NameSpace, r.Name, common.GenerateTableElementWithSummary(r.AppliedToGroups, maxColumnLength), strconv.Itoa(len(r.Rules))}
 }


### PR DESCRIPTION
- Add "NAMESPACE" field for `antctl get networkpolicy` command
- Stop using networkpolicy UID as the element of the 'NAME' column and make this column consistent
- Update the sorting order of table output for all `antctl get` commands: Sort the table rows according to columns in order (1st col, 2nd col, 3rd col, .....).
- Add support for filtering network policies using namespace/name (When only name is specified, the namespace is set to `default` by default)

Some examples of the command:
```shell
Examples:
  Get a network policy
  $ antctl get netpol/networkpolicy/networkpolicies pod1 -n ns1
  Get the list of network policies in a namespace
  $ antctl get netpol/networkpolicy/networkpolicies -n ns1
  Get the a network policy in default namespace
  $ antctl get netpol/networkpolicy/networkpolicies pod1
  Get the list of network policies in all namespaces
  $ antctl get netpol/networkpolicy/networkpolicies
```

Before:
```shell
$ antctl get netpol
NAME                                 APPLIED-TO                           RULES
0103cb1c-3891-4829-922b-86fae8759084 4fd6be1a-ec03-5b8f-9e44-7f1a4af4c117 1
03545126-bc78-42f9-bc18-2db958f47727 0473be26-4942-5647-827f-c891578402f2 1
```

After (Some examples in controller mode):
```
root@k8s-master:/# antctl get netpol
NAMESPACE   NAME         APPLIED-TO                           RULES
default     access-nginx 766a9e51-f132-5c2f-b862-9ac68e75d77d 1
kube-system access-nginx c70ce6a3-1f84-5163-b5f1-3245d1da8009 1
root@k8s-master:/# antctl get netpol access-nginx
Error: BadRequest: Please check the args for networkpolicy
root@k8s-master:/# antctl get netpol access-nginx -n kube-system
NAMESPACE   NAME         APPLIED-TO                           RULES
kube-system access-nginx c70ce6a3-1f84-5163-b5f1-3245d1da8009 1
root@k8s-master:/# antctl get netpol -n kube-system
NAMESPACE   NAME         APPLIED-TO                           RULES
kube-system access-nginx c70ce6a3-1f84-5163-b5f1-3245d1da8009 1
root@k8s-master:/# antctl get netpol -n default
NAMESPACE NAME         APPLIED-TO                           RULES
default   access-nginx 766a9e51-f132-5c2f-b862-9ac68e75d77d 1
root@k8s-master:/# antctl get netpol -n defaul

root@k8s-master:/# antctl get netpol access-nginx -n kube-systm

root@k8s-master:/# antctl get netpol access-ngix -n kube-system


```

Fixes #565
