### PR TITLE
Fix Jenkins job YAML specification for e2e tests

### DIFF
--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -314,7 +314,7 @@
 
           set +e
           mkdir -p `pwd`/antrea-test-logs
-          go test -prometheus -v github.com/vmware-tanzu/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs -timeout=20m
+          go test -v -timeout=20m github.com/vmware-tanzu/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs --prometheus
 
           test_rc=$?
           set -e

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -118,7 +118,7 @@ enabled explicitly.
 * To load Antrea into the cluster with Prometheus enabled, use: 
 `./infra/vagrant/push_antrea.sh --prometheus`
 * To run the Prometheus tests within the e2e suite, use:
-`go test -v -prometheus github.com/vmware-tanzu/antrea/test/e2e`
+`go test -v github.com/vmware-tanzu/antrea/test/e2e --prometheus`
 
 
 ## Running the e2e tests on a Kind cluster

--- a/test/e2e/infra/vagrant/push_antrea.sh
+++ b/test/e2e/infra/vagrant/push_antrea.sh
@@ -39,7 +39,7 @@ cp "${ANTREA_BASE_YML}" "${ANTREA_YML}"
 
 if [ "$RUN_PROMETHEUS" == "true" ]; then
     # Prepare Antrea yamls
-    sed -i 's|#enablePrometheusMetrics: false|enablePrometheusMetrics: true|g' "${ANTREA_YML}"
+    sed -i.bak -E 's|#enablePrometheusMetrics: false|enablePrometheusMetrics: true|g' "${ANTREA_YML}"
     echo "---" >> "${ANTREA_YML}"
     cat "${ANTREA_PROMETHEUS_YML}" >> "${ANTREA_YML}"
 fi


### PR DESCRIPTION
The `--prometheus` flag needs to come after the package name, or the job
fails with the following error:
```
"build .: cannot find module for path ."
```

Also fix test/e2e/infra/vagrant/push_antrea.sh script for macOS.