### PR TITLE
[WIP][Windows] Set local_IP option on tunnel interface

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -405,11 +405,17 @@ func (i *Initializer) configureGatewayInterface(gatewayIface *interfacestore.Int
 
 func (i *Initializer) setupDefaultTunnelInterface(tunnelPortName string) error {
 	tunnelIface, portExists := i.ifaceStore.GetInterface(tunnelPortName)
+	localIP := i.getTunnelPortLocalIP()
+	localIPStr := ""
+	if localIP != nil {
+		localIPStr = localIP.String()
+	}
 
 	// Check the default tunnel port.
 	if portExists {
 		if i.networkConfig.TrafficEncapMode.SupportsEncap() &&
-			tunnelIface.TunnelInterfaceConfig.Type == i.networkConfig.TunnelType {
+			tunnelIface.TunnelInterfaceConfig.Type == i.networkConfig.TunnelType &&
+			tunnelIface.TunnelInterfaceConfig.LocalIP.Equal(localIP) {
 			klog.V(2).Infof("Tunnel port %s already exists on OVS bridge", tunnelPortName)
 			return nil
 		}
@@ -428,12 +434,12 @@ func (i *Initializer) setupDefaultTunnelInterface(tunnelPortName string) error {
 
 	// Create default tunnel port.
 	if i.networkConfig.TrafficEncapMode.SupportsEncap() {
-		tunnelPortUUID, err := i.ovsBridgeClient.CreateTunnelPort(tunnelPortName, i.networkConfig.TunnelType, config.DefaultTunOFPort)
+		tunnelPortUUID, err := i.ovsBridgeClient.CreateTunnelPortExt(tunnelPortName, i.networkConfig.TunnelType, config.DefaultTunOFPort, localIPStr, "", "", nil)
 		if err != nil {
 			klog.Errorf("Failed to create tunnel port %s type %s on OVS bridge: %v", tunnelPortName, i.networkConfig.TunnelType, err)
 			return err
 		}
-		tunnelIface = interfacestore.NewTunnelInterface(tunnelPortName, i.networkConfig.TunnelType)
+		tunnelIface = interfacestore.NewTunnelInterface(tunnelPortName, i.networkConfig.TunnelType, localIP)
 		tunnelIface.OVSPortConfig = &interfacestore.OVSPortConfig{tunnelPortUUID, config.DefaultTunOFPort}
 		i.ifaceStore.AddInterface(tunnelIface)
 	}

--- a/pkg/agent/agent_linux.go
+++ b/pkg/agent/agent_linux.go
@@ -16,6 +16,10 @@
 
 package agent
 
+import (
+	"net"
+)
+
 // setupExternalConnectivity returns immediately on Linux. The corresponding functions are provided in routeClient.
 func (i *Initializer) setupExternalConnectivity() error {
 	return nil
@@ -33,5 +37,11 @@ func (i *Initializer) prepareOVSBridge() error {
 
 // initHostNetworkFlows returns immediately on Linux.
 func (i *Initializer) initHostNetworkFlows() error {
+	return nil
+}
+
+// getTunnelLocalIP returns local_ip of tunnel port.
+// On linux platform, local_ip option is not needed.
+func (i *Initializer) getTunnelPortLocalIP() net.IP {
 	return nil
 }

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -17,6 +17,7 @@
 package agent
 
 import (
+	"net"
 	"strings"
 
 	"github.com/Microsoft/hcsshim"
@@ -172,4 +173,9 @@ func (i *Initializer) initHostNetworkFlows() error {
 		return err
 	}
 	return nil
+}
+
+// getTunnelLocalIP returns local_ip of tunnel port
+func (i *Initializer) getTunnelPortLocalIP() net.IP {
+	return i.nodeConfig.NodeIPAddr.IP
 }

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -457,6 +457,7 @@ func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) (int3
 			portName,
 			c.networkConfig.TunnelType,
 			0, // ofPortRequest - let OVS allocate OFPort number.
+			"",
 			nodeIP.String(),
 			c.networkConfig.IPSecPSK,
 			ovsExternalIDs)
@@ -499,7 +500,7 @@ func ParseTunnelInterfaceConfig(
 		klog.V(2).Infof("OVS port %s has no options", portData.Name)
 		return nil
 	}
-	remoteIP, psk := ovsconfig.ParseTunnelInterfaceOptions(portData)
+	remoteIP, localIP, psk := ovsconfig.ParseTunnelInterfaceOptions(portData)
 
 	var interfaceConfig *interfacestore.InterfaceConfig
 	var nodeName string
@@ -514,7 +515,7 @@ func ParseTunnelInterfaceConfig(
 			remoteIP,
 			psk)
 	} else {
-		interfaceConfig = interfacestore.NewTunnelInterface(portData.Name, ovsconfig.TunnelType(portData.IFType))
+		interfaceConfig = interfacestore.NewTunnelInterface(portData.Name, ovsconfig.TunnelType(portData.IFType), localIP)
 	}
 	interfaceConfig.OVSPortConfig = portConfig
 	return interfaceConfig

--- a/pkg/agent/interfacestore/types.go
+++ b/pkg/agent/interfacestore/types.go
@@ -48,6 +48,8 @@ type TunnelInterfaceConfig struct {
 	Type ovsconfig.TunnelType
 	// Name of the remote Node.
 	NodeName string
+	// IP address of the local Node.
+	LocalIP net.IP
 	// IP address of the remote Node.
 	RemoteIP net.IP
 	PSK      string
@@ -108,8 +110,8 @@ func NewGatewayInterface(gatewayName string) *InterfaceConfig {
 
 // NewTunnelInterface creates InterfaceConfig for the default tunnel port
 // interface.
-func NewTunnelInterface(tunnelName string, tunnelType ovsconfig.TunnelType) *InterfaceConfig {
-	tunnelConfig := &TunnelInterfaceConfig{Type: tunnelType}
+func NewTunnelInterface(tunnelName string, tunnelType ovsconfig.TunnelType, localIP net.IP) *InterfaceConfig {
+	tunnelConfig := &TunnelInterfaceConfig{Type: tunnelType, LocalIP: localIP}
 	return &InterfaceConfig{InterfaceName: tunnelName, Type: TunnelInterface, TunnelInterfaceConfig: tunnelConfig}
 }
 

--- a/pkg/ovs/ovsconfig/interfaces.go
+++ b/pkg/ovs/ovsconfig/interfaces.go
@@ -35,7 +35,7 @@ type OVSBridgeClient interface {
 	CreatePort(name, ifDev string, externalIDs map[string]interface{}) (string, Error)
 	CreateInternalPort(name string, ofPortRequest int32, externalIDs map[string]interface{}) (string, Error)
 	CreateTunnelPort(name string, tunnelType TunnelType, ofPortRequest int32) (string, Error)
-	CreateTunnelPortExt(name string, tunnelType TunnelType, ofPortRequest int32, remoteIP string, psk string, externalIDs map[string]interface{}) (string, Error)
+	CreateTunnelPortExt(name string, tunnelType TunnelType, ofPortRequest int32, localIP string, remoteIP string, psk string, externalIDs map[string]interface{}) (string, Error)
 	CreateUplinkPort(name string, ofPortRequest int32, externalIDs map[string]interface{}) (string, Error)
 	DeletePort(portUUID string) Error
 	DeletePorts(portUUIDList []string) Error

--- a/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
+++ b/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
@@ -108,18 +108,18 @@ func (mr *MockOVSBridgeClientMockRecorder) CreateTunnelPort(arg0, arg1, arg2 int
 }
 
 // CreateTunnelPortExt mocks base method
-func (m *MockOVSBridgeClient) CreateTunnelPortExt(arg0 string, arg1 ovsconfig.TunnelType, arg2 int32, arg3, arg4 string, arg5 map[string]interface{}) (string, ovsconfig.Error) {
+func (m *MockOVSBridgeClient) CreateTunnelPortExt(arg0 string, arg1 ovsconfig.TunnelType, arg2 int32, arg3, arg4, arg5 string, arg6 map[string]interface{}) (string, ovsconfig.Error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateTunnelPortExt", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "CreateTunnelPortExt", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(ovsconfig.Error)
 	return ret0, ret1
 }
 
 // CreateTunnelPortExt indicates an expected call of CreateTunnelPortExt
-func (mr *MockOVSBridgeClientMockRecorder) CreateTunnelPortExt(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockOVSBridgeClientMockRecorder) CreateTunnelPortExt(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTunnelPortExt", reflect.TypeOf((*MockOVSBridgeClient)(nil).CreateTunnelPortExt), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTunnelPortExt", reflect.TypeOf((*MockOVSBridgeClient)(nil).CreateTunnelPortExt), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // CreateUplinkPort mocks base method


### PR DESCRIPTION
On windows platform, local IP is need to be set on tunnel interface which is used as source IP of encap packets.

Signed-off-by: Rui Cao <rcao@vmware.com>