### PR TITLE
Support server certificate verification

### DIFF
--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -160,6 +160,16 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - antrea-ca
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -224,6 +234,25 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - antrea-ca
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - apiregistration.k8s.io
+  resourceNames:
+  - v1beta1.system.antrea.tanzu.vmware.com
+  - v1beta1.networking.antrea.tanzu.vmware.com
+  resources:
+  - apiservices
+  verbs:
+  - get
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -269,6 +298,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: antrea-controller
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: antrea
+  name: antrea-ca
   namespace: kube-system
 ---
 apiVersion: v1
@@ -350,12 +387,19 @@ data:
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
     #enablePrometheusMetrics: false
+
+    # Indicates whether to use auto-generated self-signed TLS certificate.
+    # If false, A secret named "kube-system/antrea-controller-tls" must be provided with the following keys:
+    #   ca.crt: <CA certificate>
+    #   tls.crt: <TLS certificate>
+    #   tls.key: <TLS private key>
+    #selfSignedCert: true
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-522bfh947f
+  name: antrea-config-hmd2mdhg89
   namespace: kube-system
 ---
 apiVersion: v1
@@ -444,6 +488,8 @@ spec:
           name: antrea-config
           readOnly: true
           subPath: antrea-controller.conf
+        - mountPath: /var/run/antrea/antrea-controller-tls
+          name: antrea-controller-tls
         - mountPath: /var/log/antrea
           name: host-var-log-antrea
       hostNetwork: true
@@ -458,8 +504,13 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-522bfh947f
+          name: antrea-config-hmd2mdhg89
         name: antrea-config
+      - name: antrea-controller-tls
+        secret:
+          defaultMode: 256
+          optional: true
+          secretName: antrea-controller-tls
       - hostPath:
           path: /var/log/antrea
           type: DirectoryOrCreate
@@ -474,7 +525,6 @@ metadata:
 spec:
   group: networking.antrea.tanzu.vmware.com
   groupPriorityMinimum: 100
-  insecureSkipTLSVerify: true
   service:
     name: antrea
     namespace: kube-system
@@ -490,7 +540,6 @@ metadata:
 spec:
   group: system.antrea.tanzu.vmware.com
   groupPriorityMinimum: 100
-  insecureSkipTLSVerify: true
   service:
     name: antrea
     namespace: kube-system
@@ -667,7 +716,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-522bfh947f
+          name: antrea-config-hmd2mdhg89
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -160,6 +160,16 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - antrea-ca
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -224,6 +234,25 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - antrea-ca
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - apiregistration.k8s.io
+  resourceNames:
+  - v1beta1.system.antrea.tanzu.vmware.com
+  - v1beta1.networking.antrea.tanzu.vmware.com
+  resources:
+  - apiservices
+  verbs:
+  - get
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -269,6 +298,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: antrea-controller
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: antrea
+  name: antrea-ca
   namespace: kube-system
 ---
 apiVersion: v1
@@ -350,12 +387,19 @@ data:
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
     #enablePrometheusMetrics: false
+
+    # Indicates whether to use auto-generated self-signed TLS certificate.
+    # If false, A secret named "kube-system/antrea-controller-tls" must be provided with the following keys:
+    #   ca.crt: <CA certificate>
+    #   tls.crt: <TLS certificate>
+    #   tls.key: <TLS private key>
+    #selfSignedCert: true
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-t5f26b6m9f
+  name: antrea-config-ff5ff2btgc
   namespace: kube-system
 ---
 apiVersion: v1
@@ -444,6 +488,8 @@ spec:
           name: antrea-config
           readOnly: true
           subPath: antrea-controller.conf
+        - mountPath: /var/run/antrea/antrea-controller-tls
+          name: antrea-controller-tls
         - mountPath: /var/log/antrea
           name: host-var-log-antrea
       hostNetwork: true
@@ -458,8 +504,13 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-t5f26b6m9f
+          name: antrea-config-ff5ff2btgc
         name: antrea-config
+      - name: antrea-controller-tls
+        secret:
+          defaultMode: 256
+          optional: true
+          secretName: antrea-controller-tls
       - hostPath:
           path: /var/log/antrea
           type: DirectoryOrCreate
@@ -474,7 +525,6 @@ metadata:
 spec:
   group: networking.antrea.tanzu.vmware.com
   groupPriorityMinimum: 100
-  insecureSkipTLSVerify: true
   service:
     name: antrea
     namespace: kube-system
@@ -490,7 +540,6 @@ metadata:
 spec:
   group: system.antrea.tanzu.vmware.com
   groupPriorityMinimum: 100
-  insecureSkipTLSVerify: true
   service:
     name: antrea
     namespace: kube-system
@@ -665,7 +714,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-t5f26b6m9f
+          name: antrea-config-ff5ff2btgc
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -160,6 +160,16 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - antrea-ca
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -224,6 +234,25 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - antrea-ca
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - apiregistration.k8s.io
+  resourceNames:
+  - v1beta1.system.antrea.tanzu.vmware.com
+  - v1beta1.networking.antrea.tanzu.vmware.com
+  resources:
+  - apiservices
+  verbs:
+  - get
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -269,6 +298,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: antrea-controller
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: antrea
+  name: antrea-ca
   namespace: kube-system
 ---
 apiVersion: v1
@@ -350,12 +387,19 @@ data:
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
     #enablePrometheusMetrics: false
+
+    # Indicates whether to use auto-generated self-signed TLS certificate.
+    # If false, A secret named "kube-system/antrea-controller-tls" must be provided with the following keys:
+    #   ca.crt: <CA certificate>
+    #   tls.crt: <TLS certificate>
+    #   tls.key: <TLS private key>
+    #selfSignedCert: true
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-hdhc998mb8
+  name: antrea-config-fggkd66d2h
   namespace: kube-system
 ---
 apiVersion: v1
@@ -453,6 +497,8 @@ spec:
           name: antrea-config
           readOnly: true
           subPath: antrea-controller.conf
+        - mountPath: /var/run/antrea/antrea-controller-tls
+          name: antrea-controller-tls
         - mountPath: /var/log/antrea
           name: host-var-log-antrea
       hostNetwork: true
@@ -467,8 +513,13 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-hdhc998mb8
+          name: antrea-config-fggkd66d2h
         name: antrea-config
+      - name: antrea-controller-tls
+        secret:
+          defaultMode: 256
+          optional: true
+          secretName: antrea-controller-tls
       - hostPath:
           path: /var/log/antrea
           type: DirectoryOrCreate
