### PR TITLE
Add agent API and antctl command to dump OVS flows

### DIFF
--- a/pkg/agent/apiserver/apiserver.go
+++ b/pkg/agent/apiserver/apiserver.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver/handlers/agentinfo"
 	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver/handlers/appliedtogroup"
 	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver/handlers/networkpolicy"
+	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver/handlers/ovsflows"
 	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver/handlers/podinterface"
 	agentquerier "github.com/vmware-tanzu/antrea/pkg/agent/querier"
 	"github.com/vmware-tanzu/antrea/pkg/querier"
@@ -58,6 +59,7 @@ func installHandlers(aq agentquerier.AgentQuerier, npq querier.AgentNetworkPolic
 	s.Handler.NonGoRestfulMux.HandleFunc("/networkpolicies", networkpolicy.HandleFunc(npq))
 	s.Handler.NonGoRestfulMux.HandleFunc("/appliedtogroups", appliedtogroup.HandleFunc(npq))
 	s.Handler.NonGoRestfulMux.HandleFunc("/addressgroups", addressgroup.HandleFunc(npq))
+	s.Handler.NonGoRestfulMux.HandleFunc("/ovsflows", ovsflows.HandleFunc(aq))
 }
 
 // New creates an APIServer for running in antrea agent.

--- a/pkg/agent/apiserver/handlers/ovsflows/handler.go
+++ b/pkg/agent/apiserver/handlers/ovsflows/handler.go
@@ -1,0 +1,109 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovsflows
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"k8s.io/klog"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/querier"
+	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/common"
+)
+
+// Response is the response struct of ovsflows command.
+type Response struct {
+	Flow string `json:"flow,omitempty" yaml:"flow,omitempty"`
+}
+
+func getAllFlows(aq querier.AgentQuerier) ([]Response, error) {
+	resps := []Response{}
+	flowStrs, err := aq.GetOfctlClient().DumpFlows()
+	if err != nil {
+		klog.Errorf("Failed to dump flows: %v", err)
+		return nil, err
+	}
+	for _, s := range flowStrs {
+		resps = append(resps, Response{s})
+	}
+	return resps, nil
+}
+
+func getPodFlows(aq querier.AgentQuerier, podName, namespace string) ([]Response, error) {
+	intf, ok := aq.GetInterfaceStore().GetContainerInterface(podName, namespace)
+	if !ok {
+		return nil, nil
+	}
+
+	flowKeys := aq.GetOpenflowClient().GetPodFlowKeys(intf.InterfaceName)
+	resps := []Response{}
+	for _, f := range flowKeys {
+		flowStrs, err := aq.GetOfctlClient().DumpFlows(f)
+		if err != nil {
+			klog.Errorf("Failed to dump flows: %v", err)
+			return nil, err
+		}
+		for _, s := range flowStrs {
+			resps = append(resps, Response{s})
+		}
+	}
+	return resps, nil
+}
+
+// HandleFunc returns the function which can handle API requests to "/ovsflows".
+func HandleFunc(aq querier.AgentQuerier) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		var resps []Response
+		podName := r.URL.Query().Get("pod")
+		namespace := r.URL.Query().Get("namespace")
+
+		if podName == "" && namespace == "" {
+			resps, err = getAllFlows(aq)
+		} else if podName != "" && namespace != "" {
+			// Pod Namespace must be provided to dump flows of a Pod.
+			resps, err = getPodFlows(aq, podName, namespace)
+		} else {
+			// Not supported.
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if resps == nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		err = json.NewEncoder(w).Encode(resps)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}
+}
+
+var _ common.TableOutput = new(Response)
+
+func (r Response) GetTableHeader() []string {
+	return []string{"FLOW"}
+}
+
+func (r Response) GetTableRow(maxColumnLength int) []string {
+	return []string{r.Flow}
+}

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -121,6 +121,20 @@ func (mr *MockClientMockRecorder) GetFlowTableStatus() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFlowTableStatus", reflect.TypeOf((*MockClient)(nil).GetFlowTableStatus))
 }
 
