### PR TITLE
[Windows]Fix Pod IP changes issue during creation

### DIFF
--- a/pkg/agent/cniserver/server_linux.go
+++ b/pkg/agent/cniserver/server_linux.go
@@ -20,3 +20,19 @@ import "github.com/containernetworking/cni/pkg/types/current"
 func updateResultDNSConfig(result *current.Result, cniConfig *CNIConfig) {
 	result.DNS = cniConfig.DNS
 }
+
+// When running in a container, the host's /proc directory is mounted under s.hostProcPathPrefix, so
+// we need to prepend s.hostProcPathPrefix to the network namespace path provided by the cni. When
+// running as a simple process, s.hostProcPathPrefix will be empty.
+func (s *CNIServer) hostNetNsPath(netNS string) string {
+	if netNS == "" {
+		return ""
+	}
+	return s.hostProcPathPrefix + netNS
+}
+
+// isInfraContainer return if a container is infra container according to the network namespace path.
+// Always return true on Linux platform, because kubelet only call CNI request for infra container.
+func isInfraContainer(netNS string) bool {
+	return true
+}

--- a/pkg/agent/cniserver/server_windows.go
+++ b/pkg/agent/cniserver/server_windows.go
@@ -21,6 +21,8 @@ import (
 	"k8s.io/klog"
 )
 
+const infraContainerNetNS = "none"
+
 // updateResultDNSConfig update the DNS config from CNIConfig.
 // For windows platform, if runtime dns values are there use that else use cni conf supplied dns.
 // See PR: https://github.com/kubernetes/kubernetes/pull/63905
@@ -35,4 +37,15 @@ func updateResultDNSConfig(result *current.Result, cniConfig *CNIConfig) {
 		result.DNS.Search = cniConfig.RuntimeConfig.DNS.Search
 	}
 	klog.Infof("Got runtime DNS configuration: %v", result.DNS)
+}
+
+// On windows platform netNS is not used, return it directly.
+func (s *CNIServer) hostNetNsPath(netNS string) string {
+	return netNS
+}
+
+// isInfraContainer return if a container is infra container according to the network namespace path.
+// On Windows platform, the network namespace of infra container is "none".
+func isInfraContainer(netNS string) bool {
+	return netNS == infraContainerNetNS
 }


### PR DESCRIPTION
On windows platform, each container in a Pod will generate a CNI
request. In current implementation every container have chance to
be allocated with a IP in specific time sequence. Which may cause
the Pod IP change during the creation.

This patch fixes the issue by calling IPAM plugin only when handling
CNI request from infrastructure container.

Signed-off-by: Rui Cao <rcao@vmware.com>