### PR TITLE
Compliance to k8s log format in antrea-agent pod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/j-keck/arping v1.0.0
 	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd
 	github.com/satori/go.uuid v1.2.0
+	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3
 	github.com/streamrail/concurrent-map v0.0.0-20160823150647-8bf1e9bacbf6 // indirect

--- a/pkg/ovs/openflow/logs.go
+++ b/pkg/ovs/openflow/logs.go
@@ -1,0 +1,68 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openflow
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type logFormat struct {
+	TimestampFormat string
+}
+
+// Format fomats logrus log in compliance with k8s log
+func (f *logFormat) Format(entry *logrus.Entry) ([]byte, error) {
+
+	b := &bytes.Buffer{}
+
+	filePath := entry.Caller.File
+	filePathArray := strings.Split(filePath, "/")
+	fileName := filePathArray[len(filePathArray)-1]
+
+	pidString := strconv.Itoa(os.Getpid())
+
+	// logrus has seven logging levels: Trace, Debug, Info, Warning, Error, Fatal and Panic.
+	b.WriteString(strings.ToUpper(entry.Level.String()[:1]))
+	b.WriteString(entry.Time.Format("0102 15:04:05.000000"))
+	b.WriteString(" ")
+	for i := 0; i < (7 - len(pidString)); i++ {
+		b.WriteString(" ")
+	}
+	b.WriteString(pidString)
+	b.WriteString(" ")
+	b.WriteString(fileName)
+	b.WriteString(":")
+	fmt.Fprint(b, entry.Caller.Line)
+	b.WriteString("] ")
+
+	if entry.Message != "" {
+		b.WriteString(entry.Message)
+	}
+
+	b.WriteByte('\n')
+	return b.Bytes(), nil
+}
+
+func init() {
+	logrus.SetReportCaller(true)
+	formatter := logFormat{}
+	formatter.TimestampFormat = "2006-01-02 15:04:05"
+	logrus.SetFormatter(&formatter)
+}