+// GetPodFlowKeys mocks base method
+func (m *MockClient) GetPodFlowKeys(arg0 string) []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPodFlowKeys", arg0)
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// GetPodFlowKeys indicates an expected call of GetPodFlowKeys
+func (mr *MockClientMockRecorder) GetPodFlowKeys(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodFlowKeys", reflect.TypeOf((*MockClient)(nil).GetPodFlowKeys), arg0)
+}
+
 // Initialize mocks base method
 func (m *MockClient) Initialize(arg0 types.RoundInfo, arg1 *config.NodeConfig, arg2 config.TrafficEncapModeType, arg3 uint32) (<-chan struct{}, error) {
 	m.ctrl.T.Helper()

--- a/pkg/agent/querier/querier.go
+++ b/pkg/agent/querier/querier.go
@@ -24,6 +24,7 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
 	"github.com/vmware-tanzu/antrea/pkg/apis/clusterinformation/v1beta1"
+	"github.com/vmware-tanzu/antrea/pkg/ovs/ofctl"
 	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 	"github.com/vmware-tanzu/antrea/pkg/querier"
 )
@@ -34,6 +35,8 @@ type AgentQuerier interface {
 	GetNodeName() string
 	GetInterfaceStore() interfacestore.InterfaceStore
 	GetAgentInfo(agentInfo *v1beta1.AntreaAgentInfo, partial bool)
+	GetOpenflowClient() openflow.Client
+	GetOfctlClient() *ofctl.OfctlClient
 }
 
 type agentQuerier struct {
@@ -66,6 +69,16 @@ func (aq agentQuerier) GetNodeName() string {
 // GetInterfaceStore gets current interfacestore.
 func (aq agentQuerier) GetInterfaceStore() interfacestore.InterfaceStore {
 	return aq.interfaceStore
+}
+
+// GetOpenflowClient returns openflow.Client.
+func (aq *agentQuerier) GetOpenflowClient() openflow.Client {
+	return aq.ofClient
+}
+
+// GetOfctlClient returns a new OfctlClient.
+func (aq *agentQuerier) GetOfctlClient() *ofctl.OfctlClient {
+	return ofctl.NewClient(aq.ovsBridge)
 }
 
 // getOVSVersion gets current OVS version.

--- a/pkg/agent/querier/testing/mock_querier.go
+++ b/pkg/agent/querier/testing/mock_querier.go
@@ -22,7 +22,9 @@ package testing
 import (
 	gomock "github.com/golang/mock/gomock"
 	interfacestore "github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
+	openflow "github.com/vmware-tanzu/antrea/pkg/agent/openflow"
 	v1beta1 "github.com/vmware-tanzu/antrea/pkg/apis/clusterinformation/v1beta1"
+	ofctl "github.com/vmware-tanzu/antrea/pkg/ovs/ofctl"
 	reflect "reflect"
 )
 
@@ -87,4 +89,32 @@ func (m *MockAgentQuerier) GetNodeName() string {
 func (mr *MockAgentQuerierMockRecorder) GetNodeName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeName", reflect.TypeOf((*MockAgentQuerier)(nil).GetNodeName))
+}
+
+// GetOfctlClient mocks base method
+func (m *MockAgentQuerier) GetOfctlClient() *ofctl.OfctlClient {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOfctlClient")
+	ret0, _ := ret[0].(*ofctl.OfctlClient)
+	return ret0
+}
+
+// GetOfctlClient indicates an expected call of GetOfctlClient
+func (mr *MockAgentQuerierMockRecorder) GetOfctlClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOfctlClient", reflect.TypeOf((*MockAgentQuerier)(nil).GetOfctlClient))
+}
+
+// GetOpenflowClient mocks base method
+func (m *MockAgentQuerier) GetOpenflowClient() openflow.Client {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOpenflowClient")
+	ret0, _ := ret[0].(openflow.Client)
+	return ret0
+}
+
+// GetOpenflowClient indicates an expected call of GetOpenflowClient
+func (mr *MockAgentQuerierMockRecorder) GetOpenflowClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOpenflowClient", reflect.TypeOf((*MockAgentQuerier)(nil).GetOpenflowClient))
 }

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver/handlers/agentinfo"
+	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver/handlers/ovsflows"
 	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver/handlers/podinterface"
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/addressgroup"
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/appliedtogroup"
@@ -210,6 +211,36 @@ var CommandList = &commandList{
 			},
 			commandGroup:        get,
 			transformedResponse: reflect.TypeOf(podinterface.Response{}),
+		},
+		{
+			use:     "ovsflows",
+			aliases: []string{"of"},
+			short:   "Dump OVS flows",
+			long:    "Dump all the OVS flows or the flows installed for the specified entity.",
+			example: `  Dump all OVS flows
+  $ antctl get ovsflows
+  Dump OVS flows of a Pod
+  $ antctl get ovsflows -p pod1 -n ns1`,
+			agentEndpoint: &endpoint{
+				nonResourceEndpoint: &nonResourceEndpoint{
+					path: "/ovsflows",
+					params: []flagInfo{
+						{
+							name:      "pod",
+							usage:     "Pod name. If present, Namespace must be provided.",
+							shorthand: "p",
+						},
+						{
+							name:      "namespace",
+							usage:     "Namespace of the entity",
+							shorthand: "n",
+						},
+					},
+					outputType: multiple,
+				},
+			},
+			commandGroup:        get,
+			transformedResponse: reflect.TypeOf(ovsflows.Response{}),
 		},
 	},
 	codec: scheme.Codecs,

