### PR TITLE
[Windows] Fix issue: NodePort service can't be accessed from local Pod

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -384,7 +384,7 @@ func (c *client) Initialize(roundInfo types.RoundInfo, nodeConfig *config.NodeCo
 }
 
 func (c *client) InstallExternalFlows(nodeIP net.IP, localSubnet net.IPNet) error {
-	flows := c.snatFlows(config.UplinkOFPort, config.BridgeOFPort, nodeIP, cookie.SNAT)
+	flows := c.bridgeAndUplinkFlows(config.UplinkOFPort, config.BridgeOFPort, nodeIP, localSubnet, cookie.SNAT)
 	flows = append(flows, c.l3ToExternalFlows(nodeIP, localSubnet, config.HostGatewayOFPort, cookie.SNAT)...)
 	if err := c.ofEntryOperations.AddAll(flows); err != nil {
 		return fmt.Errorf("failed to install flows for external communication: %v", err)

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -703,7 +703,7 @@ func (c *client) localProbeFlow(localGatewayIP net.IP, category cookie.Category)
 		Done()
 }
 
-func (c *client) snatFlows(uplinkOfport uint32, bridgeLocalPort int, nodeIP net.IP, category cookie.Category) []binding.Flow {
+func (c *client) bridgeAndUplinkFlows(uplinkOfport uint32, bridgeLocalPort int, nodeIP net.IP, localSubnet net.IPNet, category cookie.Category) []binding.Flow {
 	snatIPRange := &binding.IPRange{nodeIP, nodeIP}
 	vMACInt, _ := strconv.ParseUint(strings.Replace(globalVirtualMAC.String(), ":", "", -1), 16, 64)
 	flows := []binding.Flow{
@@ -714,6 +714,15 @@ func (c *client) snatFlows(uplinkOfport uint32, bridgeLocalPort int, nodeIP net.
 			Action().LoadRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
 			Action().ResubmitToTable(conntrackTable).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+		// Resubmit the packet to conntrackTable if it enters the OVS pipeline from the bridge interface and is sent to
+		// local Pods.
+		c.pipeline[classifierTable].BuildFlow(priorityHigh).
+			MatchProtocol(binding.ProtocolIP).
+			MatchInPort(uint32(bridgeLocalPort)).
+			MatchDstIPNet(localSubnet).
+			Action().SetDstMAC(globalVirtualMAC).
+			Action().ResubmitToTable(conntrackTable).
 			Done(),
 		// Enforce IP packet into the conntrack zone with SNAT. If the connection is SNATed, the reply packet should use
 		// Pod IP as the destination, and then resubmit to conntrackStateTable.

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -774,6 +774,10 @@ func prepareExternalFlows(nodeIP net.IP, localSubnet *net.IPNet) []expectTableFl
 					fmt.Sprintf("priority=200,ip,in_port=%d", config1.UplinkOFPort),
 					"load:0x4->NXM_NX_REG0[0..15],resubmit(,30)",
 				},
+				{
+					fmt.Sprintf("priority=210,ip,in_port=LOCAL,nw_dst=%s", localSubnet.String()),
+					"set_field:aa:bb:cc:dd:ee:ff->eth_dst,resubmit(,30)",
+				},
 			},
 		},
 		{


### PR DESCRIPTION
Add OpenFlow entry to enforce packet into OVS pipeline if it is sent out from OVS bridge and to local Pods.