### PR TITLE
Use gototable instead of resubmit

### DIFF
--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -365,7 +365,7 @@ func newMockRuleFlowBuilder(ctrl *gomock.Controller) *mocks.MockFlowBuilder {
 	ruleFlowBuilder.EXPECT().MatchSCTPDstPort(gomock.Any()).Return(ruleFlowBuilder).AnyTimes()
 	ruleFlowBuilder.EXPECT().MatchConjID(gomock.Any()).Return(ruleFlowBuilder).AnyTimes()
 	ruleAction = mocks.NewMockAction(ctrl)
-	ruleAction.EXPECT().ResubmitToTable(gomock.Any()).Return(ruleFlowBuilder).AnyTimes()
+	ruleAction.EXPECT().GotoTable(gomock.Any()).Return(ruleFlowBuilder).AnyTimes()
 	ruleFlowBuilder.EXPECT().Action().Return(ruleAction).AnyTimes()
 	ruleFlow = mocks.NewMockFlow(ctrl)
 	ruleFlowBuilder.EXPECT().Done().Return(ruleFlow).AnyTimes()

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -150,6 +150,7 @@ type Action interface {
 	Conjunction(conjID uint32, clauseID uint8, nClause uint8) FlowBuilder
 	Group(id GroupIDType) FlowBuilder
 	Learn(id TableIDType, priority uint16, idleTimeout, hardTimeout uint16, cookieID uint64) LearnAction
+	GotoTable(table TableIDType) FlowBuilder
 }
 
 type FlowBuilder interface {

--- a/pkg/ovs/openflow/ofctrl_action.go
+++ b/pkg/ovs/openflow/ofctrl_action.go
@@ -398,3 +398,12 @@ func getFieldRange(name string) (*openflow13.MatchField, Range, error) {
 	}
 	return field, Range{0, uint32(field.Length)*8 - 1}, nil
 }
+
+ // GotoTable is an action to jump to the specified table.
+ func (a *ofFlowAction) GotoTable(table TableIDType) FlowBuilder {
+	// Use Table until new ofnet APIs are ready
+	// a.builder.ofFlow.Goto(uint8(table))
+	gotoTable := &ofctrl.Table{TableId: uint8(table)}
+	a.builder.ofFlow.lastAction = gotoTable
+	return a.builder
+}

--- a/pkg/ovs/openflow/ofctrl_action.go
+++ b/pkg/ovs/openflow/ofctrl_action.go
@@ -399,8 +399,8 @@ func getFieldRange(name string) (*openflow13.MatchField, Range, error) {
 	return field, Range{0, uint32(field.Length)*8 - 1}, nil
 }
 
- // GotoTable is an action to jump to the specified table.
- func (a *ofFlowAction) GotoTable(table TableIDType) FlowBuilder {
+// GotoTable is an action to jump to the specified table.
+func (a *ofFlowAction) GotoTable(table TableIDType) FlowBuilder {
 	// Use Table until new ofnet APIs are ready
 	// a.builder.ofFlow.Goto(uint8(table))
 	gotoTable := &ofctrl.Table{TableId: uint8(table)}

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -508,6 +508,20 @@ func (mr *MockActionMockRecorder) Drop() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Drop", reflect.TypeOf((*MockAction)(nil).Drop))
 }
 
+// GotoTable mocks base method
+func (m *MockAction) GotoTable(arg0 openflow.TableIDType) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GotoTable", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// GotoTable indicates an expected call of GotoTable
+func (mr *MockActionMockRecorder) GotoTable(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GotoTable", reflect.TypeOf((*MockAction)(nil).GotoTable), arg0)
+}
+
 // Group mocks base method
 func (m *MockAction) Group(arg0 openflow.GroupIDType) openflow.FlowBuilder {
 	m.ctrl.T.Helper()

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -451,13 +451,13 @@ func checkConjunctionFlows(t *testing.T, ruleTable uint8, dropTable uint8, allow
 	require.Nil(t, err, "Failed to dump flows")
 
 	conjunctionActionMatch := fmt.Sprintf("priority=%d,conj_id=%d,ip", priority-10, ruleID)
-	flow := &ofTestUtils.ExpectFlow{MatchStr: conjunctionActionMatch, ActStr: fmt.Sprintf("resubmit(,%d)", allowTable)}
+	flow := &ofTestUtils.ExpectFlow{MatchStr: conjunctionActionMatch, ActStr: fmt.Sprintf("goto_table:%d", allowTable)}
 	testFunc(t, ofTestUtils.OfctlFlowMatch(flowList, ruleTable, flow), "Failed to update conjunction action flow")
 
 	if rule.ExceptFrom != nil {
 		for _, addr := range rule.ExceptFrom {
 			exceptsMatch := fmt.Sprintf("priority=%d,conj_id=%d,ip,%s=%s", priority, ruleID, getCmdMatchKey(addr.GetMatchKey(types.SrcAddress)), addr.GetMatchValue())
-			flow := &ofTestUtils.ExpectFlow{MatchStr: exceptsMatch, ActStr: fmt.Sprintf("resubmit(,%d)", dropTable)}
+			flow := &ofTestUtils.ExpectFlow{MatchStr: exceptsMatch, ActStr: fmt.Sprintf("goto_table:%d", dropTable)}
 			testFunc(t, ofTestUtils.OfctlFlowMatch(flowList, ruleTable, flow), "Failed to install conjunction excepts flow")
 		}
 	}
@@ -465,7 +465,7 @@ func checkConjunctionFlows(t *testing.T, ruleTable uint8, dropTable uint8, allow
 	if rule.ExceptTo != nil {
 		for _, addr := range rule.ExceptTo {
 			exceptsMatch := fmt.Sprintf("priority=%d,conj_id=%d,ip,%s=%s", priority, ruleID, getCmdMatchKey(addr.GetMatchKey(types.DstAddress)), addr.GetMatchValue())
-			flow := &ofTestUtils.ExpectFlow{MatchStr: exceptsMatch, ActStr: fmt.Sprintf("resubmit(,%d)", dropTable)}
+			flow := &ofTestUtils.ExpectFlow{MatchStr: exceptsMatch, ActStr: fmt.Sprintf("goto_table:%d", dropTable)}
 			testFunc(t, ofTestUtils.OfctlFlowMatch(flowList, ruleTable, flow),
 				"Failed to install conjunction excepts flow")
 		}
@@ -549,17 +549,17 @@ func preparePodFlows(podIP net.IP, podMAC net.HardwareAddr, podOFPort uint32, gw
 		{
 			uint8(0),
 			[]*ofTestUtils.ExpectFlow{
-				{fmt.Sprintf("priority=190,in_port=%d", podOFPort), "load:0x2->NXM_NX_REG0[0..15],resubmit(,10)"},
+				{fmt.Sprintf("priority=190,in_port=%d", podOFPort), "load:0x2->NXM_NX_REG0[0..15],goto_table:10"},
 			},
 		},
 		{
 			uint8(10),
 			[]*ofTestUtils.ExpectFlow{
 				{fmt.Sprintf("priority=200,ip,in_port=%d,dl_src=%s,nw_src=%s", podOFPort, podMAC.String(), podIP.String()),
-					"resubmit(,30)"},
+					"goto_table:30"},
 				{
 					fmt.Sprintf("priority=200,arp,in_port=%d,arp_spa=%s,arp_sha=%s", podOFPort, podIP.String(), podMAC.String()),
-					"resubmit(,20)"},
+					"goto_table:20"},
 			},
 		},
 		{
@@ -567,7 +567,7 @@ func preparePodFlows(podIP net.IP, podMAC net.HardwareAddr, podOFPort uint32, gw
 			[]*ofTestUtils.ExpectFlow{
 				{
 					fmt.Sprintf("priority=200,ip,dl_dst=%s,nw_dst=%s", vMAC.String(), podIP.String()),
-					fmt.Sprintf("set_field:%s->eth_src,set_field:%s->eth_dst,dec_ttl,resubmit(,80)", gwMAC.String(), podMAC.String())},
+					fmt.Sprintf("set_field:%s->eth_src,set_field:%s->eth_dst,dec_ttl,goto_table:80", gwMAC.String(), podMAC.String())},
 			},
 		},
 		{
@@ -575,7 +575,7 @@ func preparePodFlows(podIP net.IP, podMAC net.HardwareAddr, podOFPort uint32, gw
 			[]*ofTestUtils.ExpectFlow{
 				{
 					fmt.Sprintf("priority=200,dl_dst=%s", podMAC.String()),
-					fmt.Sprintf("load:0x%x->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],resubmit(,90)", podOFPort)},
+					fmt.Sprintf("load:0x%x->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],goto_table:90", podOFPort)},
 			},
 		},
 	}
@@ -587,21 +587,21 @@ func prepareGatewayFlows(gwIP net.IP, gwMAC net.HardwareAddr, gwOFPort uint32, v
 			uint8(0),
 			[]*ofTestUtils.ExpectFlow{
 				{fmt.Sprintf("priority=200,in_port=%d", gwOFPort),
-					"load:0x1->NXM_NX_REG0[0..15],resubmit(,10)"},
+					"load:0x1->NXM_NX_REG0[0..15],goto_table:10"},
 			},
 		},
 		{
 			uint8(31),
 			[]*ofTestUtils.ExpectFlow{
 				{"priority=200,ct_state=-new+trk,ct_mark=0x20,ip",
-					fmt.Sprintf("load:0x%s->NXM_OF_ETH_DST[],resubmit(,40)", strings.Replace(gwMAC.String(), ":", "", -1))},
+					fmt.Sprintf("load:0x%s->NXM_OF_ETH_DST[],goto_table:40", strings.Replace(gwMAC.String(), ":", "", -1))},
 			},
 		},
 		{
 			uint8(10),
 			[]*ofTestUtils.ExpectFlow{
-				{fmt.Sprintf("priority=200,arp,in_port=%d,arp_spa=%s,arp_sha=%s", gwOFPort, gwIP, gwMAC), "resubmit(,20)"},
-				{fmt.Sprintf("priority=200,ip,in_port=%d", gwOFPort), "resubmit(,30)"},
+				{fmt.Sprintf("priority=200,arp,in_port=%d,arp_spa=%s,arp_sha=%s", gwOFPort, gwIP, gwMAC), "goto_table:20"},
+				{fmt.Sprintf("priority=200,ip,in_port=%d", gwOFPort), "goto_table:30"},
 			},
 		},
 		{
@@ -609,7 +609,7 @@ func prepareGatewayFlows(gwIP net.IP, gwMAC net.HardwareAddr, gwOFPort uint32, v
 			[]*ofTestUtils.ExpectFlow{
 				{
 					fmt.Sprintf("priority=200,ip,dl_dst=%s,nw_dst=%s", vMAC.String(), gwIP.String()),
-					fmt.Sprintf("set_field:%s->eth_dst,resubmit(,80)", gwMAC.String())},
+					fmt.Sprintf("set_field:%s->eth_dst,goto_table:80", gwMAC.String())},
 			},
 		},
 		{
@@ -617,7 +617,7 @@ func prepareGatewayFlows(gwIP net.IP, gwMAC net.HardwareAddr, gwOFPort uint32, v
 			[]*ofTestUtils.ExpectFlow{
 				{
 					fmt.Sprintf("priority=200,dl_dst=%s", gwMAC.String()),
-					fmt.Sprintf("load:0x%x->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],resubmit(,90)", gwOFPort)},
+					fmt.Sprintf("load:0x%x->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],goto_table:90", gwOFPort)},
 			},
 		},
 		{
@@ -625,7 +625,7 @@ func prepareGatewayFlows(gwIP net.IP, gwMAC net.HardwareAddr, gwOFPort uint32, v
 			[]*ofTestUtils.ExpectFlow{
 				{
 					fmt.Sprintf("priority=210,ip,nw_src=%s", gwIP.String()),
-					"resubmit(,105)"},
+					"goto_table:105"},
 			},
 		},
 	}
@@ -636,7 +636,7 @@ func prepareTunnelFlows(tunnelPort uint32, vMAC net.HardwareAddr) []expectTableF
 		{
 			uint8(0),
 			[]*ofTestUtils.ExpectFlow{
-				{fmt.Sprintf("priority=200,in_port=%d", tunnelPort), "load:0->NXM_NX_REG0[0..15],resubmit(,30)"},
+				{fmt.Sprintf("priority=200,in_port=%d", tunnelPort), "load:0->NXM_NX_REG0[0..15],goto_table:30"},
 			},
 		},
 	}
