### PR TITLE
Update community meeting schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Your feedback is more than welcome!
 * Join the [Kubernetes Slack](http://slack.k8s.io/) and look for our
 [#antrea](https://kubernetes.slack.com/messages/CR2J23M0X) channel.
 * Attend the [project weekly meeting](https://VMware.zoom.us/j/823654111),
-every Wednesday at 9AM PST (5PM GMT).
+every two weeks on Tuesday at 4AM GMT (9PM PDT, 6AM CET, 12PM China).
   + [Meeting minutes](https://github.com/vmware-tanzu/antrea/wiki/Community-Meetings)
   + [Meeting recordings](https://www.youtube.com/playlist?list=PLH5zTfQ3otSA6EOYDNb-MvcQRXACdCbQw)
 * Join our mailing lists to always stay up-to-date with Antrea development:


### PR DESCRIPTION
Taking into account the results of http://www.polljunkie.com/poll/tzmyzz/antrea-meeting-planning/view we will keep a single meeting for all time zones, but switch from 4PM GMT to 4AM GMT. We plan to keep this rotation going for a few month at least - or until the community asks us for a different meeting time!