### PR TITLE
Support querying OVS flows of a NetworkPolicy and NetworkPolicies applied to a Pod

### DIFF
--- a/pkg/agent/apiserver/apiserver.go
+++ b/pkg/agent/apiserver/apiserver.go
@@ -55,7 +55,7 @@ func (s *agentAPIServer) Run(stopCh <-chan struct{}) error {
 func installHandlers(aq agentquerier.AgentQuerier, npq querier.AgentNetworkPolicyInfoQuerier, s *genericapiserver.GenericAPIServer) {
 	s.Handler.NonGoRestfulMux.HandleFunc("/agentinfo", agentinfo.HandleFunc(aq))
 	s.Handler.NonGoRestfulMux.HandleFunc("/podinterfaces", podinterface.HandleFunc(aq))
-	s.Handler.NonGoRestfulMux.HandleFunc("/networkpolicies", networkpolicy.HandleFunc(npq))
+	s.Handler.NonGoRestfulMux.HandleFunc("/networkpolicies", networkpolicy.HandleFunc(aq))
 	s.Handler.NonGoRestfulMux.HandleFunc("/appliedtogroups", appliedtogroup.HandleFunc(npq))
 	s.Handler.NonGoRestfulMux.HandleFunc("/addressgroups", addressgroup.HandleFunc(npq))
 	s.Handler.NonGoRestfulMux.HandleFunc("/ovsflows", ovsflows.HandleFunc(aq))

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -103,6 +103,13 @@ func (c *Controller) GetAppliedToGroupNum() int {
 func (c *Controller) GetNetworkPolicies() []v1beta1.NetworkPolicy {
 	return c.ruleCache.GetNetworkPolicies()
 }
+
+// GetNetworkPolicy looks up and returns the cached NetworkPolicy.
+// nil is returned if the specified NetworkPolicy is not found.
+func (c *Controller) GetNetworkPolicy(npName, npNamespace string) *v1beta1.NetworkPolicy {
+	return c.ruleCache.getNetworkPolicy(npName, npNamespace)
+}
+
 func (c *Controller) GetAddressGroups() []v1beta1.AddressGroup {
 	return c.ruleCache.GetAddressGroups()
 }

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -100,8 +100,17 @@ func (c *Controller) GetAppliedToGroupNum() int {
 	return c.ruleCache.GetAppliedToGroupNum()
 }
 
-func (c *Controller) GetNetworkPolicies() []v1beta1.NetworkPolicy {
-	return c.ruleCache.GetNetworkPolicies()
+// GetNetworkPolicies returns the requested NetworkPolicies.
+// If namespace is provided, only NetworkPolicies in the Namespace are returned.
+// If namespace is not provided, NetworkPolicies in all the Namespace are
+// returned.
+func (c *Controller) GetNetworkPolicies(namespace string) []v1beta1.NetworkPolicy {
+	return c.ruleCache.getNetworkPolicies(namespace)
+}
+
+// GetAppliedToNetworkPolicies returns the NetworkPolicies applied to the Pod.
+func (c *Controller) GetAppliedNetworkPolicies(pod, namespace string) []v1beta1.NetworkPolicy {
+	return c.ruleCache.getAppliedNetworkPolicies(pod, namespace)
 }
 
 // GetNetworkPolicy looks up and returns the cached NetworkPolicy.

--- a/pkg/agent/controller/networkpolicy/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/reconciler_test.go
@@ -409,7 +409,7 @@ func TestReconcilerReconcile(t *testing.T) {
 			defer controller.Finish()
 			mockOFClient := openflowtest.NewMockClient(controller)
 			for _, ofRule := range tt.expectedOFRules {
-				mockOFClient.EXPECT().InstallPolicyRuleFlows(gomock.Any(), gomock.Eq(ofRule))
+				mockOFClient.EXPECT().InstallPolicyRuleFlows(gomock.Any(), gomock.Eq(ofRule), "", "")
 			}
 			r := newReconciler(mockOFClient, ifaceStore)
 			if err := r.Reconcile(tt.args); (err != nil) != tt.wantErr {
@@ -539,7 +539,7 @@ func TestReconcilerUpdate(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 			mockOFClient := openflowtest.NewMockClient(controller)
-			mockOFClient.EXPECT().InstallPolicyRuleFlows(gomock.Any(), gomock.Any())
+			mockOFClient.EXPECT().InstallPolicyRuleFlows(gomock.Any(), gomock.Any(), "", "")
 			if len(tt.expectedAddedFrom) > 0 {
 				mockOFClient.EXPECT().AddPolicyRuleAddress(gomock.Any(), types.SrcAddress, gomock.Eq(tt.expectedAddedFrom))
 			}

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -86,7 +86,7 @@ type Client interface {
 	// NetworkPolicy rule. Each ingress/egress policy rule installs Openflow entries on two tables, one for
 	// ruleTable and the other for dropTable. If a packet does not pass the ruleTable, it will be dropped by the
 	// dropTable.
-	InstallPolicyRuleFlows(ruleID uint32, rule *types.PolicyRule) error
+	InstallPolicyRuleFlows(ruleID uint32, rule *types.PolicyRule, npName, npNamespace string) error
 
 	// UninstallPolicyRuleFlows removes the Openflow entry relevant to the specified NetworkPolicy rule.
 	// UninstallPolicyRuleFlows will do nothing if no Openflow entry for the rule is installed.
@@ -117,8 +117,15 @@ type Client interface {
 	// the new round number.
 	DeleteStaleFlows() error
 
-	// GetPodFlowKeys returns the keys (match strings) of the cached flows for a Pod.
+	// GetPodFlowKeys returns the keys (match strings) of the cached flows for a
+	// Pod.
 	GetPodFlowKeys(interfaceName string) []string
+
+	// GetNetworkPolicyFlowKeys returns the keys (match strings) of the cached
+	// flows for a NetworkPolicy. Flows are grouped by policy rules, and duplicated
+	// entries can be added due to conjunctive match flows shared by multiple
+	// rules.
+	GetNetworkPolicyFlowKeys(npName, npNamespace string) []string
 }
 
 // GetFlowTableStatus returns an array of flow table status.

--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -160,9 +160,12 @@ func TestInstallPolicyRuleFlows(t *testing.T) {
 	assert.Equal(t, 3, getChangedFlowOPCount(matchFlows2, insertion))
 	err = c.applyConjunctiveMatchFlows(ctxChanges2)
 	require.Nil(t, err)
-	err = c.InstallPolicyRuleFlows(ruleID2, rule2)
+
+	assert.Equal(t, 0, len(c.GetNetworkPolicyFlowKeys("np1", "ns1")))
+	err = c.InstallPolicyRuleFlows(ruleID2, rule2, "np1", "ns1")
 	require.Nil(t, err)
 	checkConjunctionConfig(t, ruleID2, 1, 2, 1, 0)
+	assert.Equal(t, 6, len(c.GetNetworkPolicyFlowKeys("np1", "ns1")))
 
 	ruleID3 := uint32(103)
 	port1 := intstr.FromInt(8080)
@@ -192,9 +195,11 @@ func TestInstallPolicyRuleFlows(t *testing.T) {
 	assert.Equal(t, 1, getChangedFlowOPCount(matchFlows3, modification))
 	err = c.applyConjunctiveMatchFlows(ctxChanges3)
 	require.Nil(t, err)
-	err = c.InstallPolicyRuleFlows(ruleID3, rule3)
+
+	err = c.InstallPolicyRuleFlows(ruleID3, rule3, "np1", "ns1")
 	require.Nil(t, err, "Failed to invoke InstallPolicyRuleFlows")
 	checkConjunctionConfig(t, ruleID3, 3, 2, 1, 2)
+	assert.Equal(t, 16, len(c.GetNetworkPolicyFlowKeys("np1", "ns1")))
 
 	ctxChanges4 := conj.calculateChangesForRuleDeletion()
 	matchFlows4, dropFlows4 := getChangedFlows(ctxChanges4)
@@ -211,6 +216,7 @@ func TestInstallPolicyRuleFlows(t *testing.T) {
 	assert.Equal(t, 2, getChangedFlowOPCount(matchFlows5, deletion))
 	assert.Equal(t, 1, getChangedFlowOPCount(matchFlows5, modification))
 	err = c.applyConjunctiveMatchFlows(ctxChanges5)
+	assert.Equal(t, 13, len(c.GetNetworkPolicyFlowKeys("np1", "ns1")))
 	require.Nil(t, err)
 }
 
@@ -347,6 +353,7 @@ func newMockDropFlowBuilder(ctrl *gomock.Controller) *mocks.MockFlowBuilder {
 	dropFlowBuilder.EXPECT().Action().Return(action).AnyTimes()
 	dropFlow = mocks.NewMockFlow(ctrl)
 	dropFlowBuilder.EXPECT().Done().Return(dropFlow).AnyTimes()
+	dropFlow.EXPECT().MatchString().Return("").AnyTimes()
 	return dropFlowBuilder
 }
 
@@ -370,6 +377,7 @@ func newMockRuleFlowBuilder(ctrl *gomock.Controller) *mocks.MockFlowBuilder {
 	ruleFlow = mocks.NewMockFlow(ctrl)
 	ruleFlowBuilder.EXPECT().Done().Return(ruleFlow).AnyTimes()
 	ruleFlow.EXPECT().CopyToBuilder().Return(ruleFlowBuilder).AnyTimes()
+	ruleFlow.EXPECT().MatchString().Return("").AnyTimes()
 	return ruleFlowBuilder
 }
 

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -121,6 +121,20 @@ func (mr *MockClientMockRecorder) GetFlowTableStatus() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFlowTableStatus", reflect.TypeOf((*MockClient)(nil).GetFlowTableStatus))
 }
 
+// GetNetworkPolicyFlowKeys mocks base method
+func (m *MockClient) GetNetworkPolicyFlowKeys(arg0, arg1 string) []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNetworkPolicyFlowKeys", arg0, arg1)
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// GetNetworkPolicyFlowKeys indicates an expected call of GetNetworkPolicyFlowKeys
+func (mr *MockClientMockRecorder) GetNetworkPolicyFlowKeys(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkPolicyFlowKeys", reflect.TypeOf((*MockClient)(nil).GetNetworkPolicyFlowKeys), arg0, arg1)
+}
+
 // GetPodFlowKeys mocks base method
 func (m *MockClient) GetPodFlowKeys(arg0 string) []string {
 	m.ctrl.T.Helper()
@@ -221,17 +235,17 @@ func (mr *MockClientMockRecorder) InstallPodFlows(arg0, arg1, arg2, arg3, arg4 i
 }
 
 // InstallPolicyRuleFlows mocks base method
-func (m *MockClient) InstallPolicyRuleFlows(arg0 uint32, arg1 *types.PolicyRule) error {
+func (m *MockClient) InstallPolicyRuleFlows(arg0 uint32, arg1 *types.PolicyRule, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallPolicyRuleFlows", arg0, arg1)
+	ret := m.ctrl.Call(m, "InstallPolicyRuleFlows", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallPolicyRuleFlows indicates an expected call of InstallPolicyRuleFlows
-func (mr *MockClientMockRecorder) InstallPolicyRuleFlows(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallPolicyRuleFlows(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPolicyRuleFlows", reflect.TypeOf((*MockClient)(nil).InstallPolicyRuleFlows), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPolicyRuleFlows", reflect.TypeOf((*MockClient)(nil).InstallPolicyRuleFlows), arg0, arg1, arg2, arg3)
 }
 
 // IsConnected mocks base method

--- a/pkg/agent/querier/querier.go
+++ b/pkg/agent/querier/querier.go
@@ -33,10 +33,11 @@ var _ AgentQuerier = new(agentQuerier)
 
 type AgentQuerier interface {
 	GetNodeName() string
-	GetInterfaceStore() interfacestore.InterfaceStore
 	GetAgentInfo(agentInfo *v1beta1.AntreaAgentInfo, partial bool)
+	GetInterfaceStore() interfacestore.InterfaceStore
 	GetOpenflowClient() openflow.Client
 	GetOfctlClient() *ofctl.OfctlClient
+	GetNetworkPolicyInfoQuerier() querier.AgentNetworkPolicyInfoQuerier
 }
 
 type agentQuerier struct {
@@ -79,6 +80,11 @@ func (aq *agentQuerier) GetOpenflowClient() openflow.Client {
 // GetOfctlClient returns a new OfctlClient.
 func (aq *agentQuerier) GetOfctlClient() *ofctl.OfctlClient {
 	return ofctl.NewClient(aq.ovsBridge)
+}
+
+// GetNetworkPolicyInfoQuerier returns AgentNetworkPolicyInfoQuerier.
+func (aq agentQuerier) GetNetworkPolicyInfoQuerier() querier.AgentNetworkPolicyInfoQuerier {
+	return aq.networkPolicyInfoQuerier
 }
 
 // getOVSVersion gets current OVS version.

--- a/pkg/agent/querier/testing/mock_querier.go
+++ b/pkg/agent/querier/testing/mock_querier.go
@@ -25,6 +25,7 @@ import (
 	openflow "github.com/vmware-tanzu/antrea/pkg/agent/openflow"
 	v1beta1 "github.com/vmware-tanzu/antrea/pkg/apis/clusterinformation/v1beta1"
 	ofctl "github.com/vmware-tanzu/antrea/pkg/ovs/ofctl"
+	querier "github.com/vmware-tanzu/antrea/pkg/querier"
 	reflect "reflect"
 )
 
@@ -75,6 +76,20 @@ func (m *MockAgentQuerier) GetInterfaceStore() interfacestore.InterfaceStore {
 func (mr *MockAgentQuerierMockRecorder) GetInterfaceStore() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInterfaceStore", reflect.TypeOf((*MockAgentQuerier)(nil).GetInterfaceStore))
+}
+
+// GetNetworkPolicyInfoQuerier mocks base method
+func (m *MockAgentQuerier) GetNetworkPolicyInfoQuerier() querier.AgentNetworkPolicyInfoQuerier {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNetworkPolicyInfoQuerier")
+	ret0, _ := ret[0].(querier.AgentNetworkPolicyInfoQuerier)
+	return ret0
+}
+
+// GetNetworkPolicyInfoQuerier indicates an expected call of GetNetworkPolicyInfoQuerier
+func (mr *MockAgentQuerierMockRecorder) GetNetworkPolicyInfoQuerier() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkPolicyInfoQuerier", reflect.TypeOf((*MockAgentQuerier)(nil).GetNetworkPolicyInfoQuerier))
 }
 
 // GetNodeName mocks base method

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -58,14 +58,16 @@ var CommandList = &commandList{
 		{
 			use:     "networkpolicy",
 			aliases: []string{"networkpolicies", "netpol"},
-			short:   "Print network policies",
-			long:    "Print network policies in ${component}. \"Namespace\" is required if \"Name\" is provided.",
-			example: `  Get a NetworkPolicy in a specific Namespace
-  $ antctl get networkpolicy access-nginx -n prod
+			short:   "Print NetworkPolicies",
+			long:    "Print NetworkPolicies in ${component}. \"namespace\" is required if \"name\" is provided.",
+			example: `  Get a specific NetworkPolicy
+  $ antctl get networkpolicy np1 -n ns1
   Get the list of NetworkPolicies in a Namespace
-  $ antctl get networkpolicy -n prod
+  $ antctl get networkpolicy -n ns1
   Get the list of NetworkPolicies in all Namespaces
-  $ antctl get networkpolicy`,
+  $ antctl get networkpolicy
+  Get the list of NetworkPolicies applied to a Pod (supported by agent only)
+  $ antctl get networkpolicy -p pod1 -n ns1`,
 			commandGroup: get,
 			controllerEndpoint: &endpoint{
 				resourceEndpoint: &resourceEndpoint{
@@ -81,13 +83,18 @@ var CommandList = &commandList{
 					params: []flagInfo{
 						{
 							name:  "name",
-							usage: "Retrieve resource by name",
+							usage: "Get NetworkPolicy by name. If present, Namespace must be provided.",
 							arg:   true,
 						},
 						{
 							name:      "namespace",
-							usage:     "Get networkpolicies from specific Namespace",
+							usage:     "Get Networkpolicies from specific Namespace",
 							shorthand: "n",
+						},
+						{
+							name:      "pod",
+							usage:     "Get NetworkPolicies applied to the Pod. If present, Namespace must be provided.",
+							shorthand: "p",
 						},
 					},
 				},

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -220,20 +220,26 @@ var CommandList = &commandList{
 			example: `  Dump all OVS flows
   $ antctl get ovsflows
   Dump OVS flows of a Pod
-  $ antctl get ovsflows -p pod1 -n ns1`,
+  $ antctl get ovsflows -p pod1 -n ns1
+  Dump OVS flows of a NetworkPolicy
+  $ antctl get ovsflows --networkpolicy np1 -n ns1`,
 			agentEndpoint: &endpoint{
 				nonResourceEndpoint: &nonResourceEndpoint{
 					path: "/ovsflows",
 					params: []flagInfo{
+						{
+							name:      "namespace",
+							usage:     "Namespace of the entity",
+							shorthand: "n",
+						},
 						{
 							name:      "pod",
 							usage:     "Pod name. If present, Namespace must be provided.",
 							shorthand: "p",
 						},
 						{
-							name:      "namespace",
-							usage:     "Namespace of the entity",
-							shorthand: "n",
+							name:  "networkpolicy",
+							usage: "NetworkPolicy name. If present, Namespace must be provided.",
 						},
 					},
 					outputType: multiple,

--- a/pkg/ovs/openflow/ofctrl_builder.go
+++ b/pkg/ovs/openflow/ofctrl_builder.go
@@ -30,6 +30,7 @@ func (b *ofFlowBuilder) Done() Flow {
 
 // MatchReg adds match condition for matching data in the target register.
 func (b *ofFlowBuilder) MatchReg(regID int, data uint32) FlowBuilder {
+	b.matchers = append(b.matchers, fmt.Sprintf("reg%d=0x%x", regID, data))
 	reg := &ofctrl.NXRegister{
 		ID:   regID,
 		Data: data,
@@ -292,7 +293,7 @@ func (b *ofFlowBuilder) MatchProtocol(protocol Protocol) FlowBuilder {
 func (b *ofFlowBuilder) MatchTCPDstPort(port uint16) FlowBuilder {
 	b.MatchProtocol(ProtocolTCP)
 	b.Match.TcpDstPort = port
-	b.matchers = append(b.matchers, fmt.Sprintf("tcp_dst=%d", port))
+	b.matchers = append(b.matchers, fmt.Sprintf("tp_dst=%d", port))
 	return b
 }
 
@@ -300,7 +301,7 @@ func (b *ofFlowBuilder) MatchTCPDstPort(port uint16) FlowBuilder {
 func (b *ofFlowBuilder) MatchUDPDstPort(port uint16) FlowBuilder {
 	b.MatchProtocol(ProtocolUDP)
 	b.Match.UdpDstPort = port
-	b.matchers = append(b.matchers, fmt.Sprintf("udp_dst=%d", port))
+	b.matchers = append(b.matchers, fmt.Sprintf("tp_dst=%d", port))
 	return b
 }
 
@@ -308,7 +309,7 @@ func (b *ofFlowBuilder) MatchUDPDstPort(port uint16) FlowBuilder {
 func (b *ofFlowBuilder) MatchSCTPDstPort(port uint16) FlowBuilder {
 	b.MatchProtocol(ProtocolSCTP)
 	b.Match.SctpDstPort = port
-	b.matchers = append(b.matchers, fmt.Sprintf("sctp_dst=%d", port))
+	b.matchers = append(b.matchers, fmt.Sprintf("tp_dst=%d", port))
 	return b
 }
 

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -41,6 +41,7 @@ type AgentNetworkPolicyInfoQuerier interface {
 	GetNetworkPolicies() []networkingv1beta1.NetworkPolicy
 	GetAddressGroups() []networkingv1beta1.AddressGroup
 	GetAppliedToGroups() []networkingv1beta1.AppliedToGroup
+	GetNetworkPolicy(npName, npNamespace string) *networkingv1beta1.NetworkPolicy
 }
 
 type ControllerNetworkPolicyInfoQuerier interface {

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -38,10 +38,11 @@ type NetworkPolicyInfoQuerier interface {
 type AgentNetworkPolicyInfoQuerier interface {
 	NetworkPolicyInfoQuerier
 	GetControllerConnectionStatus() bool
-	GetNetworkPolicies() []networkingv1beta1.NetworkPolicy
+	GetNetworkPolicies(namespace string) []networkingv1beta1.NetworkPolicy
 	GetAddressGroups() []networkingv1beta1.AddressGroup
 	GetAppliedToGroups() []networkingv1beta1.AppliedToGroup
 	GetNetworkPolicy(npName, npNamespace string) *networkingv1beta1.NetworkPolicy
+	GetAppliedNetworkPolicies(pod, namespace string) []networkingv1beta1.NetworkPolicy
 }
 
 type ControllerNetworkPolicyInfoQuerier interface {

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -164,7 +164,7 @@ func TestReplayFlowsNetworkPolicyFlows(t *testing.T) {
 		Service:    []v1beta1.Service{npPort1},
 	}
 
-	err = c.InstallPolicyRuleFlows(ruleID, rule)
+	err = c.InstallPolicyRuleFlows(ruleID, rule, "np1", "ns1")
 	require.Nil(t, err, "Failed to InstallPolicyRuleFlows")
 
 	err = c.AddPolicyRuleAddress(ruleID, types.SrcAddress, prepareIPNetAddresses([]string{"192.168.5.0/24", "192.169.1.0/24"}))
@@ -306,7 +306,7 @@ func TestNetworkPolicyFlows(t *testing.T) {
 		Service:    []v1beta1.Service{npPort1},
 	}
 
-	err = c.InstallPolicyRuleFlows(ruleID, rule)
+	err = c.InstallPolicyRuleFlows(ruleID, rule, "np1", "ns1")
 	require.Nil(t, err, "Failed to InstallPolicyRuleFlows")
 	checkConjunctionFlows(t, ingressRuleTable, ingressDefaultTable, contrackCommitTable, priorityNormal, ruleID, rule, assert.True)
 	checkDefaultDropFlows(t, ingressDefaultTable, priorityNormal, types.DstAddress, toIPList, true)
@@ -338,7 +338,7 @@ func TestNetworkPolicyFlows(t *testing.T) {
 		To:        toIPList2,
 		Service:   []v1beta1.Service{npPort2},
 	}
-	err = c.InstallPolicyRuleFlows(ruleID2, rule2)
+	err = c.InstallPolicyRuleFlows(ruleID2, rule2, "np1", "ns1")
 	require.Nil(t, err, "Failed to InstallPolicyRuleFlows")
 
 	// Dump flows


### PR DESCRIPTION
Look up all cached flows of a NetworkPolicy from policyRuleConjunction
and conjMatchFlowContext. Execute ovs-ofctl dump-flows to dump the
flow strings.
Add NetworkPolicy name and Namespace to NetworkPolicyController rule
cache and policyRuleConjunction to look up a NetworkPolicy and its
flows.
Fix flow match string for TCP/UDP/SCTP port and register matches.

Look up NetworkPolicies from the NetworkPolicyController cache from:
Pod -> AppliedToGroups -> Rules -> NetworkPolicies.
Revise NetworkPolicyController NetworkPolicy lookup funcs.
antctl command to get NetworkPolicies of a Pod:
  antctl get netpol -p pod -n ns.