### PR TITLE
Apply authentication to agent apiserver endpoint

### DIFF
--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -82,6 +82,16 @@ rules:
   - system.antrea.tanzu.vmware.com
   resources:
   - controllerinfos
+  - agentinfos
+  verbs:
+  - get
+- nonResourceURLs:
+  - /agentinfo
+  - /addressgroups
+  - /appliedtogroups
+  - /networkpolicies
+  - /ovsflows
+  - /podinterfaces
   verbs:
   - get
 ---
@@ -120,6 +130,18 @@ rules:
   - get
   - watch
   - list
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -180,6 +202,22 @@ kind: RoleBinding
 metadata:
   labels:
     app: antrea
+  name: antrea-agent-authentication-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: antrea-agent
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: antrea
   name: antrea-controller-authentication-reader
   namespace: kube-system
 roleRef:
@@ -208,6 +246,9 @@ subjects:
   namespace: kube-system
 - kind: ServiceAccount
   name: antrea-controller
+  namespace: kube-system
+- kind: ServiceAccount
+  name: antrea-agent
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -82,6 +82,16 @@ rules:
   - system.antrea.tanzu.vmware.com
   resources:
   - controllerinfos
+  - agentinfos
+  verbs:
+  - get
+- nonResourceURLs:
+  - /agentinfo
+  - /addressgroups
+  - /appliedtogroups
+  - /networkpolicies
+  - /ovsflows
+  - /podinterfaces
   verbs:
   - get
 ---
@@ -120,6 +130,18 @@ rules:
   - get
   - watch
   - list
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -180,6 +202,22 @@ kind: RoleBinding
 metadata:
   labels:
     app: antrea
+  name: antrea-agent-authentication-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: antrea-agent
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: antrea
   name: antrea-controller-authentication-reader
   namespace: kube-system
 roleRef:
@@ -208,6 +246,9 @@ subjects:
   namespace: kube-system
 - kind: ServiceAccount
   name: antrea-controller
+  namespace: kube-system
+- kind: ServiceAccount
+  name: antrea-agent
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -82,6 +82,16 @@ rules:
   - system.antrea.tanzu.vmware.com
   resources:
   - controllerinfos
+  - agentinfos
+  verbs:
+  - get
+- nonResourceURLs:
+  - /agentinfo
+  - /addressgroups
+  - /appliedtogroups
+  - /networkpolicies
+  - /ovsflows
+  - /podinterfaces
   verbs:
   - get
 ---
@@ -120,6 +130,18 @@ rules:
   - get
   - watch
   - list
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -180,6 +202,22 @@ kind: RoleBinding
 metadata:
   labels:
     app: antrea
+  name: antrea-agent-authentication-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: antrea-agent
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: antrea
   name: antrea-controller-authentication-reader
   namespace: kube-system
 roleRef:
@@ -208,6 +246,9 @@ subjects:
   namespace: kube-system
 - kind: ServiceAccount
   name: antrea-controller
+  namespace: kube-system
+- kind: ServiceAccount
+  name: antrea-agent
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -82,6 +82,16 @@ rules:
   - system.antrea.tanzu.vmware.com
   resources:
   - controllerinfos
+  - agentinfos
+  verbs:
+  - get
+- nonResourceURLs:
+  - /agentinfo
+  - /addressgroups
+  - /appliedtogroups
+  - /networkpolicies
+  - /ovsflows
+  - /podinterfaces
   verbs:
   - get
 ---
@@ -120,6 +130,18 @@ rules:
   - get
   - watch
   - list
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -180,6 +202,22 @@ kind: RoleBinding
 metadata:
   labels:
     app: antrea
+  name: antrea-agent-authentication-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: antrea-agent
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: antrea
   name: antrea-controller-authentication-reader
   namespace: kube-system
 roleRef:
@@ -208,6 +246,9 @@ subjects:
   namespace: kube-system
 - kind: ServiceAccount
   name: antrea-controller
