### PR TITLE
Introduce goto_table instruction 

### DIFF
--- a/docs/ovs-pipeline.md
+++ b/docs/ovs-pipeline.md
@@ -135,10 +135,10 @@ local Pod. This information is used by matches in subsequent tables.
 
 If you dump the flows for this table, you may see the following:
 ```
-1. table=0, priority=200,in_port=gw0 actions=load:0x1->NXM_NX_REG0[0..15],resubmit(,10)
-2. table=0, priority=200,in_port=tun0 actions=load:0->NXM_NX_REG0[0..15],resubmit(,30)
-3. table=0, priority=190,in_port="coredns5-8ec607" actions=load:0x2->NXM_NX_REG0[0..15],resubmit(,10)
-4. table=0, priority=190,in_port="coredns5-9d9530" actions=load:0x2->NXM_NX_REG0[0..15],resubmit(,10)
+1. table=0, priority=200,in_port=gw0 actions=load:0x1->NXM_NX_REG0[0..15],goto_table:10
+2. table=0, priority=200,in_port=tun0 actions=load:0->NXM_NX_REG0[0..15],goto_table:30
+3. table=0, priority=190,in_port="coredns5-8ec607" actions=load:0x2->NXM_NX_REG0[0..15],goto_table:10
+4. table=0, priority=190,in_port="coredns5-9d9530" actions=load:0x2->NXM_NX_REG0[0..15],goto_table:10
 5. table=0, priority=0 actions=drop
 ```
 
@@ -147,8 +147,8 @@ coming in through a VXLAN or Geneve tunnel (i.e. from another Node). The next
 two flows (3 and 4) are for local Pods (in this case Pods from the coredns
 deployment).
 
-Local traffic is then resubmitted to [SpoofGuardTable], while tunnel traffic
-from other Nodes is resubmitted to [ConntrackTable]. The table-miss flow entry
+Local traffic then goes to [SpoofGuardTable], while tunnel traffic
+from other Nodes goes to [ConntrackTable]. The table-miss flow entry
 will drop all unmatched packets (in practice this flow entry should almost never
 be used).
 
@@ -176,17 +176,17 @@ the host to advertise a different MAC address on gw0.
 
 If you dump the flows for this table, you may see the following:
 ```
-1. table=10, priority=200,ip,in_port=gw0 actions=resubmit(,30)
-2. table=10, priority=200,arp,in_port=gw0,arp_spa=10.10.0.1,arp_sha=e2:e5:a4:9b:1c:b1 actions=resubmit(,20)
-3. table=10, priority=200,ip,in_port="coredns5-8ec607",dl_src=12:9e:a6:47:d0:70,nw_src=10.10.0.2 actions=resubmit(,30)
-4. table=10, priority=200,ip,in_port="coredns5-9d9530",dl_src=ba:a8:13:ca:ed:cf,nw_src=10.10.0.3 actions=resubmit(,30)
-5. table=10, priority=200,arp,in_port="coredns5-8ec607",arp_spa=10.10.0.2,arp_sha=12:9e:a6:47:d0:70 actions=resubmit(,20)
-6. table=10, priority=200,arp,in_port="coredns5-9d9530",arp_spa=10.10.0.3,arp_sha=ba:a8:13:ca:ed:cf actions=resubmit(,20)
+1. table=10, priority=200,ip,in_port=gw0 actions=goto_table:30
+2. table=10, priority=200,arp,in_port=gw0,arp_spa=10.10.0.1,arp_sha=e2:e5:a4:9b:1c:b1 actions=goto_table:20
+3. table=10, priority=200,ip,in_port="coredns5-8ec607",dl_src=12:9e:a6:47:d0:70,nw_src=10.10.0.2 actions=goto_table:30
+4. table=10, priority=200,ip,in_port="coredns5-9d9530",dl_src=ba:a8:13:ca:ed:cf,nw_src=10.10.0.3 actions=goto_table:30
+5. table=10, priority=200,arp,in_port="coredns5-8ec607",arp_spa=10.10.0.2,arp_sha=12:9e:a6:47:d0:70 actions=goto_table:20
+6. table=10, priority=200,arp,in_port="coredns5-9d9530",arp_spa=10.10.0.3,arp_sha=ba:a8:13:ca:ed:cf actions=goto_table:20
 7. table=10, priority=0 actions=drop
 ```
 
-After this table, ARP traffic is resubmitted to [ARPResponderTable], while IP
-traffic is resubmitted to [ConnectionTrackTable]. Traffic which does not match
+After this table, ARP traffic goes to [ARPResponderTable], while IP
+traffic goes to [ConnectionTrackTable]. Traffic which does not match
 any of the rules described above will be dropped by the table-miss flow entry.
 
 ### ARPResponderTable (20)
@@ -228,14 +228,14 @@ learning switch (using the `normal` action). In particular, this takes care of
 forwarding ARP requests and replies between local Pods.
 
 The table-miss flow entry (flow 3) will drop all other packets. This flow should
-never be used because only ARP traffic should be resubmitted to this table, and
+never be used because only ARP traffic should go to this table, and
 ARP traffic will either match flow 1 or flow 2.
 
 ### ConntrackTable (30)
 
 The sole purpose of this table is to invoke the `ct` action on all packets and
 set the `ct_zone` (connection tracking context) to an hard-coded value, then
-resubmit traffic to [ConntrackStateTable]. If you dump the flows for this table,
+forward traffic to [ConntrackStateTable]. If you dump the flows for this table,
 you should only see 1 flow:
 ```
 1. table=30, priority=200,ip actions=ct(table=31,zone=65520)
@@ -274,10 +274,10 @@ purposes:
 
 If you dump the flows for this table, you should see the following:
 ```
-1. table=31, priority=210,ct_state=-new+trk,ct_mark=0x20,ip,reg0=0x1/0xffff actions=resubmit(,40)
+1. table=31, priority=210,ct_state=-new+trk,ct_mark=0x20,ip,reg0=0x1/0xffff actions=goto_table:40
 2. table=31, priority=200,ct_state=+inv+trk,ip actions=drop
-3. table=31, priority=200,ct_state=-new+trk,ct_mark=0x20,ip actions=load:0xe2e5a49b1cb1->NXM_OF_ETH_DST[],resubmit(,40)
-4. table=31, priority=0 actions=resubmit(,40)
+3. table=31, priority=200,ct_state=-new+trk,ct_mark=0x20,ip actions=load:0xe2e5a49b1cb1->NXM_OF_ETH_DST[],goto_table:40
+4. table=31, priority=0 actions=goto_table:40
 ```
 
 Flows 1 and 3 implement the destination MAC rewrite described above. Note that
@@ -285,7 +285,7 @@ at this stage we have not committed any connection yet. We commit all connection
 after enforcing Network Policies, in [ConntrackCommitTable]. This is also when
 we set the `ct_mark` to `0x20` for connections to service backends.
 
-Flow 2 drops invalid traffic. All non-dropped traffic is finally resubmitted to
+Flow 2 drops invalid traffic. All non-dropped traffic finally goes to
 the [DNATTable].
 
 ### DNATTable (40)
@@ -297,8 +297,8 @@ service.
 
 If you dump the flows for this table, you should see something like this:
 ```
