### PR TITLE
Acquire xtables.lock before executing iptables-restore

### DIFF
--- a/pkg/agent/util/iptables/lock.go
+++ b/pkg/agent/util/iptables/lock.go
@@ -1,0 +1,50 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iptables
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	xtablesLockFilePath       = "/var/run/xtables.lock"
+	xtablesLockFilePermission = 0600
+)
+
+// lock acquires the provided file lock. It's thread-safe.
+// It will block until the lock is acquired or the timeout is reached.
+func lock(lockFilePath string, timeout time.Duration) (func() error, error) {
+	lockFile, err := os.OpenFile(lockFilePath, os.O_CREATE, xtablesLockFilePermission)
+	if err != nil {
+		return nil, fmt.Errorf("error opening xtables lock file: %v", err)
+	}
+
+	// Check whether the lock is available every 200ms.
+	if err := wait.PollImmediate(200*time.Millisecond, timeout, func() (bool, error) {
+		if err := unix.Flock(int(lockFile.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		lockFile.Close()
+		return nil, fmt.Errorf("error acquiring xtables lock: %v", err)
+	}
+	return lockFile.Close, nil
+}

--- a/pkg/agent/util/iptables/lock_test.go
+++ b/pkg/agent/util/iptables/lock_test.go
@@ -1,0 +1,88 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iptables
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+func TestLock(t *testing.T) {
+	filePath1 := "/tmp/xtables.lock." + rand.String(8)
+	filePath2 := "/tmp/xtables.lock." + rand.String(8)
+	filePath3 := "/tmp/xtables.lock." + rand.String(8)
+	filePath4 := "/tmp/xtables.lock." + rand.String(8)
+	tests := []struct {
+		name         string
+		lockFilePath string
+		prepareFunc  func(filePath string)
+		wantErr      bool
+	}{
+		{
+			name:         "non-existing-lock",
+			lockFilePath: filePath1,
+			wantErr:      false,
+		},
+		{
+			name:         "lock-already-acquired",
+			lockFilePath: filePath2,
+			prepareFunc: func(filePath string) {
+				lock(filePath, 2*time.Second)
+			},
+			wantErr: true,
+		},
+		{
+			name:         "lock-already-released",
+			lockFilePath: filePath3,
+			prepareFunc: func(filePath string) {
+				unlockFunc, _ := lock(filePath, 2*time.Second)
+				unlockFunc()
+			},
+			wantErr: false,
+		},
+		{
+			name:         "lock-released-in-one-second",
+			lockFilePath: filePath4,
+			prepareFunc: func(filePath string) {
+				unlockFunc, _ := lock(filePath, 2*time.Second)
+				go func() {
+					time.Sleep(1 * time.Second)
+					unlockFunc()
+				}()
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer os.Remove(tt.lockFilePath)
+			if tt.prepareFunc != nil {
+				tt.prepareFunc(tt.lockFilePath)
+			}
+			unlockFunc, err := lock(tt.lockFilePath, 2*time.Second)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("lock() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				if err := unlockFunc(); err != nil {
+					t.Fatalf("unlock() error: %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
We need to acquire xtables lock explicitly for iptables-restore to
prevent it from conflicting with iptables/iptables-restore which might
being called by kube-proxy. iptables supports "--wait" option and
go-iptables has enabled it. iptables-restore doesn't support the option
until 1.6.2, but it's not widely deployed yet.

Besides, this PR logs the error instead of the command when executing
iptables-restore fails.

Fixes #632