### PR TITLE
Support configurable apiserver ports

### DIFF
--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -286,6 +286,11 @@ data:
     # networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod IPAM and connectivity to primary CNI.
     #
     trafficEncapMode: networkPolicyOnly
+
+    # The port for the antrea-agent APIServer to serve on.
+    # Note that if it's set to another value, the `containerPort` of the `api` port of the
+    # `antrea-agent` container must be set to the same value.
+    #apiPort: 10350
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -303,13 +308,17 @@ data:
             }
         ]
     }
-  antrea-controller.conf: ""
+  antrea-controller.conf: |
+    # The port for the antrea-controller APIServer to serve on.
+    # Note that if it's set to another value, the `containerPort` of the `api` port of the
+    # `antrea-controller` container must be set to the same value.
+    #apiPort: 10349
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-5f8t824tmg
+  name: antrea-config-t4m46b8f6h
   namespace: kube-system
 ---
 apiVersion: v1
@@ -323,7 +332,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: api
   selector:
     app: antrea
     component: antrea-controller
@@ -377,14 +386,15 @@ spec:
         imagePullPolicy: IfNotPresent
         name: antrea-controller
         ports:
-        - containerPort: 443
+        - containerPort: 10349
+          name: api
           protocol: TCP
         readinessProbe:
           failureThreshold: 5
           httpGet:
             host: 127.0.0.1
             path: /healthz
-            port: 443
+            port: api
             scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -408,7 +418,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-5f8t824tmg
+          name: antrea-config-t4m46b8f6h
         name: antrea-config
       - hostPath:
           path: /var/log/antrea
@@ -502,12 +512,16 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
         name: antrea-agent
+        ports:
+        - containerPort: 10350
+          name: api
+          protocol: TCP
         readinessProbe:
           failureThreshold: 5
           httpGet:
             host: 127.0.0.1
             path: /healthz
-            port: 10443
+            port: api
             scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -602,7 +616,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-5f8t824tmg
+          name: antrea-config-t4m46b8f6h
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -286,6 +286,11 @@ data:
     # networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod IPAM and connectivity to primary CNI.
     #
     trafficEncapMode: noEncap
+
+    # The port for the antrea-agent APIServer to serve on.
+    # Note that if it's set to another value, the `containerPort` of the `api` port of the
+    # `antrea-agent` container must be set to the same value.
+    #apiPort: 10350
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -303,13 +308,17 @@ data:
             }
         ]
     }
-  antrea-controller.conf: ""
+  antrea-controller.conf: |
+    # The port for the antrea-controller APIServer to serve on.
+    # Note that if it's set to another value, the `containerPort` of the `api` port of the
+    # `antrea-controller` container must be set to the same value.
+    #apiPort: 10349
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-hm8m2gkt2f
+  name: antrea-config-5754dg84hf
   namespace: kube-system
 ---
 apiVersion: v1
@@ -323,7 +332,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: api
   selector:
     app: antrea
     component: antrea-controller
@@ -377,14 +386,15 @@ spec:
         imagePullPolicy: IfNotPresent
         name: antrea-controller
         ports:
-        - containerPort: 443
+        - containerPort: 10349
+          name: api
           protocol: TCP
         readinessProbe:
           failureThreshold: 5
           httpGet:
             host: 127.0.0.1
             path: /healthz
-            port: 443
+            port: api
             scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -408,7 +418,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-hm8m2gkt2f
+          name: antrea-config-5754dg84hf
         name: antrea-config
       - hostPath:
           path: /var/log/antrea
@@ -502,12 +512,16 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
         name: antrea-agent
+        ports:
+        - containerPort: 10350
+          name: api
+          protocol: TCP
         readinessProbe:
           failureThreshold: 5
           httpGet:
             host: 127.0.0.1
             path: /healthz
-            port: 10443
+            port: api
             scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -602,7 +616,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-hm8m2gkt2f
+          name: antrea-config-5754dg84hf
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -286,6 +286,11 @@ data:
     # networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod IPAM and connectivity to primary CNI.
     #
     #trafficEncapMode: encap
+
+    # The port for the antrea-agent APIServer to serve on.
+    # Note that if it's set to another value, the `containerPort` of the `api` port of the
+    # `antrea-agent` container must be set to the same value.
+    #apiPort: 10350
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -303,13 +308,17 @@ data:
             }
         ]
     }
