### PR TITLE
[Windows]Remove 'windows' branch from github CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,12 +3,10 @@ on:
   pull_request:
     branches:
     - master
-    - windows
     - release-*
   push:
     branches:
     - master
-    - windows
     - release-*
 jobs:
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     branches:
     - master
-    - windows
     - release-*
   push:
     branches:


### PR DESCRIPTION
Remove 'windows' branch from github CI before merge it into 'master'

Signed-off-by: Rui Cao <rcao@vmware.com>