### PR TITLE
Use Kustomize to generate release antrea-windows.yml

### DIFF
--- a/.github/workflows/upload_release_assets.yml
+++ b/.github/workflows/upload_release_assets.yml
@@ -106,3 +106,12 @@ jobs:
         asset_path: ./assets/antrea-octant.yml
         asset_name: antrea-octant.yml
         asset_content_type: application/octet-stream
+    - name: Upload antrea-windows.yml
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./assets/antrea-windows.yml
+        asset_name: antrea-windows.yml
+        asset_content_type: application/octet-stream

--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,7 @@ manifest:
 	$(CURDIR)/hack/generate-manifest.sh --mode dev --cloud EKS --encap-mode networkPolicyOnly > build/yamls/antrea-eks.yml
 	$(CURDIR)/hack/generate-manifest.sh --mode dev --cloud GKE --encap-mode noEncap > build/yamls/antrea-gke.yml
 	$(CURDIR)/hack/generate-manifest-octant.sh --mode dev > build/yamls/antrea-octant.yml
+	$(CURDIR)/hack/generate-manifest-windows.sh --mode dev > build/yamls/antrea-windows.yml
 
 .PHONY: octant-antrea-ubuntu
 octant-antrea-ubuntu:

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -8,10 +8,9 @@ data:
     C:/k/antrea/utils/wins.exe cli process run --path /k/antrea/bin/antrea-agent.exe --args "--config=/k/antrea/etc/antrea-agent.conf --logtostderr=false --log_dir=/k/antrea/logs/ --alsologtostderr" --envs "KUBERNETES_SERVICE_HOST=$env:KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT=$env:KUBERNETES_SERVICE_PORT ANTREA_SERVICE_HOST=$env:ANTREA_SERVICE_HOST ANTREA_SERVICE_PORT=$env:ANTREA_SERVICE_PORT NODE_NAME=$env:NODE_NAME"
 kind: ConfigMap
 metadata:
-  annotations: {}
   labels:
     app: antrea
-  name: antrea-agent-windows
+  name: antrea-agent-windows-9ffbt88hmc
   namespace: kube-system
 ---
 apiVersion: v1
@@ -39,6 +38,11 @@ data:
     # be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
     #serviceCIDR: 10.96.0.0/12
 
+    # The port for the antrea-agent APIServer to serve on.
+    #apiPort: 10350
+
+    # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
+    #enablePrometheusMetrics: false
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -53,13 +57,11 @@ data:
             }
         ]
     }
-  antrea-controller.conf: ""
 kind: ConfigMap
 metadata:
-  annotations: {}
   labels:
     app: antrea
-  name: antrea-config-bckh9m3ace
+  name: antrea-windows-config-ktmt97647h
   namespace: kube-system
 ---
 apiVersion: apps/v1
@@ -82,95 +84,95 @@ spec:
         component: antrea-agent
     spec:
       containers:
-        - command:
-            - pwsh
-          args:
-            - -file
-            - /var/lib/antrea-windows/Run-AntreaAgent.ps1
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-          image: antrea/antrea-windows:latest
-          imagePullPolicy: IfNotPresent
-          name: antrea-agent
-          volumeMounts:
-            - mountPath: /host
-              name: host
-            - mountPath: \\.\pipe\rancher_wins
-              name: wins
-            - mountPath: /etc/antrea
-              name: antrea-config
-            - mountPath: /var/lib/antrea-windows
-              name: antrea-agent-windows
-            - mountPath: /host/k/antrea/
-              name: host-antrea-home
+      - args:
+        - -file
+        - /var/lib/antrea-windows/Run-AntreaAgent.ps1
+        command:
+        - pwsh
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: antrea/antrea-windows:latest
+        imagePullPolicy: IfNotPresent
+        name: antrea-agent
+        volumeMounts:
+        - mountPath: /host
+          name: host
+        - mountPath: \\.\pipe\rancher_wins
+          name: wins
+        - mountPath: /etc/antrea
+          name: antrea-windows-config
+        - mountPath: /var/lib/antrea-windows
+          name: antrea-agent-windows
+        - mountPath: /host/k/antrea/
+          name: host-antrea-home
       hostNetwork: true
       initContainers:
