### PR TITLE
Fix antrea-agent not working with iptables>=1.6.2

### DIFF
--- a/pkg/agent/util/iptables/lock.go
+++ b/pkg/agent/util/iptables/lock.go
@@ -37,7 +37,7 @@ func lock(lockFilePath string, timeout time.Duration) (func() error, error) {
 	}
 
 	// Check whether the lock is available every 200ms.
-	if err := wait.PollImmediate(200*time.Millisecond, timeout, func() (bool, error) {
+	if err := wait.PollImmediate(waitIntervalMicroSeconds*time.Microsecond, timeout, func() (bool, error) {
 		if err := unix.Flock(int(lockFile.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
 			return false, nil
 		}


### PR DESCRIPTION
When antrea-agent ran with iptables>=1.6.2, it acquired the xtables lock
explicitly before calling iptables-restore. However, iptables-restore
will try to acquire the same lock and will fail immediately if it cannot
be acquired.

To make antrea-agent work with >=1.6.2 and <1.6.2 at the same time, this
PR detects the iptables version, uses "--wait" if it's greater than or
equal to 1.6.2, or acquire the lock explicitly.

Fixes #697