### PR TITLE
[Windows]Use windows named pipe for CNI connection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/vmware-tanzu/antrea
 go 1.13
 
 require (
+	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
 	github.com/Microsoft/hcsshim v0.8.8-0.20200327174916-04ee9e63a4ed
 	github.com/TomCodeLV/OVSDB-golang-lib v0.0.0-20200116135253-9bbdfadcd881
 	github.com/benmoss/go-powershell v0.0.0-20190925205200-09527df358ca

--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -20,8 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 
@@ -547,13 +545,7 @@ func (s *CNIServer) Run(stopCh <-chan struct{}) {
 	klog.Info("Starting CNI server")
 	defer klog.Info("Shutting down CNI server")
 
-	// remove before bind to avoid "address already in use" errors
-	_ = os.Remove(s.cniSocket)
-
-	if err := os.MkdirAll(filepath.Dir(s.cniSocket), 0755); err != nil {
-		klog.Fatalf("Failed to create directory %s: %v", filepath.Dir(s.cniSocket), err)
-	}
-	listener, err := net.Listen("unix", s.cniSocket)
+	listener, err := util.ListenLocalSocket(s.cniSocket)
 	if err != nil {
 		klog.Fatalf("Failed to bind on %s: %v", s.cniSocket, err)
 	}

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"net"
 )
 
 const (
@@ -77,4 +78,12 @@ func newLinkNotFoundError(name string) LinkNotFound {
 	return LinkNotFound{
 		fmt.Errorf("link %s not found", name),
 	}
+}
+
+func listenUnix(address string) (net.Listener, error) {
+	return net.Listen("unix", address)
+}
+
+func dialUnix(address string) (net.Conn, error) {
+	return net.Dial("unix", address)
 }

--- a/pkg/agent/util/net_linux.go
+++ b/pkg/agent/util/net_linux.go
@@ -19,6 +19,8 @@ package util
 import (
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -175,4 +177,20 @@ func ConfigureLinkAddress(idx int, gwIPNet *net.IPNet) error {
 		return err
 	}
 	return nil
+}
+
+// ListenLocalSocket creates a listener on a Unix domain socket.
+func ListenLocalSocket(address string) (net.Listener, error) {
+	// remove before bind to avoid "address already in use" errors
+	_ = os.Remove(address)
+
+	if err := os.MkdirAll(filepath.Dir(address), 0755); err != nil {
+		klog.Fatalf("Failed to create directory %s: %v", filepath.Dir(address), err)
+	}
+	return listenUnix(address)
+}
+
+// DialLocalSocket connects to a Unix domain socket.
+func DialLocalSocket(address string) (net.Conn, error) {
+	return dialUnix(address)
 }

--- a/pkg/cni/client.go
+++ b/pkg/cni/client.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/vmware-tanzu/antrea/pkg/agent/util"
 	cnipb "github.com/vmware-tanzu/antrea/pkg/apis/cni/v1beta1"
 )
 
@@ -85,7 +86,7 @@ func rpcClient(f func(client cnipb.CniClient) error) error {
 		AntreaCNISocketAddr,
 		grpc.WithInsecure(),
 		grpc.WithContextDialer(func(ctx context.Context, addr string) (conn net.Conn, e error) {
-			return net.Dial("unix", addr)
+			return util.DialLocalSocket(addr)
 		}),
 	)
 	if err != nil {

--- a/pkg/cni/default_windows.go
+++ b/pkg/cni/default_windows.go
@@ -14,5 +14,5 @@
 
 package cni
 
-// AntreaCNISocketAddr is the UNIX socket used by the CNI Protobuf / gRPC service.
-const AntreaCNISocketAddr = "c:/antrea/cni.sock"
+// On windows platform, AntreaCNISocketAddr is a named pipe used by the CNI Protobuf / gRPC service.
+const AntreaCNISocketAddr = `\\.\pipe\cnisock`


### PR DESCRIPTION
Currently, UNIX socket is used for connection between CNI client and
server. However our tests on windows show that UNIX socket may
cause Windows BSOD.

This patch replace the UNIX socket with windows named pipe to avoid
Windows machine unstable.

Signed-off-by: Rui Cao <rcao@vmware.com>