### PR TITLE
Add windows binaries compiling job to Github action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
     - master
+    - windows
     - release-*
 jobs:
 
@@ -73,6 +74,9 @@ jobs:
 
     - name: Build Antrea binaries
       run: make bin
+
+    - name: Build Antrea windows binaries
+      run: make windows-bin
 
   antctl:
     name: Build antctl for macOS, Linux and Windows

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ bin:
 	@mkdir -p $(BINDIR)
 	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' github.com/vmware-tanzu/antrea/cmd/...
 
+.PHONY: windows-bin
+windows-bin:
+	@mkdir -p $(BINDIR)
+	GOOS=windows $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' github.com/vmware-tanzu/antrea/cmd/antrea-cni \
+		github.com/vmware-tanzu/antrea/cmd/antrea-agent
+
 .PHONY: test-unit test-integration
 ifeq ($(UNAME_S),Linux)
 test-unit: .linux-test-unit
@@ -65,6 +71,10 @@ DOCKER_ENV := \
 docker-bin: $(DOCKER_CACHE)
 	$(DOCKER_ENV) make bin
 	@chmod -R 0755 $<
+
+.PHONY: docker-windows-bin
+docker-windows-bin: $(DOCKER_CACHE)
+	$(DOCKER_ENV) make windows-bin
 
 .PHONY: docker-test-unit
 docker-test-unit: $(DOCKER_CACHE)


### PR DESCRIPTION
- Compile following packages for windows:
  - antrea-cni
  - antrea-agent
- Add compile windows binaries job in Github action
