### PR TITLE
Fix Antrea Docker image vulnerability scan

### DIFF
--- a/ci/clair-scan/run.sh
+++ b/ci/clair-scan/run.sh
@@ -15,8 +15,13 @@ fi
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 pushd "$THIS_DIR" > /dev/null
 
-# The highest Antrea release version.
-VERSION=$(git ls-remote --tags https://github.com/vmware-tanzu/antrea.git | awk '{print $2}' | awk -F/ '{print $3}' | sort --version-sort -r | head -n 1)
+# The highest Antrea release version, excluding release candidates.
+# We also exclude peeled tags from the output (vX.Y.Z^{}) as they could lead to
+# an invalid version number.
+VERSION=$(git ls-remote --tags --ref https://github.com/vmware-tanzu/antrea.git | \
+              grep -v rc | \
+              awk '{print $2}' | awk -F/ '{print $3}' | \
+              sort --version-sort -r | head -n 1)
 
 echo "Scanning Antrea version $VERSION"
 


### PR DESCRIPTION
Fix the code that finds out the latest Antrea version, which determines
which image we need to scan: we exclude peeled tags and release
candidate tags from the tag list.