### PR TITLE
Enable API Server local access with privilegedLoopbackToken

### DIFF
--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -244,12 +244,6 @@ subjects:
 - kind: ServiceAccount
   name: antctl
   namespace: kube-system
-- kind: ServiceAccount
-  name: antrea-controller
-  namespace: kube-system
-- kind: ServiceAccount
-  name: antrea-agent
-  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -244,12 +244,6 @@ subjects:
 - kind: ServiceAccount
   name: antctl
   namespace: kube-system
-- kind: ServiceAccount
-  name: antrea-controller
-  namespace: kube-system
-- kind: ServiceAccount
-  name: antrea-agent
-  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -244,12 +244,6 @@ subjects:
 - kind: ServiceAccount
   name: antctl
   namespace: kube-system
-- kind: ServiceAccount
-  name: antrea-controller
-  namespace: kube-system
-- kind: ServiceAccount
-  name: antrea-agent
-  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -244,12 +244,6 @@ subjects:
 - kind: ServiceAccount
   name: antctl
   namespace: kube-system
-- kind: ServiceAccount
-  name: antrea-controller
-  namespace: kube-system
-- kind: ServiceAccount
-  name: antrea-agent
-  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/build/yamls/base/antctl.yml
+++ b/build/yamls/base/antctl.yml
@@ -51,15 +51,3 @@ subjects:
   - kind: ServiceAccount
     name: antctl
     namespace: kube-system
-  - kind: ServiceAccount
-    # This is to allow antctl to be executed inside the Antrea Controller Pod
-    # and authenticate with Controller API server using the Controller's
-    # ServiceAccount token.
-    name: antrea-controller
-    namespace: kube-system
-  - kind: ServiceAccount
-    # This is to allow antctl to be executed inside the Antrea Agent Pod
-    # and authenticate with agent API server using the agent's
-    # ServiceAccount token.
-    name: antrea-agent
-    namespace: kube-system

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -16,7 +16,10 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net"
+	"os"
+	"path"
 	"time"
 
 	genericopenapi "k8s.io/apiserver/pkg/endpoints/openapi"
@@ -142,6 +145,12 @@ func createAPIServerConfig(kubeconfig string,
 		return nil, err
 	}
 