-        - command:
-            - pwsh
-          args:
-            - -File
-            - /k/antrea/Install-WindowsCNI.ps1
-          image: antrea/antrea-windows:latest
-          imagePullPolicy: IfNotPresent
-          name: install-cni
-          volumeMounts:
-            - mountPath: /etc/antrea
-              name: antrea-config
-              readOnly: true
-            - mountPath: /host/etc/cni/net.d
-              name: host-cni-conf
-            - mountPath: /host/opt/cni/bin
-              name: host-cni-bin
-            - mountPath: /host/k/antrea/
-              name: host-antrea-home
-            - mountPath: /host
-              name: host
+      - args:
+        - -File
+        - /k/antrea/Install-WindowsCNI.ps1
+        command:
+        - pwsh
+        image: antrea/antrea-windows:latest
+        imagePullPolicy: IfNotPresent
+        name: install-cni
+        volumeMounts:
+        - mountPath: /etc/antrea
+          name: antrea-windows-config
+          readOnly: true
+        - mountPath: /host/etc/cni/net.d
+          name: host-cni-conf
+        - mountPath: /host/opt/cni/bin
+          name: host-cni-bin
+        - mountPath: /host/k/antrea/
+          name: host-antrea-home
+        - mountPath: /host
+          name: host
       nodeSelector:
         kubernetes.io/os: windows
       priorityClassName: system-node-critical
       serviceAccountName: antrea-agent
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - effect: NoSchedule
-          operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
       volumes:
-        - configMap:
-            name: antrea-config-bckh9m3ace
-          name: antrea-config
-        - configMap:
-            defaultMode: 420
-            name: antrea-agent-windows
-          name: antrea-agent-windows
-        - hostPath:
-            path: /etc/cni/net.d
-            type: DirectoryOrCreate
-          name: host-cni-conf
-        - hostPath:
-            path: /opt/cni/bin
-            type: DirectoryOrCreate
-          name: host-cni-bin
-        - hostPath:
-            path: /k/antrea
-            type: DirectoryOrCreate
-          name: host-antrea-home
-        - hostPath:
-            path: /
-          name: host
-        - name: wins
-          hostPath:
-            path: \\.\pipe\rancher_wins
-            type: null
+      - configMap:
+          name: antrea-windows-config-ktmt97647h
+        name: antrea-windows-config
+      - configMap:
+          defaultMode: 420
+          name: antrea-agent-windows-9ffbt88hmc
+        name: antrea-agent-windows
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: host-cni-conf
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: host-cni-bin
+      - hostPath:
+          path: /k/antrea
+          type: DirectoryOrCreate
+        name: host-antrea-home
+      - hostPath:
+          path: /
+        name: host
+      - hostPath:
+          path: \\.\pipe\rancher_wins
+          type: null
+        name: wins
   updateStrategy:
     type: RollingUpdate