@@ -656,7 +656,7 @@ func prepareNodeFlows(tunnelPort uint32, peerSubnet net.IPNet, peerGwIP, peerNod
 			[]*ofTestUtils.ExpectFlow{
 				{
 					fmt.Sprintf("priority=200,ip,nw_dst=%s", peerSubnet.String()),
-					fmt.Sprintf("dec_ttl,set_field:%s->eth_src,set_field:%s->eth_dst,load:0x%x->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],set_field:%s->tun_dst,resubmit(,105)", localGwMAC.String(), vMAC.String(), tunnelPort, peerNodeIP.String())},
+					fmt.Sprintf("dec_ttl,set_field:%s->eth_src,set_field:%s->eth_dst,load:0x%x->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],set_field:%s->tun_dst,goto_table:105", localGwMAC.String(), vMAC.String(), tunnelPort, peerNodeIP.String())},
 			},
 		},
 	}
@@ -668,7 +668,7 @@ func prepareServiceHelperFlows(serviceCIDR net.IPNet, gwMAC net.HardwareAddr, gw
 			uint8(40),
 			[]*ofTestUtils.ExpectFlow{
 				{fmt.Sprintf("priority=200,ip,nw_dst=%s", serviceCIDR.String()),
-					fmt.Sprintf("set_field:%s->eth_dst,load:0x%x->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],resubmit(,105)", gwMAC, gwOFPort),
+					fmt.Sprintf("set_field:%s->eth_dst,load:0x%x->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],goto_table:105", gwMAC, gwOFPort),
 				},
 			},
 		},
