### PR TITLE
Document Prometheus configuration with Antrea

### DIFF
--- a/build/yamls/antrea-prometheus.yml
+++ b/build/yamls/antrea-prometheus.yml
@@ -1,0 +1,165 @@
+# Create a namespace for Prometheus components
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+  labels:
+    name: monitoring
+---
+# Authorize Prometheus to view Kubernetes cluster components for service discovery purposes
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/proxy
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+# Authorize Prometheus to retrieve metrics from Antrea components
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: prometheus-antrea
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: monitoring
+---
+# Prometheus Server configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-server-conf
+  labels:
+    name: prometheus-server-conf
+  namespace: monitoring
+data:
+  prometheus.yml: |-
+    global:
+      scrape_interval: 5s
+      evaluation_interval: 5s
+
+    scrape_configs:
+    # Scrape Kubernetes metrics
+      - job_name: 'kubernetes-apiservers'
+        kubernetes_sd_configs:
+        - role: endpoints
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+          action: keep
+          regex: default;kubernetes;https
+
+    # Scrape Antrea Controller metrics
+      - job_name: 'antrea-controllers'
+        kubernetes_sd_configs:
+        - role: endpoints
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_container_name]
+          action: keep
+          regex: kube-system;antrea-controller
+
+    # Scrape Antrea Agents metrics
+      - job_name: 'antrea-agents'
+        kubernetes_sd_configs:
+        - role: pod
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_container_name]
+          action: keep
+          regex: kube-system;antrea-agent
+---
+# Prometheus Server deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-deployment
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: prometheus-server
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: prometheus-server
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.2.1
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+            - "--storage.tsdb.path=/prometheus/"
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: prometheus-config-volume
+              mountPath: /etc/prometheus/
+            - name: prometheus-storage-volume
+              mountPath: /prometheus/
+      volumes:
+        - name: prometheus-config-volume
+          configMap:
+            defaultMode: 420
+            name: prometheus-server-conf
+
+        - name: prometheus-storage-volume
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-service
+  namespace: monitoring
+  annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port:   '9090'
+
+spec:
+  selector:
+    app: prometheus-server
+  type: NodePort
+  ports:
+    - port: 8080
+      targetPort: 9090
+      nodePort: 30000

--- a/docs/prometheus-integration.md
+++ b/docs/prometheus-integration.md
@@ -1,0 +1,107 @@
+# Prometheus Integration
+
+## Purpose
+Prometheus server can monitor various metrics and provide an observation of the 
+Antrea Controller and Agent components. The doc provides general guidelines to 
+the configuration of Prometheus server to operate with the Antrea components.
+
+## About Prometheus
+[Prometheus](https://prometheus.io/) is an open source monitoring and alerting 
+server. Prometheus is capable of collecting metrics from various Kubernetes 
+components, storing and providing alerts.
+Prometheus can provide visibility by integrating with other products such as 
+[Grafana](https://grafana.com/).
+ 
+One of Prometheus capabilities is self-discovery of Kubernetes services which
+expose their metrics. So Prometheus can scrape the metrics of any additional 
+components which are added to the cluster without further configuration changes. 
+ 
+## Antrea Configuration
+Enable Prometheus metrics listener by setting `enablePrometheusMetrics` 
+parameter to true in the Controller and the Agent configurations.
+ 
+## Prometheus Configuration
+  
+### Kubernetes API Endpoint Access
+Prometheus requires access to Kubernetes API endpoint for service discovery
+capability.
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/proxy
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+```
+
+### Antrea Metrics Listener Access
+To scrape the metrics from Antrea Controller and Agent, Prometheus needs the
+following permissions
+```yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: prometheus-antrea
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+```
+
+### Antrea Components Scraping configuration
+Add the following jobs to Prometheus scraping configuration to enable metrics
+collection from Antrea components
+
+#### Controller Scraping
+```yaml
+- job_name: 'antrea-controllers'
+kubernetes_sd_configs:
+- role: endpoints
+scheme: https
+tls_config:
+  ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  insecure_skip_verify: true
+bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+relabel_configs:
+- source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_container_name]
+  action: keep
+  regex: kube-system;antrea-controller
+```
+
+#### Agent Scraping
+```yaml
+- job_name: 'antrea-agents'
+kubernetes_sd_configs:
+- role: pod
+scheme: https
+tls_config:
+  ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  insecure_skip_verify: true
+bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+relabel_configs:
+- source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_container_name]
+  action: keep
+  regex: kube-system;antrea-agent
+```
+For further reference see the enclosed 
+[configuration file](/build/yamls/antrea-prometheus.yml).
+
+The configuration file above can be used to deploy Prometheus Server with 
+scraping configuration for Antrea services.
+To deploy this configuration use
+`kubectl apply -f build/yamls/antrea-prometheus.yml`


### PR DESCRIPTION
Document the interoperability of Antrea controller and agents with
Prometheus monitoring server.
Add a document describing configuration changes in Antrea and Prometheus.
Also add a sample yaml file.
