### PR TITLE
Use json output annotations for yaml in antctl

### DIFF
--- a/pkg/agent/apiserver/handlers/ovsflows/handler.go
+++ b/pkg/agent/apiserver/handlers/ovsflows/handler.go
@@ -26,7 +26,7 @@ import (
 
 // Response is the response struct of ovsflows command.
 type Response struct {
-	Flow string `json:"flow,omitempty" yaml:"flow,omitempty"`
+	Flow string `json:"flow,omitempty"`
 }
 
 func getAllFlows(aq querier.AgentQuerier) ([]Response, error) {

--- a/pkg/agent/apiserver/handlers/podinterface/handler.go
+++ b/pkg/agent/apiserver/handlers/podinterface/handler.go
@@ -25,14 +25,14 @@ import (
 
 // Response describes the response struct of pod-interface command.
 type Response struct {
-	PodName       string `json:"name,omitempty" yaml:"name,omitempty" antctl:"name,Name of the Pod"`
-	PodNamespace  string `json:"podNamespace,omitempty" yaml:"podNamespace,omitempty"`
-	InterfaceName string `json:"interfaceName,omitempty" yaml:"interfaceName,omitempty"`
-	IP            string `json:"ip,omitempty" yaml:"ip,omitempty"`
-	MAC           string `json:"mac,omitempty" yaml:"mac,omitempty"`
-	PortUUID      string `json:"portUUID,omitempty" yaml:"portUUID,omitempty"`
-	OFPort        int32  `json:"ofPort,omitempty" yaml:"ofPort,omitempty"`
-	ContainerID   string `json:"containerID,omitempty" yaml:"containerID,omitempty"`
+	PodName       string `json:"name,omitempty" antctl:"name,Name of the Pod"`
+	PodNamespace  string `json:"podNamespace,omitempty"`
+	InterfaceName string `json:"interfaceName,omitempty"`
+	IP            string `json:"ip,omitempty"`
+	MAC           string `json:"mac,omitempty"`
+	PortUUID      string `json:"portUUID,omitempty"`
+	OFPort        int32  `json:"ofPort,omitempty"`
+	ContainerID   string `json:"containerID,omitempty"`
 }
 
 func generateResponse(i *interfacestore.InterfaceConfig) Response {

--- a/pkg/antctl/command_definition_test.go
+++ b/pkg/antctl/command_definition_test.go
@@ -42,7 +42,7 @@ import (
 )
 
 type Foobar struct {
-	Foo string
+	Foo string `json:"foo"`
 }
 
 func TestCommandList_tableOutputForGetCommands(t *testing.T) {
@@ -129,7 +129,7 @@ kube-system/antrea-agent-0 node-worker Healthy 192.168.1.0/24,192.168.1.1/24 1  
 		{
 			name:            "StructureData-NonTableOutput-Single",
 			rawResponseData: Foobar{Foo: "foo"},
-			expected: `Foo            
+			expected: `foo            
 foo            
 `,
 		},
@@ -139,7 +139,7 @@ foo
 				{Foo: "foo1"},
 				{Foo: "foo2"},
 			},
-			expected: `Foo            
+			expected: `foo            
 foo1           
 foo2           
 `,
@@ -310,21 +310,21 @@ func TestFormat(t *testing.T) {
 			},
 			rawResponseData: &Foobar{Foo: "foo"},
 			responseStruct:  reflect.TypeOf(struct{ Bar string }{}),
-			expected:        "bar: foo\n",
+			expected:        "Bar: foo\n",
 			formatter:       yamlFormatter,
 		},
 		{
 			name:            "StructureData-NoTransform-List-Table",
 			rawResponseData: []Foobar{{Foo: "foo"}, {Foo: "bar"}},
 			responseStruct:  reflect.TypeOf(Foobar{}),
-			expected:        "Foo            \nfoo            \nbar            \n",
+			expected:        "foo            \nfoo            \nbar            \n",
 			formatter:       tableFormatter,
 		},
 		{
 			name:            "StructureData-NoTransform-List-Table-Struct",
 			rawResponseData: []struct{ Foo Foobar }{{Foo: Foobar{"foo"}}, {Foo: Foobar{"bar"}}},
 			responseStruct:  reflect.TypeOf(struct{ Foo Foobar }{}),
-			expected:        "Foo            \n{\"Foo\":\"foo\"}  \n{\"Foo\":\"bar\"}  \n",
+			expected:        "Foo            \n{\"foo\":\"foo\"}  \n{\"foo\":\"bar\"}  \n",
 			formatter:       tableFormatter,
 		},
 	} {

--- a/pkg/antctl/transform/addressgroup/transform.go
+++ b/pkg/antctl/transform/addressgroup/transform.go
@@ -25,7 +25,7 @@ import (
 
 type Response struct {
 	Name string                  `json:"name" yaml:"name"`
-	Pods []common.GroupMemberPod `json:"pods,omitempty" yaml:"pods,omitempty"`
+	Pods []common.GroupMemberPod `json:"pods,omitempty"`
 }
 
 func listTransform(l interface{}) (interface{}, error) {

--- a/pkg/antctl/transform/appliedtogroup/transform.go
+++ b/pkg/antctl/transform/appliedtogroup/transform.go
@@ -25,7 +25,7 @@ import (
 
 type Response struct {
 	Name string                  `json:"name" yaml:"name"`
-	Pods []common.GroupMemberPod `json:"pods,omitempty" yaml:"pods,omitempty"`
+	Pods []common.GroupMemberPod `json:"pods,omitempty"`
 }
 
 func listTransform(l interface{}) (interface{}, error) {

--- a/pkg/antctl/transform/common/transform.go
+++ b/pkg/antctl/transform/common/transform.go
@@ -24,11 +24,11 @@ import (
 )
 
 type GroupMemberPod struct {
-	Pod *networkingv1beta1.PodReference `json:"pod,omitempty" yaml:"pod,omitempty"`
+	Pod *networkingv1beta1.PodReference `json:"pod,omitempty"`
 	// IP maintains the IPAddress associated with the Pod.
-	IP string `json:"ip,omitempty" yaml:"ip,omitempty"`
+	IP string `json:"ip,omitempty"`
 	// Ports maintain the named port mapping of this Pod.
-	Ports []networkingv1beta1.NamedPort `json:"ports,omitempty" yaml:"ports,omitempty"`
+	Ports []networkingv1beta1.NamedPort `json:"ports,omitempty"`
 }
 
 func GroupMemberPodTransform(pod networkingv1beta1.GroupMemberPod) GroupMemberPod {

--- a/pkg/antctl/transform/rule/transform.go
+++ b/pkg/antctl/transform/rule/transform.go
@@ -21,25 +21,25 @@ import (
 )
 
 type service struct {
-	Protocol string `json:"protocol,omitempty" yaml:"protocol,omitempty"`
-	Port     string `json:"port,omitempty" yaml:"port,omitempty"`
+	Protocol string `json:"protocol,omitempty"`
+	Port     string `json:"port,omitempty"`
 }
 
 type ipBlock struct {
 	CIDR   string   `json:"cidr" yaml:"cidr"`
-	Except []string `json:"except,omitempty" yaml:"except,omitempty"`
+	Except []string `json:"except,omitempty"`
 }
 
 type peer struct {
-	AddressGroups []string  `json:"addressGroups,omitempty" yaml:"addressGroups,omitempty"`
+	AddressGroups []string  `json:"addressGroups,omitempty"`
 	IPBlocks      []ipBlock `json:"ipBlocks,omitempty" json:"ipBlocks,omitempty"`
 }
 
 type Response struct {
-	Direction string    `json:"direction,omitempty" yaml:"direction,omitempty"`
-	From      peer      `json:"from,omitempty" yaml:"from,omitempty"`
-	To        peer      `json:"to,omitempty" yaml:"to,omitempty"`
-	Services  []service `json:"services,omitempty" yaml:"services,omitempty"`
+	Direction string    `json:"direction,omitempty"`
+	From      peer      `json:"from,omitempty"`
+	To        peer      `json:"to,omitempty"`
+	Services  []service `json:"services,omitempty"`
 }
 
 func serviceTransform(services ...networkingv1beta1.Service) []service {

--- a/pkg/antctl/transform/version/transform.go
+++ b/pkg/antctl/transform/version/transform.go
@@ -27,9 +27,9 @@ import (
 )
 
 type Response struct {
-	AgentVersion      string `json:"agentVersion,omitempty" yaml:"agentVersion,omitempty"`
-	ControllerVersion string `json:"controllerVersion,omitempty" yaml:"controllerVersion,omitempty"`
-	AntctlVersion     string `json:"antctlVersion,omitempty" yaml:"antctlVersion,omitempty"`
+	AgentVersion      string `json:"agentVersion,omitempty"`
+	ControllerVersion string `json:"controllerVersion,omitempty"`
+	AntctlVersion     string `json:"antctlVersion,omitempty"`
 }
 
 // AgentVersion is the AddonTransform for the version command. This function


### PR DESCRIPTION
- Made YAML output generated by JSON output
- Removed un-needed YAML annotations

Signed-off-by: Weiqiang TANG <weiqiangt@vmware.com>