-  antrea-controller.conf: ""
+  antrea-controller.conf: |
+    # The port for the antrea-controller APIServer to serve on.
+    # Note that if it's set to another value, the `containerPort` of the `api` port of the
+    # `antrea-controller` container must be set to the same value.
+    #apiPort: 10349
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-mmd74dm2m9
+  name: antrea-config-c7579447k2
   namespace: kube-system
 ---
 apiVersion: v1
@@ -332,7 +341,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: api
   selector:
     app: antrea
     component: antrea-controller
@@ -386,14 +395,15 @@ spec:
         imagePullPolicy: IfNotPresent
         name: antrea-controller
         ports:
-        - containerPort: 443
+        - containerPort: 10349
+          name: api
           protocol: TCP
         readinessProbe:
           failureThreshold: 5
           httpGet:
             host: 127.0.0.1
             path: /healthz
-            port: 443
+            port: api
             scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -417,7 +427,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-mmd74dm2m9
+          name: antrea-config-c7579447k2
         name: antrea-config
       - hostPath:
           path: /var/log/antrea
@@ -543,12 +553,16 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
         name: antrea-agent
+        ports:
+        - containerPort: 10350
+          name: api
+          protocol: TCP
         readinessProbe:
           failureThreshold: 5
           httpGet:
             host: 127.0.0.1
             path: /healthz
-            port: 10443
+            port: api
             scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -643,7 +657,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-mmd74dm2m9
+          name: antrea-config-c7579447k2
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -286,6 +286,11 @@ data:
     # networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod IPAM and connectivity to primary CNI.
     #
     #trafficEncapMode: encap
+
+    # The port for the antrea-agent APIServer to serve on.
+    # Note that if it's set to another value, the `containerPort` of the `api` port of the
+    # `antrea-agent` container must be set to the same value.
+    #apiPort: 10350
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -303,13 +308,17 @@ data:
             }
         ]
     }
-  antrea-controller.conf: ""
+  antrea-controller.conf: |
+    # The port for the antrea-controller APIServer to serve on.
+    # Note that if it's set to another value, the `containerPort` of the `api` port of the
+    # `antrea-controller` container must be set to the same value.
+    #apiPort: 10349
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-bckh9cmk97
+  name: antrea-config-428d4tg64g
   namespace: kube-system
 ---
 apiVersion: v1
@@ -323,7 +332,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: api
   selector:
     app: antrea
     component: antrea-controller
@@ -377,14 +386,15 @@ spec:
         imagePullPolicy: IfNotPresent
         name: antrea-controller
         ports:
-        - containerPort: 443
+        - containerPort: 10349
+          name: api
           protocol: TCP
         readinessProbe:
           failureThreshold: 5
           httpGet:
             host: 127.0.0.1
             path: /healthz
-            port: 443
+            port: api
             scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -408,7 +418,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-bckh9cmk97
+          name: antrea-config-428d4tg64g
         name: antrea-config
       - hostPath:
           path: /var/log/antrea
@@ -502,12 +512,16 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
         name: antrea-agent
+        ports:
+        - containerPort: 10350
+          name: api
+          protocol: TCP
         readinessProbe:
           failureThreshold: 5
           httpGet:
             host: 127.0.0.1
             path: /healthz
-            port: 10443
+            port: api
             scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -602,7 +616,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-bckh9cmk97
+          name: antrea-config-428d4tg64g
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/agent.yml
+++ b/build/yamls/base/agent.yml
@@ -75,6 +75,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          ports:
+            - containerPort: 10350
+              name: api
+              protocol: TCP
           livenessProbe:
             exec:
               command:
@@ -89,7 +93,7 @@ spec:
             httpGet:
               host: 127.0.0.1
               path: /healthz
-              port: 10443
+              port: api
               scheme: HTTPS
             initialDelaySeconds: 5
             timeoutSeconds: 5

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -41,3 +41,8 @@
 # networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod IPAM and connectivity to primary CNI.
 #
 #trafficEncapMode: encap
+
+# The port for the antrea-agent APIServer to serve on.
+# Note that if it's set to another value, the `containerPort` of the `api` port of the
+# `antrea-agent` container must be set to the same value.
+#apiPort: 10350

--- a/build/yamls/base/conf/antrea-controller.conf
+++ b/build/yamls/base/conf/antrea-controller.conf
@@ -1,0 +1,4 @@
+# The port for the antrea-controller APIServer to serve on.
+# Note that if it's set to another value, the `containerPort` of the `api` port of the
+# `antrea-controller` container must be set to the same value.
+#apiPort: 10349