--- a/pkg/ovs/openflow/logs.go
+++ b/pkg/ovs/openflow/logs.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Antrea Authors
+// Copyright 2020 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,25 +17,21 @@ package openflow
 import (
 	"bytes"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
-type logFormat struct {
-	TimestampFormat string
-}
+type klogFormatter struct {}
 
 // Format fomats logrus log in compliance with k8s log
-func (f *logFormat) Format(entry *logrus.Entry) ([]byte, error) {
-
+func (f *klogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	b := &bytes.Buffer{}
-
 	filePath := entry.Caller.File
 	filePathArray := strings.Split(filePath, "/")
 	fileName := filePathArray[len(filePathArray)-1]
-
 	pidString := strconv.Itoa(os.Getpid())
 
 	// logrus has seven logging levels: Trace, Debug, Info, Warning, Error, Fatal and Panic.
@@ -51,18 +47,15 @@ func (f *logFormat) Format(entry *logrus.Entry) ([]byte, error) {
 	b.WriteString(":")
 	fmt.Fprint(b, entry.Caller.Line)
 	b.WriteString("] ")
-
 	if entry.Message != "" {
 		b.WriteString(entry.Message)
 	}
-
 	b.WriteByte('\n')
+
 	return b.Bytes(), nil
 }
 
 func init() {
 	logrus.SetReportCaller(true)
-	formatter := logFormat{}
-	formatter.TimestampFormat = "2006-01-02 15:04:05"
-	logrus.SetFormatter(&formatter)
+	logrus.SetFormatter(&klogFormatter{})
 }

--- a/pkg/ovs/openflow/logs.go
+++ b/pkg/ovs/openflow/logs.go
@@ -24,7 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type klogFormatter struct {}
+type klogFormatter struct{}
 
 // Format fomats logrus log in compliance with k8s log
 func (f *klogFormatter) Format(entry *logrus.Entry) ([]byte, error) {

--- a/pkg/ovs/openflow/logs.go
+++ b/pkg/ovs/openflow/logs.go
@@ -26,7 +26,7 @@ import (
 
 type klogFormatter struct{}
 
-// Format fomats logrus log in compliance with k8s log
+// Format formats logrus log in compliance with k8s log.
 func (f *klogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	b := &bytes.Buffer{}
 	filePath := entry.Caller.File


### PR DESCRIPTION
logrus is used in some packages of Antrea-agent then it used different format of logging.
This introduces log formatting for logrus in compliance with k8s log.

Implementation of PR: #593

Signed-off-by: Yuki Tsuboi <ytsuboi@vmware.com>

Before
```
I0327 15:52:23.347943       1 agent.go:50] Starting Antrea agent (version v0.5.0-dev-14e8160.dirty)
I0327 15:52:23.348015       1 client.go:33] No kubeconfig file was specified. Falling back to in-cluster config
I0327 15:52:23.349598       1 client.go:23] No antrea kubeconfig file was specified. Falling back to in-cluster config
I0327 15:52:23.349706       1 ovs_client.go:66] Connecting to OVSDB at address /run/openvswitch/db.sock
I0327 15:52:24.350008       1 ovs_client.go:85] Not connected yet, will try again in 2s
I0327 15:52:24.351968       1 agent.go:165] Setting up node network
I0327 15:52:24.366764       1 ovs_client.go:107] Bridge exists: f0354da4-8e8c-4876-a82d-125122a08219
I0327 15:52:24.368084       1 agent.go:559] Using round number 49
time="2020-03-27T15:52:24Z" level=info msg="Initialize connection or re-connect to /var/run/openvswitch/br-int.mgmt."
time="2020-03-27T15:52:25Z" level=info msg="Connected to socket /var/run/openvswitch/br-int.mgmt"
time="2020-03-27T15:52:25Z" level=info msg="New connection.."
time="2020-03-27T15:52:25Z" level=info msg="Send hello with OF version: 4"
time="2020-03-27T15:52:25Z" level=info msg="Received Openflow 1.3 Hello message"
time="2020-03-27T15:52:25Z" level=info msg="Received ofp1.3 Switch feature response: {Header:{Version:4 Type:6 Length:32 Xid:3} DPID:00:00:a6:4d:35:f0:76:48 Buffers:0 NumTables:254 AuxilaryId:0 pad:[0 0] Capabilities:79 Actions:0 Ports:[]}"
time="2020-03-27T15:52:25Z" level=info msg="Openflow Connection for new switch: 00:00:a6:4d:35:f0:76:48"
I0327 15:52:25.371461       1 ofctrl_bridge.go:178] OFSwitch is connected: 00:00:a6:4d:35:f0:76:48
```

After
```
I0415 16:22:18.520654       1 agent.go:51] Starting Antrea agent (version v0.6.0-dev-78108bb.dirty)
I0415 16:22:18.520880       1 client.go:33] No kubeconfig file was specified. Falling back to in-cluster config
I0415 16:22:18.521973       1 client.go:23] No antrea kubeconfig file was specified. Falling back to in-cluster config
I0415 16:22:18.522042       1 ovs_client.go:66] Connecting to OVSDB at address /run/openvswitch/db.sock
I0415 16:22:19.522270       1 ovs_client.go:85] Not connected yet, will try again in 2s
I0415 16:22:19.523898       1 agent.go:165] Setting up node network
I0415 16:22:19.536383       1 ovs_client.go:107] Bridge exists: 6729ccfc-9438-45dc-a184-252a2016ebfe
I0415 16:22:19.537518       1 agent.go:559] Using round number 5
I0415 16:22:19.537632       1 ofctrl.go:166] Initialize connection or re-connect to /var/run/openvswitch/br-int.mgmt.
I0415 16:22:20.537995       1 ofctrl.go:181] Connected to socket /var/run/openvswitch/br-int.mgmt
I0415 16:22:20.538908       1 ofctrl.go:243] New connection..
I0415 16:22:20.538947       1 ofctrl.go:250] Send hello with OF version: 4
I0415 16:22:20.539030       1 ofctrl.go:264] Received Openflow 1.3 Hello message
I0415 16:22:20.540419       1 ofctrl.go:281] Received ofp1.3 Switch feature response: {Header:{Version:4 Type:6 Length:32 Xid:3} DPID:00:00:fe:cc:29:67:dc:45 Buffers:0 NumTables:254 AuxilaryId:0 pad:[0 0] Capabilities:79 Actions:0 Ports:[]}
I0415 16:22:20.540477       1 ofSwitch.go:80] Openflow Connection for new switch: 00:00:fe:cc:29:67:dc:45
I0415 16:22:20.540546       1 ofctrl_bridge.go:195] OFSwitch is connected: 00:00:fe:cc:29:67:dc:45
```