@@ -483,7 +534,6 @@ metadata:
 spec:
   group: networking.antrea.tanzu.vmware.com
   groupPriorityMinimum: 100
-  insecureSkipTLSVerify: true
   service:
     name: antrea
     namespace: kube-system
@@ -499,7 +549,6 @@ metadata:
 spec:
   group: system.antrea.tanzu.vmware.com
   groupPriorityMinimum: 100
-  insecureSkipTLSVerify: true
   service:
     name: antrea
     namespace: kube-system
@@ -709,7 +758,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-hdhc998mb8
+          name: antrea-config-fggkd66d2h
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -160,6 +160,16 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - antrea-ca
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -224,6 +234,25 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - antrea-ca
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - apiregistration.k8s.io
+  resourceNames:
+  - v1beta1.system.antrea.tanzu.vmware.com
+  - v1beta1.networking.antrea.tanzu.vmware.com
+  resources:
+  - apiservices
+  verbs:
+  - get
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -269,6 +298,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: antrea-controller
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: antrea
+  name: antrea-ca
   namespace: kube-system
 ---
 apiVersion: v1
@@ -350,12 +387,19 @@ data:
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
     #enablePrometheusMetrics: false
+
+    # Indicates whether to use auto-generated self-signed TLS certificate.
+    # If false, A secret named "kube-system/antrea-controller-tls" must be provided with the following keys:
+    #   ca.crt: <CA certificate>
+    #   tls.crt: <TLS certificate>
+    #   tls.key: <TLS private key>
+    #selfSignedCert: true
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-m8cb9g82tf
+  name: antrea-config-mf4t8c67c8
   namespace: kube-system
 ---
 apiVersion: v1
@@ -444,6 +488,8 @@ spec:
           name: antrea-config
           readOnly: true
           subPath: antrea-controller.conf
+        - mountPath: /var/run/antrea/antrea-controller-tls
+          name: antrea-controller-tls
         - mountPath: /var/log/antrea
           name: host-var-log-antrea
       hostNetwork: true
@@ -458,8 +504,13 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-m8cb9g82tf
+          name: antrea-config-mf4t8c67c8
         name: antrea-config
+      - name: antrea-controller-tls
+        secret:
+          defaultMode: 256
+          optional: true
+          secretName: antrea-controller-tls
       - hostPath:
           path: /var/log/antrea
           type: DirectoryOrCreate
@@ -474,7 +525,6 @@ metadata:
 spec:
   group: networking.antrea.tanzu.vmware.com
   groupPriorityMinimum: 100
-  insecureSkipTLSVerify: true
   service:
     name: antrea
     namespace: kube-system
@@ -490,7 +540,6 @@ metadata:
 spec:
   group: system.antrea.tanzu.vmware.com
   groupPriorityMinimum: 100
-  insecureSkipTLSVerify: true
   service:
     name: antrea
     namespace: kube-system
@@ -665,7 +714,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-m8cb9g82tf
+          name: antrea-config-mf4t8c67c8
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/agent-rbac.yml
+++ b/build/yamls/base/agent-rbac.yml
@@ -73,6 +73,16 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - antrea-ca
+    verbs:
+      - get
+      - watch
+      - list
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/build/yamls/base/conf/antrea-controller.conf
+++ b/build/yamls/base/conf/antrea-controller.conf
@@ -5,3 +5,10 @@
 
 # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
 #enablePrometheusMetrics: false
+
+# Indicates whether to use auto-generated self-signed TLS certificate.
+# If false, A secret named "kube-system/antrea-controller-tls" must be provided with the following keys:
+#   ca.crt: <CA certificate>
+#   tls.crt: <TLS certificate>
+#   tls.key: <TLS private key>
+#selfSignedCert: true

--- a/build/yamls/base/controller-rbac.yml
+++ b/build/yamls/base/controller-rbac.yml
@@ -72,6 +72,25 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - antrea-ca
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    resourceNames:
+      - v1beta1.system.antrea.tanzu.vmware.com
+      - v1beta1.networking.antrea.tanzu.vmware.com
+    verbs:
+      - get
+      - update
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/build/yamls/base/controller.yml
+++ b/build/yamls/base/controller.yml
@@ -11,12 +11,16 @@ spec:
   selector:
     component: antrea-controller
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: antrea-ca
+---
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1beta1.networking.antrea.tanzu.vmware.com
 spec:
-  insecureSkipTLSVerify: true
   group: networking.antrea.tanzu.vmware.com
   groupPriorityMinimum: 100
   version: v1beta1
@@ -30,7 +34,6 @@ kind: APIService
 metadata:
   name: v1beta1.system.antrea.tanzu.vmware.com
 spec:
-  insecureSkipTLSVerify: true
   group: system.antrea.tanzu.vmware.com
   groupPriorityMinimum: 100
   version: v1beta1
@@ -111,12 +114,20 @@ spec:
               mountPath: /etc/antrea/antrea-controller.conf
               subPath: antrea-controller.conf
               readOnly: true
+            - name: antrea-controller-tls
+              mountPath: /var/run/antrea/antrea-controller-tls
             - name: host-var-log-antrea
               mountPath: /var/log/antrea
       volumes:
         - name: antrea-config
           configMap:
             name: antrea-config
+        # Make it optional as we only read it when selfSignedCert=false.
+        - name: antrea-controller-tls
+          secret:
+            secretName: antrea-controller-tls
+            defaultMode: 0400
+            optional: true
         - name: host-var-log-antrea
           hostPath:
             path: /var/log/antrea

--- a/cmd/antrea-controller/config.go
+++ b/cmd/antrea-controller/config.go
@@ -28,4 +28,11 @@ type ControllerConfig struct {
 	// Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener
 	// Defaults to false.
 	EnablePrometheusMetrics bool `yaml:"enablePrometheusMetrics,omitempty"`
+	// Indicates whether to use auto-generated self-signed TLS certificate.
+	// If false, A secret named "kube-system/antrea-controller-tls" must be provided with the following keys:
+	//   ca.crt: <CA certificate>
+	//   tls.crt: <TLS certificate>
+	//   tls.key: <TLS private key>
+	// Defaults to true.
+	SelfSignedCert bool `yaml:"selfSignedCert,omitempty"`
 }

--- a/cmd/antrea-controller/options.go
+++ b/cmd/antrea-controller/options.go
@@ -69,7 +69,9 @@ func (o *Options) loadConfigFromFile(file string) (*ControllerConfig, error) {
 		return nil, err
 	}
 
