### PR TITLE
Register antrea metrics to apiserver registry

### DIFF
--- a/pkg/agent/metrics/prometheus.go
+++ b/pkg/agent/metrics/prometheus.go
@@ -18,6 +18,8 @@ import (
 	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
@@ -76,14 +78,14 @@ func InitializePrometheusMetrics(
 	ofClient openflow.Client) {
 
 	klog.Info("Initializing prometheus metrics")
-	podCount := prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{
+	podCount := metrics.NewGaugeFunc(
+		metrics.GaugeOpts{
 			Name: "antrea_agent_local_pod_count",
 			Help: "Number of pods on local node which are managed by the Antrea Agent.",
 		},
 		func() float64 { return float64(ifaceStore.GetContainerInterfaceNum()) },
 	)
-	if err := prometheus.Register(podCount); err != nil {
+	if err := legacyregistry.RawRegister(podCount); err != nil {
 		klog.Error("Failed to register antrea_agent_local_pod_count with Prometheus")
 	}
 
@@ -92,18 +94,20 @@ func InitializePrometheusMetrics(
 		klog.Errorf("Failed to retrieve agent K8S node name: %v", err)
 	}
 
-	gaugeHost := prometheus.NewGauge(prometheus.GaugeOpts{
+	gaugeHost := metrics.NewGauge(&metrics.GaugeOpts{
 		Name:        "antrea_agent_runtime_info",
 		Help:        "Antrea agent runtime info , defined as labels. The value of the gauge is always set to 1.",
-		ConstLabels: prometheus.Labels{"k8s_nodename": nodeName, "k8s_podname": env.GetPodName()},
+		ConstLabels: metrics.Labels{"k8s_nodename": nodeName, "k8s_podname": env.GetPodName()},
 	})
-	gaugeHost.Set(1)
-	if err := prometheus.Register(gaugeHost); err != nil {
+	if err := legacyregistry.Register(gaugeHost); err != nil {
 		klog.Error("Failed to register antrea_agent_runtime_info with Prometheus")
 	}
+	// This must be after registering the metrics.Gauge as it is lazily instantiated
+	// and will not measure anything unless the collector is first registered.
+	gaugeHost.Set(1)
 
 	ovsStats := newOVSStatManager(ovsBridge, ofClient)
-	if err := prometheus.Register(ovsStats); err != nil {
+	if err := legacyregistry.RawRegister(ovsStats); err != nil {
 		klog.Error("Failed to register antrea_agent_ovs_flow_table with Prometheus")
 	}
 }

--- a/pkg/controller/metrics/prometheus.go
+++ b/pkg/controller/metrics/prometheus.go
@@ -15,46 +15,47 @@
 package metrics
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/util/env"
 )
 
 var (
-	OpsAppliedToGroupProcessed = prometheus.NewCounter(prometheus.CounterOpts{
+	OpsAppliedToGroupProcessed = metrics.NewCounter(&metrics.CounterOpts{
 		Name: "antrea_controller_applied_to_group_processed",
 		Help: "The total number of applied-to-group processed",
 	})
-	OpsAddressGroupProcessed = prometheus.NewCounter(prometheus.CounterOpts{
+	OpsAddressGroupProcessed = metrics.NewCounter(&metrics.CounterOpts{
 		Name: "antrea_controller_address_group_processed",
 		Help: "The total number of address-group processed ",
 	})
-	OpsInternalNetworkPolicyProcessed = prometheus.NewCounter(prometheus.CounterOpts{
+	OpsInternalNetworkPolicyProcessed = metrics.NewCounter(&metrics.CounterOpts{
 		Name: "antrea_controller_network_policy_processed",
 		Help: "The total number of internal-networkpolicy processed",
 	})
-	DurationAppliedToGroupSyncing = prometheus.NewSummary(prometheus.SummaryOpts{
+	DurationAppliedToGroupSyncing = metrics.NewSummary(&metrics.SummaryOpts{
 		Name: "antrea_controller_applied_to_group_sync_duration_milliseconds",
 		Help: "The duration of syncing applied-to-group",
 	})
-	DurationAddressGroupSyncing = prometheus.NewSummary(prometheus.SummaryOpts{
+	DurationAddressGroupSyncing = metrics.NewSummary(&metrics.SummaryOpts{
 		Name: "antrea_controller_address_group_sync_duration_milliseconds",
 		Help: "The duration of syncing address-group",
 	})
-	DurationInternalNetworkPolicySyncing = prometheus.NewSummary(prometheus.SummaryOpts{
+	DurationInternalNetworkPolicySyncing = metrics.NewSummary(&metrics.SummaryOpts{
 		Name: "antrea_controller_network_policy_sync_duration_milliseconds",
 		Help: "The duration of syncing internal-networkpolicy",
 	})
-	LengthAppliedToGroupQueue = prometheus.NewGauge(prometheus.GaugeOpts{
+	LengthAppliedToGroupQueue = metrics.NewGauge(&metrics.GaugeOpts{
 		Name: "antrea_controller_length_applied_to_group_queue",
 		Help: "The length of AppliedToGroupQueue",
 	})
-	LengthAddressGroupQueue = prometheus.NewGauge(prometheus.GaugeOpts{
+	LengthAddressGroupQueue = metrics.NewGauge(&metrics.GaugeOpts{
 		Name: "antrea_controller_length_address_group_queue",
 		Help: "The length of AddressGroupQueue",
 	})
-	LengthInternalNetworkPolicyQueue = prometheus.NewGauge(prometheus.GaugeOpts{
+	LengthInternalNetworkPolicyQueue = metrics.NewGauge(&metrics.GaugeOpts{
 		Name: "antrea_controller_length_network_policy_queue",
 		Help: "The length of InternalNetworkPolicyQueue",
 	})
@@ -68,40 +69,42 @@ func InitializePrometheusMetrics() {
 	}
 
 	klog.Info("Initializing prometheus metrics")
-	gaugeHost := prometheus.NewGauge(prometheus.GaugeOpts{
+	gaugeHost := metrics.NewGauge(&metrics.GaugeOpts{
 		Name:        "antrea_controller_runtime_info",
 		Help:        "Antrea controller runtime info, defined as labels. The value of the gauge is always set to 1.",
-		ConstLabels: prometheus.Labels{"k8s_nodename": nodeName, "k8s_podname": env.GetPodName()},
+		ConstLabels: metrics.Labels{"k8s_nodename": nodeName, "k8s_podname": env.GetPodName()},
 	})
-	gaugeHost.Set(1)
-	if err = prometheus.Register(gaugeHost); err != nil {
+	if err = legacyregistry.Register(gaugeHost); err != nil {
 		klog.Errorf("Failed to register antrea_controller_runtime_info with Prometheus: %s", err.Error())
 	}
-	if err := prometheus.Register(OpsAppliedToGroupProcessed); err != nil {
+	// This must be after registering the metrics.Gauge as it is lazily instantiated
+	// and will not measure anything unless the collector is first registered.
+	gaugeHost.Set(1)
+	if err := legacyregistry.Register(OpsAppliedToGroupProcessed); err != nil {
 		klog.Errorf("Failed to register antrea_controller_applied_to_group_processed with Prometheus: %s", err.Error())
 	}
-	if err := prometheus.Register(OpsAddressGroupProcessed); err != nil {
+	if err := legacyregistry.Register(OpsAddressGroupProcessed); err != nil {
 		klog.Errorf("Failed to register antrea_controller_address_group_processed with Prometheus: %s", err.Error())
 	}
-	if err := prometheus.Register(OpsInternalNetworkPolicyProcessed); err != nil {
+	if err := legacyregistry.Register(OpsInternalNetworkPolicyProcessed); err != nil {
 		klog.Errorf("Failed to register antrea_controller_network_policy_processed with Prometheus: %s", err.Error())
 	}
-	if err := prometheus.Register(DurationAppliedToGroupSyncing); err != nil {
+	if err := legacyregistry.Register(DurationAppliedToGroupSyncing); err != nil {
 		klog.Errorf("Failed to register antrea_controller_applied_to_group_sync_duration_milliseconds with Prometheus: %s", err.Error())
 	}
-	if err := prometheus.Register(DurationAddressGroupSyncing); err != nil {
+	if err := legacyregistry.Register(DurationAddressGroupSyncing); err != nil {
 		klog.Errorf("Failed to register antrea_controller_address_group_sync_duration_milliseconds with Prometheus: %s", err.Error())
 	}
-	if err := prometheus.Register(DurationInternalNetworkPolicySyncing); err != nil {
+	if err := legacyregistry.Register(DurationInternalNetworkPolicySyncing); err != nil {
 		klog.Errorf("Failed to register antrea_controller_network_policy_sync_duration_milliseconds with Prometheus: %s", err.Error())
 	}
-	if err := prometheus.Register(LengthAppliedToGroupQueue); err != nil {
+	if err := legacyregistry.Register(LengthAppliedToGroupQueue); err != nil {
 		klog.Errorf("Failed to register antrea_controller_length_applied_to_group_queue with Prometheus: %s", err.Error())
 	}
-	if err := prometheus.Register(LengthAddressGroupQueue); err != nil {
+	if err := legacyregistry.Register(LengthAddressGroupQueue); err != nil {
 		klog.Errorf("Failed to register antrea_controller_length_address_group_queue with Prometheus: %s", err.Error())
 	}
-	if err := prometheus.Register(LengthInternalNetworkPolicyQueue); err != nil {
+	if err := legacyregistry.Register(LengthInternalNetworkPolicyQueue); err != nil {
 		klog.Errorf("Failed to register antrea_controller_length_network_policy_queue with Prometheus: %s", err.Error())
 	}
 }


### PR DESCRIPTION
Since K8s v1.16.0 (apiserver 0.16.0), apiserver serves metrics requests
with its own prometheus registry, instead of the default registry. To
continue show Antrea's metrics with the "/metrics" endpoint, this PR
registers them to the apiserver's registry.

Fixes #734