### PR TITLE
[Windows] Support set DNS from runtime config in CNI request

### DIFF
--- a/pkg/agent/cniserver/interface_configuration_windows.go
+++ b/pkg/agent/cniserver/interface_configuration_windows.go
@@ -148,7 +148,7 @@ func (ic *ifConfigurator) createContainerLink(podName string, podNameSpace strin
 		Name:           epName,
 		VirtualNetwork: ic.hnsNetwork.Id,
 		DNSServerList:  strings.Join(result.DNS.Nameservers, ","),
-		DNSSuffix:      result.DNS.Domain,
+		DNSSuffix:      strings.Join(result.DNS.Search, ","),
 		GatewayAddress: containerIP.Gateway.String(),
 		IPAddress:      containerIP.Address.IP,
 	}

--- a/pkg/agent/cniserver/server_linux.go
+++ b/pkg/agent/cniserver/server_linux.go
@@ -1,0 +1,22 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cniserver
+
+import "github.com/containernetworking/cni/pkg/types/current"
+
+// updateResultDNSConfig updates the DNS config from CNIConfig.
+func updateResultDNSConfig(result *current.Result, cniConfig *CNIConfig) {
+	result.DNS = cniConfig.DNS
+}

--- a/pkg/agent/cniserver/server_windows.go
+++ b/pkg/agent/cniserver/server_windows.go
@@ -1,0 +1,38 @@
+// +build windows
+
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cniserver
+
+import (
+	"github.com/containernetworking/cni/pkg/types/current"
+	"k8s.io/klog"
+)
+
+// updateResultDNSConfig update the DNS config from CNIConfig.
+// For windows platform, if runtime dns values are there use that else use cni conf supplied dns.
+// See PR: https://github.com/kubernetes/kubernetes/pull/63905
+// Note: For windows node, DNS Capability is needed to be set to enable DNS config can be passed to CNI.
+// See PR: https://github.com/kubernetes/kubernetes/pull/67435
+func updateResultDNSConfig(result *current.Result, cniConfig *CNIConfig) {
+	result.DNS = cniConfig.DNS
+	if len(cniConfig.RuntimeConfig.DNS.Nameservers) > 0 {
+		result.DNS.Nameservers = cniConfig.RuntimeConfig.DNS.Nameservers
+	}
+	if len(cniConfig.RuntimeConfig.DNS.Search) > 0 {
+		result.DNS.Search = cniConfig.RuntimeConfig.DNS.Search
+	}
+	klog.Infof("Got runtime DNS configuration: %v", result.DNS)
+}


### PR DESCRIPTION
On windows platform, DNS config is passed by runtime config of CNI request.
This PR support set DNS config from DNS specified in runtime config.
DNS Capability is needed to be set in CNI config file to enable DNS config
can be passed in runtime config.