+	if err := os.MkdirAll(path.Dir(apiserver.TokenPath), os.ModeDir); err != nil {
+		return nil, fmt.Errorf("error when creating dirs of token file")
+	}
+	if err := ioutil.WriteFile(apiserver.TokenPath, []byte(serverConfig.LoopbackClientConfig.BearerToken), 0600); err != nil {
+		return nil, fmt.Errorf("error when writing loopback access token to file: %v", err)
+	}
 	serverConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(
 		openapi.GetOpenAPIDefinitions,
 		genericopenapi.NewDefinitionNamer(apiserver.Scheme))

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -146,7 +146,7 @@ func createAPIServerConfig(kubeconfig string,
 	}
 
 	if err := os.MkdirAll(path.Dir(apiserver.TokenPath), os.ModeDir); err != nil {
-		return nil, fmt.Errorf("error when creating dirs of token file")
+		return nil, fmt.Errorf("error when creating dirs of token file: %v", err)
 	}
 	if err := ioutil.WriteFile(apiserver.TokenPath, []byte(serverConfig.LoopbackClientConfig.BearerToken), 0600); err != nil {
 		return nil, fmt.Errorf("error when writing loopback access token to file: %v", err)

--- a/pkg/agent/apiserver/apiserver.go
+++ b/pkg/agent/apiserver/apiserver.go
@@ -43,7 +43,7 @@ const Name = "antrea-agent-api"
 var (
 	scheme    = runtime.NewScheme()
 	codecs    = serializer.NewCodecFactory(scheme)
-	TokenPath = "/var/run/antrea/apiserver/agent-loopback-client-token"
+	TokenPath = "/var/run/antrea/apiserver/loopback-client-token"
 )
 
 type agentAPIServer struct {
@@ -101,7 +101,7 @@ func newConfig(bindPort int) (*genericapiserver.CompletedConfig, error) {
 		return nil, err
 	}
 	if err := os.MkdirAll(path.Dir(TokenPath), os.ModeDir); err != nil {
-		return nil, fmt.Errorf("error when creating dirs of token file")
+		return nil, fmt.Errorf("error when creating dirs of token file: %v", err)
 	}
 	if err := ioutil.WriteFile(TokenPath, []byte(serverConfig.LoopbackClientConfig.BearerToken), 0600); err != nil {
 		return nil, fmt.Errorf("error when writing loopback access token to file: %v", err)

--- a/pkg/agent/apiserver/apiserver.go
+++ b/pkg/agent/apiserver/apiserver.go
@@ -16,7 +16,10 @@ package apiserver
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net"
+	"os"
+	"path"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -35,13 +38,12 @@ import (
 	antreaversion "github.com/vmware-tanzu/antrea/pkg/version"
 )
 
-const (
-	Name = "antrea-agent-api"
-)
+const Name = "antrea-agent-api"
 
 var (
-	scheme = runtime.NewScheme()
-	codecs = serializer.NewCodecFactory(scheme)
+	scheme    = runtime.NewScheme()
+	codecs    = serializer.NewCodecFactory(scheme)
+	TokenPath = "/var/run/antrea/apiserver/agent-loopback-client-token"
 )
 
 type agentAPIServer struct {
@@ -97,6 +99,12 @@ func newConfig(bindPort int) (*genericapiserver.CompletedConfig, error) {
 	}
 	if err := authorization.ApplyTo(&serverConfig.Authorization); err != nil {
 		return nil, err
+	}
+	if err := os.MkdirAll(path.Dir(TokenPath), os.ModeDir); err != nil {
+		return nil, fmt.Errorf("error when creating dirs of token file")
+	}
+	if err := ioutil.WriteFile(TokenPath, []byte(serverConfig.LoopbackClientConfig.BearerToken), 0600); err != nil {
+		return nil, fmt.Errorf("error when writing loopback access token to file: %v", err)
 	}
 	v := antreaversion.GetVersion()
 	serverConfig.Version = &k8sversion.Info{

--- a/pkg/antctl/command_runtime.go
+++ b/pkg/antctl/command_runtime.go
@@ -27,10 +27,13 @@ const (
 var (
 	// runtimeMode tells which mode antctl is running against.
 	runtimeMode string
+	inPod       bool
 )
 
 func init() {
-	if strings.HasPrefix(os.Getenv("POD_NAME"), "antrea-agent") {
+	podName, found := os.LookupEnv("POD_NAME")
+	inPod = found && (strings.HasPrefix(podName, "antrea-agent") || strings.HasPrefix(podName, "antrea-controller"))
+	if strings.HasPrefix(podName, "antrea-agent") {
 		runtimeMode = ModeAgent
 	} else {
 		runtimeMode = ModeController

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -40,7 +40,8 @@ var (
 	Scheme = runtime.NewScheme()
 	// Codecs provides methods for retrieving codecs and serializers for specific
 	// versions and content types.
-	Codecs = serializer.NewCodecFactory(Scheme)
+	Codecs    = serializer.NewCodecFactory(Scheme)
+	TokenPath = "/var/run/antrea/apiserver/controller-loopback-client-token"
 )
 
 func init() {

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -41,7 +41,7 @@ var (
 	// Codecs provides methods for retrieving codecs and serializers for specific
 	// versions and content types.
 	Codecs    = serializer.NewCodecFactory(Scheme)
-	TokenPath = "/var/run/antrea/apiserver/controller-loopback-client-token"
+	TokenPath = "/var/run/antrea/apiserver/loopback-client-token"
 )
 
 func init() {


### PR DESCRIPTION
When starting the APIServer either in a agent or the controller, we generate a token file in the Pod. The antctl which runs in Pod can use this as bearer token to bypass delegation AAA.

Signed-off-by: Weiqiang TANG <weiqiangt@vmware.com>