### PR TITLE
Start ovs-vswitchd with flow-restore-wait

### DIFF
--- a/build/images/scripts/start_ovs
+++ b/build/images/scripts/start_ovs
@@ -2,6 +2,7 @@
 
 source logging
 source daemon_status
+source /usr/share/openvswitch/scripts/ovs-lib
 
 CONTAINER_NAME="antrea-ovs"
 OVS_DB_FILE="/var/run/openvswitch/conf.db"
@@ -9,8 +10,25 @@ OVS_DB_FILE="/var/run/openvswitch/conf.db"
 set -euo pipefail
 
 function start_ovs {
-    log_info $CONTAINER_NAME "Starting OVS"
-    /usr/share/openvswitch/scripts/ovs-ctl --system-id=random start --db-file=$OVS_DB_FILE
+    if daemon_is_running ovsdb-server; then
+        log_info $CONTAINER_NAME "ovsdb-server is already running"
+    else
+        log_info $CONTAINER_NAME "Starting ovsdb-server"
+        /usr/share/openvswitch/scripts/ovs-ctl --no-ovs-vswitchd --system-id=random start --db-file=$OVS_DB_FILE
+        log_info $CONTAINER_NAME "Started ovsdb-server"
+    fi
+
+    if daemon_is_running ovs-vswitchd; then
+        log_info $CONTAINER_NAME "ovs-vswitchd is already running"
+    else
+        log_info $CONTAINER_NAME "Starting ovs-vswitchd"
+        # Start ovs-vswitchd with flow-restore-wait set to true so that packets won't be
+        # mishandled in its default fashion, the config will be removed after antrea-agent
+        # restoring flows.
+        ovs-vsctl --no-wait set open_vswitch . other_config:flow-restore-wait="true"
+        /usr/share/openvswitch/scripts/ovs-ctl --no-ovsdb-server --system-id=random start --db-file=$OVS_DB_FILE
+        log_info $CONTAINER_NAME "Started ovs-vswitchd"
+    fi
 }
 
 function stop_ovs {

--- a/build/images/scripts/start_ovs_netdev
+++ b/build/images/scripts/start_ovs_netdev
@@ -48,6 +48,10 @@ function del_br_phy {
 
 function start_ovs {
     log_info $CONTAINER_NAME "Starting OVS"
+    # Unlike the start_ovs script, we don't set flow-restore-wait when starting OVS
+    # with the netdev datapath. This is because the Node's network relies on the
+    # forwarding of OVS so we cannot get Node, Pod, NetworkPolicy data from
+    # Kubernetes API to install proper flows before removing flow-restore-wait.
     /usr/share/openvswitch/scripts/ovs-ctl --system-id=random start --db-file=$OVS_DB_FILE
 }
 

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -139,6 +139,12 @@ func run(o *Options) error {
 		return fmt.Errorf("error initializing CNI server: %v", err)
 	}
 
+	// TODO: we should call this after installing flows for initial node routes
+	//  and initial NetworkPolicies so that no packets will be mishandled.
+	if err := agentInitializer.FlowRestoreComplete(); err != nil {
+		return err
+	}
+
 	// set up signal capture: the first SIGTERM / SIGINT signal is handled gracefully and will
 	// cause the stopCh channel to be closed; if another signal is received before the program
 	// exits, we will force exit.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -24,6 +24,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/vishvananda/netlink"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 
@@ -291,9 +292,40 @@ func (i *Initializer) initOpenFlowPipeline() error {
 			klog.Info("Replaying OF flows to OVS bridge")
 			i.ofClient.ReplayFlows()
 			klog.Info("Flow replay completed")
+
+			// ofClient and ovsBridgeClient have their own mechanisms to restore connections with OVS, and it could
+			// happen that ovsBridgeClient's connection is not ready when ofClient completes flow replay. We retry it
+			// with a timeout that is longer time than ovsBridgeClient's maximum connecting retry interval (8 seconds)
+			// to ensure the flag can be removed successfully.
+			err := wait.PollImmediate(200*time.Millisecond, 10*time.Second, func() (done bool, err error) {
+				if err := i.FlowRestoreComplete(); err != nil {
+					return false, nil
+				}
+				return true, nil
+			})
+			// This shouldn't happen unless OVS is disconnected again after replaying flows. If it happens, we will try
+			// to clean up the config again so an error log should be fine.
+			if err != nil {
+				klog.Errorf("Failed to clean up flow-restore-wait config: %v", err)
+			}
 		}
 	}()
 
+	return nil
+}
+
+func (i *Initializer) FlowRestoreComplete() error {
+	// ovs-vswitchd is started with flow-restore-wait set to true for the following reasons:
+	// 1. It prevents packets from being mishandled by ovs-vswitchd in its default fashion,
+	//    which could affect existing connections' conntrack state and cause issues like #625.
+	// 2. It prevents ovs-vswitchd from flushing or expiring previously set datapath flows,
+	//    so existing connections can achieve 0 downtime during OVS restart.
+	// As a result, we remove the config here after restoring necessary flows.
+	klog.Info("Cleaning up flow-restore-wait config")
+	if err := i.ovsBridgeClient.DeleteOVSOtherConfig(map[string]interface{}{"flow-restore-wait": "true"}); err != nil {
+		return fmt.Errorf("error when cleaning up flow-restore-wait config: %v", err)
+	}
+	klog.Info("Cleaned up flow-restore-wait config")
 	return nil
 }
 