@@ -701,45 +701,45 @@ func prepareDefaultFlows() []expectTableFlows {
 		{
 			uint8(31),
 			[]*ofTestUtils.ExpectFlow{
-				{"priority=210,ct_state=-new+trk,ct_mark=0x20,ip,reg0=0x1/0xffff", "resubmit(,40)"},
+				{"priority=210,ct_state=-new+trk,ct_mark=0x20,ip,reg0=0x1/0xffff", "goto_table:40"},
 				{"priority=200,ct_state=+inv+trk,ip", "drop"},
-				{"priority=0", "resubmit(,40)"},
+				{"priority=0", "goto_table:40"},
 			},
 		},
 		{
 			uint8(40),
-			[]*ofTestUtils.ExpectFlow{{"priority=0", "resubmit(,50)"}},
+			[]*ofTestUtils.ExpectFlow{{"priority=0", "goto_table:50"}},
 		},
 		{
 			uint8(50),
-			[]*ofTestUtils.ExpectFlow{{"priority=0", "resubmit(,60)"}},
+			[]*ofTestUtils.ExpectFlow{{"priority=0", "goto_table:60"}},
 		},
 		{
 			uint8(60),
-			[]*ofTestUtils.ExpectFlow{{"priority=0", "resubmit(,70)"}},
+			[]*ofTestUtils.ExpectFlow{{"priority=0", "goto_table:70"}},
 		},
 		{
 			uint8(70),
-			[]*ofTestUtils.ExpectFlow{{"priority=0", "resubmit(,80)"}},
+			[]*ofTestUtils.ExpectFlow{{"priority=0", "goto_table:80"}},
 		},
 		{
 			uint8(80),
-			[]*ofTestUtils.ExpectFlow{{"priority=0", "resubmit(,90)"}},
+			[]*ofTestUtils.ExpectFlow{{"priority=0", "goto_table:90"}},
 		},
 		{
 			uint8(90),
-			[]*ofTestUtils.ExpectFlow{{"priority=0", "resubmit(,100)"}},
+			[]*ofTestUtils.ExpectFlow{{"priority=0", "goto_table:100"}},
 		},
 		{
 			uint8(100),
-			[]*ofTestUtils.ExpectFlow{{"priority=0", "resubmit(,105)"}},
+			[]*ofTestUtils.ExpectFlow{{"priority=0", "goto_table:105"}},
 		},
 		{
 			uint8(105),
 			[]*ofTestUtils.ExpectFlow{
 				{"priority=200,ct_state=+new+trk,ip,reg0=0x1/0xffff", "ct(commit,table=110,zone=65520,exec(load:0x20->NXM_NX_CT_MARK[])"},
 				{"priority=190,ct_state=+new+trk,ip", "ct(commit,table=110,zone=65520)"},
-				{"priority=0", "resubmit(,110)"}},
+				{"priority=0", "goto_table:110"}},
 		},
 		{
 			uint8(110),

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -111,13 +111,13 @@ func prepareOverlapFlows(table binding.Table, ipStr string, sameCookie bool) ([]
 		table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 			Cookie(cookie2).
 			MatchSrcIP(srcIP).
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 	}
 	expectFlows := []*ExpectFlow{
 		{"priority=200,ip", "drop"},
 		{fmt.Sprintf("priority=200,ip,nw_src=%s", ipStr),
-			fmt.Sprintf("resubmit(,%d)", table.GetNext())},
+			fmt.Sprintf("goto_table:%d)", table.GetNext())},
 	}
 	return flows, expectFlows
 }