+  namespace: kube-system
+- kind: ServiceAccount
+  name: antrea-agent
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/build/yamls/base/agent-rbac.yml
+++ b/build/yamls/base/agent-rbac.yml
@@ -38,6 +38,18 @@ rules:
       - get
       - watch
       - list
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -47,6 +59,20 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: antrea-agent
+subjects:
+  - kind: ServiceAccount
+    name: antrea-agent
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: antrea-agent-authentication-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
 subjects:
   - kind: ServiceAccount
     name: antrea-agent

--- a/build/yamls/base/antctl.yml
+++ b/build/yamls/base/antctl.yml
@@ -23,6 +23,16 @@ rules:
       - system.antrea.tanzu.vmware.com
     resources:
       - controllerinfos
+      - agentinfos
+    verbs:
+      - get
+  - nonResourceURLs:
+      - /agentinfo
+      - /addressgroups
+      - /appliedtogroups
+      - /networkpolicies
+      - /ovsflows
+      - /podinterfaces
     verbs:
       - get
 ---
@@ -46,4 +56,10 @@ subjects:
     # and authenticate with Controller API server using the Controller's
     # ServiceAccount token.
     name: antrea-controller
+    namespace: kube-system
+  - kind: ServiceAccount
+    # This is to allow antctl to be executed inside the Antrea Agent Pod
+    # and authenticate with agent API server using the agent's
+    # ServiceAccount token.
+    name: antrea-agent
     namespace: kube-system

--- a/pkg/agent/apiserver/apiserver.go
+++ b/pkg/agent/apiserver/apiserver.go
@@ -77,27 +77,36 @@ func New(aq agentquerier.AgentQuerier, npq querier.AgentNetworkPolicyInfoQuerier
 
 func newConfig(bindPort int) (*genericapiserver.CompletedConfig, error) {
 	secureServing := genericoptions.NewSecureServingOptions().WithLoopback()
+	authentication := genericoptions.NewDelegatingAuthenticationOptions()
+	authorization := genericoptions.NewDelegatingAuthorizationOptions()
+
 	// Set the PairName but leave certificate directory blank to generate in-memory by default.
 	secureServing.ServerCert.CertDirectory = ""
 	secureServing.ServerCert.PairName = Name
-	secureServing.BindAddress = net.ParseIP("127.0.0.1")
 	secureServing.BindPort = bindPort
+
 	if err := secureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
+	serverConfig := genericapiserver.NewConfig(codecs)
+	if err := secureServing.ApplyTo(&serverConfig.SecureServing, &serverConfig.LoopbackClientConfig); err != nil {
+		return nil, err
+	}
+	if err := authentication.ApplyTo(&serverConfig.Authentication, serverConfig.SecureServing, nil); err != nil {
+		return nil, err
+	}
+	if err := authorization.ApplyTo(&serverConfig.Authorization); err != nil {
+		return nil, err
+	}
 	v := antreaversion.GetVersion()
-	serverCfg := genericapiserver.NewConfig(codecs)
-	serverCfg.Version = &k8sversion.Info{
+	serverConfig.Version = &k8sversion.Info{
 		Major:        fmt.Sprint(v.Major),
 		Minor:        fmt.Sprint(v.Minor),
 		GitVersion:   v.String(),
 		GitTreeState: antreaversion.GitTreeState,
 		GitCommit:    antreaversion.GetGitSHA(),
 	}
-	if err := secureServing.ApplyTo(&serverCfg.SecureServing, &serverCfg.LoopbackClientConfig); err != nil {
-		return nil, err
-	}
 
-	completedServerCfg := serverCfg.Complete(nil)
+	completedServerCfg := serverConfig.Complete(nil)
 	return &completedServerCfg, nil
 }


### PR DESCRIPTION
Antrea agent uses apiserver to interact with antctl. However, unlike the
controller, the API endpoint is exposed only locally which limits antctl
to local execution.
Additionally, we would like to reuse the listener for Prometheus metrics,
which would require external access to the API endpoint's metrics path.

Having authentication in a similar way to the controller's implementation
could help here as it will allow external exposure of the API endpoint.

Fixes: #613 