--- a/pkg/ovs/ovsconfig/interfaces.go
+++ b/pkg/ovs/ovsconfig/interfaces.go
@@ -42,4 +42,7 @@ type OVSBridgeClient interface {
 	GetPortList() ([]OVSPortData, Error)
 	SetInterfaceMTU(name string, MTU int) error
 	GetOVSVersion() (string, Error)
+	AddOVSOtherConfig(configs map[string]interface{}) Error
+	GetOVSOtherConfig() (map[string]string, Error)
+	DeleteOVSOtherConfig(configs map[string]interface{}) Error
 }

--- a/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
+++ b/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Antrea Authors
+// Copyright 2020 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,6 +46,20 @@ func NewMockOVSBridgeClient(ctrl *gomock.Controller) *MockOVSBridgeClient {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockOVSBridgeClient) EXPECT() *MockOVSBridgeClientMockRecorder {
 	return m.recorder
+}
+
+// AddOVSOtherConfig mocks base method
+func (m *MockOVSBridgeClient) AddOVSOtherConfig(arg0 map[string]interface{}) ovsconfig.Error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddOVSOtherConfig", arg0)
+	ret0, _ := ret[0].(ovsconfig.Error)
+	return ret0
+}
+
+// AddOVSOtherConfig indicates an expected call of AddOVSOtherConfig
+func (mr *MockOVSBridgeClientMockRecorder) AddOVSOtherConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOVSOtherConfig", reflect.TypeOf((*MockOVSBridgeClient)(nil).AddOVSOtherConfig), arg0)
 }
 
 // Create mocks base method
@@ -136,6 +150,20 @@ func (mr *MockOVSBridgeClientMockRecorder) Delete() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockOVSBridgeClient)(nil).Delete))
 }
 
