### PR TITLE
Remove unused binaries from image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,32 @@ bin:
 	@mkdir -p $(BINDIR)
 	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' github.com/vmware-tanzu/antrea/cmd/...
 
+.PHONY: antrea-agent
+antrea-agent:
+	@mkdir -p $(BINDIR)
+	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' github.com/vmware-tanzu/antrea/cmd/antrea-agent
+
+.PHONY: antrea-controller
+antrea-controller:
+	@mkdir -p $(BINDIR)
+	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' github.com/vmware-tanzu/antrea/cmd/antrea-controller
+
+
+.PHONY: antrea-cni
+antrea-cni:
+	@mkdir -p $(BINDIR)
+	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' github.com/vmware-tanzu/antrea/cmd/antrea-cni
+
+.PHONY: antctl-ubuntu
+antctl-ubuntu:
+	@mkdir -p $(BINDIR)
+	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' github.com/vmware-tanzu/antrea/cmd/antctl
+
+.PHONY: antrea-octant-plugin
+antrea-octant-plugin:
+	@mkdir -p $(BINDIR)
+	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' github.com/vmware-tanzu/antrea/cmd/antrea-octant-plugin
+
 .PHONY: test-unit test-integration
 ifeq ($(UNAME_S),Linux)
 test-unit: .linux-test-unit

--- a/build/images/Dockerfile.build.ubuntu
+++ b/build/images/Dockerfile.build.ubuntu
@@ -20,7 +20,7 @@ RUN go mod download
 
 COPY . /antrea
 
-RUN make bin
+RUN make antrea-agent antrea-controller antrea-cni antctl-ubuntu
 
 
 FROM antrea/openvswitch:2.13.0

--- a/build/images/Dockerfile.octant.ubuntu
+++ b/build/images/Dockerfile.octant.ubuntu
@@ -4,7 +4,7 @@ COPY . /antrea
 
 WORKDIR /antrea
 
-RUN make bin
+RUN make antrea-octant-plugin
 
 
 FROM ubuntu:18.04

--- a/docs/octant-plugin-installation.md
+++ b/docs/octant-plugin-installation.md
@@ -94,7 +94,7 @@ You can follow the steps listed below to install octant and antrea-octant-plugin
 3. Build antrea-octant-plugin.
 
     ```
-    make bin
+    make antrea-octant-plugin
     ```
 
 4. Move antrea-octant-plugin to OCTANT_PLUGIN_PATH.


### PR DESCRIPTION
antrea-octant-plugin can be removed from image antrea-ubuntu
and other binaries can be removed from image octant-antrea-ubuntu.

This patch adds Makefile target per binary and only includes
the necessary binaries in the docker image.

Fixes: #708