### PR TITLE
Prune unused antrea-ubuntu images

### DIFF
--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -231,7 +231,7 @@
 
           make clean
           docker pull antrea/openvswitch --all-tags
-          docker images | grep 'antrea-ubuntu' | awk '{print $3}' | xargs -r docker rmi || true
+          docker images | grep "${JOB_NAME}" | awk '{print $3}' | xargs -r docker rmi -f || true
           # Clean up dangling images generated in previous builds. Recent ones must be excluded
           # because they might be being used in other builds running simultaneously.
           docker image prune -f --filter "until=1h" || true


### PR DESCRIPTION
Remove old images in CI.
* old job images will be deleted by new job.

`docker rmi` cannot delete old images like "antrea-e2e-for-pull-request-99" because `image is referenced in multiple repositories`. Builds triggered by same PR share the same image ID.
To delete these images, `--force` is needed but it may also delete images of other current builds like those triggered by `test-all`.
Since one job isn't allowed to have concurrent builds, it is safe to force delete old images of this kind of job with filter "$JOB_NAME".