@@ -415,7 +415,7 @@ func TestBundleErrorWhenOVSRestart(t *testing.T) {
 				flows := []binding.Flow{table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 					Cookie(getCookieID()).
 					MatchInPort(uint32(count + 1)).
-					Action().ResubmitToTable(table.GetNext()).
+					Action().GotoTable(table.GetNext()).
 					Done()}
 				err = bridge.AddFlowsInBundle(flows, nil, nil)
 				if err != nil {
@@ -489,21 +489,21 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 			Cookie(getCookieID()).
 			MatchInPort(podOFport).
 			Action().LoadRegRange(int(marksReg), markTrafficFromLocal, binding.Range{0, 15}).
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 		table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolARP).
 			Cookie(getCookieID()).
 			MatchInPort(podOFport).
 			MatchARPSha(podMAC).
 			MatchARPSpa(podIP).
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 		table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 			Cookie(getCookieID()).
 			MatchInPort(podOFport).
 			MatchSrcMAC(podMAC).
 			MatchSrcIP(podIP).
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 		table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolARP).
 			Cookie(getCookieID()).
@@ -530,7 +530,7 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 			LoadRegToReg(0, 0, binding.Range{0, 15}, binding.Range{0, 15}).
 			LoadReg(0, 0x0ffe, binding.Range{16, 31}).
 			Done(). // Finish learn action.