+// DeleteOVSOtherConfig mocks base method
+func (m *MockOVSBridgeClient) DeleteOVSOtherConfig(arg0 map[string]interface{}) ovsconfig.Error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteOVSOtherConfig", arg0)
+	ret0, _ := ret[0].(ovsconfig.Error)
+	return ret0
+}
+
+// DeleteOVSOtherConfig indicates an expected call of DeleteOVSOtherConfig
+func (mr *MockOVSBridgeClientMockRecorder) DeleteOVSOtherConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOVSOtherConfig", reflect.TypeOf((*MockOVSBridgeClient)(nil).DeleteOVSOtherConfig), arg0)
+}
+
 // DeletePort mocks base method
 func (m *MockOVSBridgeClient) DeletePort(arg0 string) ovsconfig.Error {
 	m.ctrl.T.Helper()
@@ -192,6 +220,21 @@ func (m *MockOVSBridgeClient) GetOFPort(arg0 string) (int32, ovsconfig.Error) {
 func (mr *MockOVSBridgeClientMockRecorder) GetOFPort(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOFPort", reflect.TypeOf((*MockOVSBridgeClient)(nil).GetOFPort), arg0)
+}
+
+// GetOVSOtherConfig mocks base method
+func (m *MockOVSBridgeClient) GetOVSOtherConfig() (map[string]string, ovsconfig.Error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOVSOtherConfig")
+	ret0, _ := ret[0].(map[string]string)
+	ret1, _ := ret[1].(ovsconfig.Error)
+	return ret0, ret1
+}
+
+// GetOVSOtherConfig indicates an expected call of GetOVSOtherConfig
+func (mr *MockOVSBridgeClientMockRecorder) GetOVSOtherConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOVSOtherConfig", reflect.TypeOf((*MockOVSBridgeClient)(nil).GetOVSOtherConfig))
 }
 
 // GetOVSVersion mocks base method

--- a/test/integration/ovs/ovs_client_test.go
+++ b/test/integration/ovs/ovs_client_test.go
@@ -150,6 +150,36 @@ func TestOVSBridgeExternalIDs(t *testing.T) {
 	}
 }
 
+func TestOVSOtherConfig(t *testing.T) {
+	data := &testData{}
+	data.setup(t)
+	defer data.teardown(t)
+
+	otherConfigs := map[string]interface{}{"flow-restore-wait": "true", "foo1": "bar1"}
+	err := data.br.AddOVSOtherConfig(otherConfigs)
+	require.Nil(t, err, "Error when adding OVS other_config")
+
+	gotOtherConfigs, err := data.br.GetOVSOtherConfig()
+	require.Nil(t, err, "Error when getting OVS other_config")
+	require.Equal(t, map[string]string{"flow-restore-wait": "true", "foo1": "bar1"}, gotOtherConfigs, "other_config mismatched")
+
+	// Expect only the new config "foo2: bar2" will be added.
+	err = data.br.AddOVSOtherConfig(map[string]interface{}{"flow-restore-wait": "false", "foo2": "bar2"})
+	require.Nil(t, err, "Error when adding OVS other_config")
+
+	gotOtherConfigs, err = data.br.GetOVSOtherConfig()
+	require.Nil(t, err, "Error when getting OVS other_config")
+	require.Equal(t, map[string]string{"flow-restore-wait": "true", "foo1": "bar1", "foo2": "bar2"}, gotOtherConfigs, "other_config mismatched")
+
+	// Expect only the matched config "flow-restore-wait: true" will be deleted.
+	err = data.br.DeleteOVSOtherConfig(map[string]interface{}{"flow-restore-wait": "true", "foo1": "bar2"})
+	require.Nil(t, err, "Error when deleting OVS other_config")
+
+	gotOtherConfigs, err = data.br.GetOVSOtherConfig()
+	require.Nil(t, err, "Error when getting OVS other_config")
+	require.Equal(t, map[string]string{"foo1": "bar1", "foo2": "bar2"}, gotOtherConfigs, "other_config mismatched")
+}
+
 func deleteAllPorts(t *testing.T, br *ovsconfig.OVSBridge) {
 	portList, err := br.GetPortUUIDList()
 	require.Nil(t, err, "Error when retrieving port list")


### PR DESCRIPTION
This patch starts ovs-vswitchd with flow-restore-wait set to true and
removes the config after restoring necessary flows for the following
reasons:

1. It prevents packets from being mishandled by ovs-vswitchd in its
default fashion, which could affect existing connections' conntrack
state and cause issues like #625.

2. It prevents ovs-vswitchd from flushing or expiring previously set
datapath flows, so existing connections can achieve 0 downtime during
OVS restart. As a result, we remove the config here after restoring
necessary flows.

Fixes #625