### PR TITLE
Ensure order while asserting equal

### DIFF
--- a/pkg/agent/config/traffic_encap_mode_test.go
+++ b/pkg/agent/config/traffic_encap_mode_test.go
@@ -23,8 +23,8 @@ func TestGetTrafficEncapModeFromStr(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actualBool, actualMode := GetTrafficEncapModeFromStr(tt.mode)
-			assert.Equal(t, actualBool, tt.expBool, "GetTrafficEncapModeFromStr did not return correct boolean")
-			assert.Equal(t, actualMode, tt.expMode, "GetTrafficEncapModeFromStr did not return correct traffic type")
+			assert.Equal(t, tt.expBool, actualBool, "GetTrafficEncapModeFromStr did not return correct boolean")
+			assert.Equal(t, tt.expMode, actualMode, "GetTrafficEncapModeFromStr did not return correct traffic type")
 		})
 	}
 }
@@ -32,7 +32,7 @@ func TestGetTrafficEncapModeFromStr(t *testing.T) {
 func TestGetTrafficEncapModes(t *testing.T) {
 	modes := GetTrafficEncapModes()
 	expModes := []TrafficEncapModeType{0, 1, 2, 3}
-	assert.Equal(t, modes, expModes, "GetTrafficEncapModes received unexpected encap modes")
+	assert.Equal(t, expModes, modes, "GetTrafficEncapModes received unexpected encap modes")
 }
 
 func TestTrafficEncapModeTypeString(t *testing.T) {
@@ -50,7 +50,7 @@ func TestTrafficEncapModeTypeString(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actualMode := tt.modeType.String()
-			assert.Equal(t, actualMode, tt.expMode, "String did not return correct traffic type in string format")
+			assert.Equal(t, tt.expMode, actualMode, "String did not return correct traffic type in string format")
 		})
 	}
 }

--- a/pkg/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_test.go
@@ -369,9 +369,9 @@ func TestAddNetworkPolicy(t *testing.T) {
 	for _, tt := range tests {
 		npc.addNetworkPolicy(tt.inputPolicy)
 	}
-	assert.Equal(t, npc.GetNetworkPolicyNum(), 6, "expected networkPolicy number is 6")
-	assert.Equal(t, npc.GetAddressGroupNum(), 4, "expected addressGroup number is 4")
-	assert.Equal(t, npc.GetAppliedToGroupNum(), 2, "appliedToGroup number is 2")
+	assert.Equal(t, 6, npc.GetNetworkPolicyNum(), "expected networkPolicy number is 6")
+	assert.Equal(t, 4, npc.GetAddressGroupNum(), "expected addressGroup number is 4")
+	assert.Equal(t, 2, npc.GetAppliedToGroupNum(), "appliedToGroup number is 2")
 }
 
 func TestDeleteNetworkPolicy(t *testing.T) {


### PR DESCRIPTION
Expected value should come before actual value while asserting equal in unit tests. Reversed order
leads to incorrect message output on unit test failures.