-			Action().ResubmitToTable(table.GetID()).
+			Action().GotoTable(table.GetID()).
 			Done(),
 		table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 			Cookie(getCookieID()).
@@ -541,7 +541,7 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 			MatchRegRange(int(marksReg), markTrafficFromGateway, binding.Range{0, 15}).
 			MatchCTMark(gatewayCTMark).
 			MatchCTStateNew(false).MatchCTStateTrk(true).
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 		table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 			Cookie(getCookieID()).
@@ -558,7 +558,7 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 			MatchCTMark(gatewayCTMark).
 			MatchCTStateNew(false).MatchCTStateTrk(true).
 			Action().LoadRange(binding.NxmFieldDstMAC, gwMACData, binding.Range{0, 47}).
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 		table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 			Cookie(getCookieID()).
@@ -577,7 +577,7 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 			Action().SetSrcMAC(gwMAC).
 			Action().SetDstMAC(podMAC).
 			Action().DecTTL().
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 		table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 			Cookie(getCookieID()).
@@ -586,20 +586,20 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 			Action().SetSrcMAC(gwMAC).
 			Action().SetDstMAC(vMAC).
 			Action().SetTunnelDst(tunnelPeer).
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 		table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 			Cookie(getCookieID()).
 			MatchDstIP(gwIP).
 			Action().SetDstMAC(gwMAC).
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 		table.BuildFlow(priorityNormal).
 			Cookie(getCookieID()).
 			MatchDstMAC(podMAC).
 			Action().LoadRegRange(portCacheReg, podOFport, ofportRegRange).
 			Action().LoadRegRange(int(marksReg), portFoundMark, ofportMarkRange).
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 		table.BuildFlow(priorityNormal).
 			Cookie(getCookieID()).
@@ -622,30 +622,30 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 		table.BuildFlow(priorityNormal+20).MatchProtocol(binding.ProtocolIP).Cookie(getCookieID()).MatchRegRange(int(portCacheReg), podOFport, ofportRegRange).
 			Action().Conjunction(uint32(1001), uint8(2), uint8(3)).Done(),
 		table.BuildFlow(priorityNormal+20).MatchProtocol(binding.ProtocolIP).Cookie(getCookieID()).MatchConjID(1001).
