### PR TITLE
Add namespace parameter to `podWaitForIP`

### DIFF
--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package e2e
 
 import (

--- a/test/e2e/bandwidth_test.go
+++ b/test/e2e/bandwidth_test.go
@@ -34,7 +34,7 @@ func BenchmarkBandwidthIntraNode(b *testing.B) {
 		if _, err := data.clientset.CoreV1().Pods(testNamespace).Create(podDefB); err != nil {
 			b.Fatalf("Error when creating the second perftest Pod: %v", err)
 		}
-		podBIP, err := data.podWaitForIP(defaultTimeout, podDefB.Name)
+		podBIP, err := data.podWaitForIP(defaultTimeout, podDefB.Name, testNamespace)
 		if err != nil {
 			b.Fatalf("Error when getting perftest Pod IP: %v", err)
 		}

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -59,7 +59,7 @@ func TestPodAssignIP(t *testing.T) {
 	defer deletePodWrapper(t, data, podName)
 
 	t.Logf("Checking Pod networking")
-	if podIP, err := data.podWaitForIP(defaultTimeout, podName); err != nil {
+	if podIP, err := data.podWaitForIP(defaultTimeout, podName, testNamespace); err != nil {
 		t.Errorf("Error when waiting for Pod IP: %v", err)
 	} else {
 		t.Logf("Pod IP is '%s'", podIP)
@@ -141,7 +141,7 @@ func TestDeletePod(t *testing.T) {
 	if err := data.createBusyboxPodOnNode(podName, nodeName); err != nil {
 		t.Fatalf("Error when creating busybox test Pod: %v", err)
 	}
-	if err := data.podWaitForRunning(defaultTimeout, podName); err != nil {
+	if err := data.podWaitForRunning(defaultTimeout, podName, testNamespace); err != nil {
 		t.Fatalf("Error when waiting for Pod '%s' to be in the Running state", podName)
 	}
 
@@ -199,7 +199,7 @@ func TestIPAMRestart(t *testing.T) {
 			return "", err
 		}
 		pods = append(pods, podName)
-		if podIP, err := data.podWaitForIP(defaultTimeout, podName); err != nil {
+		if podIP, err := data.podWaitForIP(defaultTimeout, podName, testNamespace); err != nil {
 			return "", err
 		} else {
 			return podIP, nil

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -31,7 +31,7 @@ func waitForPodIPs(t *testing.T, data *TestData, podNames []string) map[string]s
 	t.Logf("Waiting for Pods to be ready and retrieving IPs")
 	podIPs := make(map[string]string)
 	for _, podName := range podNames {
-		if podIP, err := data.podWaitForIP(defaultTimeout, podName); err != nil {
+		if podIP, err := data.podWaitForIP(defaultTimeout, podName, testNamespace); err != nil {
 			t.Fatalf("Error when waiting for IP for Pod '%s': %v", podName, err)
 		} else {
 			podIPs[podName] = podIP
@@ -101,7 +101,7 @@ func (data *TestData) testHostPortPodConnectivity(t *testing.T) {
 	}
 	defer deletePodWrapper(t, data, hpPodName)
 	// Retrieve the IP Address of the Node on which the Pod is scheduled.
-	hpPod, err := data.podWaitFor(defaultTimeout, hpPodName, func(pod *v1.Pod) (bool, error) {
+	hpPod, err := data.podWaitFor(defaultTimeout, hpPodName, testNamespace, func(pod *v1.Pod) (bool, error) {
 		return pod.Status.Phase == v1.PodRunning, nil
 	})
 	if err != nil {
@@ -114,7 +114,7 @@ func (data *TestData) testHostPortPodConnectivity(t *testing.T) {
 		t.Fatalf("Error when creating busybox test Pod: %v", err)
 	}
 	defer deletePodWrapper(t, data, clientName)
-	if _, err := data.podWaitForIP(defaultTimeout, clientName); err != nil {
+	if _, err := data.podWaitForIP(defaultTimeout, clientName, testNamespace); err != nil {
 		t.Fatalf("Error when waiting for IP for Pod '%s': %v", clientName, err)
 	}
 

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -237,7 +237,7 @@ func createTestBusyboxPods(tb testing.TB, data *TestData, num int, nodeName stri
 			return "", "", err
 		}
 
-		if podIP, err := data.podWaitForIP(defaultTimeout, podName); err != nil {
+		if podIP, err := data.podWaitForIP(defaultTimeout, podName, testNamespace); err != nil {
 			tb.Errorf("Error when waiting for IP for Pod '%s': %v", podName, err)
 			return podName, "", err
 		} else {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -566,9 +566,9 @@ type PodCondition func(*v1.Pod) (bool, error)
 
 // podWaitFor polls the K8s apiserver until the specified Pod is found (in the test Namespace) and
 // the condition predicate is met (or until the provided timeout expires).
-func (data *TestData) podWaitFor(timeout time.Duration, name string, condition PodCondition) (*v1.Pod, error) {
+func (data *TestData) podWaitFor(timeout time.Duration, name, namespace string, condition PodCondition) (*v1.Pod, error) {
 	err := wait.Poll(1*time.Second, timeout, func() (bool, error) {
-		if pod, err := data.clientset.CoreV1().Pods(testNamespace).Get(name, metav1.GetOptions{}); err != nil {
+		if pod, err := data.clientset.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{}); err != nil {
 			if errors.IsNotFound(err) {
 				return false, nil
 			}
@@ -580,13 +580,13 @@ func (data *TestData) podWaitFor(timeout time.Duration, name string, condition P
 	if err != nil {
 		return nil, err
 	}
-	return data.clientset.CoreV1().Pods(testNamespace).Get(name, metav1.GetOptions{})
+	return data.clientset.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
 }
 
 // podWaitForRunning polls the k8s apiserver until the specified Pod is in the "running" state (or
 // until the provided timeout expires).
-func (data *TestData) podWaitForRunning(timeout time.Duration, name string) error {
-	_, err := data.podWaitFor(timeout, name, func(pod *v1.Pod) (bool, error) {
+func (data *TestData) podWaitForRunning(timeout time.Duration, name, namespace string) error {
+	_, err := data.podWaitFor(timeout, name, namespace, func(pod *v1.Pod) (bool, error) {
 		return pod.Status.Phase == v1.PodRunning, nil
 	})
 	return err
@@ -594,8 +594,8 @@ func (data *TestData) podWaitForRunning(timeout time.Duration, name string) erro
 
 // podWaitForIP polls the K8s apiserver until the specified Pod is in the "running" state (or until
 // the provided timeout expires). The function then returns the IP address assigned to the Pod.
-func (data *TestData) podWaitForIP(timeout time.Duration, name string) (string, error) {
-	pod, err := data.podWaitFor(timeout, name, func(pod *v1.Pod) (bool, error) {
+func (data *TestData) podWaitForIP(timeout time.Duration, name, namespace string) (string, error) {
+	pod, err := data.podWaitFor(timeout, name, namespace, func(pod *v1.Pod) (bool, error) {
 		return pod.Status.Phase == v1.PodRunning, nil
 	})
 	if err != nil {

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -35,7 +35,7 @@ func TestDifferentNamedPorts(t *testing.T) {
 		t.Fatalf("Error when creating server pod: %v", err)
 	}
 	defer deletePodWrapper(t, data, server0Name)
-	server0IP, err := data.podWaitForIP(defaultTimeout, server0Name)
+	server0IP, err := data.podWaitForIP(defaultTimeout, server0Name, testNamespace)
 	if err != nil {
 		t.Fatalf("Error when waiting for IP for Pod '%s': %v", server0Name, err)
 	}
@@ -46,7 +46,7 @@ func TestDifferentNamedPorts(t *testing.T) {
 		t.Fatalf("Error when creating server pod: %v", err)
 	}
 	defer deletePodWrapper(t, data, server1Name)
-	server1IP, err := data.podWaitForIP(defaultTimeout, server1Name)
+	server1IP, err := data.podWaitForIP(defaultTimeout, server1Name, testNamespace)
 	if err != nil {
 		t.Fatalf("Error when waiting for IP for Pod '%s': %v", server1Name, err)
 	}
@@ -56,7 +56,7 @@ func TestDifferentNamedPorts(t *testing.T) {
 		t.Fatalf("Error when creating busybox test Pod: %v", err)
 	}
 	defer deletePodWrapper(t, data, client0Name)
-	if _, err := data.podWaitForIP(defaultTimeout, client0Name); err != nil {
+	if _, err := data.podWaitForIP(defaultTimeout, client0Name, testNamespace); err != nil {
 		t.Fatalf("Error when waiting for IP for Pod '%s': %v", client0Name, err)
 	}
 
@@ -65,7 +65,7 @@ func TestDifferentNamedPorts(t *testing.T) {
 		t.Fatalf("Error when creating busybox test Pod: %v", err)
 	}
 	defer deletePodWrapper(t, data, client1Name)
-	if _, err := data.podWaitForIP(defaultTimeout, client1Name); err != nil {
+	if _, err := data.podWaitForIP(defaultTimeout, client1Name, testNamespace); err != nil {
 		t.Fatalf("Error when waiting for IP for Pod '%s': %v", client1Name, err)
 	}
 
@@ -135,7 +135,7 @@ func TestDefaultDenyEgressPolicy(t *testing.T) {
 		t.Fatalf("Error when creating server pod: %v", err)
 	}
 	defer deletePodWrapper(t, data, serverName)
-	serverIP, err := data.podWaitForIP(defaultTimeout, serverName)
+	serverIP, err := data.podWaitForIP(defaultTimeout, serverName, testNamespace)
 	if err != nil {
 		t.Fatalf("Error when waiting for IP for Pod '%s': %v", serverName, err)
 	}
@@ -145,7 +145,7 @@ func TestDefaultDenyEgressPolicy(t *testing.T) {
 		t.Fatalf("Error when creating busybox test Pod: %v", err)
 	}
 	defer deletePodWrapper(t, data, clientName)
-	if _, err := data.podWaitForIP(defaultTimeout, clientName); err != nil {
+	if _, err := data.podWaitForIP(defaultTimeout, clientName, testNamespace); err != nil {
 		t.Fatalf("Error when waiting for IP for Pod '%s': %v", clientName, err)
 	}
 

--- a/test/e2e/performance_test.go
+++ b/test/e2e/performance_test.go
@@ -183,7 +183,7 @@ func setupTestPods(data *TestData, b *testing.B) (nginxPodIP, perfPodIP string) 
 		b.Fatalf("Error when creating nginx test pod: %v", err)
 	}
 	b.Logf("Waiting IP assignment of the nginx test Pod")
-	nginxPodIP, err = data.podWaitForIP(defaultTimeout, benchNginxPodName)
+	nginxPodIP, err = data.podWaitForIP(defaultTimeout, benchNginxPodName, testNamespace)
 	if err != nil {
 		b.Fatalf("Error when waiting for IP assignment of nginx test Pod: %v", err)
 	}
@@ -195,7 +195,7 @@ func setupTestPods(data *TestData, b *testing.B) (nginxPodIP, perfPodIP string) 
 		b.Fatalf("Error when creating perftool test Pod: %v", err)
 	}
 	b.Logf("Waiting IP assignment of the perftool test Pod")
-	perfPodIP, err = data.podWaitForIP(defaultTimeout, perftoolPodName)
+	perfPodIP, err = data.podWaitForIP(defaultTimeout, perftoolPodName, testNamespace)
 	if err != nil {
 		b.Fatalf("Error when waiting for IP assignment of perftool test Pod: %v", err)
 	}

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -54,7 +54,7 @@ func TestUpgrade(t *testing.T) {
 	if err := data.createBusyboxPodOnNode(podName, nodeName); err != nil {
 		t.Fatalf("Error when creating busybox test Pod: %v", err)
 	}
-	if err := data.podWaitForRunning(defaultTimeout, podName); err != nil {
+	if err := data.podWaitForRunning(defaultTimeout, podName, testNamespace); err != nil {
 		t.Fatalf("Error when waiting for Pod '%s' to be in the Running state", podName)
 	}
 


### PR DESCRIPTION
This CL makes `podWaitForIP` more generic, e.g. get the IP address of an antrea component.