### PR TITLE
Add default CPU resource requests for Antrea Pods in manifests

### DIFF
--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -440,6 +440,9 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 200m
         volumeMounts:
         - mountPath: /etc/antrea/antrea-controller.conf
           name: antrea-config
@@ -567,6 +570,9 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 200m
         securityContext:
           privileged: true
         volumeMounts:
@@ -606,6 +612,9 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 5
         name: antrea-ovs
+        resources:
+          requests:
+            cpu: 200m
         securityContext:
           capabilities:
             add:
@@ -627,6 +636,9 @@ spec:
         image: antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: install-cni
+        resources:
+          requests:
+            cpu: 100m
         securityContext:
           capabilities:
             add:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -440,6 +440,9 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 200m
         volumeMounts:
         - mountPath: /etc/antrea/antrea-controller.conf
           name: antrea-config
@@ -567,6 +570,9 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 200m
         securityContext:
           privileged: true
         volumeMounts:
@@ -606,6 +612,9 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 5
         name: antrea-ovs
+        resources:
+          requests:
+            cpu: 200m
         securityContext:
           capabilities:
             add:
@@ -627,6 +636,9 @@ spec:
         image: antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: install-cni
+        resources:
+          requests:
+            cpu: 100m
         securityContext:
           capabilities:
             add:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -449,6 +449,9 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 200m
         volumeMounts:
         - mountPath: /etc/antrea/antrea-controller.conf
           name: antrea-config
@@ -540,6 +543,9 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 5
         name: antrea-ipsec
+        resources:
+          requests:
+            cpu: 50m
         securityContext:
           capabilities:
             add:
@@ -608,6 +614,9 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 200m
         securityContext:
           privileged: true
         volumeMounts:
@@ -647,6 +656,9 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 5
         name: antrea-ovs
+        resources:
+          requests:
+            cpu: 200m
         securityContext:
           capabilities:
             add:
@@ -668,6 +680,9 @@ spec:
         image: antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: install-cni
+        resources:
+          requests:
+            cpu: 100m
         securityContext:
           capabilities:
             add:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -440,6 +440,9 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 200m
         volumeMounts:
         - mountPath: /etc/antrea/antrea-controller.conf
           name: antrea-config
@@ -567,6 +570,9 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 200m
         securityContext:
           privileged: true
         volumeMounts:
@@ -606,6 +612,9 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 5
         name: antrea-ovs
+        resources:
+          requests:
+            cpu: 200m
         securityContext:
           capabilities:
             add:
@@ -627,6 +636,9 @@ spec:
         image: antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: install-cni
+        resources:
+          requests:
+            cpu: 100m
         securityContext:
           capabilities:
             add:

--- a/build/yamls/base/agent.yml
+++ b/build/yamls/base/agent.yml
@@ -31,6 +31,9 @@ spec:
       initContainers:
         - name: install-cni
           image: antrea
+          resources:
+            requests:
+              cpu: "100m"
           command: ["install_cni"]
           securityContext:
             capabilities:
@@ -58,6 +61,9 @@ spec:
       containers:
         - name: antrea-agent
           image: antrea
+          resources:
+            requests:
+              cpu: "200m"
           command: ["antrea-agent"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).
           args: ["--config", "/etc/antrea/antrea-agent.conf", "--logtostderr=false", "--log_dir", "/var/log/antrea", "--alsologtostderr"]
@@ -136,6 +142,9 @@ spec:
             mountPath: /run/xtables.lock
         - name: antrea-ovs
           image: antrea
+          resources:
+            requests:
+              cpu: "200m"
           command: ["start_ovs"]
           securityContext:
             # capabilities required by OVS daemons

--- a/build/yamls/base/controller.yml
+++ b/build/yamls/base/controller.yml
@@ -72,6 +72,9 @@ spec:
       containers:
         - name: antrea-controller
           image: antrea
+          resources:
+            requests:
+              cpu: "200m"
           command: ["antrea-controller"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).
           args: ["--config", "/etc/antrea/antrea-controller.conf", "--logtostderr=false", "--log_dir", "/var/log/antrea", "--alsologtostderr"]

--- a/build/yamls/patches/ipsec/ipsecContainer.yml
+++ b/build/yamls/patches/ipsec/ipsecContainer.yml
@@ -8,6 +8,9 @@ spec:
       containers:
         - name: antrea-ipsec
           image: antrea
+          resources:
+            requests:
+              cpu: "50m"
           command: ["start_ovs_ipsec"]
           livenessProbe:
             exec:


### PR DESCRIPTION
This is meant as an indication to the scheduler, to improve scheduling
of workload Pods.

It should not impact the likelihood of eviction of Antrea Pods. First,
CPU utilization does not seem to be used as an eviction signal. Second,
we already use a priorityClass of system-cluster-critical /
system-node-critical, which means that they are essentially treated as
Pods with a QoS class of Guaanteed (since K8s 1.14).

We do not define CPU limits as CPU usage can be very bursty (e.g. on
start up for antrea-agent, or if there is a burst of new flows for
antrea-ovs).

I don't think we should specify memory requests, as it is impossible to
come up with a number that would work for most use cases. This is also
not required to get a QoS class of Burstable. For example, memory
footprint should be much smaller with for small clusters which no
NetworkPolicies.

Fixes #647