--- a/pkg/ovs/ofctl/ofctl.go
+++ b/pkg/ovs/ofctl/ofctl.go
@@ -1,0 +1,87 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ofctl
+
+import (
+	"bufio"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type OfctlClient struct {
+	bridge string
+}
+
+func NewClient(bridge string) *OfctlClient {
+	return &OfctlClient{bridge}
+}
+
+func (c *OfctlClient) DumpFlows(args ...string) ([]string, error) {
+	flowDump, err := c.RunOfctlCmd("dump-flows", args...)
+	if err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(flowDump)))
+	scanner.Split(bufio.ScanLines)
+	// Skip the first line.
+	scanner.Scan()
+	flowList := []string{}
+	for scanner.Scan() {
+		flowList = append(flowList, scanner.Text())
+	}
+
+	return flowList, nil
+}
+
+func (c *OfctlClient) DumpGroups(args ...string) ([][]string, error) {
+	groupsDump, err := c.RunOfctlCmd("dump-groups", args...)
+	if err != nil {
+		return nil, err
+	}
+	groupsDumpStr := strings.TrimSpace(string(groupsDump))
+
+	scanner := bufio.NewScanner(strings.NewReader(groupsDumpStr))
+	scanner.Split(bufio.ScanLines)
+	// Skip the first line.
+	scanner.Scan()
+	rawGroupItems := []string{}
+	for scanner.Scan() {
+		rawGroupItems = append(rawGroupItems, scanner.Text())
+	}
+
+	var groupList [][]string
+	for _, rawGroupItem := range rawGroupItems {
+		rawGroupItem = strings.TrimSpace(rawGroupItem)
+		elems := strings.Split(rawGroupItem, ",bucket=")
+		groupList = append(groupList, elems)
+	}
+	return groupList, nil
+}
+
+func (c *OfctlClient) DumpTableFlows(table uint8) ([]string, error) {
+	return c.DumpFlows(fmt.Sprintf("table=%d", table))
+}
+
+func (c *OfctlClient) RunOfctlCmd(cmd string, args ...string) ([]byte, error) {
+	cmdStr := fmt.Sprintf("ovs-ofctl -O Openflow13 %s %s", cmd, c.bridge)
+	cmdStr = cmdStr + " " + strings.Join(args, " ")
+	out, err := exec.Command("/bin/sh", "-c", cmdStr).Output()
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/vmware-tanzu/antrea/pkg/ovs/ofctl"
 	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
 )
 
@@ -87,11 +88,13 @@ func TestDeleteFlowStrict(t *testing.T) {
 	}
 	defer bridge.Disconnect()
 
+	ofctlClient := ofctl.NewClient(br)
+
 	flows, expectFlows := prepareOverlapFlows(table, "1.1.1.1", true)
-	testDeleteSingleFlow(t, br, table, flows, expectFlows)
+	testDeleteSingleFlow(t, ofctlClient, table, flows, expectFlows)
 
 	flows2, expectFlows2 := prepareOverlapFlows(table, "2.2.2.2", false)
