### PR TITLE
Remove redundant ClusterRole in Prometheus deployment instructions

### DIFF
--- a/build/yamls/antrea-prometheus.yml
+++ b/build/yamls/antrea-prometheus.yml
@@ -7,6 +7,7 @@ metadata:
     name: monitoring
 ---
 # Authorize Prometheus to view Kubernetes cluster components for service discovery purposes
+# Authorize Prometheus to retrieve metrics
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -27,17 +28,6 @@ rules:
   verbs: ["get", "list", "watch"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
----
-# Authorize Prometheus to retrieve metrics from Antrea components
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: prometheus-antrea
-rules:
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/docs/prometheus-integration.md
+++ b/docs/prometheus-integration.md
@@ -22,9 +22,10 @@ parameter to true in the Controller and the Agent configurations.
  
 ## Prometheus Configuration
   
-### Kubernetes API Endpoint Access
-Prometheus requires access to Kubernetes API endpoint for service discovery
-capability.
+### Prometheus RBAC
+Prometheus requires access to Kubernetes API resources for the service discovery
+capability. Reading metrics also requires access to the "/metrics" API
+endpoints.
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole


### PR DESCRIPTION
The prometheus-antrea ClusterRole was not used. All the necessary
permissions are provided by the prometheus ClusterRole.