### PR TITLE
Free disk space in some workflows with "apt-get clean"

### DIFF
--- a/.github/workflows/kind-upgrade.yml
+++ b/.github/workflows/kind-upgrade.yml
@@ -28,6 +28,11 @@ jobs:
     needs: build-antrea-image
     runs-on: [ubuntu-18.04]
     steps:
+    - name: Free disk space
+      # https://github.com/actions/virtual-environments/issues/709
+      run: |
+        sudo apt-get clean
+        df -h
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
       with:
@@ -54,6 +59,11 @@ jobs:
     needs: build-antrea-image
     runs-on: [ubuntu-18.04]
     steps:
+    - name: Free disk space
+      # https://github.com/actions/virtual-environments/issues/709
+      run: |
+        sudo apt-get clean
+        df -h
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
       with:
@@ -80,6 +90,11 @@ jobs:
     needs: build-antrea-image
     runs-on: [ubuntu-18.04]
     steps:
+    - name: Free disk space
+      # https://github.com/actions/virtual-environments/issues/709
+      run: |
+        sudo apt-get clean
+        df -h
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
       with:

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -28,6 +28,11 @@ jobs:
     needs: build-antrea-image
     runs-on: [ubuntu-18.04]
     steps:
+    - name: Free disk space
+      # https://github.com/actions/virtual-environments/issues/709
+      run: |
+        sudo apt-get clean
+        df -h
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
       with:
@@ -54,6 +59,11 @@ jobs:
     needs: build-antrea-image
     runs-on: [ubuntu-18.04]
     steps:
+    - name: Free disk space
+      # https://github.com/actions/virtual-environments/issues/709
+      run: |
+        sudo apt-get clean
+        df -h
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
       with:
@@ -80,6 +90,11 @@ jobs:
     needs: build-antrea-image
     runs-on: [ubuntu-18.04]
     steps:
+    - name: Free disk space
+      # https://github.com/actions/virtual-environments/issues/709
+      run: |
+        sudo apt-get clean
+        df -h
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
       with:
@@ -106,6 +121,11 @@ jobs:
     needs: build-antrea-image
     runs-on: [ubuntu-18.04]
     steps:
+    - name: Free disk space
+      # https://github.com/actions/virtual-environments/issues/709
+      run: |
+        sudo apt-get clean
+        df -h
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
       with:


### PR DESCRIPTION
A recent update to the Github VM images has caused our Kind tests to
fail because of a pretty significant reduction in the amount of disk
space available.

Many users have reported the issue to Github:
https://github.com/actions/virtual-environments/issues/709

The recommended workaround is to run "apt-get clean" which should free
up a significant amount of space. In our case, most of the disk usage
comes from docker images and containers, and we don't have an easy way
to use the /dev/sdb1 partition (guaranteed 14GB).

According to the Github team, they have started a rollback to the old
images, but it makes sense for us to merge this workaround anyway, to
avoid disruptions in the immediate future and to potentially have more
disk space available, should we need it later.

Fixes #635