--- a/build/yamls/windows/base/agent.yml
+++ b/build/yamls/windows/base/agent.yml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    component: antrea-agent
+  name: antrea-agent-windows
+spec:
+  selector:
+    matchLabels:
+      component: antrea-agent
+  template:
+    metadata:
+      labels:
+        component: antrea-agent
+    spec:
+      containers:
+        - command:
+            - pwsh
+          args:
+            - -file
+            - /var/lib/antrea-windows/Run-AntreaAgent.ps1
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          image: antrea-windows
+          name: antrea-agent
+          volumeMounts:
+            - mountPath: /host
+              name: host
+            - mountPath: \\.\pipe\rancher_wins
+              name: wins
+            - mountPath: /etc/antrea
+              name: antrea-windows-config
+            - mountPath: /var/lib/antrea-windows
+              name: antrea-agent-windows
+            - mountPath: /host/k/antrea/
+              name: host-antrea-home
+      hostNetwork: true
+      initContainers:
+        - command:
+            - pwsh
+          args:
+            - -File
+            - /k/antrea/Install-WindowsCNI.ps1
+          image: antrea-windows
+          name: install-cni
+          volumeMounts:
+            - mountPath: /etc/antrea
+              name: antrea-windows-config
+              readOnly: true
+            - mountPath: /host/etc/cni/net.d
+              name: host-cni-conf
+            - mountPath: /host/opt/cni/bin
+              name: host-cni-bin
+            - mountPath: /host/k/antrea/
+              name: host-antrea-home
+            - mountPath: /host
+              name: host
+      nodeSelector:
+        kubernetes.io/os: windows
+      priorityClassName: system-node-critical
+      serviceAccountName: antrea-agent
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+      volumes:
+        - configMap:
+            name: antrea-windows-config
+          name: antrea-windows-config
+        - configMap:
+            defaultMode: 420
+            name: antrea-agent-windows
+          name: antrea-agent-windows
+        - hostPath:
+            path: /etc/cni/net.d
+            type: DirectoryOrCreate
+          name: host-cni-conf
+        - hostPath:
+            path: /opt/cni/bin
+            type: DirectoryOrCreate
+          name: host-cni-bin
+        - hostPath:
+            path: /k/antrea
+            type: DirectoryOrCreate
+          name: host-antrea-home
+        - hostPath:
+            path: /
+          name: host
+        - name: wins
+          hostPath:
+            path: \\.\pipe\rancher_wins
+            type: null
+  updateStrategy:
+    type: RollingUpdate