-1. table=40, priority=200,ip,nw_dst=10.96.0.0/12 actions=load:0x2->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],resubmit(,105)
-2. table=40, priority=0 actions=resubmit(,50)
+1. table=40, priority=200,ip,nw_dst=10.96.0.0/12 actions=load:0x2->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],goto_table:105
+2. table=40, priority=0 actions=goto_table:50
 ```
 
 In the example above, 10.96.0.0/12 is the service CIDR (this is the default
@@ -311,13 +311,13 @@ rules when packets come back through the gateway and the destination IP has been
 rewritten by kube-proxy (DNAT to a backend for the service). We cannot output
 the service traffic to the gateway port directly as we haven't committed the
 connection yet; instead we store the port in NXM_NX_REG1 - similarly to how we
-process non-service traffic in [L2ForwardingCalcTable] - and resubmit it to
+process non-service traffic in [L2ForwardingCalcTable] - and forward it to
 [ConntrackCommitTable]. By committing the connection we ensure that reply
 traffic (traffic from the service backend which has already gone through
 kube-proxy for source IP rewrite) will not be dropped because of Network
 Policies.
 
-The table-miss flow entry (flow 2) for this table resubmits all non-service
+The table-miss flow entry (flow 2) for this table forwards all non-service
 traffic to the next table, [EgressRuleTable].
 
 In the future this table may support an additional mode of operations, in which
@@ -334,14 +334,14 @@ are allowed to talk to each other using TCP on port 80, but nothing else.
 This table is used to implement the egress rules across all Network Policies. If
 you dump the flows for this table, you should see something like this:
 ```
-1. table=50, priority=210,ct_state=-new+est,ip actions=resubmit(,70)
+1. table=50, priority=210,ct_state=-new+est,ip actions=goto_table:70
 2. table=50, priority=200,ip,nw_src=10.10.1.2 actions=conjunction(2,1/3)
 3. table=50, priority=200,ip,nw_src=10.10.1.3 actions=conjunction(2,1/3)
 4. table=50, priority=200,ip,nw_dst=10.10.1.2 actions=conjunction(2,2/3)
 5. table=50, priority=200,ip,nw_dst=10.10.1.3 actions=conjunction(2,2/3)
 6. table=50, priority=200,tcp,tp_dst=80 actions=conjunction(2,3/3)
-7. table=50, priority=190,conj_id=2,ip actions=resubmit(,70)
-8. table=50, priority=0 actions=resubmit(,60)
+7. table=50, priority=190,conj_id=2,ip actions=goto_table:70
+8. table=50, priority=0 actions=goto_table:60
 ```
 
 Notice how we use the OVS built-in `conjunction` action to implement policies
@@ -353,8 +353,8 @@ dimensions. For our use-case we have at most 3 dimensions.
 The above example flows read as follow: if the source IP address is in set
 {10.10.1.2, 10.10.1.3}, and the destination IP address is in the set {10.10.1.2,
 10.10.1.3}, and the destination TCP port is in the set {80}, then use the
-`conjunction` action with id 2, which is resubmit to
-[L3ForwardingTable]. Otherwise, resubmit to [EgressDefaultTable].
+`conjunction` action with id 2, which goes to
+[L3ForwardingTable]. Otherwise, go to [EgressDefaultTable].
 
 The only requirements on `conj_id` is for it to be a unique 32-bit integer
 within the table. At the moment we use a single custom allocator, which is
@@ -367,7 +367,7 @@ the table will include multiple flows with conjunctive match, corresponding to
 each cidr that is present in `from` or `to` fields, but not in `except` field.
 Network Policy implementation details are not covered in this document.
 
-If the `conjunction` action is matched, packets are "allowed" and resubmitted
+If the `conjunction` action is matched, packets are "allowed" and forwarded
 directly to [L3ForwardingTable]. Other packets go to [EgressDefaultTable]. If a
 connection is established - as a reminder all connections are committed in
 [ConntrackCommitTable] - its packets go straight to [L3ForwardingTable], with no
@@ -399,10 +399,10 @@ confirmed by dumping the flows:
 ```
 1. table=60, priority=200,ip,nw_src=10.10.1.2 actions=drop
 2. table=60, priority=200,ip,nw_src=10.10.1.3 actions=drop
-3. table=60, priority=0 actions=resubmit(,70)
+3. table=60, priority=0 actions=goto_table:70
 ```
 
-The table-miss flow entry, which is used for non-isolated Pods, resubmits
+The table-miss flow entry, which is used for non-isolated Pods, forwards
 traffic to the next table ([L3ForwardingTable]).
 
 ### L3ForwardingTable (70)
@@ -418,7 +418,7 @@ This is the L3 routing table. It implements the following functionality:
    address of a local Pod). We therefore install one flow for each Pod created
    locally on the Node. For example:
 ```
-table=70, priority=200,ip,dl_dst=aa:bb:cc:dd:ee:ff,nw_dst=10.10.0.2 actions=mod_dl_src:e2:e5:a4:9b:1c:b1,mod_dl_dst:12:9e:a6:47:d0:70,dec_ttl,resubmit(,80)
+table=70, priority=200,ip,dl_dst=aa:bb:cc:dd:ee:ff,nw_dst=10.10.0.2 actions=mod_dl_src:e2:e5:a4:9b:1c:b1,mod_dl_dst:12:9e:a6:47:d0:70,dec_ttl,goto_table:80
 ```
 
  * All tunnelled traffic destined to the local gateway (i.e. for which the
@@ -426,7 +426,7 @@ table=70, priority=200,ip,dl_dst=aa:bb:cc:dd:ee:ff,nw_dst=10.10.0.2 actions=mod_
    port by rewriting the destination MAC (from the Global Virtual MAC to the
    local gateway's MAC).
 ```
-table=70, priority=200,ip,dl_dst=aa:bb:cc:dd:ee:ff,nw_dst=10.10.0.1 actions=mod_dl_dst:e2:e5:a4:9b:1c:b1,resubmit(,80)
+table=70, priority=200,ip,dl_dst=aa:bb:cc:dd:ee:ff,nw_dst=10.10.0.1 actions=mod_dl_dst:e2:e5:a4:9b:1c:b1,goto_table:80
 ```
 
  * All traffic destined to a remote Pod is forwarded through the appropriate
@@ -435,13 +435,13 @@ table=70, priority=200,ip,dl_dst=aa:bb:cc:dd:ee:ff,nw_dst=10.10.0.1 actions=mod_
    the Node. In case of a match the source MAC is set to the local gateway MAC,
    the destination MAC is set to the Global Virtual MAC and we set the OF
    `tun_dst` field to the appropriate value (i.e. the IP address of the remote
-   gateway). Traffic is then resubmitted to [ConntrackCommitTable], thus
+   gateway). Traffic then goes to [ConntrackCommitTable], thus
    skipping [L2ForwardingCalcTable] and the ingress policy rules tables, which
    are not relevant for traffic destined to a tunnel (the destination port is
    the tunnel port and the ingress policy rules will be enforced at the
    destination Node). For a given peer Node, the flow may look like this:
 ```
