### PR TITLE
Fix network policy overlapping issue

### DIFF
--- a/docs/ovs-pipeline.md
+++ b/docs/ovs-pipeline.md
@@ -363,8 +363,9 @@ to 2 in the above example (1 was allocated for the ingress rule of our Network
 Policy example).
 
 If the Network Policy specification includes exceptions (`except` field), then
-the table will include additional rules, but we will not cover them in this
-document.
+the table will include multiple flows with conjunctive match, corresponding to
+each cidr that is present in `from` or `to` fields, but not in `except` field.
+Network Policy implementation details are not covered in this document.
 
 If the `conjunction` action is matched, packets are "allowed" and resubmitted
 directly to [L3ForwardingTable]. Other packets go to [EgressDefaultTable]. If a

--- a/hack/netpol/pkg/utils/utils_test.go
+++ b/hack/netpol/pkg/utils/utils_test.go
@@ -11,8 +11,8 @@ func TestNetworkPolicyBuilder(t *testing.T) {
 	builder1 = builder1.SetName("x", "allow-client-a-via-ingress-pod-selector").SetPodSelector(map[string]string{"pod": "a"})
 	builder1.SetTypeIngress()
 	// Test UDP since its not a default.
-	builder1.AddIngress(v1.ProtocolUDP, &p80, nil, nil, map[string]string{"pod": "b"}, nil, nil, nil)
-	builder1.AddEgress(v1.ProtocolUDP, &p80, nil, nil, map[string]string{"pod": "b"}, nil, nil, nil)
+	builder1.AddIngress(v1.ProtocolUDP, &p80, nil, nil, nil, map[string]string{"pod": "b"}, nil, nil, nil)
+	builder1.AddEgress(v1.ProtocolUDP, &p80, nil, nil, nil, map[string]string{"pod": "b"}, nil, nil, nil)
 	policy1 := builder1.Get()
 
 	if policy1.Name != "allow-client-a-via-ingress-pod-selector" {

--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -177,7 +177,6 @@ func TestInstallPolicyRuleFlows(t *testing.T) {
 		Direction: v1beta1.DirectionOut,
 		From:      parseAddresses([]string{"192.168.1.40", "192.168.1.60"}),
 		To:        parseAddresses([]string{"192.168.2.0/24"}),
-		ExceptTo:  parseAddresses([]string{"192.168.2.100", "192.168.2.150"}),
 		Service:   []v1beta1.Service{npPort1, npPort2},
 	}
 	conj3 := &policyRuleConjunction{id: ruleID3}
@@ -198,8 +197,8 @@ func TestInstallPolicyRuleFlows(t *testing.T) {
 
 	err = c.InstallPolicyRuleFlows(ruleID3, rule3, "np1", "ns1")
 	require.Nil(t, err, "Failed to invoke InstallPolicyRuleFlows")
-	checkConjunctionConfig(t, ruleID3, 3, 2, 1, 2)
-	assert.Equal(t, 16, len(c.GetNetworkPolicyFlowKeys("np1", "ns1")))
+	checkConjunctionConfig(t, ruleID3, 1, 2, 1, 2)
+	assert.Equal(t, 14, len(c.GetNetworkPolicyFlowKeys("np1", "ns1")))
 
 	ctxChanges4 := conj.calculateChangesForRuleDeletion()
 	matchFlows4, dropFlows4 := getChangedFlows(ctxChanges4)
@@ -216,7 +215,7 @@ func TestInstallPolicyRuleFlows(t *testing.T) {
 	assert.Equal(t, 2, getChangedFlowOPCount(matchFlows5, deletion))
 	assert.Equal(t, 1, getChangedFlowOPCount(matchFlows5, modification))
 	err = c.applyConjunctiveMatchFlows(ctxChanges5)
-	assert.Equal(t, 13, len(c.GetNetworkPolicyFlowKeys("np1", "ns1")))
+	assert.Equal(t, 11, len(c.GetNetworkPolicyFlowKeys("np1", "ns1")))
 	require.Nil(t, err)
 }
 

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -640,6 +640,7 @@ func (c *client) addFlowMatch(fb binding.FlowBuilder, matchType int, matchValue 
 }
 
 // conjunctionExceptionFlow generates the flow to resubmit to a specific table if both policyRuleConjunction ID and except address are matched.
+// Keeping this for reference to generic exception flow.
 func (c *client) conjunctionExceptionFlow(conjunctionID uint32, tableID binding.TableIDType, nextTable binding.TableIDType, matchKey int, matchValue interface{}) binding.Flow {
 	fb := c.pipeline[tableID].BuildFlow(priorityNormal).MatchConjID(conjunctionID)
 	return c.addFlowMatch(fb, matchKey, matchValue).

--- a/pkg/agent/types/networkpolicy.go
+++ b/pkg/agent/types/networkpolicy.go
@@ -41,10 +41,8 @@ type Address interface {
 
 // PolicyRule groups configurations to set up conjunctive match for egress/ingress policy rules.
 type PolicyRule struct {
-	Direction  v1beta1.Direction
-	From       []Address
-	ExceptFrom []Address
-	To         []Address
-	ExceptTo   []Address
-	Service    []v1beta1.Service
+	Direction v1beta1.Direction
+	From      []Address
+	To        []Address
+	Service   []v1beta1.Service
 }

--- a/pkg/antctl/transform/rule/transform.go
+++ b/pkg/antctl/transform/rule/transform.go
@@ -15,9 +15,8 @@
 package rule
 
 import (
-	"net"
-
 	networkingv1beta1 "github.com/vmware-tanzu/antrea/pkg/apis/networking/v1beta1"
+	"github.com/vmware-tanzu/antrea/pkg/util/ip"
 )
 
 type service struct {
@@ -53,26 +52,15 @@ func serviceTransform(services ...networkingv1beta1.Service) []service {
 	return ret
 }
 
-func ipNetTransform(ipNet networkingv1beta1.IPNet) *net.IPNet {
-	ip := net.IP(ipNet.IP)
-	var bits int
-	if ip.To4() != nil {
-		bits = net.IPv4len * 8
-	} else {
-		bits = net.IPv6len * 8
-	}
-	return &net.IPNet{IP: ip, Mask: net.CIDRMask(int(ipNet.PrefixLength), bits)}
-}
-
 func ipBlockTransform(block networkingv1beta1.IPBlock) ipBlock {
 	var ib ipBlock
 	except := []string{}
 	for i := range block.Except {
-		except = append(except, ipNetTransform(block.Except[i]).String())
+		except = append(except, ip.IPNetToNetIPNet(&block.Except[i]).String())
 	}
 	ib.Except = except
 	if len(block.CIDR.IP) >= 4 {
-		ib.CIDR = ipNetTransform(block.CIDR).String()
+		ib.CIDR = ip.IPNetToNetIPNet(&block.CIDR).String()
 	}
 	return ib
 }

--- a/pkg/util/ip/ip.go
+++ b/pkg/util/ip/ip.go
@@ -1,0 +1,148 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ip
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"sort"
+
+	"github.com/vmware-tanzu/antrea/pkg/apis/networking/v1beta1"
+)
+
+const (
+	v4BitLen = 8 * net.IPv4len
+	v6BitLen = 8 * net.IPv6len
+)
+
+// This function takes in one allow CIDR and multiple except CIDRs and gives diff CIDRs
+// in allowCIDR eliminating except CIDRs. It currently supports only IPv4. except CIDR input
+// can be changed.
+func DiffFromCIDRs(allowCIDR *net.IPNet, exceptCIDRs []*net.IPNet) ([]*net.IPNet, error) {
+	if allowCIDR.IP.To4() == nil {
+		return nil, fmt.Errorf("allowCIDR IP type is not v4")
+	}
+	// Remove the redundant CIDRs
+	exceptCIDRs = mergeCIDRs(exceptCIDRs)
+	newCIDRs := []*net.IPNet{allowCIDR}
+	for _, exceptCIDR := range exceptCIDRs {
+		if exceptCIDR.IP.To4() == nil {
+			return nil, fmt.Errorf("exceptCIDR IP type is not v4")
+		}
+	beginLoop:
+		for i, indCIDR := range newCIDRs {
+			// Consider masked IP from IPNet struct
+			if indCIDR.Contains(exceptCIDR.IP.Mask(exceptCIDR.Mask)) {
+				result := diffFromCIDR(indCIDR, exceptCIDR)
+				// Delete the considered CIDR block and add resulting CIDR blocks
+				copy(newCIDRs[i:], newCIDRs[i+1:])
+				newCIDRs[len(newCIDRs)-1] = nil
+				newCIDRs = newCIDRs[:len(newCIDRs)-1]
+				// Append the result CIDRs
+				newCIDRs = append(newCIDRs, result...)
+				// This step can be optimized by having iterator over just the index. Went with reinitialization of iterator.
+				goto beginLoop
+			} else if exceptCIDR.Contains(indCIDR.IP) {
+				// Just delete the CIDR block
+				copy(newCIDRs[i:], newCIDRs[i+1:])
+				newCIDRs[len(newCIDRs)-1] = nil
+				newCIDRs = newCIDRs[:len(newCIDRs)-1]
+				goto beginLoop
+			}
+		}
+	}
+	return newCIDRs, nil
+}
+
+// This function gives diff CIDRs between a superset CIDR (allow CIDR) and subset CIDR
+// (except CIDR)
+func diffFromCIDR(allowCIDR, exceptCIDR *net.IPNet) []*net.IPNet {
+	allowPrefix, _ := allowCIDR.Mask.Size()
+	exceptPrefix, _ := exceptCIDR.Mask.Size()
+
+	// Mask the IP to get the start IP of range
+	allowStartIP := allowCIDR.IP.Mask(allowCIDR.Mask)
+	exceptStartIP := exceptCIDR.IP.Mask(exceptCIDR.Mask)
+
+	// New CIDRs should not contain the IPs in exceptCIDR. Manipulating the bits in start IP of
+	// exceptCIDR will give remainder IPs in allowCIDR, specifically the masked IPs for remaining
+	// CIDRs with prefix ranging from [allowPrefix+1, exceptPrefix].
+	remainingCIDRs := make([]*net.IPNet, 0, exceptPrefix-allowPrefix)
+	for i := allowPrefix + 1; i <= exceptPrefix; i++ {
+		// Flip the (ipBitLen - i)th bit from LSB in exceptCIDR to get the IP which is not in exceptCIDR
+		ipOfNewCIDR := flipSingleBit(&exceptStartIP, uint8(v4BitLen-i))
+		newCIDRMask := net.CIDRMask(i, v4BitLen)
+		for j := range allowStartIP {
+			ipOfNewCIDR[j] = allowStartIP[j] | ipOfNewCIDR[j]
+		}
+
+		newCIDR := net.IPNet{IP: ipOfNewCIDR.Mask(newCIDRMask), Mask: newCIDRMask}
+		remainingCIDRs = append(remainingCIDRs, &newCIDR)
+	}
+	return remainingCIDRs
+}
+
+func flipSingleBit(ip *net.IP, bitIndex uint8) net.IP {
+	newIP := make(net.IP, len(*ip))
+	copy(newIP, *ip)
+	byteIndex := uint8(len(newIP)) - (bitIndex / 8) - 1
+	// XOR bit operation to flip
+	newIP[byteIndex] = newIP[byteIndex] ^ (1 << (bitIndex % 8))
+	return newIP
+}
+
+// This function is to check for redundant CIDRs in the list that are
+// covered by other CIDRs and remove them. Input array can be modified.
+func mergeCIDRs(cidrBlocks []*net.IPNet) []*net.IPNet {
+	// Sort the list by netmask in ascending order
+	sort.Slice(cidrBlocks, func(i, j int) bool {
+		return bytes.Compare(cidrBlocks[i].Mask, cidrBlocks[j].Mask) < 0
+	})
+
+	// Check and remove if there are redundant CIDRs that are part of bigger CIDRs
+	// or repeated CIDRs
+	for i := 0; i < len(cidrBlocks); i++ {
+		for j := i + 1; j < len(cidrBlocks); j++ {
+			if cidrBlocks[i].Contains(cidrBlocks[j].IP) {
+				// Delete the CIDR block and truncate the slice
+				copy(cidrBlocks[j:], cidrBlocks[j+1:])
+				cidrBlocks[len(cidrBlocks)-1] = nil
+				cidrBlocks = cidrBlocks[:len(cidrBlocks)-1]
+				// Decrement the tracker to consider next element
+				j = j - 1
+			}
+		}
+	}
+	return cidrBlocks
+}
+
+// Function to transform Antrea IPNet to net.IPNet
+func IPNetToNetIPNet(ipNet *v1beta1.IPNet) *net.IPNet {
+	ip := net.IP(ipNet.IP)
+	var bits int
+	if ip.To4() != nil {
+		bits = v4BitLen
+	} else {
+		bits = v6BitLen
+	}
+	return &net.IPNet{IP: ip, Mask: net.CIDRMask(int(ipNet.PrefixLength), bits)}
+}
+
+// Function to transform net.IPNet to Antrea IPNet
+func NetIPNetToIPNet(ipNet *net.IPNet) *v1beta1.IPNet {
+	prefix, _ := ipNet.Mask.Size()
+	return &v1beta1.IPNet{IP: v1beta1.IPAddress(ipNet.IP), PrefixLength: int32(prefix)}
+}

--- a/pkg/util/ip/ip_test.go
+++ b/pkg/util/ip/ip_test.go
@@ -1,0 +1,110 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ip
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newCIDR(cidrStr string) *net.IPNet {
+	_, tmpIpNet, _ := net.ParseCIDR(cidrStr)
+	return tmpIpNet
+}
+
+func TestDiffCIDRs(t *testing.T) {
+	testList := []*net.IPNet{newCIDR("10.20.0.0/16"),
+		newCIDR("10.20.1.0/24"),
+		newCIDR("10.20.2.0/28")}
+
+	exceptList1 := []*net.IPNet{testList[1]}
+	correctList1 := []*net.IPNet{newCIDR("10.20.128.0/17"),
+		newCIDR("10.20.64.0/18"),
+		newCIDR("10.20.32.0/19"),
+		newCIDR("10.20.16.0/20"),
+		newCIDR("10.20.8.0/21"),
+		newCIDR("10.20.4.0/22"),
+		newCIDR("10.20.2.0/23"),
+		newCIDR("10.20.0.0/24")}
+
+	diffCIDRs, err := DiffFromCIDRs(testList[0], exceptList1)
+	if err != nil {
+		t.Fatalf("diffFromCIDRs() error = %v", err)
+	} else {
+		assert.ElementsMatch(t, correctList1, diffCIDRs)
+	}
+
+	exceptList2 := []*net.IPNet{testList[1], testList[2]}
+	correctList2 := []*net.IPNet{newCIDR("10.20.128.0/17"),
+		newCIDR("10.20.64.0/18"),
+		newCIDR("10.20.32.0/19"),
+		newCIDR("10.20.16.0/20"),
+		newCIDR("10.20.8.0/21"),
+		newCIDR("10.20.4.0/22"),
+		newCIDR("10.20.0.0/24"),
+		newCIDR("10.20.3.0/24"),
+		newCIDR("10.20.2.128/25"),
+		newCIDR("10.20.2.64/26"),
+		newCIDR("10.20.2.32/27"),
+		newCIDR("10.20.2.16/28")}
+	diffCIDRs, err = DiffFromCIDRs(testList[0], exceptList2)
+	if err != nil {
+		t.Fatalf("diffFromCIDRs() error = %v", err)
+	} else {
+		assert.ElementsMatch(t, correctList2, diffCIDRs)
+	}
+
+}
+
+func TestMergeCIDRs(t *testing.T) {
+	testList := []*net.IPNet{newCIDR("10.10.0.0/16"),
+		newCIDR("10.20.0.0/16"),
+		newCIDR("10.20.1.2/32"),
+		newCIDR("10.20.1.3/32")}
+
+	ipNetList0 := []*net.IPNet{testList[0], testList[1],
+		testList[2], testList[3]}
+	correctList0 := []*net.IPNet{testList[0], testList[1]}
+
+	ipNetList0 = mergeCIDRs(ipNetList0)
+
+	assert.ElementsMatch(t, correctList0, ipNetList0)
+
+	ipNetList1 := []*net.IPNet{testList[0]}
+	correctList1 := []*net.IPNet{testList[0]}
+
+	ipNetList1 = mergeCIDRs(ipNetList1)
+	assert.ElementsMatch(t, correctList1, ipNetList1)
+
+	ipNetList2 := []*net.IPNet{testList[2], testList[3]}
+	correctList2 := []*net.IPNet{testList[2], testList[3]}
+
+	ipNetList2 = mergeCIDRs(ipNetList2)
+	assert.ElementsMatch(t, correctList2, ipNetList2)
+
+	ipNetList3 := []*net.IPNet{testList[0], testList[3]}
+	correctList3 := []*net.IPNet{testList[0], testList[3]}
+
+	ipNetList3 = mergeCIDRs(ipNetList3)
+	assert.ElementsMatch(t, correctList3, ipNetList3)
+
+	ipNetList4 := []*net.IPNet{}
+	correctList4 := []*net.IPNet{}
+
+	ipNetList4 = mergeCIDRs(ipNetList4)
+	assert.ElementsMatch(t, correctList4, ipNetList4)
+}


### PR DESCRIPTION
Behavior with network policies with overlapping From/To blocks
is not as expected. Behavior changes with order change in addition of
policies, which is not expected. This is due to priority clash between
conjunctive match flows with overlapping match fields. Fixed this by
adding match flows for only diff addresses between From/To and Except
blocks, and not adding drop flows at all.

Added new package ip to compute diff CIDRs.

Added netpol test for testing cases with policies that have overlapping from/to blocks and policies with overlapping except blocks.

Fixes: #367