-			Action().ResubmitToTable(table.GetNext()).Done(),
+			Action().GotoTable(table.GetNext()).Done(),
 		table.BuildFlow(priorityNormal+20).MatchProtocol(binding.ProtocolIP).Cookie(getCookieID()).MatchConjID(1001).MatchSrcIP(gwIP).
-			Action().ResubmitToTable(table.GetNext()).Done(),
+			Action().GotoTable(table.GetNext()).Done(),
 	)
 
-	resubmitAction := fmt.Sprintf("resubmit(,%d)", table.GetNext())
+	gotoTableAction := fmt.Sprintf("goto_table:%d", table.GetNext())
 	var flowStrs []*ExpectFlow
 	flowStrs = append(flowStrs,
-		&ExpectFlow{"priority=190,in_port=3", fmt.Sprintf("load:0x2->NXM_NX_REG0[0..15],%s", resubmitAction)},
-		&ExpectFlow{"priority=200,arp,in_port=3,arp_spa=192.168.1.3,arp_sha=aa:aa:aa:aa:aa:13", resubmitAction},
-		&ExpectFlow{"priority=200,ip,in_port=3,dl_src=aa:aa:aa:aa:aa:13,nw_src=192.168.1.3", resubmitAction},
+		&ExpectFlow{"priority=190,in_port=3", fmt.Sprintf("load:0x2->NXM_NX_REG0[0..15],%s", gotoTableAction)},
+		&ExpectFlow{"priority=200,arp,in_port=3,arp_spa=192.168.1.3,arp_sha=aa:aa:aa:aa:aa:13", gotoTableAction},
+		&ExpectFlow{"priority=200,ip,in_port=3,dl_src=aa:aa:aa:aa:aa:13,nw_src=192.168.1.3", gotoTableAction},
 		&ExpectFlow{"priority=200,arp,arp_tpa=192.168.2.1,arp_op=1", "move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],set_field:aa:bb:cc:dd:ee:ff->eth_src,load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],set_field:aa:bb:cc:dd:ee:ff->arp_sha,move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],set_field:192.168.2.1->arp_spa,IN_PORT"},
 		&ExpectFlow{"priority=190,arp", "NORMAL"},
-		&ExpectFlow{"priority=200,tcp", fmt.Sprintf("learn(table=%d,idle_timeout=10,priority=190,delete_learned,cookie=0x1,eth_type=0x800,nw_proto=6,NXM_OF_TCP_DST[],NXM_NX_REG0[0..15]=0xfff,load:NXM_NX_REG0[0..15]->NXM_NX_REG0[0..15],load:0xffe->NXM_NX_REG0[16..31]),resubmit(,%d)", table.GetID(), table.GetID())},
+		&ExpectFlow{"priority=200,tcp", fmt.Sprintf("learn(table=%d,idle_timeout=10,priority=190,delete_learned,cookie=0x1,eth_type=0x800,nw_proto=6,NXM_OF_TCP_DST[],NXM_NX_REG0[0..15]=0xfff,load:NXM_NX_REG0[0..15]->NXM_NX_REG0[0..15],load:0xffe->NXM_NX_REG0[16..31]),goto_table:%d", table.GetID(), table.GetID())},
 		&ExpectFlow{"priority=200,ip", fmt.Sprintf("ct(table=%d,zone=65520)", table.GetNext())},
-		&ExpectFlow{"priority=210,ct_state=-new+trk,ct_mark=0x20,ip,reg0=0x1/0xffff", resubmitAction},
+		&ExpectFlow{"priority=210,ct_state=-new+trk,ct_mark=0x20,ip,reg0=0x1/0xffff", gotoTableAction},
 		&ExpectFlow{"priority=200,ct_state=+new+trk,ip,reg0=0x1/0xffff", fmt.Sprintf("ct(commit,table=%d,zone=65520,exec(load:0x20->NXM_NX_CT_MARK[])", table.GetNext())},
-		&ExpectFlow{"priority=200,ct_state=-new+trk,ct_mark=0x20,ip", fmt.Sprintf("load:0xaaaaaaaaaa11->NXM_OF_ETH_DST[],%s", resubmitAction)},
+		&ExpectFlow{"priority=200,ct_state=-new+trk,ct_mark=0x20,ip", fmt.Sprintf("load:0xaaaaaaaaaa11->NXM_OF_ETH_DST[],%s", gotoTableAction)},
 		&ExpectFlow{"priority=200,ct_state=+new+inv,ip", "drop"},
 		&ExpectFlow{"priority=190,ct_state=+new+trk,ip", fmt.Sprintf("ct(commit,table=%d,zone=65520)", table.GetNext())},
-		&ExpectFlow{"priority=200,ip,dl_dst=aa:bb:cc:dd:ee:ff,nw_dst=192.168.1.3", fmt.Sprintf("set_field:aa:aa:aa:aa:aa:11->eth_src,set_field:aa:aa:aa:aa:aa:13->eth_dst,dec_ttl,%s", resubmitAction)},
-		&ExpectFlow{"priority=200,ip,nw_dst=192.168.2.0/24", fmt.Sprintf("dec_ttl,set_field:aa:aa:aa:aa:aa:11->eth_src,set_field:aa:bb:cc:dd:ee:ff->eth_dst,set_field:10.1.1.2->tun_dst,%s", resubmitAction)},
-		&ExpectFlow{"priority=200,ip,nw_dst=192.168.1.1", fmt.Sprintf("set_field:aa:aa:aa:aa:aa:11->eth_dst,%s", resubmitAction)},
-		&ExpectFlow{"priority=200,dl_dst=aa:aa:aa:aa:aa:13", fmt.Sprintf("load:0x3->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],%s", resubmitAction)},
+		&ExpectFlow{"priority=200,ip,dl_dst=aa:bb:cc:dd:ee:ff,nw_dst=192.168.1.3", fmt.Sprintf("set_field:aa:aa:aa:aa:aa:11->eth_src,set_field:aa:aa:aa:aa:aa:13->eth_dst,dec_ttl,%s", gotoTableAction)},
+		&ExpectFlow{"priority=200,ip,nw_dst=192.168.2.0/24", fmt.Sprintf("dec_ttl,set_field:aa:aa:aa:aa:aa:11->eth_src,set_field:aa:bb:cc:dd:ee:ff->eth_dst,set_field:10.1.1.2->tun_dst,%s", gotoTableAction)},
+		&ExpectFlow{"priority=200,ip,nw_dst=192.168.1.1", fmt.Sprintf("set_field:aa:aa:aa:aa:aa:11->eth_dst,%s", gotoTableAction)},
+		&ExpectFlow{"priority=200,dl_dst=aa:aa:aa:aa:aa:13", fmt.Sprintf("load:0x3->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],%s", gotoTableAction)},
 		&ExpectFlow{"priority=200,ip,reg0=0x10000/0x10000", "output:NXM_NX_REG1[]"},
 		&ExpectFlow{"priority=200,ip,nw_dst=172.16.0.0/16", "output:1"},
 		&ExpectFlow{"priority=220,tcp,tp_dst=8080", "conjunction(1001,3/3)"},
@@ -653,8 +653,8 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 		&ExpectFlow{"priority=220,ip,nw_dst=192.168.3.0/24", "conjunction(1001,2/3)"},
 		&ExpectFlow{"priority=220,ip", "conjunction(1001,1/3)"},
 		&ExpectFlow{"priority=220,ip,reg1=0x3", "conjunction(1001,2/3)"},
-		&ExpectFlow{"priority=220,conj_id=1001,ip", resubmitAction},
-		&ExpectFlow{"priority=220,conj_id=1001,ip,nw_src=192.168.1.1", resubmitAction},
+		&ExpectFlow{"priority=220,conj_id=1001,ip", gotoTableAction},
+		&ExpectFlow{"priority=220,conj_id=1001,ip,nw_src=192.168.1.1", gotoTableAction},
 	)
 
 	return flows, flowStrs

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -117,7 +117,7 @@ func prepareOverlapFlows(table binding.Table, ipStr string, sameCookie bool) ([]
 	expectFlows := []*ExpectFlow{
 		{"priority=200,ip", "drop"},
 		{fmt.Sprintf("priority=200,ip,nw_src=%s", ipStr),
-			fmt.Sprintf("goto_table:%d)", table.GetNext())},
+			fmt.Sprintf("goto_table:%d", table.GetNext())},
 	}
 	return flows, expectFlows
 }


### PR DESCRIPTION
Replace resubmit with gototable instruction.
This is a part of change to use write_action and actset_output instead of NXM_NX_REG

Signed-off-by: Yuki Tsuboi <ytsuboi@vmware.com>