--- a/build/yamls/base/controller.yml
+++ b/build/yamls/base/controller.yml
@@ -7,7 +7,7 @@ spec:
   ports:
     - port: 443
       protocol: TCP
-      targetPort: 443
+      targetPort: api
   selector:
     component: antrea-controller
 ---
@@ -90,13 +90,14 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 443
+            - containerPort: 10349
+              name: api
               protocol: TCP
           readinessProbe:
             httpGet:
               host: 127.0.0.1
               path: /healthz
-              port: 443
+              port: api
               scheme: HTTPS
             initialDelaySeconds: 5
             timeoutSeconds: 5

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -165,7 +165,7 @@ func run(o *Options) error {
 
 	go agentMonitor.Run(stopCh)
 
-	apiServer, err := apiserver.New(agentQuerier, networkPolicyController)
+	apiServer, err := apiserver.New(agentQuerier, networkPolicyController, o.config.APIPort)
 	if err != nil {
 		return fmt.Errorf("error when creating agent API server: %v", err)
 	}

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -72,4 +72,7 @@ type AgentConfig struct {
 	// Hybrid: noEncap if worker Nodes on same subnet, otherwise encap.
 	// NetworkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod IPAM and connectivity to primary CNI.
 	TrafficEncapMode string `yaml:"trafficEncapMode,omitempty"`
+	// APIPort is the port for the antrea-agent APIServer to serve on.
+	// Defaults to 10350.
+	APIPort int `yaml:"apiPort,omitempty"`
 }

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -23,6 +23,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
+	"github.com/vmware-tanzu/antrea/pkg/apis"
 	"github.com/vmware-tanzu/antrea/pkg/cni"
 	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 )
