### PR TITLE
[Windows]Add antrea-agent dockerfile and deployment yaml for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,12 @@ build-ubuntu:
 	docker build -t antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.ubuntu .
 	docker tag antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) antrea/antrea-ubuntu
 
+.PHONY: build-windows
+build-windows:
+	@echo "===> Building Antrea bins and antrea/antrea-windows Docker image <==="
+	docker build -t antrea/antrea-windows:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.windows .
+	docker tag antrea/antrea-windows:$(DOCKER_IMG_VERSION) antrea/antrea-windows
+
 .PHONY: manifest
 manifest:
 	@echo "===> Generating dev manifest for Antrea <==="

--- a/build/images/Dockerfile.build.windows
+++ b/build/images/Dockerfile.build.windows
@@ -1,0 +1,54 @@
+FROM mcr.microsoft.com/powershell:lts-nanoserver-1809 as cni-binaries-windows
+SHELL ["pwsh", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV CNI_PLUGINS="./host-local.exe"
+
+WORKDIR /opt/cni/bin
+
+RUN curl.exe -LO https://github.com/containernetworking/plugins/releases/download/v0.8.1/cni-plugins-windows-amd64-v0.8.1.tgz; \
+    tar -xzf cni-plugins-windows-amd64-v0.8.1.tgz  -C C:\opt\cni\bin ${env:CNI_PLUGINS}; \
+    rm cni-plugins-windows-amd64-v0.8.1.tgz
+
+
+FROM golang:1.13 as antrea-build-windows
+
+WORKDIR /
+
+# Install 7zip, git-for-windows, mingw64 to support "make tool"
+RUN curl.exe -LO https://www.7-zip.org/a/7z1900-x64.exe; \
+    cmd /c start /wait 7z1900-x64.exe /S; \
+	del 7z1900-x64.exe; $env:Path=$env:Path + ';C:/Program Files/7-Zip'; [Environment]::SetEnvironmentVariable('PATH', $env:Path, [EnvironmentVariableTarget]::Machine)
+RUN curl.exe -LO https://cfhcable.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-posix/seh/x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z; \
+    7z x x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z; $env:Path = 'C:\mingw64\bin;' + $env:Path; cp C:\mingw64\bin\mingw32-make.exe  C:\mingw64\bin\make.exe; \
+	del x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z; [Environment]::SetEnvironmentVariable('PATH', $env:Path, [EnvironmentVariableTarget]::Machine)
+RUN curl.exe -LO https://github.com/git-for-windows/git/releases/download/v2.26.2.windows.1/Git-2.26.2-64-bit.exe; \
+    cmd /c start /wait Git-2.26.2-64-bit.exe /VERYSILENT /NORESTART /NOCANCEL /SP- /NOICONS /COMPONENTS='icons,icons\quicklaunch,ext,ext\reg,ext\reg\shellhere,ext\reg\guihere,assoc,assoc_sh' /LOG; \
+	$env:Path='C:\Program Files\Git\cmd;C:\Program Files\Git\usr\bin;' + $env:Path; [Environment]::SetEnvironmentVariable('PATH', $env:Path, [EnvironmentVariableTarget]::Machine)
+
+WORKDIR /antrea
+
+COPY go.mod /antrea/go.mod
+
+RUN go mod download
+
+COPY . /antrea
+
+RUN sh -c 'make windows-bin'
+
+
+FROM mcr.microsoft.com/powershell:lts-nanoserver-1809
+SHELL ["pwsh", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="A Docker image to deploy the Antrea CNI."
+
+USER ContainerAdministrator
+
+RUN mkdir -Force C:\k\antrea\bin
+COPY --from=cni-binaries-windows  /opt/cni/bin /k/antrea/cni
+COPY --from=antrea-build-windows  /antrea/build/images/scripts/Install-WindowsCNI.ps1 /k/antrea/
+COPY --from=antrea-build-windows  /antrea/bin/antrea-agent.exe /k/antrea/bin/
+COPY --from=antrea-build-windows  /antrea/bin/antrea-cni.exe /k/antrea/cni/antrea.exe
+
+RUN mkdir C:\k\antrea\utils; \
+    curl.exe -Lo C:/k/antrea/utils/wins.exe https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe

--- a/build/images/scripts/Install-WindowsCNI.ps1
+++ b/build/images/scripts/Install-WindowsCNI.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = "Stop";
+
+mkdir -force /host/var/run/secrets/kubernetes.io/serviceaccount
+cp -force /var/run/secrets/kubernetes.io/serviceaccount/* /host/var/run/secrets/kubernetes.io/serviceaccount/
+mkdir -force /host/k/antrea/etc/
+mkdir -force /host/k/antrea/logs/
+cp /k/antrea/cni/* /host/opt/cni/bin/
+cp /etc/antrea/antrea-agent.conf /host/k/antrea/etc/
+
+cp /etc/antrea/antrea-cni.conflist /host/etc/cni/net.d/10-antrea.conflist

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -1,0 +1,176 @@
+apiVersion: v1
+data:
+  Run-AntreaAgent.ps1: |-
+    $ErrorActionPreference = "Stop"
+    # wins will rename the binary when executing it. So we need to copy the binary everytime before running it.
+    mkdir -force /host/k/antrea/bin
+    cp /k/antrea/bin/* /host/k/antrea/bin/
+    C:/k/antrea/utils/wins.exe cli process run --path /k/antrea/bin/antrea-agent.exe --args "--config=/k/antrea/etc/antrea-agent.conf --logtostderr=false --log_dir=/k/antrea/logs/ --alsologtostderr" --envs "KUBERNETES_SERVICE_HOST=$env:KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT=$env:KUBERNETES_SERVICE_PORT ANTREA_SERVICE_HOST=$env:ANTREA_SERVICE_HOST ANTREA_SERVICE_PORT=$env:ANTREA_SERVICE_PORT NODE_NAME=$env:NODE_NAME"
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    app: antrea
+  name: antrea-agent-windows
+  namespace: kube-system
+---
+apiVersion: v1
+data:
+  antrea-agent.conf: |
+    # Name of the OpenVSwitch bridge antrea-agent will create and use.
+    # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
+    #ovsBridge: br-int
+
+    # Name of the interface antrea-agent will create and use for host <--> pod communication.
+    # Make sure it doesn't conflict with your existing interfaces.
+    #hostGateway: gw0
+
+    # Encapsulation mode for communication between Pods across Nodes, supported values:
+    # - vxlan (default)
+    # - stt
+    #tunnelType: vxlan
+
+    # Default MTU to use for the host gateway interface and the network interface of each Pod. If
+    # omitted, antrea-agent will default this value to 1450 to accommodate for tunnel encapsulate
+    # overhead.
+    #defaultMTU: 1450
+
+    # CIDR Range for services in cluster. It's required to support egress network policy, should
+    # be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
+    #serviceCIDR: 10.96.0.0/12
+
+  antrea-cni.conflist: |
+    {
+        "cniVersion":"0.3.0",
+        "name": "antrea",
+        "plugins": [
+            {
+                "type": "antrea",
+                "ipam": {
+                    "type": "host-local"
+                },
+                "capabilities": {"dns": true}
+            }
+        ]
+    }
+  antrea-controller.conf: ""
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    app: antrea
+  name: antrea-config-bckh9m3ace
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: antrea
+    component: antrea-agent
+  name: antrea-agent-windows
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: antrea
+      component: antrea-agent
+  template:
+    metadata:
+      labels:
+        app: antrea
+        component: antrea-agent
+    spec:
+      containers:
+        - command:
+            - pwsh
+          args:
+            - -file
+            - /var/lib/antrea-windows/Run-AntreaAgent.ps1
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          image: antrea/antrea-windows:latest
+          imagePullPolicy: IfNotPresent
+          name: antrea-agent
+          volumeMounts:
+            - mountPath: /host
+              name: host
+            - mountPath: \\.\pipe\rancher_wins
+              name: wins
+            - mountPath: /etc/antrea
+              name: antrea-config
+            - mountPath: /var/lib/antrea-windows
+              name: antrea-agent-windows
+            - mountPath: /host/k/antrea/
+              name: host-antrea-home
+      hostNetwork: true
+      initContainers:
+        - command:
+            - pwsh
+          args:
+            - -File
+            - /k/antrea/Install-WindowsCNI.ps1
+          image: antrea/antrea-windows:latest
+          imagePullPolicy: IfNotPresent
+          name: install-cni
+          volumeMounts:
+            - mountPath: /etc/antrea
+              name: antrea-config
+              readOnly: true
+            - mountPath: /host/etc/cni/net.d
+              name: host-cni-conf
+            - mountPath: /host/opt/cni/bin
+              name: host-cni-bin
+            - mountPath: /host/k/antrea/
+              name: host-antrea-home
+            - mountPath: /host
+              name: host
+      nodeSelector:
+        kubernetes.io/os: windows
+      priorityClassName: system-node-critical
+      serviceAccountName: antrea-agent
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+      volumes:
+        - configMap:
+            name: antrea-config-bckh9m3ace
+          name: antrea-config
+        - configMap:
+            defaultMode: 420
+            name: antrea-agent-windows
+          name: antrea-agent-windows
+        - hostPath:
+            path: /etc/cni/net.d
+            type: DirectoryOrCreate
+          name: host-cni-conf
+        - hostPath:
+            path: /opt/cni/bin
+            type: DirectoryOrCreate
+          name: host-cni-bin
+        - hostPath:
+            path: /k/antrea
+            type: DirectoryOrCreate
+          name: host-antrea-home
+        - hostPath:
+            path: /
+          name: host
+        - name: wins
+          hostPath:
+            path: \\.\pipe\rancher_wins
+            type: null
+  updateStrategy:
+    type: RollingUpdate

--- a/hack/windows/Clean-AntreaNetwork.ps1
+++ b/hack/windows/Clean-AntreaNetwork.ps1
@@ -1,0 +1,47 @@
+<#
+.SYNOPSIS
+Clean OVS bridge and HnsNetwork created by Antrea Agent
+#>
+
+function GetHnsnetworkId($NetName) {
+    $NetList= $(Get-HnsNetwork -ErrorAction SilentlyContinue)
+    if ($NetList -eq $null) {
+        return $null
+    }
+    foreach ($Net in $NetList) {
+        if ($Net.Name -eq $NetName) {
+            return $Net.Id
+        }
+    }
+    return $null
+}
+$AntreaHnsNetworkName = "antrea-hnsnetwork"
+
+Write-Host "Delete OVS bridge: br-int"
+ovs-vsctl.exe --no-wait del-br br-int
+$MaxRetryCount = 10
+$RetryCountRange = 1..$MaxRetryCount
+$BrIntDeleted = $false
+foreach ($RetryCount in $RetryCountRange) {
+    Write-Host "Waiting for OVS bridge deletion complete ($RetryCount/$MaxRetryCount)..."
+    $BrIntAdapter = $(Get-NetAdapter br-int -ErrorAction SilentlyContinue)
+    if ($BrIntAdapter -eq $null) {
+        $BrIntDeleted = $true
+        break
+    }
+    if ($RetryCount -eq $MaxRetryCount) {
+        break
+    }
+    Start-Sleep -Seconds 5
+}
+if (!$BrIntDeleted) {
+    Write-Host "Failed to delete OVS Bridge, please retry the script or delete the bridge and HNS network manually."
+    return
+}
+
+
+$NetId = GetHnsnetworkId($AntreaHnsNetworkName)
+if ($NetId -ne $null) {
+    Write-Host "Remove HnsNetwork: $AntreaHnsNetworkName"
+    Get-HnsNetwork -Id $NetId | Remove-HnsNetwork
+}

--- a/hack/windows/Install-DevTools.ps1
+++ b/hack/windows/Install-DevTools.ps1
@@ -1,0 +1,99 @@
+<#
+Install development tools used to build Antrea:
+- 7zip
+- Git-for-windows
+- mingw64
+- Golang
+#>
+
+function Add-Path($newPath) {
+    $env:Path = "$newPath;" + $env:Path
+    [Environment]::SetEnvironmentVariable("Path", $env:Path, [EnvironmentVariableTarget]::Machine)
+}
+
+function CommandExists($cmd) {
+    If (Get-Command $cmd -ErrorAction SilentlyContinue) {
+        Write-Host "Command: $cmd already exists."
+        return $true
+    }
+    return $false
+}
+
+function InstallSevenZip() {
+    Write-Host "Installing 7-Zip"
+    Write-Host "================"
+    if (CommandExists("7z")) {
+        return
+    }
+    $exePath = "$env:USERPROFILE\7z1900-x64.exe"
+    curl.exe -Lo $exePath https://www.7-zip.org/a/7z1900-x64.exe
+    cmd /c start /wait $exePath /S
+    del $exePath
+    $sevenZipFolder = 'C:\Program Files\7-Zip'
+    Add-Path "$sevenZipFolder"
+    Write-Host "Installed 7-Zip"
+}
+
+function InstallGit() {
+    Write-Host "Installing Git"
+    Write-Host "=============="
+    if (CommandExists("git")) {
+        return
+    }
+    $gitVersion="Git-2.26.2"
+    $exePath = "$env:TEMP\Git-$gitVersion-64-bit.exe"
+    Write-Host "Downloading Git $gitVersion..."
+    curl.exe -Lo $exePath https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/Git-2.21.0-64-bit.exe
+    Write-Host "Installing..."
+    cmd /c start /wait $exePath /VERYSILENT /NORESTART /NOCANCEL /SP- /NOICONS /COMPONENTS="icons,icons\quicklaunch,ext,ext\reg,ext\reg\shellhere,ext\reg\guihere,assoc,assoc_sh" /LOG
+    del $exePath
+    Add-Path "$env:ProgramFiles\Git\cmd"
+    Add-Path "$env:ProgramFiles\Git\usr\bin"
+    Write-Host "Installed Git"
+}
+
+function InstallMingw() {
+    Write-Host "Installing MinGW..."
+    Write-Host "=============="
+    if (CommandExists("make")) {
+        return
+    }
+    $mingwPath = "C:\mingw-w64"
+    $destPath = "c:\"
+    $zipPath = "$env:TEMP\mingw-w64.7z"
+    curl.exe -Lo $zipPath https://iweb.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-posix/seh/x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z
+    7z x $zipPath -o"$destPath" -aoa
+    cp C:\mingw64\bin\mingw32-make.exe  C:\mingw64\bin\make.exe
+    Add-Path("C:\mingw64\bin")
+    Remove-Item $zipPath
+    Write-Host "Installed MinGW"
+}
+
+function InstallGolang() {
+    $GOLANG_VERSION = "1.13.10"
+    Write-Host "Installing Golang $GOLANG_VERSION"
+    Write-Host "=============="
+    if (CommandExists("go")) {
+        return
+    }
+    $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $GOLANG_VERSION)
+    $zipPath = "$env:TEMP\go.zip"
+    curl.exe -Lo $zipPath $url
+    Expand-Archive $zipPath -DestinationPath C:\
+    Remove-Item $zipPath -Force
+    Add-Path("C:\go\bin")
+    mkdir C:\gopath
+    $env:GOPATH = "C:\gopath"
+    [Environment]::SetEnvironmentVariable("GOPATH", $env:GOPATH, [EnvironmentVariableTarget]::Machine)
+    Add-Path("$env:GOPATH\bin")
+    Write-Host "Installed Golang $GOLANG_VERSION"
+}
+
+# 7-Zip
+InstallSevenZip
+# Git
+InstallGit
+# MinGW 8.1
+InstallMingw
+# Golang
+InstallGolang

--- a/hack/windows/Install-OVS.ps1
+++ b/hack/windows/Install-OVS.ps1
@@ -1,0 +1,163 @@
+Param(
+    [parameter(Mandatory = $false)] [string] $DownloadDir,
+    [parameter(Mandatory = $false)] [string] $DownloadURL,
+    [parameter(Mandatory = $false)] [string] $OVSInstallDir = "C:\openvswitch"
+)
+
+$ErrorActionPreference = "Stop"
+$OVSDownloadURL = "https://github.com/vmware-tanzu/antrea/releases/download/v0.7.0/ovs-2.12.90-win64.zip"
+$OVSDownloadDir = [System.IO.Path]::GetDirectoryName($myInvocation.MyCommand.Definition)
+$InstallLog = "$OVSDownloadDir\install.log"
+$OVSZip = "$OVSDownloadDir\ovs-win64.zip"
+
+if ($DownloadDir -ne "") {
+    $OVSDownloadDir = $DownloadDir
+    $InstallLog = "$OVSDownloadDir\install_ovs.log"
+}
+
+if ($DownloadURL -ne "") {
+    $OVSDownloadURL = $DownloadURL
+}
+
+function Log($Info) {
+    $time = $(get-date -Format g)
+    Write-Host "$time $Info `n`r" | Tee-Object $InstallLog -Append
+}
+
+function CreatePath($Path){
+    if ($(Test-Path $Path)) {
+        mv $Path $($Path + "_bak")
+    }
+    mkdir -p $Path | Out-Null
+}
+
+function SetEnvVar($key, $value) {
+    [Environment]::SetEnvironmentVariable($key, $value, [EnvironmentVariableTarget]::Machine)
+}
+
+function WaitExpandFiles($Src, $Dest) {
+    Log "Extract $Src to $Dest"
+    Expand-Archive -Path $Src -DestinationPath $Dest | Out-Null
+}
+
+function ServiceExists($ServiceName) {
+    If (Get-Service $ServiceName -ErrorAction SilentlyContinue) {
+        return $true
+    }
+    return $false
+}
+
+function CheckIfOVSInstalled() {
+    if (Test-Path -Path $OVSInstallDir) {
+        Log "$OVSInstallDir already exists, exit OVS installation."
+        exit 1
+    }
+    If (ServiceExists("ovs-vswitchd")) {
+        Log "Found existing OVS service, exit OVS installation."
+        exit 0
+    }
+}
+
+function DownloadOVS() {
+    if (!(Test-Path $OVSDownloadDir)) {
+        mkdir -p $OVSDownloadDir
+    }
+    Log "Downloading OVS package from $OVSDownloadURL to $OVSZip"
+    curl.exe -sLo $OVSZip $OVSDownloadURL
+    if (!$?) {
+        Log "Download OVS failed, URL: $OVSDownloadURL"
+        exit 1
+    }
+    Log "Download OVS package success."
+}
+
+function InstallOVS() {
+    # unzip OVS.
+    WaitExpandFiles $OVSZip $OVSDownloadDir
+    # Copy OVS package to target dir.
+    Log "Copying OVS package from $OVSDownloadDir\openvswitch to $OVSInstallDir"
+    mv "$OVSDownloadDir\openvswitch" $OVSInstallDir
+    rm $OVSZip
+    # Create log and run dir.
+    $OVS_LOG_PATH = $OVSInstallDir + "\var\log\openvswitch"
+    CreatePath $OVS_LOG_PATH
+    $OVSRunDir = $OVSInstallDir + "\var\run\openvswitch"
+    CreatePath $OVSRunDir
+    # Install OVS driver certificate.
+    Log "Installing OVS driver certificate."
+    $OVSDriverDir = "$OVSInstallDir\driver"
+    $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2("$OVSDriverDir\package.cer")
+    $rootStore = Get-Item cert:\LocalMachine\TrustedPublisher
+    $rootStore.Open("ReadWrite")
+    $rootStore.Add($cert)
+    $rootStore.Close()
+    $rootStore = Get-Item cert:\LocalMachine\Root
+    $rootStore.Open("ReadWrite")
+    $rootStore.Add($cert)
+    $rootStore.Close()
+    # Install Microsoft Visual C++ 2010 Redistributable Package.
+    Log "Installing Microsoft Visual C++ 2010 Redistributable Package."
+    Start-Process -FilePath $OVSInstallDir/redist/vcredist_x64.exe -Args '/install /passive /norestart' -Verb RunAs -Wait
+    # Install OVS kernel driver.
+    Log "Installing OVS kernel driver"
+    cmd /c "cd $OVSDriverDir && install.cmd"
+    if (!$?) {
+        Log "Install OVS kernel driver failed, exit"
+        exit 1
+    }
+    $OVS_BIN_PATH="$OVSInstallDir\usr\bin;$OVSInstallDir\usr\sbin"
+    $env:Path += ";$OVS_BIN_PATH"
+    SetEnvVar "Path" $env:Path
+}
+
+function ConfigOVS() {
+    # Create ovsdb config file
+    $OVS_DB_SCHEMA_PATH = "$OVSInstallDir\usr\share\openvswitch\vswitch.ovsschema"
+    $OVS_DB_PATH = "$OVSInstallDir\etc\openvswitch\conf.db"
+    if ($(Test-Path $OVS_DB_SCHEMA_PATH) -and !$(Test-Path $OVS_DB_PATH)) {
+        Log "Creating ovsdb file"
+        ovsdb-tool create "$OVS_DB_PATH" "$OVS_DB_SCHEMA_PATH"
+    }
+    # Create and start ovsdb-server service.
+    Log "Create and start ovsdb-server service"
+    sc.exe create ovsdb-server binPath= "$OVSInstallDir\usr\sbin\ovsdb-server.exe $OVSInstallDir\etc\openvswitch\conf.db  -vfile:info --remote=punix:db.sock  --remote=ptcp:6640  --log-file  --pidfile --service --service-monitor" start= auto
+    Start-Service ovsdb-server
+    $MaxRetryCount = 10
+    $RetryCountRange = 1..$MaxRetryCount
+    $OVSDBServiceStarted = $false
+    foreach ($RetryCount in $RetryCountRange) {
+        Log "Waiting for ovsdb-server service start ($RetryCount/$MaxRetryCount)..."
+        if (ServiceExists("ovsdb-server")) {
+            $OVSDBServiceStarted = $true
+            break
+        }
+        if ($RetryCount -eq $MaxRetryCount) {
+            break
+        }
+        Start-Sleep -Seconds 5
+    }
+    if (!$OVSDBServiceStarted) {
+        Log "Waiting for ovsdb-server service start timeout to set the OVS version."
+        LOG "Please manually set the OVS version after installation."
+    } else {
+        # Set OVS version.
+        Log "Set OVS version: $OVS_VERSION"
+        $OVS_VERSION=$(Get-Item $OVSInstallDir\driver\ovsext.sys).VersionInfo.ProductVersion
+        ovs-vsctl --no-wait set Open_vSwitch . ovs_version=$OVS_VERSION
+    }
+
+    # Create and start ovs-vswitchd service.
+    Log "Create and start ovs-vswitchd service."
+    sc.exe create ovs-vswitchd binpath="$OVSInstallDir\usr\sbin\ovs-vswitchd.exe  --pidfile -vfile:info --log-file  --service --service-monitor" start= auto
+    Start-Service ovs-vswitchd
+}
+
+CheckIfOVSInstalled
+
+DownloadOVS
+
+InstallOVS
+
+ConfigOVS
+
+Log "OVS Installation Complete!"

--- a/hack/windows/Prepare-Node.ps1
+++ b/hack/windows/Prepare-Node.ps1
@@ -1,0 +1,129 @@
+<#
+.SYNOPSIS
+(Test Only)Assists with preparing a Windows VM prior to calling kubeadm join
+
+.DESCRIPTION
+This script is only used for test to assist with joining a Windows node to a cluster.
+For production environment please follow the antrea windows installation guide and use kubernetes official script: https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/PrepareNode.ps1
+- Downloads Kubernetes binaries (kubelet, kubeadm) at the version specified
+- Registers wins as a service in order to run kube-proxy and antrea-agent as DaemonSets.
+- Registers kubelet as an nssm service. More info on nssm: https://nssm.cc/
+- Adds node ip in kubelet startup params.
+- Create virtual netadapter for kube-proxy.
+- (Optional) Installs OVS kerner driver, userspace binaries. Registers ovsdb-server and ovs-vswitchd services.
+
+.PARAMETER KubernetesVersion
+Kubernetes version to download and use
+
+.PARAMETER InstallOVS
+Install OVS
+
+.PARAMETER InstallOVS
+The node ip used by kubelet
+
+.EXAMPLE
+PS> .\Prepare-Node.ps1 -KubernetesVersion v1.18.0 -InstallOVS -NodeIP 192.168.1.10
+
+#>
+
+Param(
+    [parameter(Mandatory = $false, HelpMessage="Kubernetes version to use")] [string] $KubernetesVersion="v1.18.0",
+    [parameter(Mandatory = $true, HelpMessage="Node IP")] [string] $NodeIP,
+    [parameter(Mandatory = $false)] [switch] $InstallOVS = $false
+)
+$ErrorActionPreference = 'Stop'
+
+function DownloadFile($destination, $source) {
+    Write-Host("Downloading $source to $destination")
+    curl.exe --silent --fail -Lo $destination $source
+
+    if (!$?) {
+        Write-Error "Download $source failed"
+        exit 1
+    }
+}
+
+If (Get-Service kubelet -ErrorAction SilentlyContinue) {
+    Write-Host("Found existing kubelet service, exit.")
+    exit 0
+}
+
+if (!$KubernetesVersion.StartsWith("v")) {
+    $KubernetesVersion = "v" + $KubernetesVersion
+}
+Write-Host "Using Kubernetes version: $KubernetesVersion"
+$global:Powershell = (Get-Command powershell).Source
+$global:PowershellArgs = "-ExecutionPolicy Bypass -NoProfile"
+$global:KubernetesPath = "$env:SystemDrive\k"
+$global:StartKubeletScript = "$global:KubernetesPath\StartKubelet.ps1"
+$global:NssmInstallDirectory = "$env:ProgramFiles\nssm"
+$kubeletBinPath = "$global:KubernetesPath\kubelet.exe"
+
+mkdir -force "$global:KubernetesPath"
+$env:Path += ";$global:KubernetesPath"
+[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
+[Environment]::SetEnvironmentVariable("NODE_IP", $NodeIP, [System.EnvironmentVariableTarget]::Machine)
+
+DownloadFile $kubeletBinPath https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubelet.exe
+DownloadFile "$global:KubernetesPath\kubeadm.exe" https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubeadm.exe
+DownloadFile "$global:KubernetesPath\wins.exe" https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe
+
+# Create host network to allow kubelet to schedule hostNetwork pods
+Write-Host "Creating Docker host network"
+docker network create -d nat host
+
+Write-Host "Registering wins service"
+wins.exe srv app run --register
+start-service rancher-wins
+
+mkdir -force C:\var\log\kubelet
+mkdir -force C:\var\lib\kubelet\etc\kubernetes
+mkdir -force C:\etc\kubernetes\pki
+New-Item -path C:\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value C:\etc\kubernetes\pki\
+
+$StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
+$global:KubeletArgs = $FileContent.Trim("KUBELET_KUBEADM_ARGS=`"")
+
+$netId = docker network ls -f name=host --format "{{ .ID }}"
+
+if ($netId.Length -lt 1) {
+    docker network create -d nat host
+}
+
+& C:\k\Prepare-ServiceInterface.ps1 -InterfaceAlias "HNS Internal NIC"
+
+$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:1.3.0`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --log-dir=/var/log/kubelet --logtostderr=false --image-pull-progress-deadline=20m --node-ip=$env:NODE_IP"
+
+Invoke-Expression $cmd'
+Set-Content -Path $global:StartKubeletScript -Value $StartKubeletFileContent
+
+Write-Host "Installing nssm"
+$arch = "win32"
+if ([Environment]::Is64BitOperatingSystem) {
+    $arch = "win64"
+}
+
+mkdir -Force $global:NssmInstallDirectory
+DownloadFile nssm.zip https://k8stestinfrabinaries.blob.core.windows.net/nssm-mirror/nssm-2.24.zip
+C:\Windows\system32\tar.exe C $global:NssmInstallDirectory -xvf .\nssm.zip --strip-components 2 */$arch/*.exe
+Remove-Item -Force .\nssm.zip
+
+$env:path += ";$global:NssmInstallDirectory"
+$newPath = "$global:NssmInstallDirectory;" +
+        [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
+
+[Environment]::SetEnvironmentVariable("PATH", $newPath, [EnvironmentVariableTarget]::Machine)
+
+Write-Host "Registering kubelet service"
+nssm install kubelet $global:Powershell $global:PowershellArgs $global:StartKubeletScript
+nssm set kubelet DependOnService docker
+
+New-NetFirewallRule -Name kubelet -DisplayName 'kubelet' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 10250
+
+# Create netadapter for kube-proxy, the default full name of the adapter is "vEthernet (HNS Internal NIC)"
+& ./Prepare-ServiceInterface.ps1
+
+if ($InstallOVS) {
+    Write-Host "Installing OVS"
+    & .\Install-OVS.ps1
+}

--- a/hack/windows/Prepare-ServiceInterface.ps1
+++ b/hack/windows/Prepare-ServiceInterface.ps1
@@ -1,0 +1,29 @@
+<#
+.SYNOPSIS
+Create virtual netadapter for kube-proxy. The default full name of the virtual adapter is "vEthernet (HNS Internal NIC)"
+
+.DESCRIPTION
+This script creates virtual netadapter for kube-proxy. The created virtual adapter is used by kube-proxy to configure service IPs on it.
+
+.PARAMETER KubernetesVersion
+Kubernetes version to download and use
+
+.EXAMPLE
+PS> .\PrepareServiceInterface.ps1 -InterfaceAlias "HNS Internal NIC"
+
+#>
+Param(
+    [parameter(Mandatory = $false, HelpMessage="Interface to be added service IPs by kube-proxy")] [string] $InterfaceAlias="HNS Internal NIC"
+)
+$ErrorActionPreference = 'Stop'
+
+$INTERFACE_TO_ADD_SERVICE_IP = "vEthernet ($InterfaceAlias)"
+Write-Host "Creating netadapter $INTERFACE_TO_ADD_SERVICE_IP for kube-proxy"
+if (Get-NetAdapter -InterfaceAlias $INTERFACE_TO_ADD_SERVICE_IP -ErrorAction SilentlyContinue) {
+    Write-Host "NetAdapter $INTERFACE_TO_ADD_SERVICE_IP exists, exit."
+    return
+}
+[Environment]::SetEnvironmentVariable("INTERFACE_TO_ADD_SERVICE_IP", $INTERFACE_TO_ADD_SERVICE_IP, [System.EnvironmentVariableTarget]::Machine)
+$hnsSwitchName = $(Get-VMSwitch -SwitchType Internal).Name
+Add-VMNetworkAdapter -ManagementOS -Name $InterfaceAlias -SwitchName $hnsSwitchName
+Set-NetIPInterface -ifAlias $INTERFACE_TO_ADD_SERVICE_IP -Forwarding Enabled

--- a/hack/windows/Reset-Node.ps1
+++ b/hack/windows/Reset-Node.ps1
@@ -1,0 +1,13 @@
+<#
+.SYNOPSIS
+Performs a best effort revert of changes made to this host by 'kubeadm join'
+#>
+Write-Host "Running kubeadm reset"
+kubeadm.exe reset -f
+rm -r -f C:\etc\kubernetes\pki
+rm -r -fo C:\etc\kubernetes\pki
+rm -r -fo C:\var\lib\kubelet
+
+mkdir -force C:\var\lib\kubelet\etc\kubernetes
+mkdir -force C:\etc\kubernetes\pki
+New-Item -path C:\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value C:\etc\kubernetes\pki\

--- a/hack/windows/Uninstall-OVS.ps1
+++ b/hack/windows/Uninstall-OVS.ps1
@@ -1,0 +1,50 @@
+Param(
+    [parameter(Mandatory = $false)] [string] $OVSInstallDir = "C:\openvswitch",
+    [parameter(Mandatory = $false)] [switch] $RemoveDir = $false,
+    [parameter(Mandatory = $false)] [switch] $DeleteBridges = $false
+)
+
+$ErrorActionPreference = "Continue"
+$OVSBinDir = "$OVSInstallDir\usr\bin"
+$OVSDriverDir = "$OVSInstallDir\driver\"
+
+if ($DeleteBridges) {
+    $brList = ovs-vsctl.exe list-br
+    foreach ($br in $brList) {
+        Write-Host "Delete OVS Bridge: %s $br"
+        $cmd = "$OVSBinDir\ovs-vsctl.exe --no-wait del-br $br"
+        Invoke-Expression $cmd
+    }
+}
+
+# Stop and delete ovs-vswitchd service
+stop-service ovs-vswitchd
+sc.exe delete ovs-vswitchd
+if (Get-Service ovs-vswitchd -ErrorAction SilentlyContinue) {
+    Write-Host "Failed to delete ovs-vswitchd service, exit."
+    exit 1
+}
+# Stop and delete ovsdb-service service
+stop-service ovsdb-server
+sc.exe delete ovsdb-server
+if (Get-Service ovsdb-server -ErrorAction SilentlyContinue) {
+    Write-Host "Failed to delete ovs-vswitchd service, exit."
+    exit 1
+}
+# Uninstall OVS kernel driver
+cmd /c "cd $OVSDriverDir && uninstall.cmd"
+if (!$?) {
+    Write-Host "Failed to uninstall OVS kernel driver."
+    exit 1
+}
+
+# Remove OVS installation dir
+if ($RemoveDir) {
+    Remove-Item -Recurse $OVSInstallDir
+    if (!$?) {
+        Write-Host "Failed to remove OVS dir: $OVSInstallDir."
+        exit 1
+    }
+}
+
+Write-Host "Uninstall OVS success."


### PR DESCRIPTION
- Add docker file for antrea-agent windows docker image.
- Add deployment yaml for antrea-agent and kube-proxy on windows.
- Add OVS install script. The main tasks of script are:
  - Download test OVS from a predefined location.
  - Install OVS kernel driver.
  - Install ovsdb-server and ovs-vswitchd as service.
- Add prepare windows node script for test. The main tasks of script are:
  - Download k8s binaries from official site.
  - Install kubelet as service
  - Install rancher-wins as service. rancher-wins can help start
    antrea-agent process on host from POD.
  - Create netadapter for kube-proxy.

Signed-off-by: Rui Cao <rcao@vmware.com>