-	var c ControllerConfig
+	c := ControllerConfig{
+		SelfSignedCert: true,
+	}
 	err = yaml.UnmarshalStrict(data, &c)
 	if err != nil {
 		return nil, err

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,6 +90,13 @@ clientConnection:
 
 # The port for the antrea-controller APIServer to serve on.
 #apiPort: 10349
+
+# Indicates whether to use auto-generated self-signed TLS certificate.
+# If false, A secret named "kube-system/antrea-controller-tls" must be provided with the following keys:
+#   ca.crt: <CA certificate>
+#   tls.crt: <TLS certificate>
+#   tls.key: <TLS private key>
+#selfSignedCert: true
 ```
 
 ## CNI configuration

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	k8s.io/client-go v0.17.6
 	k8s.io/component-base v0.17.6
 	k8s.io/klog v1.0.0
+	k8s.io/kube-aggregator v0.17.6
 	k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29
 )
 

--- a/go.sum
+++ b/go.sum
@@ -539,6 +539,8 @@ golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmKJ7gzohV1XkqsFehRA2FbsbkopSuQ=
@@ -607,6 +609,7 @@ k8s.io/apimachinery v0.17.6/go.mod h1:Lg8zZ5iC/O8UjCqW6DNhcQG2m4TdjF9kwG3891OWbb
 k8s.io/apiserver v0.17.6 h1:P1fEOotHOL+kuH8HGKSsos8L+GdORppaY6fBkGW1zHY=
 k8s.io/apiserver v0.17.6/go.mod h1:sAYqm8hUDNA9aj/TzqwsJoExWrxprKv0tqs/z88qym0=
 k8s.io/code-generator v0.0.0-20191004115455-8e001e5d1894/go.mod h1:mJUgkl06XV4kstAnLHAIzJPVCOzVR+ZcfPIv4fUsFCY=
+k8s.io/code-generator v0.17.6/go.mod h1:iiHz51+oTx+Z9D0vB3CH3O4HDDPWrvZyUgUYaIE9h9M=
 k8s.io/component-base v0.17.6 h1:4S4FTX7/5VvO325vHm9/4pdql91OhrZpDYVzmyLSqNU=
 k8s.io/component-base v0.17.6/go.mod h1:jgRLWl0B0rOzFNtxQ9E4BphPmDqoMafujdau6AdG2Xo=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
@@ -616,6 +619,8 @@ k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.4.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
+k8s.io/kube-aggregator v0.17.6 h1:uubljdGti+dGTXVOzcgJlTc4TrNZKl7BkXF6S0Ok9Sg=
+k8s.io/kube-aggregator v0.17.6/go.mod h1:KGKVcJHb4DVUNFvnSDHIhNtQ5tbvsEwg7MJ6BGLrq00=
 k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29 h1:NeQXVJ2XFSkRoPzRo8AId01ZER+j8oV4SZADT4iBOXQ=
 k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29/go.mod h1:F+5wygcW0wmRTnM3cOgIqGivxkwSWIWT5YdsDbeAOaU=

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package agent
 
 import (
@@ -5,50 +19,119 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"sync"
 
+	"k8s.io/apiserver/pkg/server/dynamiccertificates"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/component-base/config"
 	"k8s.io/klog"
 
+	cert "github.com/vmware-tanzu/antrea/pkg/apiserver/certificate"
 	"github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned"
 )
 
-// CreateAntreaClient creates an Antrea client from the given config.
-func CreateAntreaClient(config config.ClientConnectionConfiguration) (versioned.Interface, error) {
+// AntreaClientProvider provides a method to get Antrea client.
+type AntreaClientProvider interface {
+	GetAntreaClient() (versioned.Interface, error)
+}
+
+// antreaClientProvider provides an AntreaClientProvider that can dynamically react to ConfigMap changes.
+type antreaClientProvider struct {
+	config config.ClientConnectionConfiguration
+	// mutex protects client.
+	mutex sync.RWMutex
+	// client is the Antrea client that will be returned. It will be updated when caBundle is updated.
+	client versioned.Interface
+	// caContentProvider provides the very latest content of the ca bundle.
+	caContentProvider *dynamiccertificates.ConfigMapCAController
+}
+
+var _ dynamiccertificates.Listener = &antreaClientProvider{}
+
+func NewAntreaClientProvider(config config.ClientConnectionConfiguration, kubeClient kubernetes.Interface) *antreaClientProvider {
+	// The key "ca.crt" may not exist at the beginning, no need to fail as the CA provider will watch the ConfigMap
+	// and notify antreaClientProvider of any update. The consumers of antreaClientProvider are supposed to always
+	// call GetAntreaClient() to get a client and not cache it.
+	antreaCAProvider, _ := dynamiccertificates.NewDynamicCAFromConfigMapController("antrea-ca", cert.CAConfigMapNamespace, cert.CAConfigMapName, cert.CAConfigMapKey, kubeClient)
+	antreaClientProvider := &antreaClientProvider{
+		config:            config,
+		caContentProvider: antreaCAProvider,
+	}
+
+	antreaCAProvider.AddListener(antreaClientProvider)
+	return antreaClientProvider
+}
+
+// RunOnce runs the task a single time synchronously, ensuring client is initialized.
+func (p *antreaClientProvider) RunOnce() error {
+	p.caContentProvider.RunOnce()
+	return p.updateAntreaClient()
+}
+
+// Run starts the caContentProvider, which watches the ConfigMap and notifies changes
+// by calling Enqueue.
+func (p *antreaClientProvider) Run(stopCh <-chan struct{}) {
+	p.caContentProvider.Run(1, stopCh)
+}
+
+// Enqueue implements dynamiccertificates.Listener. It will be called by caContentProvider
+// when caBundle is updated.
+func (p *antreaClientProvider) Enqueue() {
+	if err := p.updateAntreaClient(); err != nil {
+		klog.Errorf("Failed to update Antrea client: %v", err)
+	}
+}
+
+// GetAntreaClient implements AntreaClientProvider.
+func (p *antreaClientProvider) GetAntreaClient() (versioned.Interface, error) {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+	return p.client, nil
+}
+
+func (p *antreaClientProvider) updateAntreaClient() error {
+	caBundle := p.caContentProvider.CurrentCABundleContent()
+	if caBundle == nil {
+		klog.Warningf("Didn't get CA certificate from ConfigMap. May not be able to verify server cert")
+	}
 	var kubeConfig *rest.Config
 	var err error
-
-	if len(config.Kubeconfig) == 0 {
+	if len(p.config.Kubeconfig) == 0 {
 		klog.Info("No antrea kubeconfig file was specified. Falling back to in-cluster config")
-		kubeConfig, err = inClusterConfig()
+		kubeConfig, err = inClusterConfig(caBundle)
 	} else {
 		kubeConfig, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-			&clientcmd.ClientConfigLoadingRules{ExplicitPath: config.Kubeconfig},
+			&clientcmd.ClientConfigLoadingRules{ExplicitPath: p.config.Kubeconfig},
 			&clientcmd.ConfigOverrides{}).ClientConfig()
 	}
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// ContentType will be used to define the Accept header if AcceptContentTypes is not set.
 	kubeConfig.ContentType = "application/vnd.kubernetes.protobuf"
-	kubeConfig.QPS = config.QPS
-	kubeConfig.Burst = int(config.Burst)
-
+	kubeConfig.QPS = p.config.QPS
+	kubeConfig.Burst = int(p.config.Burst)
 	client, err := versioned.NewForConfig(kubeConfig)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return client, nil
+	klog.Info("Updating Antrea client with the new CA bundle")
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	p.client = client
+
+	return nil
 }
 
 // inClusterConfig returns a config object which uses the service account
 // kubernetes gives to pods. It's intended for clients that expect to be
 // running inside a pod running on kubernetes. It will return error
 // if called from a process not running in a kubernetes environment.
-func inClusterConfig() (*rest.Config, error) {
+func inClusterConfig(caBundle []byte) (*rest.Config, error) {
 	const tokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 	host, port := os.Getenv("ANTREA_SERVICE_HOST"), os.Getenv("ANTREA_SERVICE_PORT")
 	if len(host) == 0 || len(port) == 0 {
@@ -60,9 +143,10 @@ func inClusterConfig() (*rest.Config, error) {
 		return nil, err
 	}
 
-	// Agent is not able to verify Controller's cert as it's generated in-memory with loopback address.
-	// Use Insecure for now.
-	tlsClientConfig := rest.TLSClientConfig{Insecure: true}
+	tlsClientConfig := rest.TLSClientConfig{
+		CAData:     caBundle,
+		ServerName: cert.AntreaServerNames[0],
+	}
 
 	return &rest.Config{
 		Host:            "https://" + net.JoinHostPort(host, port),

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -27,15 +27,24 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/vmware-tanzu/antrea/pkg/apis/networking/v1beta1"
+	"github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned"
 	"github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned/fake"
 )
 
 const testNamespace = "ns1"
 
+type antreaClientGetter struct {
+	clientset versioned.Interface
+}
+
+func (g *antreaClientGetter) GetAntreaClient() (versioned.Interface, error) {
+	return g.clientset, nil
+}
+
 func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 	clientset := &fake.Clientset{}
 	ch := make(chan v1beta1.PodReference, 100)
-	controller := NewNetworkPolicyController(clientset, nil, nil, "node1", ch)
+	controller := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", ch)
 	reconciler := newMockReconciler()
 	controller.reconciler = reconciler
 	return controller, clientset, reconciler

--- a/pkg/apiserver/certificate/cacert_controller.go
+++ b/pkg/apiserver/certificate/cacert_controller.go
@@ -1,0 +1,189 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/server/dynamiccertificates"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+	"k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
+)
+
+const (
+	// The namespace and name of the ConfigMap that will hold the CA certificate
+	// that signs the TLS certificate of antrea-controller.
+	CAConfigMapNamespace = "kube-system"
+	CAConfigMapName      = "antrea-ca"
+	CAConfigMapKey       = "ca.crt"
+)
+
+var (
+	// apiServiceNames contains all the APIServices backed by antrea-controller.
+	apiServiceNames = []string{
+		"v1beta1.networking.antrea.tanzu.vmware.com",
+		"v1beta1.system.antrea.tanzu.vmware.com",
+	}
+)
+
+// CACertController is responsible for taking the CA certificate from the
+// caContentProvider and publishing it to the ConfigMap and the APIServices.
+type CACertController struct {
+	// caContentProvider provides the very latest content of the ca bundle.
+	caContentProvider dynamiccertificates.CAContentProvider
+	// queue only ever has one item, but it has nice error handling backoff/retry semantics
+	queue workqueue.RateLimitingInterface
+
+	client           kubernetes.Interface
+	aggregatorClient clientset.Interface
+}
+
+var _ dynamiccertificates.Listener = &CACertController{}
+
+func newCACertController(caContentProvider dynamiccertificates.CAContentProvider,
+	client kubernetes.Interface,
+	aggregatorClient clientset.Interface,
+) *CACertController {
+	c := &CACertController{
+		caContentProvider: caContentProvider,
+		queue:             workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "CACertController"),
+		client:            client,
+		aggregatorClient:  aggregatorClient,
+	}
+	if notifier, ok := caContentProvider.(dynamiccertificates.Notifier); ok {
+		notifier.AddListener(c)
+	}
+	return c
+}
+
+// Enqueue will be called after CACertController is registered as a listener of CA cert change.
+func (c *CACertController) Enqueue() {
+	// The key can be anything as we only have single item.
+	c.queue.Add("key")
+}
+
+func (c *CACertController) syncCACert() error {
+	caCert := c.caContentProvider.CurrentCABundleContent()
+
+	if err := c.syncConfigMap(caCert); err != nil {
+		return err
+	}
+
+	if err := c.syncAPIServices(caCert); err != nil {
+		return err
+	}
+	return nil
+}
+
+// syncAPIServices updates the CABundle of the APIServices backed by antrea-controller.
+func (c *CACertController) syncAPIServices(caCert []byte) error {
+	klog.Info("Syncing CA certificate with APIServices")
+	for _, name := range apiServiceNames {
+		apiService, err := c.aggregatorClient.ApiregistrationV1().APIServices().Get(name, v1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("error getting APIService %s: %v", name, err)
+		}
+		if bytes.Equal(apiService.Spec.CABundle, caCert) {
+			continue
+		}
+		apiService.Spec.CABundle = caCert
+		if _, err := c.aggregatorClient.ApiregistrationV1().APIServices().Update(apiService); err != nil {
+			return fmt.Errorf("error updating antrea CA cert of APIService %s: %v", name, err)
+		}
+	}
+	return nil
+}
+
+// syncConfigMap updates the ConfigMap that holds the CA bundle, which will be read by API clients, e.g. antrea-agent.
+func (c *CACertController) syncConfigMap(caCert []byte) error {
+	klog.Info("Syncing CA certificate with ConfigMap")
+	caConfigMap, err := c.client.CoreV1().ConfigMaps(CAConfigMapNamespace).Get(CAConfigMapName, v1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error getting ConfigMap %s: %v", CAConfigMapName, err)
+	}
+	if caConfigMap.Data != nil && caConfigMap.Data[CAConfigMapKey] == string(caCert) {
+		return nil
+	}
+	caConfigMap.Data = map[string]string{
+		CAConfigMapKey: string(caCert),
+	}
+	if _, err := c.client.CoreV1().ConfigMaps(CAConfigMapNamespace).Update(caConfigMap); err != nil {
+		return fmt.Errorf("error updating ConfigMap %s: %v", CAConfigMapName, err)
+	}
+	return nil
+}
+
+// RunOnce runs a single sync step to ensure that we have a valid starting configuration.
+func (c *CACertController) RunOnce() error {
+	if controller, ok := c.caContentProvider.(dynamiccertificates.ControllerRunner); ok {
+		if err := controller.RunOnce(); err != nil {
+			klog.Warningf("Initial population of CA content failed: %v", err)
+			c.Enqueue()
+			return err
+		}
+	}
+	if err := c.syncCACert(); err != nil {
+		klog.Warningf("Initial sync of CA content failed: %v", err)
+		c.Enqueue()
+		return err
+	}
+	return nil
+}
+
+// Run starts the CACertController and blocks until stopCh is closed.
+func (c *CACertController) Run(workers int, stopCh <-chan struct{}) {
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting CACertController")
+	defer klog.Infof("Shutting down CACertController")
+
+	if controller, ok := c.caContentProvider.(dynamiccertificates.ControllerRunner); ok {
+		go controller.Run(1, stopCh)
+	}
+
+	go wait.Until(c.runWorker, time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (c *CACertController) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *CACertController) processNextWorkItem() bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	err := c.syncCACert()
+	if err == nil {
+		c.queue.Forget(key)
+		return true
+	}
+
+	klog.Errorf("Error syncing CA cert, requeuing it: %v", err)
+	c.queue.AddRateLimited(key)
+
+	return true
+}

--- a/pkg/apiserver/certificate/certificate.go
+++ b/pkg/apiserver/certificate/certificate.go
@@ -1,0 +1,105 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/server/dynamiccertificates"
+	"k8s.io/apiserver/pkg/server/options"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+	"k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
+)
+
+var (
+	// certDir is the directory that the TLS Secret should be mounted to. Declaring it as a variable for testing.
+	certDir = "/var/run/antrea/antrea-controller-tls"
+	// certReadyTimeout is the timeout we will wait for the TLS Secret being ready. Declaring it as a variable for testing.
+	certReadyTimeout = 2 * time.Minute
+	// The DNS names that the TLS certificate will be signed with.
+	// TODO: Although antrea-agent and kube-aggregator only verify the server name "antrea.kube-system.svc",
+	// We should add the whole FQDN "antrea.kube-system.svc.<Cluster Domain>" as an alternate DNS name when
+	// other clients need to access it directly with that name.
+	AntreaServerNames = []string{
+		"antrea.kube-system.svc",
+	}
+)
+
+const (
+	// The namespace and name of the Secret that holds user-provided TLS certificate.
+	TLSSecretNamespace = "kube-system"
+	TLSSecretName      = "antrea-controller-tls"
+	// The names of the files that should contain the CA certificate and the TLS key pair.
+	CACertFile  = "ca.crt"
+	TLSCertFile = "tls.crt"
+	TLSKeyFile  = "tls.key"
+)
+
+func ApplyServerCert(selfSignedCert bool, client kubernetes.Interface, aggregatorClient clientset.Interface, secureServing *options.SecureServingOptionsWithLoopback) (*CACertController, error) {
+	var err error
+	var caContentProvider dynamiccertificates.CAContentProvider
+	if selfSignedCert {
+		// Set the PairName but leave certificate directory blank to generate in-memory by default.
+		secureServing.ServerCert.CertDirectory = ""
+		secureServing.ServerCert.PairName = "antrea-controller"
+
+		if err := secureServing.MaybeDefaultWithSelfSignedCerts("antrea", AntreaServerNames, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
+			return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
+		}
+
+		certPEMBlock, _ := secureServing.ServerCert.GeneratedCert.CurrentCertKeyContent()
+		caContentProvider, err = dynamiccertificates.NewStaticCAContent("self-signed cert", certPEMBlock)
+		if err != nil {
+			return nil, fmt.Errorf("error reading self-signed CA certificate: %v", err)
+		}
+	} else {
+		caCertPath := path.Join(certDir, CACertFile)
+		tlsCertPath := path.Join(certDir, TLSCertFile)
+		tlsKeyPath := path.Join(certDir, TLSKeyFile)
+		// The secret may be created after the Pod is created, for example, when cert-manager is used the secret
+		// is created asynchronously. It waits for a while before it's considered to be failed.
+		if err = wait.PollImmediate(2*time.Second, certReadyTimeout, func() (bool, error) {
+			for _, path := range []string{caCertPath, tlsCertPath, tlsKeyPath} {
+				f, err := os.Open(path)
+				if err != nil {
+					klog.Warningf("Couldn't read %s when applying server certificate, retrying", path)
+					return false, nil
+				}
+				f.Close()
+			}
+			return true, nil
+		}); err != nil {
+			return nil, fmt.Errorf("error reading TLS certificate and/or key. Please make sure the Secret '%s' is present and has '%s', '%s', and '%s' when selfSignedCert is set to false", TLSSecretName, CACertFile, TLSCertFile, TLSKeyFile)
+		}
+		// Since 1.17.0 (https://github.com/kubernetes/kubernetes/commit/3f5fbfbfac281f40c11de2f57d58cc332affc37b),
+		// apiserver reloads certificate cert and key file from disk every minute, allowing serving tls config to be updated.
+		secureServing.ServerCert.CertKey.CertFile = tlsCertPath
+		secureServing.ServerCert.CertKey.KeyFile = tlsKeyPath
+
+		caContentProvider, err = dynamiccertificates.NewDynamicCAContentFromFile("user-provided CA cert", caCertPath)
+		if err != nil {
+			return nil, fmt.Errorf("error reading user-provided CA certificate: %v", err)
+		}
+	}
+
+	caCertController := newCACertController(caContentProvider, client, aggregatorClient)
+	return caCertController, nil
+}

--- a/pkg/apiserver/certificate/certificate_test.go
+++ b/pkg/apiserver/certificate/certificate_test.go
@@ -1,0 +1,179 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	genericoptions "k8s.io/apiserver/pkg/server/options"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
+	fakeaggregatorclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
+)
+
+const (
+	fakeTLSCert = `-----BEGIN CERTIFICATE-----
+MIICBDCCAW2gAwIBAgIJAPgVBh+4xbGoMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNV
+BAMMEHdlYmhvb2tfdGVzdHNfY2EwIBcNMTcwNzI4MjMxNTI4WhgPMjI5MTA1MTMy
+MzE1MjhaMB8xHTAbBgNVBAMMFHdlYmhvb2tfdGVzdHNfY2xpZW50MIGfMA0GCSqG
+SIb3DQEBAQUAA4GNADCBiQKBgQDkGXXSm6Yun5o3Jlmx45rItcQ2pmnoDk4eZfl0
+rmPa674s2pfYo3KywkXQ1Fp3BC8GUgzPLSfJ8xXya9Lg1Wo8sHrDln0iRg5HXxGu
+uFNhRBvj2S0sIff0ZG/IatB9I6WXVOUYuQj6+A0CdULNj1vBqH9+7uWbLZ6lrD4b
+a44x/wIDAQABo0owSDAJBgNVHRMEAjAAMAsGA1UdDwQEAwIF4DAdBgNVHSUEFjAU
+BggrBgEFBQcDAgYIKwYBBQUHAwEwDwYDVR0RBAgwBocEfwAAATANBgkqhkiG9w0B
+AQsFAAOBgQCpN27uh/LjUVCaBK7Noko25iih/JSSoWzlvc8CaipvSPofNWyGx3Vu
+OdcSwNGYX/pp4ZoAzFij/Y5u0vKTVLkWXATeTMVmlPvhmpYjj9gPkCSY6j/SiKlY
+kGy0xr+0M5UQkMBcfIh9oAp9um1fZHVWAJAGP/ikZgkcUey0LmBn8w==
+-----END CERTIFICATE-----`
+	fakeTLSKey = `-----BEGIN RSA PRIVATE KEY-----
+MIICWwIBAAKBgQDkGXXSm6Yun5o3Jlmx45rItcQ2pmnoDk4eZfl0rmPa674s2pfY
+o3KywkXQ1Fp3BC8GUgzPLSfJ8xXya9Lg1Wo8sHrDln0iRg5HXxGuuFNhRBvj2S0s
+Iff0ZG/IatB9I6WXVOUYuQj6+A0CdULNj1vBqH9+7uWbLZ6lrD4ba44x/wIDAQAB
+AoGAZbWwowvCq1GBq4vPPRI3h739Uz0bRl1ymf1woYXNguXRtCB4yyH+2BTmmrrF
+6AIWkePuUEdbUaKyK5nGu3iOWM+/i6NP3kopQANtbAYJ2ray3kwvFlhqyn1bxX4n
+gl/Cbdw1If4zrDrB66y8mYDsjzK7n/gFaDNcY4GArjvOXKkCQQD9Lgv+WD73y4RP
+yS+cRarlEeLLWVsX/pg2oEBLM50jsdUnrLSW071MjBgP37oOXzqynF9SoDbP2Y5C
+x+aGux9LAkEA5qPlQPv0cv8Wc3qTI+LixZ/86PPHKWnOnwaHm3b9vQjZAkuVQg3n
+Wgg9YDmPM87t3UFH7ZbDihUreUxwr9ZjnQJAZ9Z95shMsxbOYmbSVxafu6m1Sc+R
+M+sghK7/D5jQpzYlhUspGf8n0YBX0hLhXUmjamQGGH5LXL4Owcb4/mM6twJAEVio
+SF/qva9jv+GrKVrKFXT374lOJFY53Qn/rvifEtWUhLCslCA5kzLlctRBafMZPrfH
+Mh5RrJP1BhVysDbenQJASGcc+DiF7rB6K++ZGyC11E2AP29DcZ0pgPESSV7npOGg
++NqPRZNVCSZOiVmNuejZqmwKhZNGZnBFx1Y+ChAAgw==
+-----END RSA PRIVATE KEY-----`
+	fakeCACert = `-----BEGIN CERTIFICATE-----
+MIICBDCCAW2gAwIBAgIJAPgVBh+4xbGoMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNV
+BAMMEHdlYmhvb2tfdGVzdHNfY2EwIBcNMTcwNzI4MjMxNTI4WhgPMjI5MTA1MTMy
+MzE1MjhaMB8xHTAbBgNVBAMMFHdlYmhvb2tfdGVzdHNfY2xpZW50MIGfMA0GCSqG
+SIb3DQEBAQUAA4GNADCBiQKBgQDkGXXSm6Yun5o3Jlmx45rItcQ2pmnoDk4eZfl0
+rmPa674s2pfYo3KywkXQ1Fp3BC8GUgzPLSfJ8xXya9Lg1Wo8sHrDln0iRg5HXxGu
+uFNhRBvj2S0sIff0ZG/IatB9I6WXVOUYuQj6+A0CdULNj1vBqH9+7uWbLZ6lrD4b
+a44x/wIDAQABo0owSDAJBgNVHRMEAjAAMAsGA1UdDwQEAwIF4DAdBgNVHSUEFjAU
+BggrBgEFBQcDAgYIKwYBBQUHAwEwDwYDVR0RBAgwBocEfwAAATANBgkqhkiG9w0B
+AQsFAAOBgQCpN27uh/LjUVCaBK7Noko25iih/JSSoWzlvc8CaipvSPofNWyGx3Vu
+OdcSwNGYX/pp4ZoAzFij/Y5u0vKTVLkWXATeTMVmlPvhmpYjj9gPkCSY6j/SiKlY
+kGy0xr+0M5UQkMBcfIh9oAp9um1fZHVWAJAGP/ikZgkcUey0LmBn8w==
+-----END CERTIFICATE-----`
+)
+
+func TestApplyServerCert(t *testing.T) {
+	tests := []struct {
+		name              string
+		selfSignedCert    bool
+		tlsCert           []byte
+		tlsKey            []byte
+		caCert            []byte
+		wantErr           bool
+		wantCertKey       bool
+		wantGeneratedCert bool
+		wantCACert        []byte
+	}{
+		{
+			name:              "self-signed",
+			selfSignedCert:    true,
+			tlsCert:           nil,
+			tlsKey:            nil,
+			caCert:            nil,
+			wantErr:           false,
+			wantCertKey:       false,
+			wantGeneratedCert: true,
+			wantCACert:        nil,
+		},
+		{
+			name:              "user-provided",
+			selfSignedCert:    false,
+			tlsCert:           []byte(fakeTLSCert),
+			tlsKey:            []byte(fakeTLSKey),
+			caCert:            []byte(fakeCACert),
+			wantErr:           false,
+			wantCertKey:       true,
+			wantGeneratedCert: false,
+			wantCACert:        []byte(fakeCACert),
+		},
+		{
+			name:           "user-provided-missing-tls-crt",
+			selfSignedCert: false,
+			tlsCert:        nil,
+			tlsKey:         []byte(fakeTLSKey),
+			caCert:         []byte(fakeCACert),
+			wantErr:        true,
+		},
+		{
+			name:           "user-provided-missing-tls-key",
+			selfSignedCert: false,
+			tlsCert:        []byte(fakeTLSCert),
+			tlsKey:         nil,
+			caCert:         []byte(fakeCACert),
+			wantErr:        true,
+		},
+		{
+			name:           "user-provided-missing-ca-crt",
+			selfSignedCert: false,
+			tlsCert:        []byte(fakeTLSCert),
+			tlsKey:         []byte(fakeTLSKey),
+			caCert:         nil,
+			wantErr:        true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			certDir, err = ioutil.TempDir("", "antrea-tls-test")
+			certReadyTimeout = 100 * time.Millisecond
+			if err != nil {
+				t.Fatalf("Unable to create temporary directory: %v", err)
+			}
+			defer os.RemoveAll(certDir)
+			secureServing := genericoptions.NewSecureServingOptions().WithLoopback()
+			if tt.tlsCert != nil {
+				certutil.WriteCert(path.Join(certDir, TLSCertFile), tt.tlsCert)
+			}
+			if tt.tlsKey != nil {
+				keyutil.WriteKey(path.Join(certDir, TLSKeyFile), tt.tlsKey)
+			}
+			if tt.caCert != nil {
+				certutil.WriteCert(path.Join(certDir, CACertFile), tt.caCert)
+			}
+			clientset := fakeclientset.NewSimpleClientset()
+			aggregatorClientset := fakeaggregatorclientset.NewSimpleClientset()
+			got, err := ApplyServerCert(tt.selfSignedCert, clientset, aggregatorClientset, secureServing)
+
+			if err != nil || tt.wantErr {
+				if (err != nil) != tt.wantErr {
+					t.Errorf("ApplyServerCert() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+			if tt.wantCertKey {
+				assert.Equal(t, genericoptions.CertKey{CertFile: certDir + "/tls.crt", KeyFile: certDir + "/tls.key"}, secureServing.ServerCert.CertKey, "CertKey doesn't match")
+			}
+			if tt.wantGeneratedCert {
+				assert.NotNil(t, secureServing.ServerCert.GeneratedCert)
+			} else {
+				assert.Nil(t, secureServing.ServerCert.GeneratedCert)
+			}
+			if tt.wantCACert != nil {
+				assert.Equal(t, tt.wantCACert, got.caContentProvider.CurrentCABundleContent(), "CA cert doesn't match")
+			} else {
+				assert.NotEmpty(t, got.caContentProvider.CurrentCABundleContent(), "CA cert is empty")
+			}
+		})
+	}
+}

--- a/test/e2e/security_test.go
+++ b/test/e2e/security_test.go
@@ -1,0 +1,230 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	restclient "k8s.io/client-go/rest"
+	certutil "k8s.io/client-go/util/cert"
+
+	"github.com/vmware-tanzu/antrea/pkg/apis"
+	"github.com/vmware-tanzu/antrea/pkg/apis/clusterinformation/v1beta1"
+	"github.com/vmware-tanzu/antrea/pkg/apiserver/certificate"
+)
+
+// TestUserProvidedCert tests the selfSignedCert=false case. It covers dynamic server certificate.
+func TestUserProvidedCert(t *testing.T) {
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	// Re-configure antrea-controller to use user-provided cert.
+	// Note antrea-controller must be restarted to take effect.
+	deployment, err := data.clientset.AppsV1().Deployments(antreaNamespace).Get(antreaDeployment, metav1.GetOptions{})
+	var configMapName string
+	for _, volume := range deployment.Spec.Template.Spec.Volumes {
+		if volume.ConfigMap != nil {
+			configMapName = volume.ConfigMap.Name
+			break
+		}
+	}
+	if len(configMapName) == 0 {
+		t.Fatalf("Failed to find ConfigMap volume")
+	}
+	configMap, err := data.clientset.CoreV1().ConfigMaps(antreaNamespace).Get(configMapName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get ConfigMap %s: %v", configMapName, err)
+	}
+	antreaControllerConf, _ := configMap.Data["antrea-controller.conf"]
+	antreaControllerConf = strings.Replace(antreaControllerConf, "#selfSignedCert: true", "selfSignedCert: false", 1)
+	configMap.Data["antrea-controller.conf"] = antreaControllerConf
+	if _, err := data.clientset.CoreV1().ConfigMaps(antreaNamespace).Update(configMap); err != nil {
+		t.Fatalf("Failed to update ConfigMap %s: %v", configMapName, err)
+	}
+
+	genCertKeyAndUpdateSecret := func() ([]byte, []byte) {
+		certPem, keyPem, err := certutil.GenerateSelfSignedCertKey("antrea", nil, certificate.AntreaServerNames)
+		secret, err := data.clientset.CoreV1().Secrets(certificate.TLSSecretNamespace).Get(certificate.TLSSecretName, metav1.GetOptions{})
+		exists := true
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				t.Fatalf("Failed to get Secret %s: %v", certificate.TLSSecretName, err)
+			}
+			exists = false
+			secret = &v1.Secret{
+				Data: map[string][]byte{
+					certificate.CACertFile:  certPem,
+					certificate.TLSCertFile: certPem,
+					certificate.TLSKeyFile:  keyPem,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      certificate.TLSSecretName,
+					Namespace: certificate.TLSSecretNamespace,
+				},
+				Type: v1.SecretTypeTLS,
+			}
+		}
+		secret.Data = map[string][]byte{
+			certificate.CACertFile:  certPem,
+			certificate.TLSCertFile: certPem,
+			certificate.TLSKeyFile:  keyPem,
+		}
+		if exists {
+			if _, err := data.clientset.CoreV1().Secrets(certificate.TLSSecretNamespace).Update(secret); err != nil {
+				t.Fatalf("Failed to update Secret %s: %v", certificate.TLSSecretName, err)
+			}
+		} else {
+			if _, err := data.clientset.CoreV1().Secrets(certificate.TLSSecretNamespace).Create(secret); err != nil {
+				t.Fatalf("Failed to create Secret %s: %v", certificate.TLSSecretName, err)
+			}
+		}
+		return certPem, keyPem
+	}
+
+	// Create/update the secret and restart antrea-controller, then verify apiserver and its clients are using the
+	// provided certificate.
+	certPem, _ := genCertKeyAndUpdateSecret()
+	testCert(t, data, string(certPem), true)
+
+	// Update the secret and do not restart antrea-controller, then verify apiserver and its clients are using the
+	// new certificate.
+	certPem, _ = genCertKeyAndUpdateSecret()
+	testCert(t, data, string(certPem), false)
+}
+
+// TestSelfSignedCert tests the selfSignedCert=true case.
+func TestSelfSignedCert(t *testing.T) {
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	testCert(t, data, "", true)
+}
+
+// testCert optionally restarts antrea-controller, then checks:
+// 1. The CA bundle published in antrea-ca ConfigMap matches expectedCABundle if provided.
+// 1. The CA bundle published in antrea-ca ConfigMap can be used to verify antrea-controller's serving cert.
+// 2. The CA bundle in Antrea APIServices match the one in antrea-ca ConfigMap.
+// 3. All antrea-agents can use the CA bundle to verify antrea-controller's serving cert.
+func testCert(t *testing.T, data *TestData, expectedCABundle string, restartPod bool) {
+	var antreaController *v1.Pod
+	var err error
+	// We expect the CA to be published very soon after antrea-controller restarts, while it may take up to 2 minutes
+	// (1 minute kubelet sync period + 1 minute DynamicFileCAContent sync period) to detect the certificate change if
+	// antrea-controller doesn't restart.
+	timeout := 10 * time.Second
+	if restartPod {
+		antreaController, err = data.restartAntreaControllerPod(defaultTimeout)
+		if err != nil {
+			t.Fatalf("Error when restarting antrea-controller Pod: %v", err)
+		}
+	} else {
+		antreaController, err = data.getAntreaController()
+		timeout += 2 * time.Minute
+	}
+
+	var caBundle string
+	if err := wait.Poll(2*time.Second, timeout, func() (bool, error) {
+		configMap, err := data.clientset.CoreV1().ConfigMaps(certificate.CAConfigMapNamespace).Get(certificate.CAConfigMapName, metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("cannot get ConfigMap antrea-ca")
+		}
+		var exists bool
+		caBundle, exists = configMap.Data[certificate.CAConfigMapKey]
+		if !exists {
+			t.Log("Missing content for CA bundle, retrying")
+			return false, nil
+		}
+
+		if expectedCABundle != "" && expectedCABundle != caBundle {
+			t.Log("CA bundle doesn't match the expected one, retrying")
+			return false, nil
+		}
+		clientConfig := restclient.Config{
+			TLSClientConfig: restclient.TLSClientConfig{
+				Insecure:   false,
+				ServerName: certificate.AntreaServerNames[0],
+				CAData:     []byte(caBundle),
+			},
+		}
+		trans, _ := restclient.TransportFor(&clientConfig)
+		hc := &http.Client{Transport: trans, Timeout: 5 * time.Second}
+		req, err := http.NewRequest("GET", fmt.Sprintf("https://%s:%d/healthz", antreaController.Status.PodIP, apis.AntreaControllerAPIPort), nil)
+		if err != nil {
+			return false, err
+		}
+
+		resp, err := hc.Do(req)
+		if err != nil {
+			t.Logf("Failed to connect antrea-controller or verify its serving cert: %v, retrying", err)
+			return false, nil
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Logf("Expected status code %v, got %v, retrying", http.StatusOK, resp.StatusCode)
+			return false, nil
+		}
+		t.Logf("The CABundle in ConfigMap antrea-ca is valid")
+		return true, nil
+	}); err != nil {
+		t.Fatalf("Failed to get a valid CA cert from ConfigMap: %v", err)
+	}
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: "app=antrea",
+	}
+	apiServices, err := data.aggregatorClient.ApiregistrationV1().APIServices().List(listOptions)
+	if err != nil {
+		t.Fatalf("Failed to list Antrea APIServices: %v", err)
+	}
+	for _, apiService := range apiServices.Items {
+		if caBundle != string(apiService.Spec.CABundle) {
+			t.Logf("The CABundle in APIService %s is invalid", apiService.Name)
+		}
+		t.Logf("The CABundle in APIService %s is valid", apiService.Name)
+	}
+
+	// antrea-agents reconnect every 5 seconds, we expect their connections are restored in a few seconds.
+	if err := wait.Poll(2*time.Second, 30*time.Second, func() (bool, error) {
+		cmds := []string{"antctl", "get", "controllerinfo", "-o", "json"}
+		stdout, _, err := runAntctl(antreaController.Name, cmds, data, t)
+		var controllerInfo v1beta1.AntreaControllerInfo
+		err = json.Unmarshal([]byte(stdout), &controllerInfo)
+		if err != nil {
+			return true, err
+		}
+		if clusterInfo.numNodes != int(controllerInfo.ConnectedAgentNum) {
+			t.Logf("Expected %d connected agents, got %d", clusterInfo.numNodes, controllerInfo.ConnectedAgentNum)
+			return false, nil
+		}
+		t.Logf("Got connections from all %d antrea-agents", clusterInfo.numNodes)
+		return true, nil
+	}); err != nil {
+		t.Fatalf("Didn't get connections from all %d antrea-agents: %v", clusterInfo.numNodes, err)
+	}
+}


### PR DESCRIPTION
To support server cert verification, this PR adds an option "selfSignedCert" (defaults to true) indicating whether to use auto-generated self-signed TLS certificate.

If it's set to false, antrea-controller will read user-provided TLS certificate key pair and its CA certificate from the path "/var/run/antrea/antrea-controller-tls", expecting a secret with the keys "ca.crt", "tls.crt" and "tls.key" is mounted to that path, and will serve HTTPS requests with the TLS certificate key pair.
Otherwise it will generate self-signed TLS certificate key pair on every start.

In either way, antrea-controller will publish the CA certificate to a well-known ConfigMap "antrea-ca" and the CABundle field of APIServices backed by it.

antrea-agent will read the CA certificate from the ConfigMap "antrea-ca" and use it to verify server certificate.

The secret can be updated at runtime and antrea-controller will react to its change, updating its serving certificate and update the CA certificate in the ConfigMap and the APIServices. The antrea-agents will react to the ConfigMap's change and update the CA certificate then use to verify server.

Fixes #692 #366 #616

Will have another PR to document how user could provide TLS certs, and steps to use cert-manager to achieve it.