### PR TITLE
Upgrade Antrea versions used for upgrade test

### DIFF
--- a/.github/workflows/kind-upgrade.yml
+++ b/.github/workflows/kind-upgrade.yml
@@ -23,38 +23,9 @@ jobs:
         name: antrea-ubuntu
         path: antrea-ubuntu.tar
 
-  from-v0_4_1:
-    name: Upgrade from Antrea v0.4.1
-    needs: build-antrea-image
-    runs-on: [ubuntu-18.04]
-    steps:
-    - name: Free disk space
-      # https://github.com/actions/virtual-environments/issues/709
-      run: |
-        sudo apt-get clean
-        df -h
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v1
-      with:
-        go-version: 1.13
-    - name: Download Antrea image from previous job
-      uses: actions/download-artifact@v1
-      with:
-        name: antrea-ubuntu
-    - name: Load Antrea image
-      run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
-    - name: Install Kind
-      env:
-        KIND_VERSION: v0.7.0
-      run: |
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
-    - name: Run test
-      run: |
-        ./ci/kind/test-upgrade-antrea.sh --from-tag v0.4.1
+# TODO: define an action to avoid repetition?
 
-  from-v0_5_0: # TODO: define an action to avoid repetiion?
+  from-v0_5_0:
     name: Upgrade from Antrea v0.5.0
     needs: build-antrea-image
     runs-on: [ubuntu-18.04]
@@ -115,3 +86,34 @@ jobs:
     - name: Run test
       run: |
         ./ci/kind/test-upgrade-antrea.sh --from-tag v0.5.1
+
+  from-v0_6_0:
+    name: Upgrade from Antrea v0.6.0
+    needs: build-antrea-image
+    runs-on: [ubuntu-18.04]
+    steps:
+    - name: Free disk space
+      # https://github.com/actions/virtual-environments/issues/709
+      run: |
+        sudo apt-get clean
+        df -h
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - name: Download Antrea image from previous job
+      uses: actions/download-artifact@v1
+      with:
+        name: antrea-ubuntu
+    - name: Load Antrea image
+      run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
+    - name: Install Kind
+      env:
+        KIND_VERSION: v0.7.0
+      run: |
+        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
+        chmod +x ./kind
+        sudo mv kind /usr/local/bin
+    - name: Run test
+      run: |
+        ./ci/kind/test-upgrade-antrea.sh --from-tag v0.6.0


### PR DESCRIPTION
Old: 0.4.1, 0.5.0, 0.5.1
New: 0.5.0, 0.5.1, 0.6.0