-table=70, priority=200,ip,nw_dst=10.10.1.0/24 actions=dec_ttl,mod_dl_src:e2:e5:a4:9b:1c:b1,mod_dl_dst:aa:bb:cc:dd:ee:ff,load:0x1->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],load:0xc0a84d65->NXM_NX_TUN_IPV4_DST[],resubmit(,105)
+table=70, priority=200,ip,nw_dst=10.10.1.0/24 actions=dec_ttl,mod_dl_src:e2:e5:a4:9b:1c:b1,mod_dl_dst:aa:bb:cc:dd:ee:ff,load:0x1->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],load:0xc0a84d65->NXM_NX_TUN_IPV4_DST[],goto_table:105
 ```
 
 If none of the flows described above are hit, traffic
@@ -456,11 +456,11 @@ This is essentially the "dmac" table of the switch. We program one flow for each
 port (gateway port, Pod ports and tunnel port), as you can see if you dump the
 flows:
 ```
-1. table=80, priority=200,dl_dst=e2:e5:a4:9b:1c:b1 actions=load:0x2->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],resubmit(,90)
-2. table=80, priority=200,dl_dst=aa:bb:cc:dd:ee:ff actions=load:0x1->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],resubmit(,90)
-3. table=80, priority=200,dl_dst=12:9e:a6:47:d0:70 actions=load:0x3->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],resubmit(,90)
-4. table=80, priority=200,dl_dst=ba:a8:13:ca:ed:cf actions=load:0x4->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],resubmit(,90)
-5. table=80, priority=0 actions=resubmit(,90)
+1. table=80, priority=200,dl_dst=e2:e5:a4:9b:1c:b1 actions=load:0x2->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],goto_table:90
+2. table=80, priority=200,dl_dst=aa:bb:cc:dd:ee:ff actions=load:0x1->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],goto_table:90
+3. table=80, priority=200,dl_dst=12:9e:a6:47:d0:70 actions=load:0x3->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],goto_table:90
+4. table=80, priority=200,dl_dst=ba:a8:13:ca:ed:cf actions=load:0x4->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],goto_table:90
+5. table=80, priority=0 actions=goto_table:90
 ```
 
 For each port flow (1 through 4 in the example above), we set bit 16 of the
@@ -471,13 +471,13 @@ this bit is not set. We also use the NXM_NX_REG1 register to store the egress
 port for the packet, which will be used as a parameter to the `output` OpenFlow
 action in [L2ForwardingOutTable].
 
-All packets - whether they have a matching dmac entry or not - are then
-resubmitted to the next table, [IngressRuleTable].
+All packets - whether they have a matching dmac entry or not - then goes
+to the next table, [IngressRuleTable].
 
 What about L2 multicast / broadcast traffic? ARP requests will never reach this
 table, as they will be handled by the OpenFlow `normal` action in the
 [ArpResponderTable]. As for the rest, if it is IP traffic, it will hit the
-"last" flow in this table and be resubmitted to [IngressRuleTable]. Assuming it
+"last" flow in this table and go to [IngressRuleTable]. Assuming it
 makes it to the last table of the pipeline ([L2ForwardingOutTable]), it will be
 dropped there since bit 16 of the NXM_NX_REG0 will not be set. Traffic which is
 non-ARP and non-IP (assuming any can be received by the switch) is actually
@@ -494,15 +494,15 @@ are allowed to talk to each other using TCP on port 80, but nothing else.
 
 If you dump the flows for this table, you should see something like this:
 ```
-1. table=90, priority=210,ct_state=-new+est,ip actions=resubmit(,105)
-2. table=90, priority=210,ip,nw_src=10.10.1.1 actions=resubmit(,105)
+1. table=90, priority=210,ct_state=-new+est,ip actions=goto_table:105
+2. table=90, priority=210,ip,nw_src=10.10.1.1 actions=goto_table:105
 3. table=90, priority=200,ip,nw_src=10.10.1.2 actions=conjunction(1,1/3)
 4. table=90, priority=200,ip,nw_src=10.10.1.3 actions=conjunction(1,1/3)
 5. table=90, priority=200,ip,reg1=0x3 actions=conjunction(1,2/3)
 6. table=90, priority=200,ip,reg1=0x4 actions=conjunction(1,2/3)
 7. table=90, priority=200,tcp,tp_dst=80 actions=conjunction(1,3/3)
-8. table=90, priority=190,conj_id=1,ip actions=resubmit(,105)
-9. table=90, priority=0 actions=resubmit(,100)
+8. table=90, priority=190,conj_id=1,ip actions=goto_table:105
+9. table=90, priority=0 actions=goto_table:100
 ```
 
 As for [EgressRuleTable], flow 1 (highest priority) ensures that for established
@@ -518,8 +518,8 @@ can go through.
 The rest of the flows read as follows: if the source IP address is in set
 {10.10.1.2, 10.10.1.3}, and the destination OF port is in the set {3, 4} (which
 correspond to IP addresses {10.10.1.2, 10.10.1.3}, and the destination TCP port
-is in the set {80}, then use `conjunction` action with id 1, which is resubmit
-to [L2ForwardingOutTable]. Otherwise, resubmit to [IngressDefaultTable]. One
+is in the set {80}, then use `conjunction` action with id 1, which goes
+to [L2ForwardingOutTable]. Otherwise, go to [IngressDefaultTable]. One
 notable difference is how we use OF ports to identify the destination of the
 traffic, while we use IP addresses in [EgressRuleTable] to identify the source
 of the traffic. We do this as an increased security measure in case a local Pod
@@ -545,10 +545,10 @@ the flows:
 ```
 1. table=100, priority=200,ip,reg1=0x3 actions=drop
 2. table=100, priority=200,ip,reg1=0x4 actions=drop
-3. table=100, priority=0 actions=resubmit(,105)
+3. table=100, priority=0 actions=goto_table:105
 ```
 
-The table-miss flow entry, which is used for non-isolated Pods, resubmits
+The table-miss flow entry, which is used for non-isolated Pods, forwards
 traffic to the next table ([ConntrackCommitTable]).
 
 ### ConntrackCommitTable (105)
@@ -560,7 +560,7 @@ table, you should see something like this:
 ```
 1. table=105, priority=200,ct_state=+new+trk,ip,reg0=0x1/0xffff actions=ct(commit,table=110,zone=65520,exec(load:0x20->NXM_NX_CT_MARK[]))
 2. table=105, priority=190,ct_state=+new+trk,ip actions=ct(commit,table=110,zone=65520)
