### PR TITLE
Fix return path for NodePort Service traffic in EKS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ manifest:
 	@echo "===> Generating dev manifest for Antrea <==="
 	$(CURDIR)/hack/generate-manifest.sh --mode dev > build/yamls/antrea.yml
 	$(CURDIR)/hack/generate-manifest.sh --mode dev --ipsec > build/yamls/antrea-ipsec.yml
-	$(CURDIR)/hack/generate-manifest.sh --mode dev --encap-mode networkPolicyOnly > build/yamls/antrea-eks.yml
+	$(CURDIR)/hack/generate-manifest.sh --mode dev --cloud EKS --encap-mode networkPolicyOnly > build/yamls/antrea-eks.yml
 	$(CURDIR)/hack/generate-manifest.sh --mode dev --cloud GKE --encap-mode noEncap > build/yamls/antrea-gke.yml
 	$(CURDIR)/hack/generate-manifest-octant.sh --mode dev > build/yamls/antrea-octant.yml
 

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -531,6 +531,8 @@ spec:
         command:
         - antrea-agent
         env:
+        - name: ANTREA_CLOUD_EKS
+          value: "true"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/build/yamls/patches/eks/eksEnv.yml
+++ b/build/yamls/patches/eks/eksEnv.yml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: antrea-agent
+spec:
+  template:
+    spec:
+      containers:
+        - name: antrea-agent
+          env:
+            # Antrea Agent needs to be aware that it is being used in EKS, as
+            # additional iptables rules may have to be installed.
+            - name: ANTREA_CLOUD_EKS
+              value: "true"

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -184,16 +184,24 @@ if [[ $ENCAP_MODE == "networkPolicyOnly" ]] ; then
     cd ..
 fi
 
-if [[ $CLOUD != "" ]]; then
-    if [[ $CLOUD == "GKE" ]]; then
-        mkdir gke && cd gke
-        cp ../../patches/gke/*.yml .
-        touch kustomization.yml
-        $KUSTOMIZE edit add base $BASE
-        $KUSTOMIZE edit add patch cniPath.yml
-        BASE=../gke
-        cd ..
-    fi
+if [[ $CLOUD == "GKE" ]]; then
+    mkdir gke && cd gke
+    cp ../../patches/gke/*.yml .
+    touch kustomization.yml
+    $KUSTOMIZE edit add base $BASE
+    $KUSTOMIZE edit add patch cniPath.yml
+    BASE=../gke
+    cd ..
+fi
+
+if [[ $CLOUD == "EKS" ]]; then
+    mkdir eks && cd eks
+    cp ../../patches/eks/*.yml .
+    touch kustomization.yml
+    $KUSTOMIZE edit add base $BASE
+    $KUSTOMIZE edit add patch eksEnv.yml
+    BASE=../eks
+    cd ..
 fi
 
 if $KIND; then

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -16,6 +16,7 @@ package env
 
 import (
 	"os"
+	"strconv"
 
 	"k8s.io/klog"
 )
@@ -24,6 +25,8 @@ import (
 const (
 	nodeNameEnvKey = "NODE_NAME"
 	podNameEnvKey  = "POD_NAME"
+
+	antreaCloudEKSEnvKey = "ANTREA_CLOUD_EKS"
 )
 
 // GetNodeName returns the node's name used in Kubernetes, based on the priority:
@@ -51,4 +54,21 @@ func GetPodName() string {
 		klog.Warningf("Environment variable %s not found", podNameEnvKey)
 	}
 	return podName
+}
+
+func getBoolEnvVar(name string, defaultValue bool) bool {
+	if strValue := os.Getenv(name); strValue != "" {
+		parsedValue, err := strconv.ParseBool(strValue)
+		if err != nil {
+			klog.Errorf("Failed to parse env variable '%s' (using default '%t'): %v", name, defaultValue, err)
+			return defaultValue
+		}
+		return parsedValue
+	}
+	return defaultValue
+}
+
+// Returns true if Antrea is used to enforce NetworkPolicies in an EKS cluster.
+func IsCloudEKS() bool {
+	return getBoolEnvVar(antreaCloudEKSEnvKey, false)
 }


### PR DESCRIPTION
When Antrea is used to enforce NetworkPolicies in EKS, an additional
iptables rule is required in the mangle table, to ensure that return
NodePort Service traffic which was load-balanced to a Pod attached to a
secondary ENI takes the correct reverse path through eth0.

This requires communicating to the Antrea Agent that it is being run in
an EKS managed cluster, which we do through an environment variable
(ANTREA_CLOUD_EKS).

Some future improvements are possible: this rule is only necessary if
NodePort is enabled in AWS VPC CNI, and in some rare cases it may be
possible for the packet mark to differ from the default value (0x80).

This patch also improves the test-conformance-eks.sh script which was
used for testing. In particular it ensures that the script can be used
on macOS.

Fixes #678