### PR TITLE
[Windows] Fix Interface conflict in Linux and Windows

### DIFF
--- a/pkg/agent/cniserver/interface_configuration_windows.go
+++ b/pkg/agent/cniserver/interface_configuration_windows.go
@@ -17,6 +17,7 @@
 package cniserver
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -336,6 +337,15 @@ func (ic *ifConfigurator) validateContainerPeerInterface(interfaces []*current.I
 
 	return nil, fmt.Errorf("peer veth interface not found for container interface %s",
 		containerVeth.name)
+}
+
+// getInterceptedInterfaces is not supported on Windows.
+func (ic *ifConfigurator) getInterceptedInterfaces(
+	sandbox string,
+	containerNetNS string,
+	containerIFDev string,
+) (*current.Interface, *current.Interface, error) {
+	return nil, nil, errors.New("getInterceptedInterfaces is unsupported on Windows")
 }
 
 // getOVSInterfaceType returns "internal". Windows uses internal OVS interface for container vNIC.

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -17,6 +17,7 @@
 package route
 
 import (
+	"errors"
 	"net"
 	"sync"
 
@@ -116,6 +117,16 @@ func (c *Client) DeleteRoutes(podCIDR *net.IPNet) error {
 	c.hostRoutes.Delete(podCIDR.String())
 	klog.V(2).Infof("Deleted route with destination %s from host gateway", podCIDR.String())
 	return nil
+}
+
+// MigrateRoutesToGw is not supported on Windows.
+func (c *Client) MigrateRoutesToGw(linkName string) error {
+	return errors.New("MigrateRoutesToGw is unsupported on Windows")
+}
+
+// UnMigrateRoutesFromGw is not supported on Windows.
+func (c *Client) UnMigrateRoutesFromGw(route *net.IPNet, linkName string) error {
+	return errors.New("UnMigrateRoutesFromGw is unsupported on Windows")
 }
 
 func (c *Client) listRoutes() (map[string]*netroute.Route, error) {


### PR DESCRIPTION
Windows doesn't support policy-only mode. To be compatible with Linux and avoid compilation issue, add empty implementations on Windows for Interface "interfaceConfigurator" and "route.Client".