-	testDeleteSingleFlow(t, br, table, flows2, expectFlows2)
+	testDeleteSingleFlow(t, ofctlClient, table, flows2, expectFlows2)
 }
 
 func prepareOverlapFlows(table binding.Table, ipStr string, sameCookie bool) ([]binding.Flow, []*ExpectFlow) {
@@ -122,21 +125,21 @@ func prepareOverlapFlows(table binding.Table, ipStr string, sameCookie bool) ([]
 	return flows, expectFlows
 }
 
-func testDeleteSingleFlow(t *testing.T, br string, table binding.Table, flows []binding.Flow, expectFlows []*ExpectFlow) {
+func testDeleteSingleFlow(t *testing.T, ofctlClient *ofctl.OfctlClient, table binding.Table, flows []binding.Flow, expectFlows []*ExpectFlow) {
 	for id, flow := range flows {
 		if err := flow.Add(); err != nil {
 			t.Fatalf("Failed to install flow%d: %v", id, err)
 		}
 	}
 	dumpTable := uint8(table.GetID())
-	CheckFlowExists(t, br, dumpTable, true, expectFlows)
+	CheckFlowExists(t, ofctlClient, dumpTable, true, expectFlows)
 
 	err := flows[0].Delete()
 	if err != nil {
 		t.Fatalf("Failed to delete 'match-all' flow")
 	}
-	CheckFlowExists(t, br, dumpTable, false, []*ExpectFlow{expectFlows[0]})
-	flowList := CheckFlowExists(t, br, dumpTable, true, []*ExpectFlow{expectFlows[1]})
+	CheckFlowExists(t, ofctlClient, dumpTable, false, []*ExpectFlow{expectFlows[0]})
+	flowList := CheckFlowExists(t, ofctlClient, dumpTable, true, []*ExpectFlow{expectFlows[1]})
 	if len(flowList) != 1 {
 		t.Errorf("Failed to delete flow with strict mode")
 	}
@@ -144,7 +147,7 @@ func testDeleteSingleFlow(t *testing.T, br string, table binding.Table, flows []
 	if err != nil {
 		t.Fatalf("Failed to delete 'match-all' flow")
 	}
-	CheckFlowExists(t, br, dumpTable, false, []*ExpectFlow{expectFlows[1]})
+	CheckFlowExists(t, ofctlClient, dumpTable, false, []*ExpectFlow{expectFlows[1]})
 }
 
 type tableFlows struct {
@@ -175,6 +178,8 @@ func TestOFctrlFlow(t *testing.T) {
 	}
 	defer bridge.Disconnect()
 
+	ofctlClient := ofctl.NewClient(br)
+
 	for _, test := range []tableFlows{
 		{table: table1, flowGenerator: prepareFlows},
 		{table: table2, flowGenerator: prepareNATflows},
@@ -189,7 +194,7 @@ func TestOFctrlFlow(t *testing.T) {
 		}
 
 		dumpTable := uint8(myTable.GetID())
-		flowList := CheckFlowExists(t, br, dumpTable, true, expectflows)
+		flowList := CheckFlowExists(t, ofctlClient, dumpTable, true, expectflows)
 
 		// Test: DumpTableStatus
 		for _, tableStates := range bridge.DumpTableStatus() {
@@ -213,14 +218,14 @@ func TestOFctrlFlow(t *testing.T) {
 				t.Errorf("Failed to uninstall flow1 %v", err)
 			}
 		}
-		CheckFlowExists(t, br, dumpTable, false, expectflows[0:2])
+		CheckFlowExists(t, ofctlClient, dumpTable, false, expectflows[0:2])
 
 		// Test: DeleteFlowsByCookie
 		err = bridge.DeleteFlowsByCookie(dumpCookieID, dumpCookieMask)
 		if err != nil {
 			t.Errorf("Failed to DeleteFlowsByCookie: %v", err)
 		}
-		flowList, _ = OfctlDumpTableFlows(br, uint8(myTable.GetID()))
+		flowList, _ = OfctlDumpTableFlows(ofctlClient, uint8(myTable.GetID()))
 		if len(flowList) > 0 {
 			t.Errorf("Failed to delete flows by CookieID")
 		}
@@ -247,6 +252,8 @@ func TestOFctrlGroup(t *testing.T) {
 	}
 	defer br.Disconnect()
 
+	ofctlClient := ofctl.NewClient(brName)
+
 	for name, buckets := range map[string][]struct {
 		weight        uint16      // Must have non-zero value.
 		reg2reg       [][4]uint32 // regNum, data, startIndex, endIndex
@@ -272,7 +279,7 @@ func TestOFctrlGroup(t *testing.T) {
 			}
 			// Check if the group could be added.
 			require.Nil(t, group.Add())
-			groups, err := OfctlDumpGroups(brName)
+			groups, err := ofctlClient.DumpGroups(brName)
 			require.Nil(t, err)
 			require.Len(t, groups, 1)
 			dumpedGroup := groups[0]
@@ -294,7 +301,7 @@ func TestOFctrlGroup(t *testing.T) {
 			}
 			// Check if the group could be deleted.
 			require.Nil(t, group.Delete())
-			groups, err = OfctlDumpGroups(brName)
+			groups, err = ofctlClient.DumpGroups(brName)
 			require.Nil(t, err)
 			require.Len(t, groups, 0)
 		})
@@ -317,11 +324,13 @@ func TestTransactions(t *testing.T) {
 	require.Nil(t, err, "Failed to start OFService")
 	defer bridge.Disconnect()
 
+	ofctlClient := ofctl.NewClient(br)
+
 	flows, expectflows := prepareFlows(table)
 	err = bridge.AddFlowsInBundle(flows, nil, nil)
 	require.Nil(t, err, fmt.Sprintf("Failed to add flows in a transaction: %v", err))
 	dumpTable := uint8(table.GetID())
-	flowList := CheckFlowExists(t, br, dumpTable, true, expectflows)
+	flowList := CheckFlowExists(t, ofctlClient, dumpTable, true, expectflows)
 
 	// Test: DumpTableStatus
 	for _, tableStates := range bridge.DumpTableStatus() {
@@ -336,7 +345,7 @@ func TestTransactions(t *testing.T) {
 	err = bridge.AddFlowsInBundle(nil, nil, flows)
 	require.Nil(t, err, fmt.Sprintf("Failed to delete flows in a transaction: %v", err))
 	dumpTable = uint8(table.GetID())
-	flowList = CheckFlowExists(t, br, dumpTable, false, expectflows)
+	flowList = CheckFlowExists(t, ofctlClient, dumpTable, false, expectflows)
 
 	for _, tableStates := range bridge.DumpTableStatus() {
 		if tableStates.ID == uint(dumpTable) {
@@ -492,6 +501,9 @@ func TestBundleWithGroupAndFlow(t *testing.T) {
 	err = bridge.Connect(maxRetry, make(chan struct{}))
 	require.Nil(t, err, "Failed to start OFService")
 	defer bridge.Disconnect()
+
+	ofctlClient := ofctl.NewClient(br)
+
 	groupID := binding.GroupIDType(4)
 	group := bridge.CreateGroup(groupID).
 		Bucket().Weight(100).
@@ -524,13 +536,13 @@ func TestBundleWithGroupAndFlow(t *testing.T) {
 	expectedGroupBuckets := []string{bucket0, bucket1}
 	err = bridge.AddOFEntriesInBundle([]binding.OFEntry{flow, group}, nil, nil)
 	require.Nil(t, err)
-	CheckFlowExists(t, br, uint8(table.GetID()), true, expectedFlows)
-	CheckGroupExists(t, br, groupID, "select", expectedGroupBuckets, true)
+	CheckFlowExists(t, ofctlClient, uint8(table.GetID()), true, expectedFlows)
+	CheckGroupExists(t, ofctlClient, groupID, "select", expectedGroupBuckets, true)
 
 	err = bridge.AddOFEntriesInBundle(nil, nil, []binding.OFEntry{flow, group})
 	require.Nil(t, err)
-	CheckFlowExists(t, br, uint8(table.GetID()), false, expectedFlows)
-	CheckGroupExists(t, br, groupID, "select", expectedGroupBuckets, false)
+	CheckFlowExists(t, ofctlClient, uint8(table.GetID()), false, expectedFlows)
+	CheckGroupExists(t, ofctlClient, groupID, "select", expectedGroupBuckets, false)
 }
 
 func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {


### PR DESCRIPTION
Add agent API with path /ovsflows to return OVS flows.
Add antctl command to dump OVS flows retrieved from /ovsflows.
For now we support only dumping all flows and dumping flows of a
specified Pod. Later we will support dumping flows of a NetworkPolicy,
a remote Node, a Service, etc.
In the current implementation,  agent dumps OVS flows by executing
"ovs-ofctl dump-flows". In future we should extend openflow.Flow to
support converting a flow to a readable string directly, and we should
check or track whether a flow is realized in OVS using an more
efficient way. Then we no more need to use ovs-ofctl to dump flows.

Example outputs:
antctl get of -p coredns-xyz -n kube-system

FLOW                                                                                                                                                                        
cookie=0x1d030000000000, table=0, priority=190,in_port=5 actions=load:0x2->NXM_NX_REG0[0..15],resubmit(,10)                                                                 
cookie=0x1d030000000000, table=10, priority=200,arp,in_port=5,arp_spa=172.100.1.7,arp_sha=52:bd:c6:e0:eb:c1 actions=resubmit(,20)                                           
cookie=0x1d030000000000, table=10, priority=200,ip,in_port=5,dl_src=52:bd:c6:e0:eb:c1,nw_src=172.100.1.7 actions=resubmit(,30)                                              
cookie=0x1d030000000000, table=70, priority=200,ip,dl_dst=aa:bb:cc:dd:ee:ff,nw_dst=172.100.1.7 actions=set_field:62:39:b4:e8:05:76->eth_src,set_field:52:bd:c6:e0:eb:c1->eth_dst,dec_ttl,resubmit(,80)
cookie=0x1d030000000000, table=80, priority=200,dl_dst=52:bd:c6:e0:eb:c1 actions=load:0x5->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],resubmit(,90)