### PR TITLE
Clean up stale NetworkPolicies after reconnection

### DIFF
--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -157,6 +157,7 @@ func TestAddSingleGroupRule(t *testing.T) {
 	// policy1 comes first, no rule will be synced due to missing addressGroup1 and appliedToGroup1.
 	policy1 := newNetworkPolicy("policy1", []string{"addressGroup1"}, []string{}, []string{"appliedToGroup1"}, services)
 	networkPolicyWatcher.Add(policy1)
+	networkPolicyWatcher.Action(watch.Bookmark, nil)
 	select {
 	case ruleID := <-reconciler.updated:
 		t.Fatalf("Expected no update, got %v", ruleID)
@@ -169,6 +170,7 @@ func TestAddSingleGroupRule(t *testing.T) {
 
 	// addressGroup1 comes, no rule will be synced due to missing appliedToGroup1 data.
 	addressGroupWatcher.Add(newAddressGroup("addressGroup1", []v1beta1.GroupMemberPod{*newAddressGroupMember("1.1.1.1"), *newAddressGroupMember("2.2.2.2")}))
+	addressGroupWatcher.Action(watch.Bookmark, nil)
 	select {
 	case ruleID := <-reconciler.updated:
 		t.Fatalf("Expected no update, got %v", ruleID)
@@ -180,6 +182,7 @@ func TestAddSingleGroupRule(t *testing.T) {
 
 	// appliedToGroup1 comes, policy1 will be synced.
 	appliedToGroupWatcher.Add(newAppliedToGroup("appliedToGroup1", []v1beta1.GroupMemberPod{*newAppliedToGroupMember("pod1", "ns1")}))
+	appliedToGroupWatcher.Action(watch.Bookmark, nil)
 	select {
 	case ruleID := <-reconciler.updated:
 		actualRule, _ := reconciler.getLastRealized(ruleID)
@@ -230,11 +233,14 @@ func TestAddMultipleGroupsRule(t *testing.T) {
 
 	// addressGroup1 comes, no rule will be synced.
 	addressGroupWatcher.Add(newAddressGroup("addressGroup1", []v1beta1.GroupMemberPod{*newAddressGroupMember("1.1.1.1"), *newAddressGroupMember("2.2.2.2")}))
+	addressGroupWatcher.Action(watch.Bookmark, nil)
 	// appliedToGroup1 comes, no rule will be synced.
 	appliedToGroupWatcher.Add(newAppliedToGroup("appliedToGroup1", []v1beta1.GroupMemberPod{*newAppliedToGroupMember("pod1", "ns1")}))
+	appliedToGroupWatcher.Action(watch.Bookmark, nil)
 	// policy1 comes first, no rule will be synced due to missing addressGroup2 and appliedToGroup2.
 	policy1 := newNetworkPolicy("policy1", []string{"addressGroup1", "addressGroup2"}, []string{}, []string{"appliedToGroup1", "appliedToGroup2"}, services)
 	networkPolicyWatcher.Add(policy1)
+	networkPolicyWatcher.Action(watch.Bookmark, nil)
 	select {
 	case ruleID := <-reconciler.updated:
 		t.Fatalf("Expected no update, got %v", ruleID)
@@ -301,8 +307,11 @@ func TestDeleteRule(t *testing.T) {
 	go controller.Run(stopCh)
 
 	addressGroupWatcher.Add(newAddressGroup("addressGroup1", []v1beta1.GroupMemberPod{*newAddressGroupMember("1.1.1.1"), *newAddressGroupMember("2.2.2.2")}))
+	addressGroupWatcher.Action(watch.Bookmark, nil)
 	appliedToGroupWatcher.Add(newAppliedToGroup("appliedToGroup1", []v1beta1.GroupMemberPod{*newAppliedToGroupMember("pod1", "ns1")}))
+	appliedToGroupWatcher.Action(watch.Bookmark, nil)
 	networkPolicyWatcher.Add(newNetworkPolicy("policy1", []string{"addressGroup1"}, []string{}, []string{"appliedToGroup1"}, services))
+	networkPolicyWatcher.Action(watch.Bookmark, nil)
 	select {
 	case ruleID := <-reconciler.updated:
 		_, exists := reconciler.getLastRealized(ruleID)
@@ -359,9 +368,12 @@ func TestAddNetworkPolicyWithMultipleRules(t *testing.T) {
 	// Test NetworkPolicyInfoQuerier functions when the NetworkPolicy has multiple rules.
 	policy1 := getNetworkPolicyWithMultipleRules("policy1", []string{"addressGroup1"}, []string{"addressGroup2"}, []string{"appliedToGroup1"}, services)
 	networkPolicyWatcher.Add(policy1)
+	networkPolicyWatcher.Action(watch.Bookmark, nil)
 	addressGroupWatcher.Add(newAddressGroup("addressGroup1", []v1beta1.GroupMemberPod{*newAddressGroupMember("1.1.1.1"), *newAddressGroupMember("2.2.2.2")}))
 	addressGroupWatcher.Add(newAddressGroup("addressGroup2", []v1beta1.GroupMemberPod{*newAddressGroupMember("3.3.3.3"), *newAddressGroupMember("4.4.4.4")}))
+	addressGroupWatcher.Action(watch.Bookmark, nil)
 	appliedToGroupWatcher.Add(newAppliedToGroup("appliedToGroup1", []v1beta1.GroupMemberPod{*newAppliedToGroupMember("pod1", "ns1")}))
+	appliedToGroupWatcher.Action(watch.Bookmark, nil)
 	for i := 0; i < 2; i++ {
 		select {
 		case ruleID := <-reconciler.updated:

--- a/pkg/apiserver/storage/interfaces.go
+++ b/pkg/apiserver/storage/interfaces.go
@@ -22,10 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
-// Patched is an EventType in addition to EventTypes defined in k8s.io/apimachinery/pkg/watch/watch.go.
-// It indicates watch.Event contains an incremental update, not the object itself.
-const Patched watch.EventType = "PATCHED"
-
 // Selectors represent a watcher's conditions to select objects.
 type Selectors struct {
 	// Key is the identifier of the object the watcher monitors. It can be empty.

--- a/pkg/apiserver/storage/ram/watch_test.go
+++ b/pkg/apiserver/storage/ram/watch_test.go
@@ -85,6 +85,7 @@ func TestEvents(t *testing.T) {
 				},
 			},
 			expected: []watch.Event{
+				{Type: watch.Bookmark, Object: &v1.Pod{}},
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}},
 				{Type: watch.Modified, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2"}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3"}}},
@@ -113,6 +114,7 @@ func TestEvents(t *testing.T) {
 			},
 			expected: []watch.Event{
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}},
+				{Type: watch.Bookmark, Object: &v1.Pod{}},
 				{Type: watch.Modified, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2"}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3"}}},
 			},
@@ -137,13 +139,14 @@ func TestEvents(t *testing.T) {
 			},
 			expected: []watch.Event{
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}},
+				{Type: watch.Bookmark, Object: &v1.Pod{}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3"}}},
 			},
 		},
 	}
 
 	for i, testCase := range testCases {
-		w := newStoreWatcher(10, &storage.Selectors{}, func() {})
+		w := newStoreWatcher(10, &storage.Selectors{}, func() {}, func() runtime.Object { return new(v1.Pod) })
 		go w.process(context.Background(), testCase.initEvents, 0)
 
 		for _, event := range testCase.addedEvents {
@@ -166,7 +169,7 @@ func TestEvents(t *testing.T) {
 }
 
 func TestAddTimeout(t *testing.T) {
-	w := newStoreWatcher(1, &storage.Selectors{}, func() {})
+	w := newStoreWatcher(1, &storage.Selectors{}, func() {}, func() runtime.Object { return new(v1.Pod) })
 	events := []storage.InternalEvent{
 		&simpleInternalEvent{
 			Type:            watch.Added,

--- a/pkg/controller/networkpolicy/store/addressgroup.go
+++ b/pkg/controller/networkpolicy/store/addressgroup.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 
@@ -162,5 +163,5 @@ func NewAddressGroupStore() storage.Interface {
 			return []string{ag.Selector.Namespace}, nil
 		},
 	}
-	return ram.NewStore(AddressGroupKeyFunc, indexers, genAddressGroupEvent, keyAndSpanSelectFunc)
+	return ram.NewStore(AddressGroupKeyFunc, indexers, genAddressGroupEvent, keyAndSpanSelectFunc, func() runtime.Object { return new(networking.AddressGroup) })
 }

--- a/pkg/controller/networkpolicy/store/addressgroup_test.go
+++ b/pkg/controller/networkpolicy/store/addressgroup_test.go
@@ -59,6 +59,7 @@ func TestWatchAddressGroupEvent(t *testing.T) {
 				})
 			},
 			expected: []watch.Event{
+				{watch.Bookmark, nil},
 				{watch.Added, &networking.AddressGroup{
 					ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 					Pods:       []networking.GroupMemberPod{*newAddressGroupMember("1.1.1.1"), *newAddressGroupMember("2.2.2.2")},
@@ -100,6 +101,7 @@ func TestWatchAddressGroupEvent(t *testing.T) {
 				})
 			},
 			expected: []watch.Event{
+				{watch.Bookmark, nil},
 				{watch.Added, &networking.AddressGroup{
 					ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 					Pods:       []networking.GroupMemberPod{*newAddressGroupMember("1.1.1.1"), *newAddressGroupMember("2.2.2.2")},

--- a/pkg/controller/networkpolicy/store/appliedtogroup.go
+++ b/pkg/controller/networkpolicy/store/appliedtogroup.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 
@@ -174,5 +175,5 @@ func NewAppliedToGroupStore() storage.Interface {
 			return []string{atg.Selector.Namespace}, nil
 		},
 	}
-	return ram.NewStore(AppliedToGroupKeyFunc, indexers, genAppliedToGroupEvent, keyAndSpanSelectFunc)
+	return ram.NewStore(AppliedToGroupKeyFunc, indexers, genAppliedToGroupEvent, keyAndSpanSelectFunc, func() runtime.Object { return new(networking.AppliedToGroup) })
 }

--- a/pkg/controller/networkpolicy/store/appliedtogroup_test.go
+++ b/pkg/controller/networkpolicy/store/appliedtogroup_test.go
@@ -63,6 +63,7 @@ func TestWatchAppliedToGroupEvent(t *testing.T) {
 				})
 			},
 			expected: []watch.Event{
+				{watch.Bookmark, nil},
 				{watch.Added, &networking.AppliedToGroup{
 					ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 					Pods:       []networking.GroupMemberPod{*pod1, *pod2},
@@ -110,6 +111,7 @@ func TestWatchAppliedToGroupEvent(t *testing.T) {
 				})
 			},
 			expected: []watch.Event{
+				{watch.Bookmark, nil},
 				{watch.Added, &networking.AppliedToGroup{
 					ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 					Pods:       []networking.GroupMemberPod{*pod3},

--- a/pkg/controller/networkpolicy/store/networkpolicy.go
+++ b/pkg/controller/networkpolicy/store/networkpolicy.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 
@@ -157,5 +158,5 @@ func NewNetworkPolicyStore() storage.Interface {
 			return groupNames, nil
 		},
 	}
-	return ram.NewStore(NetworkPolicyKeyFunc, indexers, genNetworkPolicyEvent, keyAndSpanSelectFunc)
+	return ram.NewStore(NetworkPolicyKeyFunc, indexers, genNetworkPolicyEvent, keyAndSpanSelectFunc, func() runtime.Object { return new(networking.NetworkPolicy) })
 }

--- a/pkg/controller/networkpolicy/store/networkpolicy_test.go
+++ b/pkg/controller/networkpolicy/store/networkpolicy_test.go
@@ -84,6 +84,7 @@ func TestWatchNetworkPolicyEvent(t *testing.T) {
 				store.Update(policyV2)
 			},
 			expected: []watch.Event{
+				{watch.Bookmark, &networking.NetworkPolicy{}},
 				{watch.Added, &networking.NetworkPolicy{
 					ObjectMeta:      metav1.ObjectMeta{Namespace: "foo", Name: "bar"},
 					Rules:           policyV1.Rules,
@@ -110,6 +111,7 @@ func TestWatchNetworkPolicyEvent(t *testing.T) {
 				store.Update(policyV1)
 			},
 			expected: []watch.Event{
+				{watch.Bookmark, &networking.NetworkPolicy{}},
 				{watch.Added, &networking.NetworkPolicy{
 					ObjectMeta:      metav1.ObjectMeta{Namespace: "foo", Name: "bar"},
 					Rules:           policyV2.Rules,

--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -45,7 +45,6 @@ func runAntctl(podName string, cmds []string, data *TestData, tb testing.TB) (st
 		containerName = "antrea-controller"
 	}
 	stdout, stderr, err := data.runCommandFromPod(antreaNamespace, podName, containerName, cmds)
-	antctlOutput(stdout, stderr, tb)
 	return stdout, stderr, err
 }
 

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -46,6 +46,7 @@ const (
 	// antreaNamespace is the K8s Namespace in which all Antrea resources are running.
 	antreaNamespace      string = "kube-system"
 	antreaDaemonSet      string = "antrea-agent"
+	antreaDeployment     string = "antrea-controller"
 	antreaGWName         string = "gw0"
 	testNamespace        string = "antrea-test"
 	busyboxContainerName string = "busybox"
@@ -408,7 +409,7 @@ func (data *TestData) deleteAntrea(timeout time.Duration) error {
 		GracePeriodSeconds: &gracePeriodSeconds,
 		PropagationPolicy:  &propagationPolicy,
 	}
-	if err := data.clientset.AppsV1().DaemonSets(antreaNamespace).Delete("antrea-agent", deleteOptions); err != nil {
+	if err := data.clientset.AppsV1().DaemonSets(antreaNamespace).Delete(antreaDaemonSet, deleteOptions); err != nil {
 		if errors.IsNotFound(err) {
 			// no Antrea DaemonSet running, we return right away
 			return nil

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -15,11 +15,18 @@
 package e2e
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver/handlers/agentinfo"
+	"github.com/vmware-tanzu/antrea/pkg/apis/clusterinformation/v1beta1"
 )
 
 func TestDifferentNamedPorts(t *testing.T) {
@@ -29,45 +36,23 @@ func TestDifferentNamedPorts(t *testing.T) {
 	}
 	defer teardownTest(t, data)
 
-	server0Name := randName("test-server-")
 	server0Port := 80
-	if err = data.createServerPod(server0Name, "http", server0Port, false); err != nil {
-		t.Fatalf("Error when creating server pod: %v", err)
-	}
-	defer deletePodWrapper(t, data, server0Name)
-	server0IP, err := data.podWaitForIP(defaultTimeout, server0Name, testNamespace)
-	if err != nil {
-		t.Fatalf("Error when waiting for IP for Pod '%s': %v", server0Name, err)
-	}
+	_, server0IP, cleanupFunc := createAndWaitForPod(t, data, func(name string, nodeName string) error {
+		return data.createServerPod(name, "http", server0Port, false)
+	}, "test-server-", "")
+	defer cleanupFunc()
 
-	server1Name := randName("test-server-")
 	server1Port := 8080
-	if err = data.createServerPod(server1Name, "http", server1Port, false); err != nil {
-		t.Fatalf("Error when creating server pod: %v", err)
-	}
-	defer deletePodWrapper(t, data, server1Name)
-	server1IP, err := data.podWaitForIP(defaultTimeout, server1Name, testNamespace)
-	if err != nil {
-		t.Fatalf("Error when waiting for IP for Pod '%s': %v", server1Name, err)
-	}
+	_, server1IP, cleanupFunc := createAndWaitForPod(t, data, func(name string, nodeName string) error {
+		return data.createServerPod(name, "http", server1Port, false)
+	}, "test-server-", "")
+	defer cleanupFunc()
 
-	client0Name := randName("test-client-")
-	if err := data.createBusyboxPod(client0Name); err != nil {
-		t.Fatalf("Error when creating busybox test Pod: %v", err)
-	}
-	defer deletePodWrapper(t, data, client0Name)
-	if _, err := data.podWaitForIP(defaultTimeout, client0Name, testNamespace); err != nil {
-		t.Fatalf("Error when waiting for IP for Pod '%s': %v", client0Name, err)
-	}
+	client0Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "")
+	defer cleanupFunc()
 
-	client1Name := randName("test-client-")
-	if err := data.createBusyboxPod(client1Name); err != nil {
-		t.Fatalf("Error when creating busybox test Pod: %v", err)
-	}
-	defer deletePodWrapper(t, data, client1Name)
-	if _, err := data.podWaitForIP(defaultTimeout, client1Name, testNamespace); err != nil {
-		t.Fatalf("Error when waiting for IP for Pod '%s': %v", client1Name, err)
-	}
+	client1Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "")
+	defer cleanupFunc()
 
 	// Both clients can connect to both servers.
 	for _, clientName := range []string{client0Name, client1Name} {
@@ -129,25 +114,12 @@ func TestDefaultDenyEgressPolicy(t *testing.T) {
 	}
 	defer teardownTest(t, data)
 
-	serverName := randName("test-server-")
 	serverPort := 80
-	if err = data.createServerPod(serverName, "http", serverPort, false); err != nil {
-		t.Fatalf("Error when creating server pod: %v", err)
-	}
-	defer deletePodWrapper(t, data, serverName)
-	serverIP, err := data.podWaitForIP(defaultTimeout, serverName, testNamespace)
-	if err != nil {
-		t.Fatalf("Error when waiting for IP for Pod '%s': %v", serverName, err)
-	}
+	_, serverIP, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "")
+	defer cleanupFunc()
 
-	clientName := randName("test-client-")
-	if err := data.createBusyboxPod(clientName); err != nil {
-		t.Fatalf("Error when creating busybox test Pod: %v", err)
-	}
-	defer deletePodWrapper(t, data, clientName)
-	if _, err := data.podWaitForIP(defaultTimeout, clientName, testNamespace); err != nil {
-		t.Fatalf("Error when waiting for IP for Pod '%s': %v", clientName, err)
-	}
+	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "")
+	defer cleanupFunc()
 
 	if err = data.runNetcatCommandFromTestPod(clientName, serverIP, serverPort); err != nil {
 		t.Fatalf("Pod %s should be able to connect %s:%d, but was not able to connect", clientName, serverIP, serverPort)
@@ -170,5 +142,143 @@ func TestDefaultDenyEgressPolicy(t *testing.T) {
 
 	if err = data.runNetcatCommandFromTestPod(clientName, serverIP, serverPort); err == nil {
 		t.Fatalf("Pod %s should not be able to connect %s:%d, but was able to connect", clientName, serverIP, serverPort)
+	}
+}
+
+func TestNetworkPolicyResyncAfterRestart(t *testing.T) {
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	workerNode := workerNodeName(1)
+	antreaPod, err := data.getAntreaPodOnNode(workerNode)
+	if err != nil {
+		t.Fatalf("Error when getting antrea-agent pod name: %v", err)
+	}
+
+	server0Name, server0IP, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", workerNode)
+	defer cleanupFunc()
+
+	server1Name, server1IP, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", workerNode)
+	defer cleanupFunc()
+
+	client0Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", workerNode)
+	defer cleanupFunc()
+
+	client1Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", workerNode)
+	defer cleanupFunc()
+
+	netpol0, err := data.createNetworkPolicy("test-isolate-server0", &networkingv1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"antrea-e2e": server0Name,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Error when creating network policy: %v", err)
+	}
+	cleanupNetpol0 := func() {
+		if netpol0 == nil {
+			return
+		}
+		if err = data.deleteNetworkpolicy(netpol0); err != nil {
+			t.Fatalf("Error when deleting network policy: %v", err)
+		}
+		netpol0 = nil
+	}
+	defer cleanupNetpol0()
+
+	if err = data.runNetcatCommandFromTestPod(client0Name, server0IP, 80); err == nil {
+		t.Fatalf("Pod %s should not be able to connect %s, but was able to connect", client0Name, server0Name)
+	}
+	if err = data.runNetcatCommandFromTestPod(client1Name, server1IP, 80); err != nil {
+		t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", client1Name, server1Name)
+	}
+
+	scaleFunc := func(replicas int32) {
+		scale, err := data.clientset.AppsV1().Deployments(antreaNamespace).GetScale(antreaDeployment, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("error when getting scale of Antrea Deployment: %v", err)
+		}
+		scale.Spec.Replicas = replicas
+		if _, err := data.clientset.AppsV1().Deployments(antreaNamespace).UpdateScale(antreaDeployment, scale); err != nil {
+			t.Fatalf("error when scaling Antrea Deployment to %d: %v", replicas, err)
+		}
+	}
+
+	// Scale antrea-controller to 0 so antrea-agent will lose connection with antrea-controller.
+	scaleFunc(0)
+	defer scaleFunc(1)
+	// Make sure antrea-agent disconnects from antrea-controller.
+	waitForAgentCondition(t, data, antreaPod, v1beta1.ControllerConnectionUp, corev1.ConditionFalse)
+
+	// Remove netpol0, we expect client0 can connect server0 after antrea-controller is up.
+	cleanupNetpol0()
+	// Create netpol1, we expect client1 cannot connect server1 after antrea-controller is up.
+	netpol1, err := data.createNetworkPolicy("test-isolate-server1", &networkingv1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"antrea-e2e": server1Name,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Error when creating network policy: %v", err)
+	}
+	defer func() {
+		if err = data.deleteNetworkpolicy(netpol1); err != nil {
+			t.Fatalf("Error when deleting network policy: %v", err)
+		}
+	}()
+
+	// Scale antrea-controller to 1 so antrea-agent will connect to antrea-controller.
+	scaleFunc(1)
+	// Make sure antrea-agent connects to antrea-controller.
+	waitForAgentCondition(t, data, antreaPod, v1beta1.ControllerConnectionUp, corev1.ConditionTrue)
+
+	if err = data.runNetcatCommandFromTestPod(client0Name, server0IP, 80); err != nil {
+		t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", client0Name, server0Name)
+	}
+	if err = data.runNetcatCommandFromTestPod(client1Name, server1IP, 80); err == nil {
+		t.Fatalf("Pod %s should not be able to connect %s, but was able to connect", client1Name, server1Name)
+	}
+}
+
+func createAndWaitForPod(t *testing.T, data *TestData, createFunc func(name string, nodeName string) error, namePrefix string, nodeName string) (string, string, func()) {
+	name := randName(namePrefix)
+	if err := createFunc(name, nodeName); err != nil {
+		t.Fatalf("Error when creating busybox test Pod: %v", err)
+	}
+	cleanupFunc := func() {
+		deletePodWrapper(t, data, name)
+	}
+	podIP, err := data.podWaitForIP(defaultTimeout, name, testNamespace)
+	if err != nil {
+		cleanupFunc()
+		t.Fatalf("Error when waiting for IP for Pod '%s': %v", name, err)
+	}
+	return name, podIP, cleanupFunc
+}
+
+func waitForAgentCondition(t *testing.T, data *TestData, podName string, conditionType v1beta1.AgentConditionType, expectedStatus corev1.ConditionStatus) {
+	if err := wait.Poll(1*time.Second, defaultTimeout, func() (bool, error) {
+		cmds := []string{"antctl", "get", "agentinfo", "-o", "json"}
+		stdout, _, err := runAntctl(podName, cmds, data, t)
+		var agentInfo agentinfo.AntreaAgentInfoResponse
+		err = json.Unmarshal([]byte(stdout), &agentInfo)
+		if err != nil {
+			return true, err
+		}
+		for _, condition := range agentInfo.AgentConditions {
+			if condition.Type == conditionType && condition.Status == expectedStatus {
+				return true, nil
+			}
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatalf("Error when waiting for condition '%s'=='%s': %v", conditionType, expectedStatus, err)
 	}
 }


### PR DESCRIPTION
We must do a full sync between the NetworkPolicy cache and the latest
objects after reconnecting to antrea-controller, otherwise stale
NetworkPolicies won't be cleaned up and will cause unexpected behavior.

This PR adds a dummy Bookmark event after initial events of a new watch
so that antrea-agent can know its end and do an atomic update to cache
which can identify stale objects.

Fixes #666