--- a/build/yamls/windows/base/conf/Run-AntreaAgent.ps1
+++ b/build/yamls/windows/base/conf/Run-AntreaAgent.ps1
@@ -1,0 +1,5 @@
+$ErrorActionPreference = "Stop"
+# wins will rename the binary when executing it. So we need to copy the binary everytime before running it.
+mkdir -force /host/k/antrea/bin
+cp /k/antrea/bin/* /host/k/antrea/bin/
+C:/k/antrea/utils/wins.exe cli process run --path /k/antrea/bin/antrea-agent.exe --args "--config=/k/antrea/etc/antrea-agent.conf --logtostderr=false --log_dir=/k/antrea/logs/ --alsologtostderr" --envs "KUBERNETES_SERVICE_HOST=$env:KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT=$env:KUBERNETES_SERVICE_PORT ANTREA_SERVICE_HOST=$env:ANTREA_SERVICE_HOST ANTREA_SERVICE_PORT=$env:ANTREA_SERVICE_PORT NODE_NAME=$env:NODE_NAME"

--- a/build/yamls/windows/base/conf/antrea-agent.conf
+++ b/build/yamls/windows/base/conf/antrea-agent.conf
@@ -1,0 +1,27 @@
+# Name of the OpenVSwitch bridge antrea-agent will create and use.
+# Make sure it doesn't conflict with your existing OpenVSwitch bridges.
+#ovsBridge: br-int
+
+# Name of the interface antrea-agent will create and use for host <--> pod communication.
+# Make sure it doesn't conflict with your existing interfaces.
+#hostGateway: gw0
+
+# Encapsulation mode for communication between Pods across Nodes, supported values:
+# - vxlan (default)
+# - stt
+#tunnelType: vxlan
+
+# Default MTU to use for the host gateway interface and the network interface of each Pod. If
+# omitted, antrea-agent will default this value to 1450 to accommodate for tunnel encapsulate
+# overhead.
+#defaultMTU: 1450
+
+# CIDR Range for services in cluster. It's required to support egress network policy, should
+# be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
+#serviceCIDR: 10.96.0.0/12
+
+# The port for the antrea-agent APIServer to serve on.
+#apiPort: 10350
+
+# Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
+#enablePrometheusMetrics: false

--- a/build/yamls/windows/base/conf/antrea-cni.conflist
+++ b/build/yamls/windows/base/conf/antrea-cni.conflist
@@ -1,0 +1,13 @@
+{
+    "cniVersion":"0.3.0",
+    "name": "antrea",
+    "plugins": [
+        {
+            "type": "antrea",
+            "ipam": {
+                "type": "host-local"
+            },
+            "capabilities": {"dns": true}
+        }
+    ]
+}

--- a/build/yamls/windows/base/kustomization.yml
+++ b/build/yamls/windows/base/kustomization.yml
@@ -1,0 +1,15 @@
+resources:
+- agent.yml
+configMapGenerator:
+- files:
+  - conf/antrea-agent.conf
+  - conf/antrea-cni.conflist
+  name: antrea-windows-config
+- files:
+  - conf/Run-AntreaAgent.ps1
+  name: antrea-agent-windows
+commonLabels:
+  app: antrea
+namespace: kube-system
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/build/yamls/windows/patches/dev/imagePullPolicy.yml
+++ b/build/yamls/windows/patches/dev/imagePullPolicy.yml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: antrea-agent-windows
+spec:
+  template:
+    spec:
+      containers:
+        - name: antrea-agent
+          imagePullPolicy: IfNotPresent
+      initContainers:
+        - name: install-cni
+          imagePullPolicy: IfNotPresent

--- a/build/yamls/windows/patches/release/.gitignore
+++ b/build/yamls/windows/patches/release/.gitignore
@@ -1,0 +1,1 @@
+# placeholder

--- a/ci/check-manifest.sh
+++ b/ci/check-manifest.sh
@@ -25,11 +25,17 @@ function echoerr {
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 pushd $THIS_DIR/.. > /dev/null
 
-YAMLS="build/yamls/antrea.yml build/yamls/antrea-ipsec.yml build/yamls/antrea-eks.yml build/yamls/antrea-octant.yml"
+YAMLS=(
+    "build/yamls/antrea.yml"
+    "build/yamls/antrea-ipsec.yml"
+    "build/yamls/antrea-eks.yml"
+    "build/yamls/antrea-octant.yml"
+    "build/yamls/antrea-windows.yml"
+)
 
-rm $YAMLS
+rm "${YAMLS[@]}"
 make manifest
-diff="$(git status --porcelain $YAMLS)"
+diff="$(git status --porcelain ${YAMLS[@]})"
 
 if [ ! -z "$diff" ]; then
     echoerr "The generated manifest YAMLs are not up-to-date"

--- a/hack/generate-manifest-windows.sh
+++ b/hack/generate-manifest-windows.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+_usage="Usage: $0 [--mode (dev|release)] [--keep] [--help|-h]
+Generate a YAML manifest to run Antrea on Windows Nodes, using Kustomize, and print it to stdout.
+        --mode (dev|release)  Choose the configuration variant that you need (default is 'dev')
+        --keep                Debug flag which will preserve the generated kustomization.yml
+        --help, -h            Print this message and exit
+
+In 'release' mode, environment variables IMG_NAME and IMG_TAG must be set.
+
+This tool uses kustomize (https://github.com/kubernetes-sigs/kustomize) to generate manifests for
+running Antrea on Windows Nodes. You can set the KUSTOMIZE environment variable to the path of the
+kustomize binary you want us to use. Otherwise we will look for kustomize in your PATH and your
+GOPATH. If we cannot find kustomize there, we will try to install it."
+
+function print_usage {
+    echoerr "$_usage"
+}
+
+function print_help {
+    echoerr "Try '$0 --help' for more information."
+}
+
+MODE="dev"
+KEEP=false
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    --mode)
+    MODE="$2"
+    shift 2
+    ;;
+    --keep)
+    KEEP=true
+    shift
+    ;;
+    -h|--help)
+    print_usage
+    exit 0
+    ;;
+    *)    # unknown option
+    echoerr "Unknown option $1"
+    exit 1
+    ;;
+esac
+done
+
+if [ "$MODE" != "dev" ] && [ "$MODE" != "release" ]; then
+    echoerr "--mode must be one of 'dev' or 'release'"
+    print_help
+    exit 1
+fi
+
+if [ "$MODE" == "release" ] && [ -z "$IMG_NAME" ]; then
+    echoerr "In 'release' mode, environment variable IMG_NAME must be set"
+    print_help
+    exit 1
+fi
+
+if [ "$MODE" == "release" ] && [ -z "$IMG_TAG" ]; then
+    echoerr "In 'release' mode, environment variable IMG_TAG must be set"
+    print_help
+    exit 1
+fi
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+source $THIS_DIR/verify-kustomize.sh
+
+if [ -z "$KUSTOMIZE" ]; then
+    KUSTOMIZE="$(verify_kustomize)"
+elif ! $KUSTOMIZE version > /dev/null 2>&1; then
+    echoerr "$KUSTOMIZE does not appear to be a valid kustomize binary"
+    print_help
+    exit 1
+fi
+
+KUSTOMIZATION_DIR=$THIS_DIR/../build/yamls/windows
+
+TMP_DIR=$(mktemp -d $KUSTOMIZATION_DIR/overlays.XXXXXXXX)
+
+pushd $TMP_DIR > /dev/null
+
+BASE=../../base
+
+mkdir $MODE && cd $MODE
+touch kustomization.yml
+$KUSTOMIZE edit add base $BASE
+# ../../patches/$MODE may be empty so we use find and not simply cp
+find ../../patches/$MODE -name \*.yml -exec cp {} . \;
+
+if [ "$MODE" == "dev" ]; then
+    $KUSTOMIZE edit set image antrea-windows=antrea/antrea-windows:latest
+    $KUSTOMIZE edit add patch imagePullPolicy.yml
+fi
+
+if [ "$MODE" == "release" ]; then
+    $KUSTOMIZE edit set image antrea-windows=$IMG_NAME:$IMG_TAG
+fi
+
+$KUSTOMIZE build
+
+popd > /dev/null
+
+if $KEEP; then
+    echoerr "Kustomization file is at $TMP_DIR/$MODE/kustomization.yml"
+else
+    rm -rf $TMP_DIR
+fi

--- a/hack/release/prepare-assets.sh
+++ b/hack/release/prepare-assets.sh
@@ -65,4 +65,7 @@ export IMG_NAME=antrea/antrea-ubuntu
 export IMG_NAME=antrea/octant-antrea-ubuntu
 ./hack/generate-manifest-octant.sh --mode release > $1/antrea-octant.yml
 
+export IMG_NAME=antrea/antrea-windows
+./hack/generate-manifest-windows.sh --mode release > $1/antrea-windows.yml
+
 ls $1 | cat


### PR DESCRIPTION
We follow the same model for antrea-windows.yml as we do for our other
YAML manifests. The YAML file can now be generated (using
hack/generate-manifest-windows.sh) in both "dev" and "release" modes,
using the appropriate container image for both.

antrea-windows.yml is added to the `make manifest` target and we verify
that it is up-to-date in CI.

The release antrea-window.yml will also automatically be uploaded as
part of release assets starting with Antrea v0.7.0.

The only notable changes in antrea-window.yml itself are that:
 - the ConfigMap used by the agent DaemonSet for Windows has been
   renamed to avoid conflicting with the ConfigMap used by the Linux
   agent DaemonSet
 - the missing enablePrometheus and apiPort conf parameters were added
   to antrea-agent.conf as I don't think they were omitted on purpose in
   the first place