### PR TITLE
Use bash shell for Windows Github workflow jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
       run: |
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         docker push antrea/antrea-windows:latest
+      shell: bash
 
   build-octant-antrea-ubuntu:
     runs-on: [ubuntu-18.04]

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -30,9 +30,11 @@ jobs:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         TAG: ${{ github.ref }}
       run: |
-        VERSION="${TAG:10}" make build-windows
+        export VERSION="${TAG:10}"
+        make build-windows
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         docker push antrea/antrea-windows:"${TAG:10}"
+      shell: bash
 
   build-octant-antrea-ubuntu:
     runs-on: [ubuntu-18.04]


### PR DESCRIPTION
Bash is provided by "Git for Windows"
This simplifies things as we can use the same scripts as for the Ubuntu
jobs instead of using powershell equivalents.
At the moment these jobs fails because of incorrect syntax.