### PR TITLE
Support getting kubeconfig path from KUBECONFIG env variable

### DIFF
--- a/pkg/antctl/client.go
+++ b/pkg/antctl/client.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -64,6 +65,13 @@ type client struct {
 func (c *client) resolveKubeconfig(opt *requestOption) (*rest.Config, error) {
 	var err error
 	var kubeconfig *rest.Config
+	if len(opt.kubeconfig) == 0 {
+		var hasIt bool
+		opt.kubeconfig, hasIt = os.LookupEnv("KUBECONFIG")
+		if !hasIt || len(strings.TrimSpace(opt.kubeconfig)) == 0 {
+			opt.kubeconfig = clientcmd.RecommendedHomeFile
+		}
+	}
 	if _, err = os.Stat(opt.kubeconfig); opt.kubeconfig == clientcmd.RecommendedHomeFile && os.IsNotExist(err) {
 		kubeconfig, err = rest.InClusterConfig()
 		if err != nil {

--- a/pkg/antctl/command_list.go
+++ b/pkg/antctl/command_list.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
 )
 
@@ -35,7 +34,7 @@ type commandList struct {
 
 func (cl *commandList) applyPersistentFlagsToRoot(root *cobra.Command) {
 	root.PersistentFlags().BoolP("verbose", "v", false, "enable verbose output")
-	root.PersistentFlags().StringP("kubeconfig", "k", clientcmd.RecommendedHomeFile, "absolute path to the kubeconfig file")
+	root.PersistentFlags().StringP("kubeconfig", "k", "", "absolute path to the kubeconfig file")
 	root.PersistentFlags().DurationP("timeout", "t", 0, "time limit of the execution of the command")
 	root.PersistentFlags().StringP("server", "s", "", "address and port of the API server, taking precedence over the default endpoint and the one set in kubeconfig")
 }


### PR DESCRIPTION
The default value of `--kubeconfig` will try to use `KUBECONFIG`first. If the value is empty, then the default value would be Kubernetes recommend path.

Fixes #720
Signed-off-by: Weiqiang TANG <weiqiangt@vmware.com>