-3. table=105, priority=0 actions=resubmit(,110)
+3. table=105, priority=0 actions=goto_table:110
 ```
 
 Flow 1 ensures that we commit connections to service backends and mark them
@@ -570,7 +570,7 @@ MAC address for service backend reply traffic.
 
 Flow 2 commits all other new connections.
 
-All traffic is then resubmitted to the next table ([L2ForwardingOutTable]).
+All traffic then goes to the next table ([L2ForwardingOutTable]).
 
 ### L2ForwardingOutTable (110)
 

--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -371,7 +371,7 @@ func newMockRuleFlowBuilder(ctrl *gomock.Controller) *mocks.MockFlowBuilder {
 	ruleFlowBuilder.EXPECT().MatchSCTPDstPort(gomock.Any()).Return(ruleFlowBuilder).AnyTimes()
 	ruleFlowBuilder.EXPECT().MatchConjID(gomock.Any()).Return(ruleFlowBuilder).AnyTimes()
 	ruleAction = mocks.NewMockAction(ctrl)
-	ruleAction.EXPECT().ResubmitToTable(gomock.Any()).Return(ruleFlowBuilder).AnyTimes()
+	ruleAction.EXPECT().GotoTable(gomock.Any()).Return(ruleFlowBuilder).AnyTimes()
 	ruleFlowBuilder.EXPECT().Action().Return(ruleAction).AnyTimes()
 	ruleFlow = mocks.NewMockFlow(ctrl)
 	ruleFlowBuilder.EXPECT().Done().Return(ruleFlow).AnyTimes()

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -267,7 +267,7 @@ func (c *client) podClassifierFlow(podOFPort uint32, category cookie.Category) b
 // 2) Add ct_mark on the packet if it is sent to the switch from the host gateway.
 // 3) Allow traffic if it hits ct_mark and is sent from the host gateway.
 // 4) Drop all invalid traffic.
-// 5) Goto other traffic to the next table by the table-miss flow.
+// 5) Let other traffic go to the next table by the table-miss flow.
 func (c *client) connectionTrackFlows(category cookie.Category) (flows []binding.Flow) {
 	connectionTrackTable := c.pipeline[conntrackTable]
 	connectionTrackStateTable := c.pipeline[conntrackStateTable]

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -639,7 +639,7 @@ func (c *client) addFlowMatch(fb binding.FlowBuilder, matchType int, matchValue 
 	return fb
 }
 
-// conjunctionExceptionFlow generates the flow to resubmit to a specific table if both policyRuleConjunction ID and except address are matched.
+// conjunctionExceptionFlow generates the flow to jump to a specific table if both policyRuleConjunction ID and except address are matched.
 // Keeping this for reference to generic exception flow.
 func (c *client) conjunctionExceptionFlow(conjunctionID uint32, tableID binding.TableIDType, nextTable binding.TableIDType, matchKey int, matchValue interface{}) binding.Flow {
 	fb := c.pipeline[tableID].BuildFlow(priorityNormal).MatchConjID(conjunctionID)

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -215,7 +215,7 @@ func (c *client) defaultFlows() (flows []binding.Flow) {
 		flowBuilder := table.BuildFlow(priorityMiss)
 		switch table.GetMissAction() {
 		case binding.TableMissActionNext:
-			flowBuilder = flowBuilder.Action().ResubmitToTable(table.GetNext())
+			flowBuilder = flowBuilder.Action().GotoTable(table.GetNext())
 		case binding.TableMissActionNormal:
 			flowBuilder = flowBuilder.Action().Normal()
 		case binding.TableMissActionDrop:
@@ -235,7 +235,7 @@ func (c *client) tunnelClassifierFlow(tunnelOFPort uint32, category cookie.Categ
 	return c.pipeline[classifierTable].BuildFlow(priorityNormal).
 		MatchInPort(tunnelOFPort).
 		Action().LoadRegRange(int(marksReg), markTrafficFromTunnel, binding.Range{0, 15}).
-		Action().ResubmitToTable(conntrackTable).
+		Action().GotoTable(conntrackTable).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
@@ -246,7 +246,7 @@ func (c *client) gatewayClassifierFlow(gatewayOFPort uint32, category cookie.Cat
 	return classifierTable.BuildFlow(priorityNormal).
 		MatchInPort(gatewayOFPort).
 		Action().LoadRegRange(int(marksReg), markTrafficFromGateway, binding.Range{0, 15}).
-		Action().ResubmitToTable(classifierTable.GetNext()).
+		Action().GotoTable(classifierTable.GetNext()).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
@@ -257,7 +257,7 @@ func (c *client) podClassifierFlow(podOFPort uint32, category cookie.Category) b
 	return classifierTable.BuildFlow(priorityLow).
 		MatchInPort(podOFPort).
 		Action().LoadRegRange(int(marksReg), markTrafficFromLocal, binding.Range{0, 15}).
-		Action().ResubmitToTable(classifierTable.GetNext()).
+		Action().GotoTable(classifierTable.GetNext()).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
@@ -267,7 +267,7 @@ func (c *client) podClassifierFlow(podOFPort uint32, category cookie.Category) b
 // 2) Add ct_mark on the packet if it is sent to the switch from the host gateway.
 // 3) Allow traffic if it hits ct_mark and is sent from the host gateway.
 // 4) Drop all invalid traffic.
-// 5) Resubmit other traffic to the next table by the table-miss flow.
+// 5) Goto other traffic to the next table by the table-miss flow.
 func (c *client) connectionTrackFlows(category cookie.Category) (flows []binding.Flow) {
 	connectionTrackTable := c.pipeline[conntrackTable]
 	connectionTrackStateTable := c.pipeline[conntrackStateTable]
@@ -281,7 +281,7 @@ func (c *client) connectionTrackFlows(category cookie.Category) (flows []binding
 			MatchRegRange(int(marksReg), markTrafficFromGateway, binding.Range{0, 15}).
 			MatchCTMark(gatewayCTMark).
 			MatchCTStateNew(false).MatchCTStateTrk(true).
-			Action().ResubmitToTable(connectionTrackStateTable.GetNext()).
+			Action().GotoTable(connectionTrackStateTable.GetNext()).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done(),
 		connectionTrackStateTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
@@ -313,7 +313,7 @@ func (c *client) reEntranceBypassCTFlow(gwPort, reentPort uint32, category cooki
 	return conntrackCommitTable.BuildFlow(priorityHigh).MatchProtocol(binding.ProtocolIP).
 		MatchRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
 		MatchInPort(gwPort).MatchReg(int(portCacheReg), reentPort).
-		Action().ResubmitToTable(conntrackCommitTable.GetNext()).
+		Action().GotoTable(conntrackCommitTable.GetNext()).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
@@ -326,7 +326,7 @@ func (c *client) ctRewriteDstMACFlow(gatewayMAC net.HardwareAddr, category cooki
 		MatchCTMark(gatewayCTMark).
 		MatchCTStateNew(false).MatchCTStateTrk(true).
 		Action().LoadRange(binding.NxmFieldDstMAC, macData, binding.Range{0, 47}).
-		Action().ResubmitToTable(connectionTrackStateTable.GetNext()).
+		Action().GotoTable(connectionTrackStateTable.GetNext()).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
@@ -338,7 +338,7 @@ func (c *client) l2ForwardCalcFlow(dstMAC net.HardwareAddr, ofPort uint32, categ
 		MatchDstMAC(dstMAC).
 		Action().LoadRegRange(int(portCacheReg), ofPort, ofPortRegRange).
 		Action().LoadRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
-		Action().ResubmitToTable(l2FwdCalcTable.GetNext()).
+		Action().GotoTable(l2FwdCalcTable.GetNext()).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
@@ -371,7 +371,7 @@ func (c *client) l3BypassMACRewriteFlow(gatewayMAC net.HardwareAddr, category co
 	return l3FwdTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 		MatchCTMark(gatewayCTMark).
 		MatchDstMAC(gatewayMAC).
-		Action().ResubmitToTable(l3FwdTable.GetNext()).
+		Action().GotoTable(l3FwdTable.GetNext()).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
@@ -386,7 +386,7 @@ func (c *client) l3FlowsToPod(localGatewayMAC net.HardwareAddr, podInterfaceIP n
 		Action().SetSrcMAC(localGatewayMAC).
 		Action().SetDstMAC(podInterfaceMAC).
 		Action().DecTTL().
-		Action().ResubmitToTable(l3FwdTable.GetNext()).
+		Action().GotoTable(l3FwdTable.GetNext()).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
@@ -399,7 +399,7 @@ func (c *client) l3ToPodFlow(podInterfaceIP net.IP, podInterfaceMAC net.Hardware
 		MatchDstIP(podInterfaceIP).
 		Action().SetDstMAC(podInterfaceMAC).
 		Action().DecTTL().
-		Action().ResubmitToTable(l3FwdTable.GetNext()).
+		Action().GotoTable(l3FwdTable.GetNext()).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
@@ -411,7 +411,7 @@ func (c *client) l3ToGWFlow(gwMAC net.HardwareAddr, category cookie.Category) bi
 	return l3FwdTable.BuildFlow(priorityLow).MatchProtocol(binding.ProtocolIP).
 		Action().SetDstMAC(gwMAC).
 		Action().DecTTL().
-		Action().ResubmitToTable(l3FwdTable.GetNext()).
+		Action().GotoTable(l3FwdTable.GetNext()).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
@@ -423,7 +423,7 @@ func (c *client) l3ToGatewayFlow(localGatewayIP net.IP, localGatewayMAC net.Hard
 		MatchDstMAC(globalVirtualMAC).
 		MatchDstIP(localGatewayIP).
 		Action().SetDstMAC(localGatewayMAC).
-		Action().ResubmitToTable(l3FwdTable.GetNext()).
+		Action().GotoTable(l3FwdTable.GetNext()).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
@@ -449,7 +449,7 @@ func (c *client) l3FwdFlowToRemote(
 		Action().SetTunnelDst(tunnelPeer).
 		// Bypass l2ForwardingCalcTable and tables for ingress rules (which won't
 		// apply to packets to remote Nodes).
-		Action().ResubmitToTable(conntrackCommitTable).
+		Action().GotoTable(conntrackCommitTable).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
@@ -464,7 +464,7 @@ func (c *client) l3FwdFlowToRemoteViaGW(
 		MatchDstIPNet(peerSubnet).
 		Action().DecTTL().
 		Action().SetDstMAC(localGatewayMAC).
-		Action().ResubmitToTable(l3FwdTable.GetNext()).
+		Action().GotoTable(l3FwdTable.GetNext()).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
@@ -515,7 +515,7 @@ func (c *client) podIPSpoofGuardFlow(ifIP net.IP, ifMAC net.HardwareAddr, ifOFPo
 		MatchInPort(ifOFPort).
 		MatchSrcMAC(ifMAC).
 		MatchSrcIP(ifIP).
-		Action().ResubmitToTable(ipSpoofGuardTable.GetNext()).
+		Action().GotoTable(ipSpoofGuardTable.GetNext()).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
@@ -526,7 +526,7 @@ func (c *client) gatewayARPSpoofGuardFlow(gatewayOFPort uint32, gatewayIP net.IP
 		MatchInPort(gatewayOFPort).
 		MatchARPSha(gatewayMAC).
 		MatchARPSpa(gatewayIP).
-		Action().ResubmitToTable(arpResponderTable).
+		Action().GotoTable(arpResponderTable).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
@@ -537,7 +537,7 @@ func (c *client) arpSpoofGuardFlow(ifIP net.IP, ifMAC net.HardwareAddr, ifOFPort
 		MatchInPort(ifOFPort).
 		MatchARPSha(ifMAC).
 		MatchARPSpa(ifIP).
-		Action().ResubmitToTable(arpResponderTable).
+		Action().GotoTable(arpResponderTable).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
@@ -548,7 +548,7 @@ func (c *client) gatewayIPSpoofGuardFlow(gatewayOFPort uint32, category cookie.C
 	ipSpoofGuardTable := ipPipeline[spoofGuardTable]
 	return ipSpoofGuardTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 		MatchInPort(gatewayOFPort).
-		Action().ResubmitToTable(ipSpoofGuardTable.GetNext()).
+		Action().GotoTable(ipSpoofGuardTable.GetNext()).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
@@ -560,7 +560,7 @@ func (c *client) serviceCIDRDNATFlow(serviceCIDR *net.IPNet, gatewayMAC net.Hard
 		Action().SetDstMAC(gatewayMAC).
 		Action().LoadRegRange(int(portCacheReg), gatewayOFPort, ofPortRegRange).
 		Action().LoadRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
-		Action().ResubmitToTable(conntrackCommitTable).
+		Action().GotoTable(conntrackCommitTable).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
@@ -578,7 +578,7 @@ func (c *client) arpNormalFlow(category cookie.Category) binding.Flow {
 func (c *client) conjunctionActionFlow(conjunctionID uint32, tableID binding.TableIDType, nextTable binding.TableIDType) binding.Flow {
 	return c.pipeline[tableID].BuildFlow(priorityLow).MatchProtocol(binding.ProtocolIP).
 		MatchConjID(conjunctionID).
-		Action().ResubmitToTable(nextTable).
+		Action().GotoTable(nextTable).
 		Cookie(c.cookieAllocator.Request(cookie.Policy).Raw()).
 		Done()
 }
@@ -599,7 +599,7 @@ func (c *client) establishedConnectionFlows(category cookie.Category) (flows []b
 	egressDropTable := c.pipeline[egressDefaultTable]
 	egressEstFlow := c.pipeline[egressRuleTable].BuildFlow(priorityHigh).MatchProtocol(binding.ProtocolIP).
 		MatchCTStateNew(false).MatchCTStateEst(true).
-		Action().ResubmitToTable(egressDropTable.GetNext()).
+		Action().GotoTable(egressDropTable.GetNext()).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 	// ingressDropTable checks the destination address of packets, and drops packets sent to the AppliedToGroup but not
@@ -608,7 +608,7 @@ func (c *client) establishedConnectionFlows(category cookie.Category) (flows []b
 	ingressDropTable := c.pipeline[ingressDefaultTable]
 	ingressEstFlow := c.pipeline[ingressRuleTable].BuildFlow(priorityHigh).MatchProtocol(binding.ProtocolIP).
 		MatchCTStateNew(false).MatchCTStateEst(true).
-		Action().ResubmitToTable(ingressDropTable.GetNext()).
+		Action().GotoTable(ingressDropTable.GetNext()).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 	return []binding.Flow{egressEstFlow, ingressEstFlow}
@@ -644,7 +644,7 @@ func (c *client) addFlowMatch(fb binding.FlowBuilder, matchType int, matchValue 
 func (c *client) conjunctionExceptionFlow(conjunctionID uint32, tableID binding.TableIDType, nextTable binding.TableIDType, matchKey int, matchValue interface{}) binding.Flow {
 	fb := c.pipeline[tableID].BuildFlow(priorityNormal).MatchConjID(conjunctionID)
 	return c.addFlowMatch(fb, matchKey, matchValue).
-		Action().ResubmitToTable(nextTable).
+		Action().GotoTable(nextTable).
 		Cookie(c.cookieAllocator.Request(cookie.Policy).Raw()).
 		Done()
 }
@@ -673,7 +673,7 @@ func (c *client) localProbeFlow(localGatewayIP net.IP, category cookie.Category)
 	return c.pipeline[ingressRuleTable].BuildFlow(priorityHigh).
 		MatchProtocol(binding.ProtocolIP).
 		MatchSrcIP(localGatewayIP).
-		Action().ResubmitToTable(conntrackCommitTable).
+		Action().GotoTable(conntrackCommitTable).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -573,7 +573,7 @@ func (c *client) arpNormalFlow(category cookie.Category) binding.Flow {
 		Done()
 }
 
-// conjunctionActionFlow generates the flow to resubmit to a specific table if policyRuleConjunction ID is matched. Priority of
+// conjunctionActionFlow generates the flow to jump to a specific table if policyRuleConjunction ID is matched. Priority of
 // conjunctionActionFlow is priorityLow.
 func (c *client) conjunctionActionFlow(conjunctionID uint32, tableID binding.TableIDType, nextTable binding.TableIDType) binding.Flow {
 	return c.pipeline[tableID].BuildFlow(priorityLow).MatchProtocol(binding.ProtocolIP).
@@ -668,7 +668,7 @@ func (c *client) defaultDropFlow(tableID binding.TableIDType, matchKey int, matc
 		Done()
 }
 
-// localProbeFlow generates the flow to resubmit packets to conntrackCommitTable. The packets are sent from Node to probe the liveness/readiness of local Pods.
+// localProbeFlow generates the flow to forward packets to conntrackCommitTable. The packets are sent from Node to probe the liveness/readiness of local Pods.
 func (c *client) localProbeFlow(localGatewayIP net.IP, category cookie.Category) binding.Flow {
 	return c.pipeline[ingressRuleTable].BuildFlow(priorityHigh).
 		MatchProtocol(binding.ProtocolIP).

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -169,6 +169,7 @@ type Action interface {
 	Conjunction(conjID uint32, clauseID uint8, nClause uint8) FlowBuilder
 	Group(id GroupIDType) FlowBuilder
 	Learn(id TableIDType, priority uint16, idleTimeout, hardTimeout uint16, cookieID uint64) LearnAction
+	GotoTable(table TableIDType) FlowBuilder
 }
 
 type FlowBuilder interface {

--- a/pkg/ovs/openflow/ofctrl_action.go
+++ b/pkg/ovs/openflow/ofctrl_action.go
@@ -398,3 +398,12 @@ func getFieldRange(name string) (*openflow13.MatchField, Range, error) {
 	}
 	return field, Range{0, uint32(field.Length)*8 - 1}, nil
 }
+
+ // GotoTable is an action to jump to the specified table.
+ func (a *ofFlowAction) GotoTable(table TableIDType) FlowBuilder {
+	// Use Table until new ofnet APIs are ready
+	// a.builder.ofFlow.Goto(uint8(table))
+	gotoTable := &ofctrl.Table{TableId: uint8(table)}
+	a.builder.ofFlow.lastAction = gotoTable
+	return a.builder
+}

--- a/pkg/ovs/openflow/ofctrl_action.go
+++ b/pkg/ovs/openflow/ofctrl_action.go
@@ -399,8 +399,8 @@ func getFieldRange(name string) (*openflow13.MatchField, Range, error) {
 	return field, Range{0, uint32(field.Length)*8 - 1}, nil
 }
 
- // GotoTable is an action to jump to the specified table.
- func (a *ofFlowAction) GotoTable(table TableIDType) FlowBuilder {
+// GotoTable is an action to jump to the specified table.
+func (a *ofFlowAction) GotoTable(table TableIDType) FlowBuilder {
 	// Use Table until new ofnet APIs are ready
 	// a.builder.ofFlow.Goto(uint8(table))
 	gotoTable := &ofctrl.Table{TableId: uint8(table)}

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -538,6 +538,20 @@ func (mr *MockActionMockRecorder) Drop() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Drop", reflect.TypeOf((*MockAction)(nil).Drop))
 }
 
+// GotoTable mocks base method
+func (m *MockAction) GotoTable(arg0 openflow.TableIDType) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GotoTable", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// GotoTable indicates an expected call of GotoTable
+func (mr *MockActionMockRecorder) GotoTable(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GotoTable", reflect.TypeOf((*MockAction)(nil).GotoTable), arg0)
+}
+
 // Group mocks base method
 func (m *MockAction) Group(arg0 openflow.GroupIDType) openflow.FlowBuilder {
 	m.ctrl.T.Helper()

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -701,7 +701,7 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 		&ExpectFlow{"priority=200,ip,in_port=3,dl_src=aa:aa:aa:aa:aa:13,nw_src=192.168.1.3", gotoTableAction},
 		&ExpectFlow{"priority=200,arp,arp_tpa=192.168.2.1,arp_op=1", "move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],set_field:aa:bb:cc:dd:ee:ff->eth_src,load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],set_field:aa:bb:cc:dd:ee:ff->arp_sha,move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],set_field:192.168.2.1->arp_spa,IN_PORT"},
 		&ExpectFlow{"priority=190,arp", "NORMAL"},
-		&ExpectFlow{"priority=200,tcp", fmt.Sprintf("learn(table=%d,idle_timeout=10,priority=190,delete_learned,cookie=0x1,eth_type=0x800,nw_proto=6,NXM_OF_TCP_DST[],NXM_NX_REG0[0..15]=0xfff,load:NXM_NX_REG0[0..15]->NXM_NX_REG0[0..15],load:0xffe->NXM_NX_REG0[16..31]),goto_table:%d", table.GetID(), table.GetID())},
+		&ExpectFlow{"priority=200,tcp", fmt.Sprintf("learn(table=%d,idle_timeout=10,priority=190,delete_learned,cookie=0x1,eth_type=0x800,nw_proto=6,NXM_OF_TCP_DST[],NXM_NX_REG0[0..15]=0xfff,load:NXM_NX_REG0[0..15]->NXM_NX_REG0[0..15],load:0xffe->NXM_NX_REG0[16..31]),resubmit(,%d)", table.GetID(), table.GetID())},
 		&ExpectFlow{"priority=200,ip", fmt.Sprintf("ct(table=%d,zone=65520)", table.GetNext())},
 		&ExpectFlow{"priority=210,ct_state=-new+trk,ct_mark=0x20,ip,reg0=0x1/0xffff", gotoTableAction},
 		&ExpectFlow{"priority=200,ct_state=+new+trk,ip,reg0=0x1/0xffff", fmt.Sprintf("ct(commit,table=%d,zone=65520,exec(load:0x20->NXM_NX_CT_MARK[])", table.GetNext())},

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -596,7 +596,7 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 			LoadRegToReg(0, 0, binding.Range{0, 15}, binding.Range{0, 15}).
 			LoadReg(0, 0x0ffe, binding.Range{16, 31}).
 			Done(). // Finish learn action.
-			Action().GotoTable(table.GetID()).
+			Action().ResubmitToTable(table.GetID()).
 			Done(),
 		table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 			Cookie(getCookieID()).

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -114,13 +114,13 @@ func prepareOverlapFlows(table binding.Table, ipStr string, sameCookie bool) ([]
 		table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 			Cookie(cookie2).
 			MatchSrcIP(srcIP).
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 	}
 	expectFlows := []*ExpectFlow{
 		{"priority=200,ip", "drop"},
 		{fmt.Sprintf("priority=200,ip,nw_src=%s", ipStr),
-			fmt.Sprintf("resubmit(,%d)", table.GetNext())},
+			fmt.Sprintf("goto_table:%d)", table.GetNext())},
 	}
 	return flows, expectFlows
 }
@@ -424,7 +424,7 @@ func TestBundleErrorWhenOVSRestart(t *testing.T) {
 				flows := []binding.Flow{table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 					Cookie(getCookieID()).
 					MatchInPort(uint32(count + 1)).
-					Action().ResubmitToTable(table.GetNext()).
+					Action().GotoTable(table.GetNext()).
 					Done()}
 				err = bridge.AddFlowsInBundle(flows, nil, nil)
 				if err != nil {
@@ -555,21 +555,21 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 			Cookie(getCookieID()).
 			MatchInPort(podOFport).
 			Action().LoadRegRange(int(marksReg), markTrafficFromLocal, binding.Range{0, 15}).
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 		table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolARP).
 			Cookie(getCookieID()).
 			MatchInPort(podOFport).
 			MatchARPSha(podMAC).
 			MatchARPSpa(podIP).
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 		table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 			Cookie(getCookieID()).
 			MatchInPort(podOFport).
 			MatchSrcMAC(podMAC).
 			MatchSrcIP(podIP).
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 		table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolARP).
 			Cookie(getCookieID()).
@@ -596,7 +596,7 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 			LoadRegToReg(0, 0, binding.Range{0, 15}, binding.Range{0, 15}).
 			LoadReg(0, 0x0ffe, binding.Range{16, 31}).
 			Done(). // Finish learn action.
-			Action().ResubmitToTable(table.GetID()).
+			Action().GotoTable(table.GetID()).
 			Done(),
 		table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 			Cookie(getCookieID()).
@@ -607,7 +607,7 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 			MatchRegRange(int(marksReg), markTrafficFromGateway, binding.Range{0, 15}).
 			MatchCTMark(gatewayCTMark).
 			MatchCTStateNew(false).MatchCTStateTrk(true).
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 		table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 			Cookie(getCookieID()).
@@ -624,7 +624,7 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 			MatchCTMark(gatewayCTMark).
 			MatchCTStateNew(false).MatchCTStateTrk(true).
 			Action().LoadRange(binding.NxmFieldDstMAC, gwMACData, binding.Range{0, 47}).
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 		table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 			Cookie(getCookieID()).
@@ -643,7 +643,7 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 			Action().SetSrcMAC(gwMAC).
 			Action().SetDstMAC(podMAC).
 			Action().DecTTL().
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 		table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 			Cookie(getCookieID()).
@@ -652,20 +652,20 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 			Action().SetSrcMAC(gwMAC).
 			Action().SetDstMAC(vMAC).
 			Action().SetTunnelDst(tunnelPeer).
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 		table.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 			Cookie(getCookieID()).
 			MatchDstIP(gwIP).
 			Action().SetDstMAC(gwMAC).
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 		table.BuildFlow(priorityNormal).
 			Cookie(getCookieID()).
 			MatchDstMAC(podMAC).
 			Action().LoadRegRange(portCacheReg, podOFport, ofportRegRange).
 			Action().LoadRegRange(int(marksReg), portFoundMark, ofportMarkRange).
-			Action().ResubmitToTable(table.GetNext()).
+			Action().GotoTable(table.GetNext()).
 			Done(),
 		table.BuildFlow(priorityNormal).
 			Cookie(getCookieID()).
@@ -688,30 +688,30 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 		table.BuildFlow(priorityNormal+20).MatchProtocol(binding.ProtocolIP).Cookie(getCookieID()).MatchRegRange(int(portCacheReg), podOFport, ofportRegRange).
 			Action().Conjunction(uint32(1001), uint8(2), uint8(3)).Done(),
 		table.BuildFlow(priorityNormal+20).MatchProtocol(binding.ProtocolIP).Cookie(getCookieID()).MatchConjID(1001).
-			Action().ResubmitToTable(table.GetNext()).Done(),
+			Action().GotoTable(table.GetNext()).Done(),
 		table.BuildFlow(priorityNormal+20).MatchProtocol(binding.ProtocolIP).Cookie(getCookieID()).MatchConjID(1001).MatchSrcIP(gwIP).
-			Action().ResubmitToTable(table.GetNext()).Done(),
+			Action().GotoTable(table.GetNext()).Done(),
 	)
 
-	resubmitAction := fmt.Sprintf("resubmit(,%d)", table.GetNext())
+	gotoTableAction := fmt.Sprintf("goto_table:%d", table.GetNext())
 	var flowStrs []*ExpectFlow
 	flowStrs = append(flowStrs,
-		&ExpectFlow{"priority=190,in_port=3", fmt.Sprintf("load:0x2->NXM_NX_REG0[0..15],%s", resubmitAction)},
-		&ExpectFlow{"priority=200,arp,in_port=3,arp_spa=192.168.1.3,arp_sha=aa:aa:aa:aa:aa:13", resubmitAction},
-		&ExpectFlow{"priority=200,ip,in_port=3,dl_src=aa:aa:aa:aa:aa:13,nw_src=192.168.1.3", resubmitAction},
+		&ExpectFlow{"priority=190,in_port=3", fmt.Sprintf("load:0x2->NXM_NX_REG0[0..15],%s", gotoTableAction)},
+		&ExpectFlow{"priority=200,arp,in_port=3,arp_spa=192.168.1.3,arp_sha=aa:aa:aa:aa:aa:13", gotoTableAction},
+		&ExpectFlow{"priority=200,ip,in_port=3,dl_src=aa:aa:aa:aa:aa:13,nw_src=192.168.1.3", gotoTableAction},
 		&ExpectFlow{"priority=200,arp,arp_tpa=192.168.2.1,arp_op=1", "move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],set_field:aa:bb:cc:dd:ee:ff->eth_src,load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],set_field:aa:bb:cc:dd:ee:ff->arp_sha,move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],set_field:192.168.2.1->arp_spa,IN_PORT"},
 		&ExpectFlow{"priority=190,arp", "NORMAL"},
-		&ExpectFlow{"priority=200,tcp", fmt.Sprintf("learn(table=%d,idle_timeout=10,priority=190,delete_learned,cookie=0x1,eth_type=0x800,nw_proto=6,NXM_OF_TCP_DST[],NXM_NX_REG0[0..15]=0xfff,load:NXM_NX_REG0[0..15]->NXM_NX_REG0[0..15],load:0xffe->NXM_NX_REG0[16..31]),resubmit(,%d)", table.GetID(), table.GetID())},
+		&ExpectFlow{"priority=200,tcp", fmt.Sprintf("learn(table=%d,idle_timeout=10,priority=190,delete_learned,cookie=0x1,eth_type=0x800,nw_proto=6,NXM_OF_TCP_DST[],NXM_NX_REG0[0..15]=0xfff,load:NXM_NX_REG0[0..15]->NXM_NX_REG0[0..15],load:0xffe->NXM_NX_REG0[16..31]),goto_table:%d", table.GetID(), table.GetID())},
 		&ExpectFlow{"priority=200,ip", fmt.Sprintf("ct(table=%d,zone=65520)", table.GetNext())},
-		&ExpectFlow{"priority=210,ct_state=-new+trk,ct_mark=0x20,ip,reg0=0x1/0xffff", resubmitAction},
+		&ExpectFlow{"priority=210,ct_state=-new+trk,ct_mark=0x20,ip,reg0=0x1/0xffff", gotoTableAction},
 		&ExpectFlow{"priority=200,ct_state=+new+trk,ip,reg0=0x1/0xffff", fmt.Sprintf("ct(commit,table=%d,zone=65520,exec(load:0x20->NXM_NX_CT_MARK[])", table.GetNext())},
-		&ExpectFlow{"priority=200,ct_state=-new+trk,ct_mark=0x20,ip", fmt.Sprintf("load:0xaaaaaaaaaa11->NXM_OF_ETH_DST[],%s", resubmitAction)},
+		&ExpectFlow{"priority=200,ct_state=-new+trk,ct_mark=0x20,ip", fmt.Sprintf("load:0xaaaaaaaaaa11->NXM_OF_ETH_DST[],%s", gotoTableAction)},
 		&ExpectFlow{"priority=200,ct_state=+new+inv,ip", "drop"},
 		&ExpectFlow{"priority=190,ct_state=+new+trk,ip", fmt.Sprintf("ct(commit,table=%d,zone=65520)", table.GetNext())},
-		&ExpectFlow{"priority=200,ip,dl_dst=aa:bb:cc:dd:ee:ff,nw_dst=192.168.1.3", fmt.Sprintf("set_field:aa:aa:aa:aa:aa:11->eth_src,set_field:aa:aa:aa:aa:aa:13->eth_dst,dec_ttl,%s", resubmitAction)},
-		&ExpectFlow{"priority=200,ip,nw_dst=192.168.2.0/24", fmt.Sprintf("dec_ttl,set_field:aa:aa:aa:aa:aa:11->eth_src,set_field:aa:bb:cc:dd:ee:ff->eth_dst,set_field:10.1.1.2->tun_dst,%s", resubmitAction)},
-		&ExpectFlow{"priority=200,ip,nw_dst=192.168.1.1", fmt.Sprintf("set_field:aa:aa:aa:aa:aa:11->eth_dst,%s", resubmitAction)},
-		&ExpectFlow{"priority=200,dl_dst=aa:aa:aa:aa:aa:13", fmt.Sprintf("load:0x3->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],%s", resubmitAction)},
+		&ExpectFlow{"priority=200,ip,dl_dst=aa:bb:cc:dd:ee:ff,nw_dst=192.168.1.3", fmt.Sprintf("set_field:aa:aa:aa:aa:aa:11->eth_src,set_field:aa:aa:aa:aa:aa:13->eth_dst,dec_ttl,%s", gotoTableAction)},
+		&ExpectFlow{"priority=200,ip,nw_dst=192.168.2.0/24", fmt.Sprintf("dec_ttl,set_field:aa:aa:aa:aa:aa:11->eth_src,set_field:aa:bb:cc:dd:ee:ff->eth_dst,set_field:10.1.1.2->tun_dst,%s", gotoTableAction)},
+		&ExpectFlow{"priority=200,ip,nw_dst=192.168.1.1", fmt.Sprintf("set_field:aa:aa:aa:aa:aa:11->eth_dst,%s", gotoTableAction)},
+		&ExpectFlow{"priority=200,dl_dst=aa:aa:aa:aa:aa:13", fmt.Sprintf("load:0x3->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],%s", gotoTableAction)},
 		&ExpectFlow{"priority=200,ip,reg0=0x10000/0x10000", "output:NXM_NX_REG1[]"},
 		&ExpectFlow{"priority=200,ip,nw_dst=172.16.0.0/16", "output:1"},
 		&ExpectFlow{"priority=220,tcp,tp_dst=8080", "conjunction(1001,3/3)"},
@@ -719,8 +719,8 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 		&ExpectFlow{"priority=220,ip,nw_dst=192.168.3.0/24", "conjunction(1001,2/3)"},
 		&ExpectFlow{"priority=220,ip", "conjunction(1001,1/3)"},
 		&ExpectFlow{"priority=220,ip,reg1=0x3", "conjunction(1001,2/3)"},
-		&ExpectFlow{"priority=220,conj_id=1001,ip", resubmitAction},
-		&ExpectFlow{"priority=220,conj_id=1001,ip,nw_src=192.168.1.1", resubmitAction},
+		&ExpectFlow{"priority=220,conj_id=1001,ip", gotoTableAction},
+		&ExpectFlow{"priority=220,conj_id=1001,ip,nw_src=192.168.1.1", gotoTableAction},
 	)
 
 	return flows, flowStrs

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -120,7 +120,7 @@ func prepareOverlapFlows(table binding.Table, ipStr string, sameCookie bool) ([]
 	expectFlows := []*ExpectFlow{
 		{"priority=200,ip", "drop"},
 		{fmt.Sprintf("priority=200,ip,nw_src=%s", ipStr),
-			fmt.Sprintf("goto_table:%d)", table.GetNext())},
+			fmt.Sprintf("goto_table:%d", table.GetNext())},
 	}
 	return flows, expectFlows
 }


### PR DESCRIPTION
This PR introduce goto_table instruction and is a part of PR #326.

goto_table will be used In most of pipeline.
But keep resubmit in some cases.
i.e.) Resubmit packets to a previous table or the same table in learn flows.