### PR TITLE
Add clear error message for antctl

### DIFF
--- a/pkg/agent/apiserver/handlers/networkpolicy/handler.go
+++ b/pkg/agent/apiserver/handlers/networkpolicy/handler.go
@@ -29,7 +29,7 @@ func HandleFunc(npq querier.AgentNetworkPolicyInfoQuerier) http.HandlerFunc {
 		name := r.URL.Query().Get("name")
 		ns := r.URL.Query().Get("namespace")
 		if len(name) > 0 && len(ns) == 0 {
-			w.WriteHeader(http.StatusBadRequest)
+			http.Error(w, "an empty namespace may not be set when a resource name is provided", http.StatusBadRequest)
 			return
 		}
 

--- a/pkg/antctl/client.go
+++ b/pkg/antctl/client.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/rest"
@@ -105,15 +106,15 @@ func (c *client) nonResourceRequest(e *nonResourceEndpoint, opt *requestOption) 
 	}
 	u.RawQuery = q.Encode()
 	getter := restClient.Get().RequestURI(u.RequestURI()).Timeout(opt.timeout)
-	result := getter.Do()
-	if result.Error() != nil {
-		return nil, generateMessage(opt, result)
-	}
-	raw, err := result.Raw()
+	result, err := getter.DoRaw()
 	if err != nil {
-		return nil, err
+		statusErr, ok := err.(*errors.StatusError)
+		if !ok {
+			return nil, err
+		}
+		return nil, generateMessageForStatusErr(opt.commandDefinition, opt.args, statusErr)
 	}
-	return bytes.NewReader(raw), nil
+	return bytes.NewReader(result), nil
 }
 
 func (c *client) resourceRequest(e *resourceEndpoint, opt *requestOption) (io.Reader, error) {

--- a/pkg/antctl/command_definition.go
+++ b/pkg/antctl/command_definition.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"reflect"
 	"sort"
@@ -573,9 +572,6 @@ func (cd *commandDefinition) collectFlags(cmd *cobra.Command, args []string) (ma
 	}
 	if cd.namespaced() {
 		argMap["namespace"], _ = cmd.Flags().GetString("namespace")
-		if len(argMap["name"]) > 0 && len(argMap["namespace"]) == 0 {
-			return nil, generate(cd, argMap, http.StatusBadRequest)
-		}
 	}
 	return argMap, nil
 }

--- a/pkg/antctl/command_message_test.go
+++ b/pkg/antctl/command_message_test.go
@@ -63,7 +63,7 @@ func TestGenerate(t *testing.T) {
 			expected: `BadRequest: Please check the args for foo`,
 		},
 	} {
-		generated := generate(tc.cd, tc.args, tc.code)
+		generated := generate(tc.cd, tc.args, tc.code, "")
 		assert.Equal(t, tc.expected, generated.Error())
 	}
 }


### PR DESCRIPTION
- Add clear antctl error message from k8s:

Before:
```shell
$ sudo ./bin/antctl-linux get netpol --kubeconfig /etc/kubernetes/kubelet.conf
Error: Unknown error

$ sudo ./bin/antctl-linux get netpol sdf
Error: BadRequest: Please check the args for networkpolicy
```

After:
```shell
$ sudo ./bin/antctl-linux get netpol --kubeconfig /etc/kubernetes/kubelet.conf
Error: Forbidden: networkpolicies.networking.antrea.tanzu.vmware.com is forbidden: User "system:node:k8s-master" cannot list resource "networkpolicies" in API group "networking.antrea.tanzu.vmware.com" at the cluster scope

$ sudo ./bin/antctl-linux get netpol sdf
Error: an empty namespace may not be set when a resource name is provided
```

Fixes #612 