### PR TITLE
[Windows]Fix Pod IP changes issue during creation

### DIFF
--- a/pkg/agent/cniserver/interface_configuration_windows.go
+++ b/pkg/agent/cniserver/interface_configuration_windows.go
@@ -99,10 +99,19 @@ func (ic *ifConfigurator) configureContainerLink(
 	mtu int,
 	result *current.Result,
 ) error {
-	// Create HNS Endpoint.
-	endpoint, err := ic.createContainerLink(podName, podNameSpace, containerID, result)
-	if err != nil {
-		return err
+	epName := util.GenerateContainerInterfaceName(podName, podNameSpace)
+	// Search endpoint from local cache.
+	endpoint, found := ic.getEndpoint(epName)
+	if !found {
+		if !util.IsInfraContainer(containerNetNS) {
+			return fmt.Errorf("failed to find HNSEndpoint: %s", epName)
+		}
+		// Only create HNS Endpoint for infra container.
+		ep, err := ic.createContainerLink(podName, podNameSpace, containerID, result)
+		if err != nil {
+			return err
+		}
+		endpoint = ep
 	}
 	// Attach HNSEndpoint to the container. Note that HNSEndpoint must be attached to the container before adding OVS port,
 	// otherwise an error will be returned when creating OVS port.
@@ -131,11 +140,6 @@ func (ic *ifConfigurator) configureContainerLink(
 // createContainerLink creates HNSEndpoint using the IP configuration in the IPAM result.
 func (ic *ifConfigurator) createContainerLink(podName string, podNameSpace string, containerID string, result *current.Result) (hostLink *hcsshim.HNSEndpoint, err error) {
 	epName := util.GenerateContainerInterfaceName(podName, podNameSpace)
-	// Search endpoint from local cache.
-	ep, found := ic.getEndpoint(epName)
-	if found {
-		return ep, nil
-	}
 
 	// Create a new Endpoint if not found.
 	if err := ic.ensureHNSNetwork(); err != nil {
@@ -175,7 +179,9 @@ func attachContainerLink(ep *hcsshim.HNSEndpoint, containerID, sandbox, containe
 		klog.V(2).Infof("HNS Endpoint %s already attached on container %s", ep.Id, containerID)
 	} else {
 		if err := hcsshim.HotAttachEndpoint(containerID, ep.Id); err != nil {
-			return nil, err
+			if util.IsInfraContainer(sandbox) || hcsshim.ErrComputeSystemDoesNotExist != err {
+				return nil, err
+			}
 		}
 	}
 	containerIface := &current.Interface{

--- a/pkg/agent/cniserver/ipam/ipam_service.go
+++ b/pkg/agent/cniserver/ipam/ipam_service.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/containernetworking/cni/pkg/invoke"
 	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/vmware-tanzu/antrea/pkg/agent/util"
 	cnipb "github.com/vmware-tanzu/antrea/pkg/apis/cni/v1beta1"
 )
 
@@ -70,6 +71,12 @@ func ExecIPAMAdd(cniArgs *cnipb.CniCmdArgs, ipamType string, resultKey string) (
 	if ok {
 		result := obj.(*current.Result)
 		return result, nil
+	}
+
+	// Only allocate IP when handling CNI request from infra container.
+	// On windows platform, CNI plugin is called for all containers in a Pod.
+	if !util.IsInfraContainer(cniArgs.Netns) {
+		return nil, fmt.Errorf("allocated IP address not found")
 	}
 
 	args := argsFromEnv(cniArgs)

--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -198,6 +198,11 @@ func (pc *podConfigurator) configureInterfaces(
 	hostIface := result.Interfaces[0]
 	containerIface := result.Interfaces[1]
 
+	if !util.IsInfraContainer(containerNetNS) {
+		klog.Infof("Not infra container: %s, skip add OVS port.", containerNetNS)
+		return nil
+	}
+
 	// Delete veth pair if any failure occurs in later manipulation.
 	success := false
 	defer func() {

--- a/pkg/agent/cniserver/server_linux.go
+++ b/pkg/agent/cniserver/server_linux.go
@@ -20,3 +20,13 @@ import "github.com/containernetworking/cni/pkg/types/current"
 func updateResultDNSConfig(result *current.Result, cniConfig *CNIConfig) {
 	result.DNS = cniConfig.DNS
 }
+
+// When running in a container, the host's /proc directory is mounted under s.hostProcPathPrefix, so
+// we need to prepend s.hostProcPathPrefix to the network namespace path provided by the cni. When
+// running as a simple process, s.hostProcPathPrefix will be empty.
+func (s *CNIServer) hostNetNsPath(netNS string) string {
+	if netNS == "" {
+		return ""
+	}
+	return s.hostProcPathPrefix + netNS
+}

--- a/pkg/agent/cniserver/server_windows.go
+++ b/pkg/agent/cniserver/server_windows.go
@@ -36,3 +36,8 @@ func updateResultDNSConfig(result *current.Result, cniConfig *CNIConfig) {
 	}
 	klog.Infof("Got runtime DNS configuration: %v", result.DNS)
 }
+
+// On windows platform netNS is not used, return it directly.
+func (s *CNIServer) hostNetNsPath(netNS string) string {
+	return netNS
+}

--- a/pkg/agent/util/net_linux.go
+++ b/pkg/agent/util/net_linux.go
@@ -194,3 +194,9 @@ func ListenLocalSocket(address string) (net.Listener, error) {
 func DialLocalSocket(address string) (net.Conn, error) {
 	return dialUnix(address)
 }
+
+// IsInfraContainer return if a container is infra container according to the network namespace path.
+// Always return true on Linux platform, because kubelet only call CNI request for infra container.
+func IsInfraContainer(netNS string) bool {
+	return true
+}

--- a/pkg/agent/util/net_windows.go
+++ b/pkg/agent/util/net_windows.go
@@ -37,6 +37,7 @@ const (
 	LocalHNSNetwork     = "antrea-hnsnetwork"
 	OVSExtensionID      = "583CC151-73EC-4A6A-8B47-578297AD7623"
 	namedPipePrefix     = `\\.\pipe\`
+	infraContainerNetNS = "none"
 )
 
 func GetNSPath(containerNetNS string) (string, error) {
@@ -392,4 +393,10 @@ func DialLocalSocket(address string) (net.Conn, error) {
 		return winio.DialPipe(address, nil)
 	}
 	return dialUnix(address)
+}
+
+// IsInfraContainer return if a container is infra container according to the network namespace path.
+// On Windows platform, the network namespace of infra container is "none".
+func IsInfraContainer(netNS string) bool {
+	return netNS == infraContainerNetNS
 }


### PR DESCRIPTION
On windows platform, each container in a Pod will generate a CNI
request. In current implementation every container have chance to
be allocated with a IP in specific time sequence. Which may cause
the Pod IP change during the creation.

This patch fixes the issue by calling IPAM plugin only when handling
CNI request from infrastructure container.

Signed-off-by: Rui Cao <rcao@vmware.com>