### PR TITLE
Fix flaky unit test TestAddNetworkPolicyWithMultipleRules

### DIFF
--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -399,7 +399,8 @@ func TestAddNetworkPolicyWithMultipleRules(t *testing.T) {
 			t.Fatal("Expected two rule updates, got timeout")
 		}
 	}
-	assert.Equal(t, policy1, controller.GetNetworkPolicy(policy1.Name, policy1.Namespace))
+	assert.ElementsMatch(t, policy1.Rules, controller.GetNetworkPolicy(policy1.Name, policy1.Namespace).Rules)
+	assert.ElementsMatch(t, policy1.AppliedToGroups, controller.GetNetworkPolicy(policy1.Name, policy1.Namespace).AppliedToGroups)
 	assert.Equal(t, 1, controller.GetNetworkPolicyNum())
 	assert.Equal(t, 2, controller.GetAddressGroupNum())
 	assert.Equal(t, 1, controller.GetAppliedToGroupNum())


### PR DESCRIPTION
The return value of `GetNetworkPolicy` is not deterministic as it
constructs rules from a map. Use `ElementsMatch` to ignore the order of
rules.

Fixes #661