### PR TITLE
Optimization on OpenFlow control interface

### DIFF
--- a/build/images/ovs/apply-patches.sh
+++ b/build/images/ovs/apply-patches.sh
@@ -57,6 +57,10 @@ curl https://github.com/openvswitch/ovs/commit/79eadafeb1b47a3871cb792aa972f6e4d
 curl https://github.com/openvswitch/ovs/commit/7cc77b301f80a63cd4893198d82be0eef303f731.patch | \
     git apply
 
+# This patch (post 2.13.0) ensures that ct_nw_src/ct_nw_dst supports IP Mask.
+curl https://github.com/openvswitch/ovs/commit/1740aaf49dad6f533705dc3dce8d955a1840052a.patch | \
+    git apply
+
 if version_get "$OVS_VERSION" "2.13.0"; then
     # OVS hardcodes the installation path to /usr/lib/python3.7/dist-packages/ but this location
     # does not seem to be in the Python path in Ubuntu 18.04. There may be a better way to do this,

--- a/build/images/test/Dockerfile
+++ b/build/images/test/Dockerfile
@@ -1,11 +1,22 @@
-FROM golang:1.13
+FROM antrea/openvswitch:2.13.0
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A Docker image for antrea integration tests."
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends openvswitch-switch iproute2 iptables ipset && \
+    apt-get install -y --no-install-recommends iproute2 iptables ipset make wget gcc libc6-dev ca-certificates && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+
+ENV GO_VERSION=1.13.12
+ENV GOPATH /go
+
+RUN wget -q -O - https://golang.org/dl/go$GO_VERSION.linux-amd64.tar.gz | tar xz -C /usr/local/ && \
+    export PATH="/usr/local/go/bin:$PATH" && \
+    mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+
+ENV PATH $GOPATH/bin:/usr/local/go/bin/:$PATH
+
+WORKDIR $GOPATH
 
 COPY build/images/scripts/* /usr/local/bin/
 COPY build/images/test/test-integration /usr/local/bin/

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 )
 
 replace (
-	github.com/contiv/ofnet => github.com/wenyingd/ofnet v0.0.0-20200508122021-ed82d5d15cea
+	github.com/contiv/ofnet => github.com/wenyingd/ofnet v0.0.0-20200601065543-2c7a62482f16
 	// fake.NewSimpleClientset is quite slow when it's initialized with massive objects due to
 	// https://github.com/kubernetes/kubernetes/issues/89574. It takes more than tens of minutes to
 	// init a fake client with 200k objects, which makes it hard to run the NetworkPolicy scale test.

--- a/go.sum
+++ b/go.sum
@@ -460,8 +460,8 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7Zo
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vmware-tanzu/octant v0.10.2 h1:sqXei1wyxhajUt90HGHPEyRTv12T8Mwv6vyKKdLUYg4=
 github.com/vmware-tanzu/octant v0.10.2/go.mod h1:ree4Qu6ULumg1MlGrAG7avEQx3+NjWPc0Zs4nQWOmQE=
-github.com/wenyingd/ofnet v0.0.0-20200508122021-ed82d5d15cea h1:ikZqLrJNXLwo8OtCE1ZRoSzVatVJVQN+HKWYLopmPEo=
-github.com/wenyingd/ofnet v0.0.0-20200508122021-ed82d5d15cea/go.mod h1:+g6SfqhTVqeGEmUJ0l4WtCgsL4dflTUJE4k+TPCKqXo=
+github.com/wenyingd/ofnet v0.0.0-20200601065543-2c7a62482f16 h1:z0XCuYk5XS77LJI5wRIqUNUfCZR82eCAhtrCHq5GwcQ=
+github.com/wenyingd/ofnet v0.0.0-20200601065543-2c7a62482f16/go.mod h1:+g6SfqhTVqeGEmUJ0l4WtCgsL4dflTUJE4k+TPCKqXo=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -185,6 +185,7 @@ type Action interface {
 	Learn(id TableIDType, priority uint16, idleTimeout, hardTimeout uint16, cookieID uint64) LearnAction
 	GotoTable(table TableIDType) FlowBuilder
 	SendToController(reason uint8) FlowBuilder
+	Note(notes string) FlowBuilder
 }
 
 type FlowBuilder interface {
@@ -215,6 +216,20 @@ type FlowBuilder interface {
 	MatchUDPDstPort(port uint16) FlowBuilder
 	MatchSCTPDstPort(port uint16) FlowBuilder
 	MatchTunMetadata(index int, data uint32) FlowBuilder
+	// MatchCTSrcIP matches the source IPv4 address of the connection tracker original direction tuple.
+	MatchCTSrcIP(ip net.IP) FlowBuilder
+	// MatchCTSrcIPNet matches the source IPv4 address of the connection tracker original direction tuple with IP masking.
+	MatchCTSrcIPNet(ipnet net.IPNet) FlowBuilder
+	// MatchCTDstIP matches the destination IPv4 address of the connection tracker original direction tuple.
+	MatchCTDstIP(ip net.IP) FlowBuilder
+	// MatchCTDstIP matches the destination IPv4 address of the connection tracker original direction tuple with IP masking.
+	MatchCTDstIPNet(ipNet net.IPNet) FlowBuilder
+	// MatchCTSrcPort matches the transport source port of the connection tracker original direction tuple.
+	MatchCTSrcPort(port uint16) FlowBuilder
+	// MatchCTDstPort matches the transport destination port of the connection tracker original direction tuple.
+	MatchCTDstPort(port uint16) FlowBuilder
+	// MatchCTProtocol matches the IP protocol type of the connection tracker original direction tuple.
+	MatchCTProtocol(proto Protocol) FlowBuilder
 	Cookie(cookieID uint64) FlowBuilder
 	SetHardTimeout(timout uint16) FlowBuilder
 	SetIdleTimeout(timeout uint16) FlowBuilder

--- a/pkg/ovs/openflow/ofctrl_flow.go
+++ b/pkg/ovs/openflow/ofctrl_flow.go
@@ -31,8 +31,6 @@ type ofFlow struct {
 	// ctStates is a temporary variable to maintain openflow13.CTStates. When FlowBuilder.Done is called, it is used to
 	// set the CtStates field in ofctrl.Flow.Match.
 	ctStates *openflow13.CTStates
-	// lastAction is used to set ofctrl.Flow nextElem field. It is the last action of the Flow.
-	lastAction ofctrl.FgraphElem
 }
 
 // Reset updates the ofFlow.Flow.Table field with ofFlow.table.Table.
@@ -44,8 +42,7 @@ func (f *ofFlow) Reset() {
 }
 
 func (f *ofFlow) Add() error {
-	f.Flow.UpdateInstallStatus(false)
-	err := f.Flow.Next(f.lastAction)
+	err := f.Flow.Send(openflow13.FC_ADD)
 	if err != nil {
 		return err
 	}
@@ -54,8 +51,7 @@ func (f *ofFlow) Add() error {
 }
 
 func (f *ofFlow) Modify() error {
-	f.Flow.UpdateInstallStatus(true)
-	err := f.Flow.Next(f.lastAction)
+	err := f.Flow.Send(openflow13.FC_MODIFY_STRICT)
 	if err != nil {
 		return err
 	}
@@ -65,7 +61,7 @@ func (f *ofFlow) Modify() error {
 
 func (f *ofFlow) Delete() error {
 	f.Flow.UpdateInstallStatus(true)
-	err := f.Flow.Delete()
+	err := f.Flow.Send(openflow13.FC_DELETE_STRICT)
 	if err != nil {
 		return err
 	}
@@ -111,7 +107,7 @@ func (f *ofFlow) GetBundleMessage(entryOper OFOperation) (ofctrl.OpenFlowModMess
 }
 
 // CopyToBuilder returns a new FlowBuilder that copies the table, protocols,
-// matches, and CookieID of the Flow, but does not copy the actions, lastAction,
+// matches, and CookieID of the Flow, but does not copy the actions,
 // and other private status fields of the ofctrl.Flow, e.g. "realized" and
 // "isInstalled". Reset the priority in the new FlowBuilder if it is provided.
 func (f *ofFlow) CopyToBuilder(priority uint16) FlowBuilder {

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -721,6 +721,20 @@ func (mr *MockActionMockRecorder) Normal() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Normal", reflect.TypeOf((*MockAction)(nil).Normal))
 }
 
+// Note mocks base method
+func (m *MockAction) Note(arg0 string) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Note", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// Note indicates an expected call of Note
+func (mr *MockActionMockRecorder) Note(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Note", reflect.TypeOf((*MockAction)(nil).Note), arg0)
+}
+
 // Output mocks base method
 func (m *MockAction) Output(arg0 int) openflow.FlowBuilder {
 	m.ctrl.T.Helper()
@@ -1080,6 +1094,48 @@ func (mr *MockFlowBuilderMockRecorder) MatchARPTpa(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchARPTpa", reflect.TypeOf((*MockFlowBuilder)(nil).MatchARPTpa), arg0)
 }
 
+// MatchCTDstIP mocks base method
+func (m *MockFlowBuilder) MatchCTDstIP(arg0 net.IP) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MatchCTDstIP", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// MatchCTDstIP indicates an expected call of MatchCTDstIP
+func (mr *MockFlowBuilderMockRecorder) MatchCTDstIP(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchCTDstIP", reflect.TypeOf((*MockFlowBuilder)(nil).MatchCTDstIP), arg0)
+}
+
+// MatchCTDstIPNet mocks base method
+func (m *MockFlowBuilder) MatchCTDstIPNet(arg0 net.IPNet) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MatchCTDstIPNet", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// MatchCTDstIPNet indicates an expected call of MatchCTDstIPNet
+func (mr *MockFlowBuilderMockRecorder) MatchCTDstIPNet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchCTDstIPNet", reflect.TypeOf((*MockFlowBuilder)(nil).MatchCTDstIPNet), arg0)
+}
+
+// MatchCTDstPort mocks base method
+func (m *MockFlowBuilder) MatchCTDstPort(arg0 uint16) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MatchCTDstPort", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// MatchCTDstPort indicates an expected call of MatchCTDstPort
+func (mr *MockFlowBuilderMockRecorder) MatchCTDstPort(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchCTDstPort", reflect.TypeOf((*MockFlowBuilder)(nil).MatchCTDstPort), arg0)
+}
+
 // MatchCTMark mocks base method
 func (m *MockFlowBuilder) MatchCTMark(arg0 uint32) openflow.FlowBuilder {
 	m.ctrl.T.Helper()
@@ -1092,6 +1148,62 @@ func (m *MockFlowBuilder) MatchCTMark(arg0 uint32) openflow.FlowBuilder {
 func (mr *MockFlowBuilderMockRecorder) MatchCTMark(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchCTMark", reflect.TypeOf((*MockFlowBuilder)(nil).MatchCTMark), arg0)
+}
+
+// MatchCTProtocol mocks base method
+func (m *MockFlowBuilder) MatchCTProtocol(arg0 openflow.Protocol) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MatchCTProtocol", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// MatchCTProtocol indicates an expected call of MatchCTProtocol
+func (mr *MockFlowBuilderMockRecorder) MatchCTProtocol(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchCTProtocol", reflect.TypeOf((*MockFlowBuilder)(nil).MatchCTProtocol), arg0)
+}
+
+// MatchCTSrcIP mocks base method
+func (m *MockFlowBuilder) MatchCTSrcIP(arg0 net.IP) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MatchCTSrcIP", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// MatchCTSrcIP indicates an expected call of MatchCTSrcIP
+func (mr *MockFlowBuilderMockRecorder) MatchCTSrcIP(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchCTSrcIP", reflect.TypeOf((*MockFlowBuilder)(nil).MatchCTSrcIP), arg0)
+}
+
+// MatchCTSrcIPNet mocks base method
+func (m *MockFlowBuilder) MatchCTSrcIPNet(arg0 net.IPNet) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MatchCTSrcIPNet", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// MatchCTSrcIPNet indicates an expected call of MatchCTSrcIPNet
+func (mr *MockFlowBuilderMockRecorder) MatchCTSrcIPNet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchCTSrcIPNet", reflect.TypeOf((*MockFlowBuilder)(nil).MatchCTSrcIPNet), arg0)
+}
+
+// MatchCTSrcPort mocks base method
+func (m *MockFlowBuilder) MatchCTSrcPort(arg0 uint16) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MatchCTSrcPort", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// MatchCTSrcPort indicates an expected call of MatchCTSrcPort
+func (mr *MockFlowBuilderMockRecorder) MatchCTSrcPort(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchCTSrcPort", reflect.TypeOf((*MockFlowBuilder)(nil).MatchCTSrcPort), arg0)
 }
 
 // MatchCTStateEst mocks base method

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -180,7 +180,7 @@ func TestInitialize(t *testing.T) {
 `,
 			"nat": `:ANTREA-POSTROUTING - [0:0]
 -A POSTROUTING -m comment --comment "Antrea: jump to Antrea postrouting rules" -j ANTREA-POSTROUTING
--A ANTREA-POSTROUTING -s 10.10.10.0/24 -m set ! --match-set ANTREA-POD-IP dst -m comment --comment "Antrea: masquerade pod to external packets" -j MASQUERADE
+-A ANTREA-POSTROUTING -s 10.10.10.0/24 -m comment --comment "Antrea: masquerade pod to external packets" -m set ! --match-set ANTREA-POD-IP dst -j MASQUERADE
 `,
 		}
 		if tc.mode.SupportsNoEncap() {
@@ -191,7 +191,7 @@ func TestInitialize(t *testing.T) {
 `
 			expectedIPTables["raw"] = `:ANTREA-RAW - [0:0]
 -A PREROUTING -m comment --comment "Antrea: jump to Antrea raw rules" -j ANTREA-RAW
--A ANTREA-RAW -i gw0 -m mac --mac-source DE:AD:BE:EF:DE:AD -m comment --comment "Antrea: reentry pod traffic skip conntrack" -j CT --notrack
+-A ANTREA-RAW -i gw0 -m comment --comment "Antrea: reentry pod traffic skip conntrack" -m mac --mac-source DE:AD:BE:EF:DE:AD -j CT --notrack
 `
 		}
 


### PR DESCRIPTION
1. Add support for matching original connection info in conntrack.
2. Simplify OpenFlow actions in the control interface
3. Add support for "note" action
4. Apply OVS patch in antrea/openvswitch image to support masking in ct_nw_xx/ct_tp_xx.
5. Modify "test" image to use antrea/openvswitch:2.13.0 as the base, and
    install golang 1.13 in this new image
6. Change the integration test cases "TestInitialize" to follow the output
    of iptables v1.6.1 which is installed in the new "test" image.