@@ -160,5 +161,9 @@ func (o *Options) setDefaults() {
 		if o.config.EnableIPSecTunnel {
 			o.config.DefaultMTU -= ipsecESPOverhead
 		}
+	}
+
+	if o.config.APIPort == 0 {
+		o.config.APIPort = apis.AntreaAgentAPIPort
 	}
 }

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -74,6 +74,7 @@ func run(o *Options) error {
 	controllerMonitor := monitor.NewControllerMonitor(crdClient, nodeInformer, controllerQuerier)
 
 	apiServerConfig, err := createAPIServerConfig(o.config.ClientConnection.Kubeconfig,
+		o.config.APIPort,
 		addressGroupStore,
 		appliedToGroupStore,
 		networkPolicyStore,
@@ -105,13 +106,13 @@ func run(o *Options) error {
 }
 
 func createAPIServerConfig(kubeconfig string,
+	bindPort int,
 	addressGroupStore storage.Interface,
 	appliedToGroupStore storage.Interface,
 	networkPolicyStore storage.Interface,
 	controllerQuerier querier.ControllerQuerier) (*apiserver.Config, error) {
 	// TODO:
 	// 1. Support user-provided certificate.
-	// 2. Support configurable https port.
 	secureServing := genericoptions.NewSecureServingOptions().WithLoopback()
 	authentication := genericoptions.NewDelegatingAuthenticationOptions()
 	authorization := genericoptions.NewDelegatingAuthorizationOptions()
@@ -119,6 +120,7 @@ func createAPIServerConfig(kubeconfig string,
 	// Set the PairName but leave certificate directory blank to generate in-memory by default
 	secureServing.ServerCert.CertDirectory = ""
 	secureServing.ServerCert.PairName = "antrea-apiserver"
+	secureServing.BindPort = bindPort
 	// kubeconfig file is useful when antrea-controller isn't not running as a pod, like during development.
 	if len(kubeconfig) > 0 {
 		authentication.RemoteKubeConfigFile = kubeconfig

--- a/cmd/antrea-controller/options.go
+++ b/cmd/antrea-controller/options.go
@@ -16,11 +16,12 @@ package main
 
 import (
 	"errors"
-
 	"io/ioutil"
 
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
+
+	"github.com/vmware-tanzu/antrea/pkg/apis"
 )
 
 type Options struct {
@@ -50,6 +51,7 @@ func (o *Options) complete(args []string) error {
 		}
 		o.config = c
 	}
+	o.setDefaults()
 	return nil
 }
 
@@ -73,4 +75,10 @@ func (o *Options) loadConfigFromFile(file string) (*ControllerConfig, error) {
 		return nil, err
 	}
 	return &c, nil
+}
+
+func (o *Options) setDefaults() {
+	if o.config.APIPort == 0 {
+		o.config.APIPort = apis.AntreaControllerAPIPort
+	}
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ Use `antrea-agent -h` to see complete options.
   # Path of the kubeconfig file that is used to configure access to a K8s cluster.
   # If not specified, InClusterConfig will be used.
   #kubeconfig: <PATH_TO_KUBE_CONF>
+
 # antreaClientConnection specifies the kubeconfig file and client connection settings for the
 # agent to communicate with the Antrea Controller apiserver.
 #antreaClientConnection:
@@ -64,6 +65,9 @@ Use `antrea-agent -h` to see complete options.
 # as /host/proc in the antrea-agent container). When running antrea-agent as a process,
 # hostProcPathPrefix should be set to "/" in the YAML config.
 #hostProcPathPrefix: /host
+
+# The port for the antrea-agent APIServer to serve on.
+#apiPort: 10350
 ```
 
 ## antrea-controller
@@ -83,6 +87,9 @@ clientConnection:
   # Path of the kubeconfig file that is used to configure access to a K8s cluster.
   # If not specified, InClusterConfig will be used, which handles API host discovery and authentication automatically.
   #kubeconfig: <PATH_TO_KUBE_CONF>
+
+# The port for the antrea-controller APIServer to serve on.
+#apiPort: 10349
 ```
 
 ## CNI configuration

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -108,7 +108,7 @@ If you want to directly access the antrea-agent API, you need to log into the
 Node that the antrea-agent runs on or any Pod in hostNetwork mode that runs on
 this Node. Then access the local endpoint directly:
 ```
-curl --insecure https://127.0.0.1:10443/
+curl --insecure https://127.0.0.1:10350/
 ```
 
 ## Debugging OVS

--- a/pkg/antctl/command_definition.go
+++ b/pkg/antctl/command_definition.go
@@ -585,11 +585,13 @@ func (cd *commandDefinition) newCommandRunE(c *client) func(*cobra.Command, []st
 		}
 		kubeconfigPath, _ := cmd.Flags().GetString("kubeconfig")
 		timeout, _ := cmd.Flags().GetDuration("timeout")
+		server, _ := cmd.Flags().GetString("server")
 		resp, err := c.request(&requestOption{
 			commandDefinition: cd,
 			kubeconfig:        kubeconfigPath,
 			args:              argMap,
 			timeout:           timeout,
+			server:            server,
 		})
 		if err != nil {
 			return err

--- a/pkg/antctl/command_list.go
+++ b/pkg/antctl/command_list.go
@@ -37,6 +37,7 @@ func (cl *commandList) applyPersistentFlagsToRoot(root *cobra.Command) {
 	root.PersistentFlags().BoolP("verbose", "v", false, "enable verbose output")
 	root.PersistentFlags().StringP("kubeconfig", "k", clientcmd.RecommendedHomeFile, "absolute path to the kubeconfig file")
 	root.PersistentFlags().DurationP("timeout", "t", 0, "time limit of the execution of the command")
+	root.PersistentFlags().StringP("server", "s", "", "address and port of the API server, taking precedence over the default endpoint and the one set in kubeconfig")
 }
 
 // ApplyToRootCommand applies the commandList to the root cobra command, it applies

--- a/pkg/apis/ports.go
+++ b/pkg/apis/ports.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Antrea Authors
+// Copyright 2020 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,17 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package apis
 
-import (
-	componentbaseconfig "k8s.io/component-base/config"
+const (
+	// AntreaControllerAPIPort is the default port for the antrea-controller APIServer.
+	AntreaControllerAPIPort = 10349
+	// AntreaAgentAPIPort is the default port for the antrea-agent APIServer.
+	AntreaAgentAPIPort = 10350
 )
-
-type ControllerConfig struct {
-	// clientConnection specifies the kubeconfig file and client connection settings for the
-	// antrea-controller to communicate with the Kubernetes apiserver.
-	ClientConnection componentbaseconfig.ClientConnectionConfiguration `yaml:"clientConnection"`
-	// APIPort is the port for the antrea-controller APIServer to serve on.
-	// Defaults to 10349.
-	APIPort int `yaml:"apiPort,omitempty"`
-}


### PR DESCRIPTION
* Use unpopular ports as antrea components' default ports
* Support overriding the ports via config files
* Support overriding the server address via "-s" for antctl

Fixes #365