### PR TITLE
Implement Antrea proxy

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -54,6 +54,37 @@ jobs:
       run: |
         ./ci/kind/test-e2e-kind.sh encap
 
+  test-e2e-encap-proxy:
+    name: E2e tests on a Kind cluster on Linux with proxy enabled
+    needs: build-antrea-image
+    runs-on: [ubuntu-18.04]
+    steps:
+    - name: Free disk space
+      # https://github.com/actions/virtual-environments/issues/709
+      run: |
+        sudo apt-get clean
+        df -h
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - name: Download Antrea image from previous job
+      uses: actions/download-artifact@v1
+      with:
+        name: antrea-ubuntu
+    - name: Load Antrea image
+      run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
+    - name: Install Kind
+      env:
+        KIND_VERSION: v0.7.0
+      run: |
+        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
+        chmod +x ./kind
+        sudo mv kind /usr/local/bin
+    - name: Run e2e tests
+      run: |
+        ./ci/kind/test-e2e-kind.sh encap --proxy
+
   test-e2e-noencap:
     name: E2e tests on a Kind cluster on Linux (noEncap)
     needs: build-antrea-image
@@ -85,6 +116,37 @@ jobs:
       run: |
         ./ci/kind/test-e2e-kind.sh noEncap
 
+  test-e2e-noencap-proxy:
+    name: E2e tests on a Kind cluster on Linux (noEncap) with proxy enabled
+    needs: build-antrea-image
+    runs-on: [ubuntu-18.04]
+    steps:
+    - name: Free disk space
+      # https://github.com/actions/virtual-environments/issues/709
+      run: |
+        sudo apt-get clean
+        df -h
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - name: Download Antrea image from previous job
+      uses: actions/download-artifact@v1
+      with:
+        name: antrea-ubuntu
+    - name: Load Antrea image
+      run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
+    - name: Install Kind
+      env:
+        KIND_VERSION: v0.7.0
+      run: |
+        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
+        chmod +x ./kind
+        sudo mv kind /usr/local/bin
+    - name: Run e2e tests
+      run: |
+        ./ci/kind/test-e2e-kind.sh noEncap --proxy
+
   test-e2e-hybrid:
     name: E2e tests on a Kind cluster on Linux (hybrid)
     needs: build-antrea-image
@@ -115,6 +177,37 @@ jobs:
     - name: Run e2e tests
       run: |
         ./ci/kind/test-e2e-kind.sh hybrid
+
+  test-e2e-hybrid-proxy:
+    name: E2e tests on a Kind cluster on Linux (hybrid) with proxy enabled
+    needs: build-antrea-image
+    runs-on: [ubuntu-18.04]
+    steps:
+    - name: Free disk space
+      # https://github.com/actions/virtual-environments/issues/709
+      run: |
+        sudo apt-get clean
+        df -h
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - name: Download Antrea image from previous job
+      uses: actions/download-artifact@v1
+      with:
+        name: antrea-ubuntu
+    - name: Load Antrea image
+      run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
+    - name: Install Kind
+      env:
+        KIND_VERSION: v0.7.0
+      run: |
+        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
+        chmod +x ./kind
+        sudo mv kind /usr/local/bin
+    - name: Run e2e tests
+      run: |
+        ./ci/kind/test-e2e-kind.sh hybrid --proxy
 
   test-netpol-tmp:
     name: Run experimental network policy tests (netpol) on Kind cluster

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -148,9 +148,11 @@ rules:
   - ""
   resources:
   - pods
+  - endpoints
   - services
   verbs:
   - get
+  - watch
   - list
 - apiGroups:
   - clusterinformation.antrea.tanzu.vmware.com
@@ -345,7 +347,11 @@ apiVersion: v1
 data:
   antrea-agent.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
-    #featureGates:
+    featureGates:
+    # Enable antrea proxy which provides ServiceLB for in-cluster services in antrea agent.
+    # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
+    # Service traffic.
+    #  AntreaProxy: false
 
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
@@ -440,7 +446,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-6kd8dg2mdc
+  name: antrea-config-9bcct72f2b
   namespace: kube-system
 ---
 apiVersion: v1
@@ -545,7 +551,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-6kd8dg2mdc
+          name: antrea-config-9bcct72f2b
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -761,7 +767,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-6kd8dg2mdc
+          name: antrea-config-9bcct72f2b
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -148,9 +148,11 @@ rules:
   - ""
   resources:
   - pods
+  - endpoints
   - services
   verbs:
   - get
+  - watch
   - list
 - apiGroups:
   - clusterinformation.antrea.tanzu.vmware.com
@@ -345,7 +347,11 @@ apiVersion: v1
 data:
   antrea-agent.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
-    #featureGates:
+    featureGates:
+    # Enable antrea proxy which provides ServiceLB for in-cluster services in antrea agent.
+    # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
+    # Service traffic.
+    #  AntreaProxy: false
 
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
@@ -440,7 +446,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-df75dft74m
+  name: antrea-config-66g79mckkh
   namespace: kube-system
 ---
 apiVersion: v1
@@ -545,7 +551,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-df75dft74m
+          name: antrea-config-66g79mckkh
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -759,7 +765,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-df75dft74m
+          name: antrea-config-66g79mckkh
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -148,9 +148,11 @@ rules:
   - ""
   resources:
   - pods
+  - endpoints
   - services
   verbs:
   - get
+  - watch
   - list
 - apiGroups:
   - clusterinformation.antrea.tanzu.vmware.com
@@ -345,7 +347,11 @@ apiVersion: v1
 data:
   antrea-agent.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
-    #featureGates:
+    featureGates:
+    # Enable antrea proxy which provides ServiceLB for in-cluster services in antrea agent.
+    # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
+    # Service traffic.
+    #  AntreaProxy: false
 
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
@@ -440,7 +446,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-6fg7ftb7c2
+  name: antrea-config-6dfb5t2tkk
   namespace: kube-system
 ---
 apiVersion: v1
@@ -554,7 +560,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-6fg7ftb7c2
+          name: antrea-config-6dfb5t2tkk
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -803,7 +809,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-6fg7ftb7c2
+          name: antrea-config-6dfb5t2tkk
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -16,6 +16,13 @@ metadata:
 apiVersion: v1
 data:
   antrea-agent.conf: |
+    # FeatureGates is a map of feature names to bools that enable or disable experimental features.
+    featureGates:
+    # Enable antrea proxy which provides ServiceLB for in-cluster services in antrea agent.
+    # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
+    # Service traffic.
+      AntreaProxy: true
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     #ovsBridge: br-int
@@ -62,7 +69,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-windows-config-kc69htmck4
+  name: antrea-windows-config-8ktf86t8d5
   namespace: kube-system
 ---
 apiVersion: apps/v1
@@ -150,7 +157,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-windows-config-kc69htmck4
+          name: antrea-windows-config-8ktf86t8d5
         name: antrea-windows-config
       - configMap:
           defaultMode: 420

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -148,9 +148,11 @@ rules:
   - ""
   resources:
   - pods
+  - endpoints
   - services
   verbs:
   - get
+  - watch
   - list
 - apiGroups:
   - clusterinformation.antrea.tanzu.vmware.com
@@ -345,7 +347,11 @@ apiVersion: v1
 data:
   antrea-agent.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
-    #featureGates:
+    featureGates:
+    # Enable antrea proxy which provides ServiceLB for in-cluster services in antrea agent.
+    # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
+    # Service traffic.
+    #  AntreaProxy: false
 
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
@@ -440,7 +446,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-g9c588t985
+  name: antrea-config-689fgt2cdb
   namespace: kube-system
 ---
 apiVersion: v1
@@ -545,7 +551,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-g9c588t985
+          name: antrea-config-689fgt2cdb
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -759,7 +765,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-g9c588t985
+          name: antrea-config-689fgt2cdb
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/agent-rbac.yml
+++ b/build/yamls/base/agent-rbac.yml
@@ -22,9 +22,11 @@ rules:
       - ""
     resources:
       - pods
+      - endpoints
       - services
     verbs:
       - get
+      - watch
       - list
   - apiGroups:
       - clusterinformation.antrea.tanzu.vmware.com

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -1,5 +1,9 @@
 # FeatureGates is a map of feature names to bools that enable or disable experimental features.
-#featureGates:
+featureGates:
+# Enable antrea proxy which provides ServiceLB for in-cluster services in antrea agent.
+# It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
+# Service traffic.
+#  AntreaProxy: false
 
 # Name of the OpenVSwitch bridge antrea-agent will create and use.
 # Make sure it doesn't conflict with your existing OpenVSwitch bridges.

--- a/build/yamls/windows/base/conf/antrea-agent.conf
+++ b/build/yamls/windows/base/conf/antrea-agent.conf
@@ -1,3 +1,10 @@
+# FeatureGates is a map of feature names to bools that enable or disable experimental features.
+featureGates:
+# Enable antrea proxy which provides ServiceLB for in-cluster services in antrea agent.
+# It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
+# Service traffic.
+  AntreaProxy: true
+
 # Name of the OpenVSwitch bridge antrea-agent will create and use.
 # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
 #ovsBridge: br-int

--- a/ci/kind/kind-setup.sh
+++ b/ci/kind/kind-setup.sh
@@ -26,6 +26,7 @@ POD_CIDR="10.10.0.0/16"
 NUM_WORKERS=2
 SUBNETS=""
 ENCAP_MODE=""
+PROXY=false
 
 set -eo pipefail
 function echoerr {
@@ -43,6 +44,7 @@ where:
   modify-node: modify kind node with name NODE_NAME
   --pod-cidr: specifies pod cidr used in kind cluster, default is $POD_CIDR
   --encap-mode: inter-node pod traffic encap mode, default is encap
+  --proxy: enable Antrea proxy, default is false
   --antrea-cni: specifies install Antrea CNI in kind cluster, default is true.
   --num-workers: specifies number of worker nodes in kind cluster, default is $NUM_WORKERS
   --images: specifies images loaded to kind cluster, default is $IMAGES
@@ -261,6 +263,9 @@ EOF
   if [[ $ANTREA_CNI == true ]]; then
     cmd=$(dirname $0)
     cmd+="/../../hack/generate-manifest.sh"
+    if [[ $PROXY == true ]]; then
+      cmd+=" --proxy"
+    fi
     echo "$cmd --kind $(get_encap_mode) | kubectl apply --context kind-$CLUSTER_NAME -f -"
     eval "$cmd --kind $(get_encap_mode) | kubectl apply --context kind-$CLUSTER_NAME -f -"
   fi
@@ -305,6 +310,10 @@ while [[ $# -gt 0 ]]
       ;;
     --encap-mode)
       ENCAP_MODE="$2"
+      shift 2
+      ;;
+    --proxy)
+      PROXY=true
       shift 2
       ;;
     --subnets)

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -32,10 +32,17 @@ trap "quit" INT EXIT
 
 function run_test {
   mode=$1
-  args=$2
+  proxy=$2
+  args=$3
+  if [[ $proxy != "--proxy" ]]; then
+    proxy=""
+    args=$2
+  fi
+
   echo "create test bed with args $args"
   eval "timeout 600 $TESTBED_CMD create kind --antrea-cni false $args"
-  $YML_CMD --kind  --encap-mode $mode | docker exec -i kind-control-plane dd of=/root/antrea.yml
+
+  $YML_CMD --kind --encap-mode $mode $proxy | docker exec -i kind-control-plane dd of=/root/antrea.yml
   sleep 1
   go test -v -timeout=20m github.com/vmware-tanzu/antrea/test/e2e -provider=kind
   $TESTBED_CMD destroy kind
@@ -46,15 +53,15 @@ docker pull nginx
 
 if [[ $# == 0 ]] || [[ $1 == "encap" ]]; then
   echo "======== Test encap mode =========="
-  run_test encap "--images \"$COMMON_IMAGES\""
+  run_test encap $2 "--images \"$COMMON_IMAGES\""
 fi
 if [[ $# == 0 ]] || [[ $1 == "noEncap" ]]; then
   echo "======== Test noencap mode =========="
-  run_test noEncap "--images \"$COMMON_IMAGES\""
+  run_test noEncap $2 "--images \"$COMMON_IMAGES\""
 fi
 if [[ $# == 0 ]] || [[ $1 == "hybrid" ]]; then
   echo "======== Test hybrid mode =========="
-  run_test hybrid "--subnets \"20.20.20.0/24\" --images \"$COMMON_IMAGES\""
+  run_test hybrid $2 "--subnets \"20.20.20.0/24\" --images \"$COMMON_IMAGES\""
 fi
 exit 0
 

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -27,6 +27,7 @@ Generate a YAML manifest for Antrea using Kustomize and print it to stdout.
         --kind                Generate a manifest appropriate for running Antrea in a Kind cluster
         --cloud               Generate a manifest appropriate for running Antrea in Public Cloud
         --ipsec               Generate a manifest with IPSec encryption of tunnel traffic enabled
+        --proxy               Generate a manifest with Antrea proxy enabled
         --np                  Generate a manifest with Namespaced Antrea NetworkPolicy CRDs and ClusterNetworkPolicy related CRDs enabled
         --keep                Debug flag which will preserve the generated kustomization.yml
         --help, -h            Print this message and exit
@@ -49,6 +50,7 @@ function print_help {
 MODE="dev"
 KIND=false
 IPSEC=false
+PROXY=false
 NP=false
 KEEP=false
 ENCAP_MODE=""
@@ -77,6 +79,10 @@ case $key in
     ;;
     --ipsec)
     IPSEC=true
+    shift
+    ;;
+    --proxy)
+    PROXY=true
     shift
     ;;
     --np)
@@ -150,6 +156,10 @@ if $IPSEC; then
     sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*enableIPSecTunnel[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/enableIPSecTunnel: true/" antrea-agent.conf
     # change the tunnel type to GRE which works better with IPSec encryption than other types.
     sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*tunnelType[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/tunnelType: gre/" antrea-agent.conf
+fi
+
+if $PROXY; then
+    sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*AntreaProxy[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/  AntreaProxy: true/" antrea-agent.conf
 fi
 
 if $NP; then

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -88,7 +88,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}
@@ -116,7 +116,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}
@@ -157,7 +157,7 @@ func TestFlowInstallationFailed(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}
@@ -191,7 +191,7 @@ func TestConcurrentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}

--- a/pkg/agent/openflow/cookie/allocator.go
+++ b/pkg/agent/openflow/cookie/allocator.go
@@ -62,15 +62,16 @@ func (c Category) String() string {
 
 // ID defines segments a cookie ID contains. An ID is composed like:
 //  |------------------------- ID --------------------------|
-//  |- round 16bits -|- category 8bits -|- reserved 40bits -|
+//  |- round 16bits -|- category 8bits -|- reserved 8bits -|- objectID 32bits -|
 // The round segment represents the round id.
 // The category segment represents the category of flow this ID belongs.
 type ID uint64
 
-func newID(round uint64, cat Category) ID {
+func newID(round uint64, cat Category, objectID uint32) ID {
 	r := uint64(0)
 	r |= round << (64 - BitwidthRound)
 	r |= (uint64(cat) << BitwidthReserved) & CategoryMask
+	r |= uint64(objectID)
 	return ID(r)
 }
 
@@ -102,8 +103,10 @@ func (i ID) String() string {
 
 // Allocator defines operations of a cookie ID allocator.
 type Allocator interface {
-	// Request cookie IDs of flow categories.
+	// Request gets a cookie IDs of the flow category.
 	Request(cat Category) ID
+	// RequestWithObjectID gets a cookie ID of the flow category and objectID.
+	RequestWithObjectID(cat Category, objectID uint32) ID
 }
 
 type allocator struct {
@@ -112,7 +115,11 @@ type allocator struct {
 
 // Request returns a ID with the given category.
 func (a *allocator) Request(cat Category) ID {
-	return newID(a.round, cat)
+	return newID(a.round, cat, 0)
+}
+
+func (a *allocator) RequestWithObjectID(cat Category, objectID uint32) ID {
+	return newID(a.round, cat, objectID)
 }
 
 // NewAllocator creates a cookie ID allocator by using the given round number.

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -15,6 +15,7 @@
 package openflow
 
 import (
+	"encoding/binary"
 	"fmt"
 	"net"
 	"strconv"
@@ -25,6 +26,7 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow/cookie"
 	"github.com/vmware-tanzu/antrea/pkg/agent/types"
 	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
+	"github.com/vmware-tanzu/antrea/third_party/proxy"
 )
 
 const (
@@ -32,9 +34,13 @@ const (
 	classifierTable       binding.TableIDType = 0
 	spoofGuardTable       binding.TableIDType = 10
 	arpResponderTable     binding.TableIDType = 20
+	serviceHairpinTable   binding.TableIDType = 29
 	conntrackTable        binding.TableIDType = 30
 	conntrackStateTable   binding.TableIDType = 31
+	sessionAffinityTable  binding.TableIDType = 40
 	dnatTable             binding.TableIDType = 40
+	serviceLBTable        binding.TableIDType = 41
+	endpointDNATTable     binding.TableIDType = 42
 	egressRuleTable       binding.TableIDType = 50
 	egressDefaultTable    binding.TableIDType = 60
 	l3ForwardingTable     binding.TableIDType = 70
@@ -42,6 +48,7 @@ const (
 	ingressRuleTable      binding.TableIDType = 90
 	ingressDefaultTable   binding.TableIDType = 100
 	conntrackCommitTable  binding.TableIDType = 105
+	hairpinSNATTable      binding.TableIDType = 106
 	l2ForwardingOutTable  binding.TableIDType = 110
 
 	// Flow priority level
@@ -66,16 +73,21 @@ var (
 		{classifierTable, "Classification"},
 		{spoofGuardTable, "SpoofGuard"},
 		{arpResponderTable, "ARPResponder"},
+		{serviceHairpinTable, "ServiceHairpin"},
 		{conntrackTable, "ConntrackZone"},
-		{conntrackStateTable, "ContrackState"},
-		{dnatTable, "DNAT"},
+		{conntrackStateTable, "ConntrackState"},
+		{dnatTable, "DNAT(SessionAffinity)"},
+		{sessionAffinityTable, "SessionAffinity"},
+		{serviceLBTable, "ServiceLB"},
+		{endpointDNATTable, "EndpointDNAT"},
 		{egressRuleTable, "EgressRule"},
 		{egressDefaultTable, "EgressDefaultRule"},
-		{l3ForwardingTable, "L3Forwarding"},
+		{l3ForwardingTable, "l3Forwarding"},
 		{l2ForwardingCalcTable, "L2Forwarding"},
 		{ingressRuleTable, "IngressRule"},
 		{ingressDefaultTable, "IngressDefaultRule"},
 		{conntrackCommitTable, "ConntrackCommit"},
+		{hairpinSNATTable, "HairpinSNATTable"},
 		{l2ForwardingOutTable, "Output"},
 	}
 )
@@ -120,17 +132,30 @@ func (rt regType) reg() string {
 const (
 	// marksReg stores traffic-source mark and pod-found mark.
 	// traffic-source resides in [0..15], pod-found resides in [16].
-	marksReg     regType = 0
-	portCacheReg regType = 1
-	swapReg      regType = 2
+	marksReg        regType = 0
+	portCacheReg    regType = 1
+	swapReg         regType = 2
+	endpointIPReg   regType = 3               // Use reg3 to store endpoint IP
+	endpointPortReg regType = 4               // Use reg4[0..15] to store endpoint port
+	serviceLearnReg         = endpointPortReg // Use reg4[16..18] to store endpoint selection states.
+	// marksRegServiceNeedLB indicates a packet need to do service selection.
+	marksRegServiceNeedLB uint32 = 0b001
+	// marksRegServiceSelected indicates a packet has done service selection.
+	marksRegServiceSelected uint32 = 0b010
+	// marksRegServiceNeedLearn indicates a packet has done service selection and
+	// the selection result needs to be cached.
+	marksRegServiceNeedLearn uint32 = 0b011
 
 	ctZone = 0xfff0
 
-	portFoundMark    = 0x1
-	snatRequiredMark = 0x1
+	portFoundMark    = 0b1
+	snatRequiredMark = 0b1
+	hairpinMark      = 0b1
+	macRewriteMark   = 0b1
 
 	gatewayCTMark = 0x20
 	snatCTMark    = 0x40
+	serviceCTMark = 0x21
 )
 
 var (
@@ -142,9 +167,27 @@ var (
 	// snatMarkRange takes the 17th bit of register marksReg to indicate if the packet needs to be SNATed with Node's IP
 	// or not. Its value is 0x1 if yes.
 	snatMarkRange = binding.Range{17, 17}
+	// hairpinMarkRange takes the 18th bit of register marksReg to indicate
+	// if the packet needs DNAT to virtual IP or not. Its value is 0x1 if yes.
+	hairpinMarkRange = binding.Range{18, 18}
+	// macRewriteMarkRange takes the 19th bit of register marksReg to indicate
+	// if the packet's MAC addresses need to be rewritten. Its value is 0x1 if yes.
+	macRewriteMarkRange = binding.Range{19, 19}
+	// endpointIPRegRange takes a 32-bit range of register endpointIPReg to store
+	// the selected Service Endpoint IP.
+	endpointIPRegRange = binding.Range{0, 31}
+	// endpointPortRegRange takes a 16-bit range of register endpointPortReg to store
+	// the selected Service Endpoint port.
+	endpointPortRegRange = binding.Range{0, 15}
+	// serviceLearnRegRange takes a 3-bit range of register serviceLearnReg to
+	// indicate if the packet accessing a Service has already selected the Service
+	// Endpoint, still needs to select an Endpoint, or if an Endpoint has already
+	// been selected and the selection decision needs to be learned.
+	serviceLearnRegRange = binding.Range{16, 18}
 
 	globalVirtualMAC, _ = net.ParseMAC("aa:bb:cc:dd:ee:ff")
 	ReentranceMAC, _    = net.ParseMAC("de:ad:be:ef:de:ad")
+	hairpinIP           = net.ParseIP("169.254.169.252").To4()
 )
 
 type OFEntryOperations interface {
@@ -164,14 +207,15 @@ type flowCategoryCache struct {
 }
 
 type client struct {
-	roundInfo                   types.RoundInfo
-	cookieAllocator             cookie.Allocator
-	bridge                      binding.Bridge
-	pipeline                    map[binding.TableIDType]binding.Table
-	nodeFlowCache, podFlowCache *flowCategoryCache // cache for corresponding deletions
+	enableProxy                                   bool
+	roundInfo                                     types.RoundInfo
+	cookieAllocator                               cookie.Allocator
+	bridge                                        binding.Bridge
+	pipeline                                      map[binding.TableIDType]binding.Table
+	nodeFlowCache, podFlowCache, serviceFlowCache *flowCategoryCache // cache for corresponding deletions
 	// "fixed" flows installed by the agent after initialization and which do not change during
 	// the lifetime of the client.
-	gatewayFlows, clusterServiceCIDRFlows, defaultTunnelFlows, hostNetworkingFlows []binding.Flow
+	gatewayFlows, defaultServiceFlows, defaultTunnelFlows, hostNetworkingFlows []binding.Flow
 	// ofEntryOperations is a wrapper interface for OpenFlow entry Add / Modify / Delete operations. It
 	// enables convenient mocking in unit tests.
 	ofEntryOperations OFEntryOperations
@@ -179,6 +223,7 @@ type client struct {
 	// is processed by at most one goroutine at any given time.
 	policyCache       sync.Map
 	conjMatchFlowLock sync.Mutex // Lock for access globalConjMatchFlowCache
+	groupCache        sync.Map
 	// globalConjMatchFlowCache is a global map for conjMatchFlowContext. The key is a string generated from the
 	// conjMatchFlowContext.
 	globalConjMatchFlowCache map[string]*conjMatchFlowContext
@@ -247,6 +292,7 @@ func (c *client) tunnelClassifierFlow(tunnelOFPort uint32, category cookie.Categ
 	return c.pipeline[classifierTable].BuildFlow(priorityNormal).
 		MatchInPort(tunnelOFPort).
 		Action().LoadRegRange(int(marksReg), markTrafficFromTunnel, binding.Range{0, 15}).
+		Action().LoadRegRange(int(marksReg), macRewriteMark, macRewriteMarkRange).
 		Action().GotoTable(conntrackTable).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
@@ -296,16 +342,45 @@ func (c *client) hostBridgeUplinkFlows(uplinkPort uint32, bridgeLocalPort uint32
 // 2) Add ct_mark on the packet if it is sent to the switch from the host gateway.
 // 3) Allow traffic if it hits ct_mark and is sent from the host gateway.
 // 4) Drop all invalid traffic.
-// 5) Let other traffic go to the next table by the table-miss flow.
-func (c *client) connectionTrackFlows(category cookie.Category) (flows []binding.Flow) {
+// 5) Let other traffic go to the sessionAffinityTable first and then the serviceLBTable.
+//    The sessionAffinityTable is a side-effect table which means traffic will not
+//    be resubmitted to any table. serviceLB does Endpoint selection for traffic
+//    to a Service.
+func (c *client) connectionTrackFlows(category cookie.Category) []binding.Flow {
 	connectionTrackTable := c.pipeline[conntrackTable]
 	connectionTrackStateTable := c.pipeline[conntrackStateTable]
 	connectionTrackCommitTable := c.pipeline[conntrackCommitTable]
-	flows = []binding.Flow{
-		connectionTrackTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
-			Action().CT(false, connectionTrackTable.GetNext(), ctZone).CTDone().
-			Cookie(c.cookieAllocator.Request(category).Raw()).
-			Done(),
+	var flows []binding.Flow
+	if c.enableProxy {
+		flows = append(flows,
+			// Replace the default flow with multiple resubmits actions.
+			connectionTrackStateTable.BuildFlow(priorityMiss).
+				Cookie(c.cookieAllocator.Request(category).Raw()).
+				Action().ResubmitToTable(sessionAffinityTable).
+				Action().ResubmitToTable(serviceLBTable).
+				Done(),
+			// Enable NAT.
+			connectionTrackTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
+				Action().CT(false, connectionTrackTable.GetNext(), ctZone).NAT().CTDone().
+				Cookie(c.cookieAllocator.Request(category).Raw()).
+				Done(),
+			connectionTrackCommitTable.BuildFlow(priorityLow).MatchProtocol(binding.ProtocolIP).
+				MatchCTStateTrk(true).
+				MatchCTMark(serviceCTMark).
+				MatchRegRange(int(serviceLearnReg), marksRegServiceSelected, serviceLearnRegRange).
+				Cookie(c.cookieAllocator.Request(category).Raw()).
+				Action().GotoTable(connectionTrackCommitTable.GetNext()).
+				Done(),
+		)
+	} else {
+		flows = append(flows,
+			connectionTrackTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
+				Action().CT(false, connectionTrackTable.GetNext(), ctZone).CTDone().
+				Cookie(c.cookieAllocator.Request(category).Raw()).
+				Done(),
+		)
+	}
+	return append(flows,
 		connectionTrackStateTable.BuildFlow(priorityHigh).MatchProtocol(binding.ProtocolIP).
 			MatchRegRange(int(marksReg), markTrafficFromGateway, binding.Range{0, 15}).
 			MatchCTMark(gatewayCTMark).
@@ -329,8 +404,7 @@ func (c *client) connectionTrackFlows(category cookie.Category) (flows []binding
 			Action().CT(true, connectionTrackCommitTable.GetNext(), ctZone).CTDone().
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done(),
-	}
-	return
+	)
 }
 
 // reEntranceBypassCTFlow generates flow that bypass CT for traffic re-entering host network space.
@@ -357,6 +431,19 @@ func (c *client) ctRewriteDstMACFlow(gatewayMAC net.HardwareAddr, category cooki
 		Action().LoadRange(binding.NxmFieldDstMAC, macData, binding.Range{0, 47}).
 		Action().GotoTable(connectionTrackStateTable.GetNext()).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
+		Done()
+}
+
+// serviceLBBypassFlow makes packets that belong to a tracked connection bypass
+// service LB tables and enter egressRuleTable directly.
+func (c *client) serviceLBBypassFlow() binding.Flow {
+	connectionTrackStateTable := c.pipeline[conntrackStateTable]
+	return connectionTrackStateTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
+		MatchCTMark(serviceCTMark).
+		MatchCTStateNew(false).MatchCTStateTrk(true).
+		Action().LoadRegRange(int(marksReg), macRewriteMark, macRewriteMarkRange).
+		Action().GotoTable(egressRuleTable).
+		Cookie(c.cookieAllocator.Request(cookie.Service).Raw()).
 		Done()
 }
 
@@ -393,6 +480,16 @@ func (c *client) l2ForwardOutputReentInPortFlow(gwPort uint32, category cookie.C
 		Done()
 }
 
+// l2ForwardOutputServiceHairpinFlow uses in_port action for Service
+// hairpin packets to avoid packets from being dropped by OVS.
+func (c *client) l2ForwardOutputServiceHairpinFlow() binding.Flow {
+	return c.pipeline[l2ForwardingOutTable].BuildFlow(priorityHigh).MatchProtocol(binding.ProtocolIP).
+		MatchRegRange(int(marksReg), hairpinMark, hairpinMarkRange).
+		Action().OutputInPort().
+		Cookie(c.cookieAllocator.Request(cookie.Service).Raw()).
+		Done()
+}
+
 // l3BypassMACRewriteFlow bypasses remaining l3forwarding flows if the MAC is set via ctRewriteDstMACFlow in
 // conntrackState stage.
 func (c *client) l3BypassMACRewriteFlow(gatewayMAC net.HardwareAddr, category cookie.Category) binding.Flow {
@@ -408,9 +505,14 @@ func (c *client) l3BypassMACRewriteFlow(gatewayMAC net.HardwareAddr, category co
 // l3FlowsToPod generates the flow to rewrite MAC if the packet is received from tunnel port and destined for local Pods.
 func (c *client) l3FlowsToPod(localGatewayMAC net.HardwareAddr, podInterfaceIP net.IP, podInterfaceMAC net.HardwareAddr, category cookie.Category) binding.Flow {
 	l3FwdTable := c.pipeline[l3ForwardingTable]
+	flowBuilder := l3FwdTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP)
+	if c.enableProxy {
+		flowBuilder = flowBuilder.MatchRegRange(int(marksReg), macRewriteMark, macRewriteMarkRange)
+	} else {
+		flowBuilder = flowBuilder.MatchDstMAC(globalVirtualMAC)
+	}
 	// Rewrite src MAC to local gateway MAC, and rewrite dst MAC to pod MAC
-	return l3FwdTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
-		MatchDstMAC(globalVirtualMAC).
+	return flowBuilder.
 		MatchDstIP(podInterfaceIP).
 		Action().SetSrcMAC(localGatewayMAC).
 		Action().SetDstMAC(podInterfaceMAC).
@@ -549,6 +651,18 @@ func (c *client) podIPSpoofGuardFlow(ifIP net.IP, ifMAC net.HardwareAddr, ifOFPo
 		Done()
 }
 
+// serviceHairpinResponseDNATFlow generates the flow which transforms destination
+// IP of the hairpin packet to the source IP.
+func (c *client) serviceHairpinResponseDNATFlow() binding.Flow {
+	return c.pipeline[serviceHairpinTable].BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
+		MatchDstIP(hairpinIP).
+		Action().Move("NXM_OF_IP_SRC", "NXM_OF_IP_DST").
+		Action().LoadRegRange(int(marksReg), hairpinMark, hairpinMarkRange).
+		Action().GotoTable(conntrackTable).
+		Cookie(c.cookieAllocator.Request(cookie.Service).Raw()).
+		Done()
+}
+
 // gatewayARPSpoofGuardFlow generates the flow to check ARP traffic sent out from the local gateway interface.
 func (c *client) gatewayARPSpoofGuardFlow(gatewayOFPort uint32, gatewayIP net.IP, gatewayMAC net.HardwareAddr, category cookie.Category) binding.Flow {
 	return c.pipeline[spoofGuardTable].BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolARP).
@@ -582,15 +696,36 @@ func (c *client) gatewayIPSpoofGuardFlow(gatewayOFPort uint32, category cookie.C
 		Done()
 }
 
+// sessionAffinityReselectFlow generates the flow which resubmits the service accessing
+// packet back to serviceLBTable if there is no endpointDNAT flow matched. This
+// case will occur if an Endpoint is removed and is the learned Endpoint
+// selection of the Service.
+func (c *client) sessionAffinityReselectFlow() binding.Flow {
+	return c.pipeline[endpointDNATTable].BuildFlow(priorityLow).
+		MatchRegRange(int(serviceLearnReg), marksRegServiceSelected, serviceLearnRegRange).
+		Action().LoadRegRange(int(serviceLearnReg), marksRegServiceNeedLB, serviceLearnRegRange).
+		Action().ResubmitToTable(serviceLBTable).
+		Cookie(c.cookieAllocator.Request(cookie.Service).Raw()).
+		Done()
+}
+
 // serviceCIDRDNATFlow generates flows to match dst IP in service CIDR and output to host gateway interface directly.
-func (c *client) serviceCIDRDNATFlow(serviceCIDR *net.IPNet, gatewayMAC net.HardwareAddr, gatewayOFPort uint32, category cookie.Category) binding.Flow {
+func (c *client) serviceCIDRDNATFlow(serviceCIDR *net.IPNet, gatewayMAC net.HardwareAddr, gatewayOFPort uint32) binding.Flow {
 	return c.pipeline[dnatTable].BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 		MatchDstIPNet(*serviceCIDR).
 		Action().SetDstMAC(gatewayMAC).
 		Action().LoadRegRange(int(portCacheReg), gatewayOFPort, ofPortRegRange).
 		Action().LoadRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
 		Action().GotoTable(conntrackCommitTable).
-		Cookie(c.cookieAllocator.Request(category).Raw()).
+		Cookie(c.cookieAllocator.Request(cookie.Service).Raw()).
+		Done()
+}
+
+// serviceNeedLBFlow generates flows to mark packets as LB needed.
+func (c *client) serviceNeedLBFlow() binding.Flow {
+	return c.pipeline[sessionAffinityTable].BuildFlow(priorityMiss).
+		Cookie(c.cookieAllocator.Request(cookie.Service).Raw()).
+		Action().LoadRegRange(int(serviceLearnReg), marksRegServiceNeedLB, serviceLearnRegRange).
 		Done()
 }
 
@@ -722,6 +857,10 @@ func (c *client) localProbeFlow(localGatewayIP net.IP, category cookie.Category)
 func (c *client) bridgeAndUplinkFlows(uplinkOfport uint32, bridgeLocalPort uint32, nodeIP net.IP, localSubnet net.IPNet, category cookie.Category) []binding.Flow {
 	snatIPRange := &binding.IPRange{nodeIP, nodeIP}
 	vMACInt, _ := strconv.ParseUint(strings.Replace(globalVirtualMAC.String(), ":", "", -1), 16, 64)
+	ctStateNext := dnatTable
+	if c.enableProxy {
+		ctStateNext = endpointDNATTable
+	}
 	flows := []binding.Flow{
 		// Forward the packet to conntrackTable if it enters the OVS pipeline from the uplink interface.
 		c.pipeline[classifierTable].BuildFlow(priorityNormal).
@@ -754,7 +893,8 @@ func (c *client) bridgeAndUplinkFlows(uplinkOfport uint32, bridgeLocalPort uint3
 			MatchCTMark(snatCTMark).
 			MatchRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
 			Action().LoadRange(binding.NxmFieldDstMAC, vMACInt, binding.Range{0, 47}).
-			Action().GotoTable(dnatTable).
+			Action().LoadRegRange(int(marksReg), macRewriteMark, macRewriteMarkRange).
+			Action().GotoTable(ctStateNext).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done(),
 		// Forward the packet to dnatTable if it is sent from local Pod to the external IP address.
@@ -762,7 +902,7 @@ func (c *client) bridgeAndUplinkFlows(uplinkOfport uint32, bridgeLocalPort uint3
 			MatchProtocol(binding.ProtocolIP).
 			MatchCTStateNew(false).MatchCTStateTrk(true).
 			MatchCTMark(snatCTMark).
-			Action().GotoTable(dnatTable).
+			Action().GotoTable(ctStateNext).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done(),
 		// Output the non-SNAT packet to the bridge interface directly if it is received from the uplink interface.
@@ -814,7 +954,7 @@ func (c *client) l3ToExternalFlows(nodeIP net.IP, localSubnet net.IPNet, outputP
 			MatchProtocol(binding.ProtocolIP).
 			MatchRegRange(int(marksReg), markTrafficFromLocal, binding.Range{0, 15}).
 			MatchDstIPNet(localSubnet).
-			Action().GotoTable(l2ForwardingCalcTable).
+			Action().GotoTable(c.pipeline[l3ForwardingTable].GetNext()).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done(),
 		// Add SNAT mark on the packet that is not filtered by other flow entries in L3Forwarding table. This is the
@@ -837,17 +977,140 @@ func (c *client) l3ToExternalFlows(nodeIP net.IP, localSubnet net.IPNet, outputP
 	return flows
 }
 
-// NewClient is the constructor of the Client interface.
-func NewClient(bridgeName, mgmtAddr string) Client {
-	bridge := binding.NewOFBridge(bridgeName, mgmtAddr)
-	c := &client{
-		bridge: bridge,
-		pipeline: map[binding.TableIDType]binding.Table{
+// serviceLearnFlow generates the flow with learn action which adds new flows in
+// sessionAffinityTable according to the Endpoint selection decision.
+func (c *client) serviceLearnFlow(groupID binding.GroupIDType, svcIP net.IP, svcPort uint16, protocol binding.Protocol, affinityTimeout uint16) binding.Flow {
+	// Using unique cookie ID here to avoid learned flow cascade deletion.
+	cookieID := c.cookieAllocator.RequestWithObjectID(cookie.Service, uint32(groupID)).Raw()
+	learnFlowBuilder := c.pipeline[serviceLBTable].BuildFlow(priorityLow).
+		MatchRegRange(int(serviceLearnReg), marksRegServiceNeedLearn, serviceLearnRegRange).
+		MatchDstIP(svcIP).
+		Cookie(cookieID)
+	learnFlowBuilderLearnAction := learnFlowBuilder.
+		Action().Learn(sessionAffinityTable, priorityNormal, affinityTimeout, 0, cookieID).
+		DeleteLearned()
+	if protocol == binding.ProtocolTCP {
+		learnFlowBuilder = learnFlowBuilder.MatchTCPDstPort(svcPort)
+		learnFlowBuilderLearnAction = learnFlowBuilderLearnAction.MatchLearnedTCPDstPort()
+	} else if protocol == binding.ProtocolUDP {
+		learnFlowBuilder = learnFlowBuilder.MatchUDPDstPort(svcPort)
+		learnFlowBuilderLearnAction = learnFlowBuilderLearnAction.MatchLearnedUDPDstPort()
+	} else if protocol == binding.ProtocolSCTP {
+		learnFlowBuilder = learnFlowBuilder.MatchSCTPDstPort(svcPort)
+		learnFlowBuilderLearnAction = learnFlowBuilderLearnAction.MatchLearnedSCTPDstPort()
+	}
+	return learnFlowBuilderLearnAction.
+		MatchLearnedDstIP().
+		MatchLearnedSrcIP().
+		LoadRegToReg(int(endpointIPReg), int(endpointIPReg), endpointIPRegRange, endpointIPRegRange).
+		LoadRegToReg(int(endpointPortReg), int(endpointPortReg), endpointPortRegRange, endpointPortRegRange).
+		LoadReg(int(serviceLearnReg), marksRegServiceSelected, serviceLearnRegRange).
+		LoadReg(int(marksReg), macRewriteMark, macRewriteMarkRange).
+		Done().
+		Action().LoadRegRange(int(serviceLearnReg), marksRegServiceSelected, serviceLearnRegRange).
+		Action().GotoTable(endpointDNATTable).
+		Done()
+}
+
+// serviceLBFlow generates the flow which uses the specific group to do Endpoint
+// selection.
+func (c *client) serviceLBFlow(groupID binding.GroupIDType, svcIP net.IP, svcPort uint16, protocol binding.Protocol) binding.Flow {
+	lbFlowBuilder := c.pipeline[serviceLBTable].BuildFlow(priorityNormal)
+	if protocol == binding.ProtocolTCP {
+		lbFlowBuilder = lbFlowBuilder.MatchTCPDstPort(svcPort)
+	} else if protocol == binding.ProtocolUDP {
+		lbFlowBuilder = lbFlowBuilder.MatchUDPDstPort(svcPort)
+	} else if protocol == binding.ProtocolSCTP {
+		lbFlowBuilder = lbFlowBuilder.MatchSCTPDstPort(svcPort)
+	}
+	lbFlow := lbFlowBuilder.
+		MatchDstIP(svcIP).
+		MatchRegRange(int(serviceLearnReg), marksRegServiceNeedLB, serviceLearnRegRange).
+		Action().Group(groupID).
+		Cookie(c.cookieAllocator.Request(cookie.Service).Raw()).
+		Done()
+	return lbFlow
+}
+
+// endpointDNATFlow generates the flow which transforms the Service Cluster IP
+// to the Endpoint IP according to the Endpoint selection decision which is stored
+// in regs.
+func (c *client) endpointDNATFlow(endpointIP net.IP, endpointPort uint16, protocol binding.Protocol) binding.Flow {
+	ipVal := binary.BigEndian.Uint32(endpointIP)
+	unionVal := (marksRegServiceSelected << endpointPortRegRange.Length()) + uint32(endpointPort)
+	return c.pipeline[endpointDNATTable].BuildFlow(priorityNormal).
+		Cookie(c.cookieAllocator.Request(cookie.Service).Raw()).
+		MatchProtocol(protocol).
+		MatchReg(int(endpointIPReg), ipVal).
+		MatchRegRange(int(endpointPortReg), unionVal, binding.Range{0, 18}).
+		Action().CT(true, egressRuleTable, ctZone).
+		DNAT(
+			&binding.IPRange{StartIP: endpointIP, EndIP: endpointIP},
+			&binding.PortRange{StartPort: endpointPort, EndPort: endpointPort},
+		).
+		LoadToMark(serviceCTMark).
+		CTDone().
+		Done()
+}
+
+// hairpinSNATFlow generates the flow which does SNAT for Service
+// hairpin packets and loads the hairpin mark to markReg.
+func (c *client) hairpinSNATFlow(endpointIP net.IP) binding.Flow {
+	return c.pipeline[hairpinSNATTable].BuildFlow(priorityNormal).
+		Cookie(c.cookieAllocator.Request(cookie.Service).Raw()).
+		MatchProtocol(binding.ProtocolIP).
+		MatchDstIP(endpointIP).
+		MatchSrcIP(endpointIP).
+		Action().SetSrcIP(hairpinIP).
+		Action().LoadRegRange(int(marksReg), hairpinMark, hairpinMarkRange).
+		Action().GotoTable(l2ForwardingOutTable).
+		Done()
+}
+
+// serviceEndpointGroup creates/modifies the group/buckets of Endpoints. If the
+// withSessionAffinity is true, then buckets will resubmit packets back to
+// serviceLBTable to trigger the learn flow, the learn flow will then send packets
+// to endpointDNATTable. Otherwise, buckets will resubmit packets to
+// endpointDNATTable directly.
+func (c *client) serviceEndpointGroup(groupID binding.GroupIDType, withSessionAffinity bool, endpoints ...proxy.Endpoint) binding.Group {
+	group := c.bridge.CreateGroup(groupID).ResetBuckets()
+	var resubmitTableID binding.TableIDType
+	var lbResultMark uint32
+	if withSessionAffinity {
+		resubmitTableID = serviceLBTable
+		lbResultMark = marksRegServiceNeedLearn
+	} else {
+		resubmitTableID = endpointDNATTable
+		lbResultMark = marksRegServiceSelected
+	}
+
+	for _, endpoint := range endpoints {
+		endpointPort, _ := endpoint.Port()
+		endpointIP := net.ParseIP(endpoint.IP()).To4()
+		ipVal := binary.BigEndian.Uint32(endpointIP)
+		portVal := uint16(endpointPort)
+		group = group.Bucket().Weight(100).
+			LoadReg(int(endpointIPReg), ipVal).
+			LoadRegRange(int(endpointPortReg), uint32(portVal), endpointPortRegRange).
+			LoadRegRange(int(serviceLearnReg), lbResultMark, serviceLearnRegRange).
+			LoadRegRange(int(marksReg), macRewriteMark, macRewriteMarkRange).
+			ResubmitToTable(resubmitTableID).
+			Done()
+	}
+	return group
+}
+
+func generatePipeline(bridge binding.Bridge, enableProxy bool) map[binding.TableIDType]binding.Table {
+	if enableProxy {
+		return map[binding.TableIDType]binding.Table{
 			classifierTable:       bridge.CreateTable(classifierTable, spoofGuardTable, binding.TableMissActionDrop),
-			spoofGuardTable:       bridge.CreateTable(spoofGuardTable, conntrackTable, binding.TableMissActionDrop),
+			spoofGuardTable:       bridge.CreateTable(spoofGuardTable, serviceHairpinTable, binding.TableMissActionDrop),
+			serviceHairpinTable:   bridge.CreateTable(serviceHairpinTable, conntrackTable, binding.TableMissActionNext),
 			conntrackTable:        bridge.CreateTable(conntrackTable, conntrackStateTable, binding.TableMissActionNone),
-			conntrackStateTable:   bridge.CreateTable(conntrackStateTable, dnatTable, binding.TableMissActionNext),
-			dnatTable:             bridge.CreateTable(dnatTable, egressRuleTable, binding.TableMissActionNext),
+			conntrackStateTable:   bridge.CreateTable(conntrackStateTable, endpointDNATTable, binding.TableMissActionNext),
+			sessionAffinityTable:  bridge.CreateTable(sessionAffinityTable, binding.LastTableID, binding.TableMissActionNone),
+			serviceLBTable:        bridge.CreateTable(serviceLBTable, endpointDNATTable, binding.TableMissActionNext),
+			endpointDNATTable:     bridge.CreateTable(endpointDNATTable, egressRuleTable, binding.TableMissActionNext),
 			egressRuleTable:       bridge.CreateTable(egressRuleTable, egressDefaultTable, binding.TableMissActionNext),
 			egressDefaultTable:    bridge.CreateTable(egressDefaultTable, l3ForwardingTable, binding.TableMissActionNext),
 			l3ForwardingTable:     bridge.CreateTable(l3ForwardingTable, l2ForwardingCalcTable, binding.TableMissActionNext),
@@ -855,14 +1118,43 @@ func NewClient(bridgeName, mgmtAddr string) Client {
 			arpResponderTable:     bridge.CreateTable(arpResponderTable, binding.LastTableID, binding.TableMissActionDrop),
 			ingressRuleTable:      bridge.CreateTable(ingressRuleTable, ingressDefaultTable, binding.TableMissActionNext),
 			ingressDefaultTable:   bridge.CreateTable(ingressDefaultTable, conntrackCommitTable, binding.TableMissActionNext),
-			conntrackCommitTable:  bridge.CreateTable(conntrackCommitTable, l2ForwardingOutTable, binding.TableMissActionNext),
+			conntrackCommitTable:  bridge.CreateTable(conntrackCommitTable, hairpinSNATTable, binding.TableMissActionNext),
+			hairpinSNATTable:      bridge.CreateTable(hairpinSNATTable, l2ForwardingOutTable, binding.TableMissActionNext),
 			l2ForwardingOutTable:  bridge.CreateTable(l2ForwardingOutTable, binding.LastTableID, binding.TableMissActionDrop),
-		},
+		}
+	}
+	return map[binding.TableIDType]binding.Table{
+		classifierTable:       bridge.CreateTable(classifierTable, spoofGuardTable, binding.TableMissActionDrop),
+		spoofGuardTable:       bridge.CreateTable(spoofGuardTable, conntrackTable, binding.TableMissActionDrop),
+		conntrackTable:        bridge.CreateTable(conntrackTable, conntrackStateTable, binding.TableMissActionNone),
+		conntrackStateTable:   bridge.CreateTable(conntrackStateTable, dnatTable, binding.TableMissActionNext),
+		dnatTable:             bridge.CreateTable(dnatTable, egressRuleTable, binding.TableMissActionNext),
+		egressRuleTable:       bridge.CreateTable(egressRuleTable, egressDefaultTable, binding.TableMissActionNext),
+		egressDefaultTable:    bridge.CreateTable(egressDefaultTable, l3ForwardingTable, binding.TableMissActionNext),
+		l3ForwardingTable:     bridge.CreateTable(l3ForwardingTable, l2ForwardingCalcTable, binding.TableMissActionNext),
+		l2ForwardingCalcTable: bridge.CreateTable(l2ForwardingCalcTable, ingressRuleTable, binding.TableMissActionNext),
+		arpResponderTable:     bridge.CreateTable(arpResponderTable, binding.LastTableID, binding.TableMissActionDrop),
+		ingressRuleTable:      bridge.CreateTable(ingressRuleTable, ingressDefaultTable, binding.TableMissActionNext),
+		ingressDefaultTable:   bridge.CreateTable(ingressDefaultTable, conntrackCommitTable, binding.TableMissActionNext),
+		conntrackCommitTable:  bridge.CreateTable(conntrackCommitTable, l2ForwardingOutTable, binding.TableMissActionNext),
+		l2ForwardingOutTable:  bridge.CreateTable(l2ForwardingOutTable, binding.LastTableID, binding.TableMissActionDrop),
+	}
+}
+
+// NewClient is the constructor of the Client interface.
+func NewClient(bridgeName, mgmtAddr string, enableProxy bool) Client {
+	bridge := binding.NewOFBridge(bridgeName, mgmtAddr)
+	c := &client{
+		bridge:                   bridge,
+		pipeline:                 generatePipeline(bridge, enableProxy),
 		nodeFlowCache:            newFlowCategoryCache(),
 		podFlowCache:             newFlowCategoryCache(),
+		serviceFlowCache:         newFlowCategoryCache(),
 		policyCache:              sync.Map{},
+		groupCache:               sync.Map{},
 		globalConjMatchFlowCache: map[string]*conjMatchFlowContext{},
 	}
 	c.ofEntryOperations = c
+	c.enableProxy = enableProxy
 	return c
 }

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -24,6 +24,7 @@ import (
 	config "github.com/vmware-tanzu/antrea/pkg/agent/config"
 	types "github.com/vmware-tanzu/antrea/pkg/agent/types"
 	openflow "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
+	proxy "github.com/vmware-tanzu/antrea/third_party/proxy"
 	net "net"
 	reflect "reflect"
 )
@@ -206,6 +207,20 @@ func (mr *MockClientMockRecorder) InstallClusterServiceCIDRFlows(arg0, arg1, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallClusterServiceCIDRFlows", reflect.TypeOf((*MockClient)(nil).InstallClusterServiceCIDRFlows), arg0, arg1, arg2)
 }
 
+// InstallClusterServiceFlows mocks base method
+func (m *MockClient) InstallClusterServiceFlows() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallClusterServiceFlows")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallClusterServiceFlows indicates an expected call of InstallClusterServiceFlows
+func (mr *MockClientMockRecorder) InstallClusterServiceFlows() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallClusterServiceFlows", reflect.TypeOf((*MockClient)(nil).InstallClusterServiceFlows))
+}
+
 // InstallDefaultTunnelFlows mocks base method
 func (m *MockClient) InstallDefaultTunnelFlows(arg0 uint32) error {
 	m.ctrl.T.Helper()
@@ -218,6 +233,20 @@ func (m *MockClient) InstallDefaultTunnelFlows(arg0 uint32) error {
 func (mr *MockClientMockRecorder) InstallDefaultTunnelFlows(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallDefaultTunnelFlows", reflect.TypeOf((*MockClient)(nil).InstallDefaultTunnelFlows), arg0)
+}
+
+// InstallEndpointFlows mocks base method
+func (m *MockClient) InstallEndpointFlows(arg0 openflow.Protocol, arg1 []proxy.Endpoint) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallEndpointFlows", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallEndpointFlows indicates an expected call of InstallEndpointFlows
+func (mr *MockClientMockRecorder) InstallEndpointFlows(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallEndpointFlows", reflect.TypeOf((*MockClient)(nil).InstallEndpointFlows), arg0, arg1)
 }
 
 // InstallExternalFlows mocks base method
@@ -290,6 +319,34 @@ func (mr *MockClientMockRecorder) InstallPolicyRuleFlows(arg0, arg1, arg2, arg3 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPolicyRuleFlows", reflect.TypeOf((*MockClient)(nil).InstallPolicyRuleFlows), arg0, arg1, arg2, arg3)
 }
 
+// InstallServiceFlows mocks base method
+func (m *MockClient) InstallServiceFlows(arg0 openflow.GroupIDType, arg1 net.IP, arg2 uint16, arg3 openflow.Protocol, arg4 uint16) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallServiceFlows", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallServiceFlows indicates an expected call of InstallServiceFlows
+func (mr *MockClientMockRecorder) InstallServiceFlows(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallServiceFlows", reflect.TypeOf((*MockClient)(nil).InstallServiceFlows), arg0, arg1, arg2, arg3, arg4)
+}
+
+// InstallServiceGroup mocks base method
+func (m *MockClient) InstallServiceGroup(arg0 openflow.GroupIDType, arg1 bool, arg2 []proxy.Endpoint) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallServiceGroup", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallServiceGroup indicates an expected call of InstallServiceGroup
+func (mr *MockClientMockRecorder) InstallServiceGroup(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallServiceGroup", reflect.TypeOf((*MockClient)(nil).InstallServiceGroup), arg0, arg1, arg2)
+}
+
 // IsConnected mocks base method
 func (m *MockClient) IsConnected() bool {
 	m.ctrl.T.Helper()
@@ -314,6 +371,20 @@ func (m *MockClient) ReplayFlows() {
 func (mr *MockClientMockRecorder) ReplayFlows() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplayFlows", reflect.TypeOf((*MockClient)(nil).ReplayFlows))
+}
+
+// UninstallEndpointFlows mocks base method
+func (m *MockClient) UninstallEndpointFlows(arg0 openflow.Protocol, arg1 proxy.Endpoint) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UninstallEndpointFlows", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UninstallEndpointFlows indicates an expected call of UninstallEndpointFlows
+func (mr *MockClientMockRecorder) UninstallEndpointFlows(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninstallEndpointFlows", reflect.TypeOf((*MockClient)(nil).UninstallEndpointFlows), arg0, arg1)
 }
 
 // UninstallNodeFlows mocks base method
@@ -356,6 +427,34 @@ func (m *MockClient) UninstallPolicyRuleFlows(arg0 uint32) error {
 func (mr *MockClientMockRecorder) UninstallPolicyRuleFlows(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninstallPolicyRuleFlows", reflect.TypeOf((*MockClient)(nil).UninstallPolicyRuleFlows), arg0)
+}
+
+// UninstallServiceFlows mocks base method
+func (m *MockClient) UninstallServiceFlows(arg0 net.IP, arg1 uint16, arg2 openflow.Protocol) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UninstallServiceFlows", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UninstallServiceFlows indicates an expected call of UninstallServiceFlows
+func (mr *MockClientMockRecorder) UninstallServiceFlows(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninstallServiceFlows", reflect.TypeOf((*MockClient)(nil).UninstallServiceFlows), arg0, arg1, arg2)
+}
+
+// UninstallServiceGroup mocks base method
+func (m *MockClient) UninstallServiceGroup(arg0 openflow.GroupIDType) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UninstallServiceGroup", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UninstallServiceGroup indicates an expected call of UninstallServiceGroup
+func (mr *MockClientMockRecorder) UninstallServiceGroup(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninstallServiceGroup", reflect.TypeOf((*MockClient)(nil).UninstallServiceGroup), arg0)
 }
 
 // MockOFEntryOperations is a mock of OFEntryOperations interface

--- a/pkg/agent/proxy/endpoints.go
+++ b/pkg/agent/proxy/endpoints.go
@@ -1,0 +1,202 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/proxy/types"
+	k8sproxy "github.com/vmware-tanzu/antrea/third_party/proxy"
+)
+
+// endpointsChange describes an Endpoints change, previous is the state from before
+// all of them, current is state after applying all of those.
+type endpointsChange struct {
+	previous types.EndpointsMap
+	current  types.EndpointsMap
+}
+
+// endpointsChangesTracker tracks Endpoints changes.
+type endpointsChangesTracker struct {
+	// hostname is used to tell whether the Endpoint is located on current Node.
+	hostname string
+
+	sync.RWMutex
+	// initialized tells whether Endpoints have been synced.
+	initialized bool
+	// changes contains endpoints changes since the last checkoutChanges call.
+	changes map[apimachinerytypes.NamespacedName]*endpointsChange
+}
+
+func newEndpointsChangesTracker(hostname string) *endpointsChangesTracker {
+	return &endpointsChangesTracker{
+		hostname: hostname,
+		changes:  map[apimachinerytypes.NamespacedName]*endpointsChange{},
+	}
+}
+
+// OnEndpointUpdate updates given Service's Endpoints change map based on the
+// <previous, current> Endpoints pair. It returns true if items changed,
+// otherwise it returns false.
+// Update can be used to add/update/delete items of EndpointsChangeMap.
+// For example,
+// Add item
+//   - pass <nil, Endpoints> as the <previous, current> pair.
+// Update item
+//   - pass <oldEndpoints, Endpoints> as the <previous, current> pair.
+// Delete item
+//   - pass <Endpoints, nil> as the <previous, current> pair.
+func (t *endpointsChangesTracker) OnEndpointUpdate(previous, current *corev1.Endpoints) bool {
+	endpoints := current
+	if endpoints == nil {
+		endpoints = previous
+	}
+	// previous == nil && current == nil is unexpected, we should return false directly.
+	if endpoints == nil {
+		return false
+	}
+	namespacedName := apimachinerytypes.NamespacedName{Namespace: endpoints.Namespace, Name: endpoints.Name}
+
+	t.Lock()
+	defer t.Unlock()
+
+	change, exists := t.changes[namespacedName]
+	if !exists {
+		change = &endpointsChange{}
+		change.previous = t.endpointsToEndpointsMap(previous)
+		t.changes[namespacedName] = change
+	}
+
+	change.current = t.endpointsToEndpointsMap(current)
+	// If change.previous equals to change.current, it means no change.
+	if reflect.DeepEqual(change.previous, change.current) {
+		delete(t.changes, namespacedName)
+	}
+
+	return len(t.changes) > 0
+}
+
+func (t *endpointsChangesTracker) checkoutChanges() []*endpointsChange {
+	t.Lock()
+	defer t.Unlock()
+
+	var changes []*endpointsChange
+	for _, change := range t.changes {
+		changes = append(changes, change)
+	}
+	t.changes = make(map[apimachinerytypes.NamespacedName]*endpointsChange)
+	return changes
+}
+
+func (t *endpointsChangesTracker) OnEndpointsSynced() {
+	t.Lock()
+	defer t.Unlock()
+
+	t.initialized = true
+}
+
+func (t *endpointsChangesTracker) Synced() bool {
+	t.RLock()
+	defer t.RUnlock()
+
+	return t.initialized
+}
+
+// endpointsToEndpointsMap translates single Endpoints object to EndpointsMap.
+// This function is used for incremental update of EndpointsMap.
+func (t *endpointsChangesTracker) endpointsToEndpointsMap(endpoints *corev1.Endpoints) types.EndpointsMap {
+	if endpoints == nil {
+		return nil
+	}
+	endpointsMap := make(types.EndpointsMap)
+	// We need to build a map of portname -> all ip:ports for that
+	// portname.  Explode Endpoints.Subsets[*] into this structure.
+	for i := range endpoints.Subsets {
+		ss := &endpoints.Subsets[i]
+		for i := range ss.Ports {
+			port := &ss.Ports[i]
+			if port.Port == 0 {
+				klog.Warningf("Ignoring invalid endpoint port %s", port.Name)
+				continue
+			}
+			svcPortName := k8sproxy.ServicePortName{
+				NamespacedName: apimachinerytypes.NamespacedName{Namespace: endpoints.Namespace, Name: endpoints.Name},
+				Protocol:       port.Protocol,
+				Port:           port.Name,
+			}
+			if _, ok := endpointsMap[svcPortName]; !ok {
+				endpointsMap[svcPortName] = map[string]k8sproxy.Endpoint{}
+			}
+			for i := range ss.Addresses {
+				addr := &ss.Addresses[i]
+				if addr.IP == "" {
+					klog.Warningf("ignoring invalid endpoint port %s with empty host", port.Name)
+					continue
+				}
+				isLocal := addr.NodeName != nil && *addr.NodeName == t.hostname
+				ei := types.NewEndpointInfo(&k8sproxy.BaseEndpointInfo{
+					Endpoint: net.JoinHostPort(addr.IP, fmt.Sprint(port.Port)),
+					IsLocal:  isLocal,
+				})
+				endpointsMap[svcPortName][ei.String()] = ei
+			}
+		}
+	}
+	return endpointsMap
+}
+
+// Update updates an EndpointsMap based on current changes and returns stale
+// Endpoints of each Service.
+func (t *endpointsChangesTracker) Update(em types.EndpointsMap) map[k8sproxy.ServicePortName]map[string]k8sproxy.Endpoint {
+	staleEndpoints := map[k8sproxy.ServicePortName]map[string]k8sproxy.Endpoint{}
+	for _, change := range t.checkoutChanges() {
+		for spn := range change.previous {
+			delete(em, spn)
+		}
+		for spn, endpoints := range change.current {
+			em[spn] = endpoints
+		}
+		detectStaleConnections(change.previous, change.current, staleEndpoints)
+	}
+	return staleEndpoints
+}
+
+// detectStaleConnections updates staleEndpoints with detected stale connections.
+func detectStaleConnections(oldEndpointsMap, newEndpointsMap types.EndpointsMap, staleEndpoints map[k8sproxy.ServicePortName]map[string]k8sproxy.Endpoint) {
+	for svcPortName, epList := range oldEndpointsMap {
+		for _, ep := range epList {
+			stale := true
+			for i := range newEndpointsMap[svcPortName] {
+				if newEndpointsMap[svcPortName][i].Equal(ep) {
+					stale = false
+					break
+				}
+			}
+			if stale {
+				if _, ok := staleEndpoints[svcPortName]; !ok {
+					staleEndpoints[svcPortName] = map[string]k8sproxy.Endpoint{}
+				}
+				staleEndpoints[svcPortName][ep.String()] = ep
+			}
+		}
+	}
+}

--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -1,0 +1,271 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
+	"github.com/vmware-tanzu/antrea/pkg/agent/proxy/types"
+	"github.com/vmware-tanzu/antrea/pkg/agent/querier"
+	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
+	k8sproxy "github.com/vmware-tanzu/antrea/third_party/proxy"
+	"github.com/vmware-tanzu/antrea/third_party/proxy/config"
+)
+
+const (
+	resyncPeriod  = time.Minute
+	componentName = "antrea-agent-proxy"
+)
+
+// TODO: Add metrics
+type Proxier struct {
+	once            sync.Once
+	endpointsConfig *config.EndpointsConfig
+	serviceConfig   *config.ServiceConfig
+	// endpointsChanges and serviceChanges contains all changes to endpoints and
+	// services that happened since last syncProxyRules call. For a single object,
+	// changes are accumulated. Once both endpointsChanges and serviceChanges
+	// have been synced, syncProxyRules will start syncing rules to OVS.
+	endpointsChanges *endpointsChangesTracker
+	serviceChanges   *serviceChangesTracker
+	// syncProxyRulesMutex protects internal caches and states.
+	syncProxyRulesMutex sync.Mutex
+	// serviceMap stores services we expect to be installed.
+	serviceMap k8sproxy.ServiceMap
+	// serviceInstalledMap stores services we actually installed.
+	serviceInstalledMap k8sproxy.ServiceMap
+	// endpointsMap stores endpoints we expect to be installed.
+	endpointsMap types.EndpointsMap
+	// endpointInstalledMap stores endpoints we actually installed.
+	endpointInstalledMap map[k8sproxy.ServicePortName]map[string]struct{}
+	groupCounter         types.GroupCounter
+
+	runner       *k8sproxy.BoundedFrequencyRunner
+	stopChan     <-chan struct{}
+	agentQuerier querier.AgentQuerier
+	ofClient     openflow.Client
+}
+
+func (p *Proxier) isInitialized() bool {
+	return p.endpointsChanges.Synced() && p.serviceChanges.Synced()
+}
+
+func (p *Proxier) removeStaleServices() {
+	for svcPortName, svcPort := range p.serviceInstalledMap {
+		if _, ok := p.serviceMap[svcPortName]; ok {
+			continue
+		}
+		svcInfo := svcPort.(*types.ServiceInfo)
+		if err := p.ofClient.UninstallServiceFlows(svcInfo.ClusterIP(), uint16(svcInfo.Port()), svcInfo.OFProtocol); err != nil {
+			klog.Errorf("Failed to remove flows of Service %v: %v", svcPortName, err)
+			continue
+		}
+		for _, endpoint := range p.endpointsMap[svcPortName] {
+			if err := p.ofClient.UninstallEndpointFlows(svcInfo.OFProtocol, endpoint); err != nil {
+				klog.Errorf("Failed to remove flows of Service Endpoints %v: %v", svcPortName, err)
+				continue
+			}
+		}
+		groupID, _ := p.groupCounter.Get(svcPortName)
+		if err := p.ofClient.UninstallServiceGroup(groupID); err != nil {
+			klog.Errorf("Failed to remove flows of Service %v: %v", svcPortName, err)
+			continue
+		}
+		delete(p.serviceInstalledMap, svcPortName)
+		p.groupCounter.Recycle(svcPortName)
+	}
+}
+
+func (p *Proxier) removeStaleEndpoints(staleEndpoints map[k8sproxy.ServicePortName]map[string]k8sproxy.Endpoint) {
+	for svcPortName, endpoints := range staleEndpoints {
+		bindingProtocol := binding.ProtocolTCP
+		if svcPortName.Protocol == corev1.ProtocolUDP {
+			bindingProtocol = binding.ProtocolUDP
+		} else if svcPortName.Protocol == corev1.ProtocolSCTP {
+			bindingProtocol = binding.ProtocolSCTP
+		}
+		for _, endpoint := range endpoints {
+			if err := p.ofClient.UninstallEndpointFlows(bindingProtocol, endpoint); err != nil {
+				klog.Errorf("Error when removing Endpoint %v for %v", endpoint, svcPortName)
+				continue
+			}
+			if m, ok := p.endpointInstalledMap[svcPortName]; ok {
+				delete(m, endpoint.String())
+				if len(m) == 0 {
+					delete(p.endpointInstalledMap, svcPortName)
+				}
+			}
+		}
+	}
+}
+
+func (p *Proxier) installServices() {
+	for svcPortName, svcPort := range p.serviceMap {
+		svcInfo := svcPort.(*types.ServiceInfo)
+		groupID, _ := p.groupCounter.Get(svcPortName)
+		endpoints, ok := p.endpointsMap[svcPortName]
+		if !ok || len(endpoints) == 0 {
+			continue
+		}
+
+		endpointInstalled, ok := p.endpointInstalledMap[svcPortName]
+		if !ok {
+			p.endpointInstalledMap[svcPortName] = map[string]struct{}{}
+			endpointInstalled = p.endpointInstalledMap[svcPortName]
+		}
+
+		installedSvcPort, ok := p.serviceInstalledMap[svcPortName]
+		needUpdate := !ok || !installedSvcPort.(*types.ServiceInfo).Equal(svcInfo)
+
+		var endpointUpdateList []k8sproxy.Endpoint
+		for _, endpoint := range endpoints {
+			if _, ok := endpointInstalled[endpoint.String()]; !ok {
+				needUpdate = true
+				endpointInstalled[endpoint.String()] = struct{}{}
+			}
+			endpointUpdateList = append(endpointUpdateList, endpoint)
+		}
+
+		if !needUpdate {
+			continue
+		}
+
+		if err := p.ofClient.InstallEndpointFlows(svcInfo.OFProtocol, endpointUpdateList); err != nil {
+			klog.Errorf("Error when installing Endpoints flows: %v", err)
+			continue
+		}
+		err := p.ofClient.InstallServiceGroup(groupID, svcInfo.StickyMaxAgeSeconds() != 0, endpointUpdateList)
+		if err != nil {
+			klog.Errorf("Error when installing Endpoints groups: %v", err)
+			p.endpointInstalledMap[svcPortName] = nil
+			continue
+		}
+		if err := p.ofClient.InstallServiceFlows(groupID, svcInfo.ClusterIP(), uint16(svcInfo.Port()), svcInfo.OFProtocol, uint16(svcInfo.StickyMaxAgeSeconds())); err != nil {
+			klog.Errorf("Error when installing Service flows: %v", err)
+			continue
+		}
+		p.serviceInstalledMap[svcPortName] = svcPort
+	}
+}
+
+// syncProxyRulesMutex applies current changes in change trackers and then updates
+// flows for services and endpoints. It will abort if either endpoints or services
+// resources is not synced.
+func (p *Proxier) syncProxyRules() {
+	p.syncProxyRulesMutex.Lock()
+	defer p.syncProxyRulesMutex.Unlock()
+
+	start := time.Now()
+	defer func() {
+		klog.V(4).Infof("syncProxyRules took %v", time.Since(start))
+	}()
+	if !p.isInitialized() {
+		klog.V(4).Info("Not syncing rules until both Services and Endpoints have been synced")
+		return
+	}
+
+	staleEndpoints := p.endpointsChanges.Update(p.endpointsMap)
+	p.serviceChanges.Update(p.serviceMap)
+
+	p.removeStaleEndpoints(staleEndpoints)
+	p.removeStaleServices()
+	p.installServices()
+}
+
+func (p *Proxier) SyncLoop() {
+	p.runner.Loop(p.stopChan)
+}
+
+func (p *Proxier) OnEndpointsAdd(endpoints *corev1.Endpoints) {
+	p.OnEndpointsUpdate(nil, endpoints)
+}
+
+func (p *Proxier) OnEndpointsUpdate(oldEndpoints, endpoints *corev1.Endpoints) {
+	if p.endpointsChanges.OnEndpointUpdate(oldEndpoints, endpoints) && p.isInitialized() {
+		p.runner.Run()
+	}
+}
+
+func (p *Proxier) OnEndpointsDelete(endpoints *corev1.Endpoints) {
+	p.OnEndpointsUpdate(endpoints, nil)
+}
+
+func (p *Proxier) OnEndpointsSynced() {
+	p.endpointsChanges.OnEndpointsSynced()
+	if p.isInitialized() {
+		p.runner.Run()
+	}
+}
+
+func (p *Proxier) OnServiceAdd(service *corev1.Service) {
+	p.OnServiceUpdate(nil, service)
+}
+
+func (p *Proxier) OnServiceUpdate(oldService, service *corev1.Service) {
+	if p.serviceChanges.OnServiceUpdate(oldService, service) && p.isInitialized() {
+		p.runner.Run()
+	}
+}
+
+func (p *Proxier) OnServiceDelete(service *corev1.Service) {
+	p.OnServiceUpdate(service, nil)
+}
+
+func (p *Proxier) OnServiceSynced() {
+	p.serviceChanges.OnServiceSynced()
+	if p.isInitialized() {
+		p.runner.Run()
+	}
+}
+
+func (p *Proxier) Run(stopCh <-chan struct{}) {
+	p.once.Do(func() {
+		go p.serviceConfig.Run(stopCh)
+		go p.endpointsConfig.Run(stopCh)
+		p.stopChan = stopCh
+		p.SyncLoop()
+	})
+}
+
+func New(hostname string, informerFactory informers.SharedInformerFactory, ofClient openflow.Client) *Proxier {
+	recorder := record.NewBroadcaster().NewRecorder(
+		runtime.NewScheme(),
+		corev1.EventSource{Component: componentName, Host: hostname},
+	)
+	p := &Proxier{
+		endpointsConfig:      config.NewEndpointsConfig(informerFactory.Core().V1().Endpoints(), resyncPeriod),
+		serviceConfig:        config.NewServiceConfig(informerFactory.Core().V1().Services(), resyncPeriod),
+		endpointsChanges:     newEndpointsChangesTracker(hostname),
+		serviceChanges:       newServiceChangesTracker(recorder),
+		serviceMap:           k8sproxy.ServiceMap{},
+		serviceInstalledMap:  k8sproxy.ServiceMap{},
+		endpointInstalledMap: map[k8sproxy.ServicePortName]map[string]struct{}{},
+		endpointsMap:         types.EndpointsMap{},
+		groupCounter:         types.NewGroupCounter(),
+		ofClient:             ofClient,
+	}
+	p.serviceConfig.RegisterEventHandler(p)
+	p.endpointsConfig.RegisterEventHandler(p)
+	p.runner = k8sproxy.NewBoundedFrequencyRunner(componentName, p.syncProxyRules, 0, 30*time.Second, -1)
+	return p
+}

--- a/pkg/agent/proxy/proxier_test.go
+++ b/pkg/agent/proxy/proxier_test.go
@@ -1,0 +1,457 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
+	ofmock "github.com/vmware-tanzu/antrea/pkg/agent/openflow/testing"
+	"github.com/vmware-tanzu/antrea/pkg/agent/proxy/types"
+	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
+	k8sproxy "github.com/vmware-tanzu/antrea/third_party/proxy"
+)
+
+func makeNamespaceName(namespace, name string) apimachinerytypes.NamespacedName {
+	return apimachinerytypes.NamespacedName{Namespace: namespace, Name: name}
+}
+
+func makeServiceMap(proxier *Proxier, allServices ...*corev1.Service) {
+	for i := range allServices {
+		proxier.serviceChanges.OnServiceUpdate(nil, allServices[i])
+	}
+	proxier.serviceChanges.OnServiceSynced()
+}
+
+func makeTestService(namespace, name string, svcFunc func(*corev1.Service)) *corev1.Service {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: map[string]string{},
+		},
+		Spec:   corev1.ServiceSpec{},
+		Status: corev1.ServiceStatus{},
+	}
+	svcFunc(svc)
+	return svc
+}
+
+func makeEndpointsMap(proxier *Proxier, allEndpoints ...*corev1.Endpoints) {
+	for i := range allEndpoints {
+		proxier.endpointsChanges.OnEndpointUpdate(nil, allEndpoints[i])
+	}
+	proxier.endpointsChanges.OnEndpointsSynced()
+}
+
+func makeTestEndpoints(namespace, name string, eptFunc func(*corev1.Endpoints)) *corev1.Endpoints {
+	ept := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	eptFunc(ept)
+	return ept
+}
+
+func NewFakeProxier(ofClient openflow.Client) *Proxier {
+	hostname := "localhost"
+	eventBroadcaster := record.NewBroadcaster()
+	recorder := eventBroadcaster.NewRecorder(
+		runtime.NewScheme(),
+		corev1.EventSource{Component: componentName, Host: hostname},
+	)
+	p := &Proxier{
+		endpointsChanges:     newEndpointsChangesTracker(hostname),
+		serviceChanges:       newServiceChangesTracker(recorder),
+		serviceMap:           k8sproxy.ServiceMap{},
+		serviceInstalledMap:  k8sproxy.ServiceMap{},
+		endpointInstalledMap: map[k8sproxy.ServicePortName]map[string]struct{}{},
+		endpointsMap:         types.EndpointsMap{},
+		groupCounter:         types.NewGroupCounter(),
+		ofClient:             ofClient,
+	}
+	return p
+}
+
+func TestClusterIP(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockOFClient := ofmock.NewMockClient(ctrl)
+	fp := NewFakeProxier(mockOFClient)
+
+	svcIPv4 := net.ParseIP("10.20.30.41")
+	svcPort := 80
+	svcPortName := k8sproxy.ServicePortName{
+		NamespacedName: makeNamespaceName("ns1", "svc1"),
+		Port:           "80",
+		Protocol:       corev1.ProtocolTCP,
+	}
+	makeServiceMap(fp,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *corev1.Service) {
+			svc.Spec.ClusterIP = svcIPv4.String()
+			svc.Spec.Ports = []corev1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: corev1.ProtocolTCP,
+			}}
+		}),
+	)
+
+	epIP := net.ParseIP("10.180.0.1")
+	makeEndpointsMap(fp,
+		makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, func(ept *corev1.Endpoints) {
+			ept.Subsets = []corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{
+					IP: epIP.String(),
+				}},
+				Ports: []corev1.EndpointPort{{
+					Name:     svcPortName.Port,
+					Port:     int32(svcPort),
+					Protocol: corev1.ProtocolTCP,
+				}},
+			}}
+		}),
+	)
+
+	groupID, _ := fp.groupCounter.Get(svcPortName)
+	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
+	mockOFClient.EXPECT().InstallEndpointFlows(binding.ProtocolTCP, gomock.Any()).Times(1)
+	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIPv4, uint16(svcPort), binding.ProtocolTCP, uint16(0)).Times(1)
+
+	fp.syncProxyRules()
+}
+
+func TestClusterIPRemoval(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockOFClient := ofmock.NewMockClient(ctrl)
+	fp := NewFakeProxier(mockOFClient)
+
+	svcIPv4 := net.ParseIP("10.20.30.41")
+	svcPort := 80
+	svcPortName := k8sproxy.ServicePortName{
+		NamespacedName: makeNamespaceName("ns1", "svc1"),
+		Port:           fmt.Sprint(svcPort),
+		Protocol:       corev1.ProtocolTCP,
+	}
+	svc := makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *corev1.Service) {
+		svc.Spec.ClusterIP = svcIPv4.String()
+		svc.Spec.Ports = []corev1.ServicePort{{
+			Name:     svcPortName.Port,
+			Port:     int32(svcPort),
+			Protocol: corev1.ProtocolTCP,
+		}}
+	})
+	makeServiceMap(fp, svc)
+
+	epIP := net.ParseIP("10.180.0.1")
+	epFunc := func(ept *corev1.Endpoints) {
+		ept.Subsets = []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{
+				IP: epIP.String(),
+			}},
+			Ports: []corev1.EndpointPort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: corev1.ProtocolTCP,
+			}},
+		}}
+	}
+	ep := makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, epFunc)
+	makeEndpointsMap(fp, ep)
+	groupID, _ := fp.groupCounter.Get(svcPortName)
+	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
+	mockOFClient.EXPECT().InstallEndpointFlows(binding.ProtocolTCP, gomock.Any()).Times(1)
+	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIPv4, uint16(svcPort), binding.ProtocolTCP, uint16(0)).Times(1)
+	mockOFClient.EXPECT().UninstallServiceFlows(svcIPv4, uint16(svcPort), binding.ProtocolTCP).Times(1)
+	mockOFClient.EXPECT().UninstallEndpointFlows(binding.ProtocolTCP, gomock.Any()).Times(1)
+	mockOFClient.EXPECT().UninstallServiceGroup(groupID).Times(1)
+
+	fp.syncProxyRules()
+
+	fp.serviceChanges.OnServiceUpdate(svc, nil)
+	fp.syncProxyRules()
+}
+
+func TestClusterIPNoEndpoint(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockOFClient := ofmock.NewMockClient(ctrl)
+	fp := NewFakeProxier(mockOFClient)
+
+	svcIP := "10.20.30.41"
+	svcPort := 80
+	svcNodePort := 3001
+	svcPortName := k8sproxy.ServicePortName{
+		NamespacedName: makeNamespaceName("ns1", "svc1"),
+		Port:           "80",
+		Protocol:       corev1.ProtocolTCP,
+	}
+
+	makeServiceMap(fp,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *corev1.Service) {
+			svc.Spec.ClusterIP = svcIP
+			svc.Spec.Ports = []corev1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: corev1.ProtocolTCP,
+				NodePort: int32(svcNodePort),
+			}}
+		}),
+	)
+	makeEndpointsMap(fp)
+
+	fp.syncProxyRules()
+}
+
+func TestClusterIPRemoveSamePortEndpoint(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockOFClient := ofmock.NewMockClient(ctrl)
+	fp := NewFakeProxier(mockOFClient)
+
+	svcIPv4 := net.ParseIP("10.20.30.41")
+	svcPort := 80
+	svcPortName := k8sproxy.ServicePortName{
+		NamespacedName: makeNamespaceName("ns1", "svc1"),
+		Port:           "80",
+		Protocol:       corev1.ProtocolTCP,
+	}
+	svcPortNameUDP := k8sproxy.ServicePortName{
+		NamespacedName: makeNamespaceName("ns1", "svc1-udp"),
+		Port:           "80",
+		Protocol:       corev1.ProtocolUDP,
+	}
+	makeServiceMap(fp,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *corev1.Service) {
+			svc.Spec.ClusterIP = svcIPv4.String()
+			svc.Spec.Ports = []corev1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: corev1.ProtocolTCP,
+			}}
+		}),
+		makeTestService(svcPortName.Namespace, svcPortNameUDP.Name, func(svc *corev1.Service) {
+			svc.Spec.ClusterIP = svcIPv4.String()
+			svc.Spec.Ports = []corev1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: corev1.ProtocolUDP,
+			}}
+		}),
+	)
+
+	epIP := "10.180.0.1"
+	ep := makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, func(ept *corev1.Endpoints) {
+		ept.Subsets = []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{
+				IP: epIP,
+			}},
+			Ports: []corev1.EndpointPort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: corev1.ProtocolTCP,
+			}},
+		}}
+	})
+	epUDP := makeTestEndpoints(svcPortName.Namespace, svcPortNameUDP.Name, func(ept *corev1.Endpoints) {
+		ept.Subsets = []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{
+				IP: epIP,
+			}},
+			Ports: []corev1.EndpointPort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: corev1.ProtocolUDP,
+			}},
+		}}
+	})
+	makeEndpointsMap(fp, ep, epUDP)
+
+	groupID, _ := fp.groupCounter.Get(svcPortName)
+	groupIDUDP, _ := fp.groupCounter.Get(svcPortNameUDP)
+	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
+	mockOFClient.EXPECT().InstallServiceGroup(groupIDUDP, false, gomock.Any()).Times(1)
+	mockOFClient.EXPECT().InstallEndpointFlows(binding.ProtocolTCP, gomock.Any()).Times(1)
+	mockOFClient.EXPECT().InstallEndpointFlows(binding.ProtocolUDP, gomock.Any()).Times(1)
+	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIPv4, uint16(svcPort), binding.ProtocolTCP, uint16(0)).Times(1)
+	mockOFClient.EXPECT().InstallServiceFlows(groupIDUDP, svcIPv4, uint16(svcPort), binding.ProtocolUDP, uint16(0)).Times(1)
+	mockOFClient.EXPECT().UninstallEndpointFlows(binding.ProtocolUDP, gomock.Any()).Times(1)
+	fp.syncProxyRules()
+
+	fp.endpointsChanges.OnEndpointUpdate(epUDP, nil)
+	fp.syncProxyRules()
+}
+
+func TestClusterIPRemoveEndpoints(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockOFClient := ofmock.NewMockClient(ctrl)
+	fp := NewFakeProxier(mockOFClient)
+
+	svcIPv4 := net.ParseIP("10.20.30.41")
+	svcPort := 80
+	svcPortName := k8sproxy.ServicePortName{
+		NamespacedName: makeNamespaceName("ns1", "svc1"),
+		Port:           "80",
+		Protocol:       corev1.ProtocolTCP,
+	}
+	makeServiceMap(fp,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *corev1.Service) {
+			svc.Spec.ClusterIP = svcIPv4.String()
+			svc.Spec.Ports = []corev1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: corev1.ProtocolTCP,
+			}}
+		}),
+	)
+
+	epIP := "10.180.0.1"
+	ep := makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, func(ept *corev1.Endpoints) {
+		ept.Subsets = []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{
+				IP: epIP,
+			}},
+			Ports: []corev1.EndpointPort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: corev1.ProtocolTCP,
+			}},
+		}}
+	})
+	makeEndpointsMap(fp, ep)
+	groupID, _ := fp.groupCounter.Get(svcPortName)
+	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
+	mockOFClient.EXPECT().InstallEndpointFlows(binding.ProtocolTCP, gomock.Any()).Times(1)
+	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIPv4, uint16(svcPort), binding.ProtocolTCP, uint16(0)).Times(1)
+	mockOFClient.EXPECT().UninstallEndpointFlows(binding.ProtocolTCP, gomock.Any()).Times(1)
+	fp.syncProxyRules()
+
+	fp.endpointsChanges.OnEndpointUpdate(ep, nil)
+	fp.syncProxyRules()
+}
+
+func TestSessionAffinityNoEndpoint(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockOFClient := ofmock.NewMockClient(ctrl)
+	fp := NewFakeProxier(mockOFClient)
+
+	svcIP := net.ParseIP("10.20.30.41")
+	svcPort := 80
+	svcNodePort := 3001
+	svcExternalIPs := "50.60.70.81"
+	svcPortName := k8sproxy.ServicePortName{
+		NamespacedName: makeNamespaceName("ns1", "svc1"),
+		Port:           "80",
+		Protocol:       corev1.ProtocolTCP,
+	}
+	timeoutSeconds := corev1.DefaultClientIPServiceAffinitySeconds
+
+	makeServiceMap(fp,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *corev1.Service) {
+			svc.Spec.Type = "NodePort"
+			svc.Spec.ClusterIP = svcIP.String()
+			svc.Spec.ExternalIPs = []string{svcExternalIPs}
+			svc.Spec.SessionAffinity = corev1.ServiceAffinityClientIP
+			svc.Spec.SessionAffinityConfig = &corev1.SessionAffinityConfig{
+				ClientIP: &corev1.ClientIPConfig{
+					TimeoutSeconds: &timeoutSeconds,
+				},
+			}
+			svc.Spec.Ports = []corev1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: corev1.ProtocolTCP,
+				NodePort: int32(svcNodePort),
+			}}
+		}),
+	)
+	epIPv4 := "10.180.0.1"
+	makeEndpointsMap(fp,
+		makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, func(ept *corev1.Endpoints) {
+			ept.Subsets = []corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{
+					IP: epIPv4,
+				}},
+				Ports: []corev1.EndpointPort{{
+					Name:     svcPortName.Port,
+					Port:     int32(svcPort),
+					Protocol: corev1.ProtocolTCP,
+				}},
+			}}
+		}),
+	)
+
+	groupID, _ := fp.groupCounter.Get(svcPortName)
+	mockOFClient.EXPECT().InstallServiceGroup(groupID, true, gomock.Any()).Times(1)
+	mockOFClient.EXPECT().InstallEndpointFlows(binding.ProtocolTCP, gomock.Any()).Times(1)
+	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), binding.ProtocolTCP, uint16(corev1.DefaultClientIPServiceAffinitySeconds)).Times(1)
+
+	fp.syncProxyRules()
+}
+
+func TestSessionAffinity(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockOFClient := ofmock.NewMockClient(ctrl)
+	fp := NewFakeProxier(mockOFClient)
+
+	svcIP := net.ParseIP("10.20.30.41")
+	svcPort := 80
+	svcNodePort := 3001
+	svcExternalIPs := "50.60.70.81"
+	svcPortName := k8sproxy.ServicePortName{
+		NamespacedName: makeNamespaceName("ns1", "svc1"),
+		Port:           "80",
+		Protocol:       corev1.ProtocolTCP,
+	}
+	timeoutSeconds := corev1.DefaultClientIPServiceAffinitySeconds
+
+	makeServiceMap(fp,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *corev1.Service) {
+			svc.Spec.Type = "NodePort"
+			svc.Spec.ClusterIP = svcIP.String()
+			svc.Spec.ExternalIPs = []string{svcExternalIPs}
+			svc.Spec.SessionAffinity = corev1.ServiceAffinityClientIP
+			svc.Spec.SessionAffinityConfig = &corev1.SessionAffinityConfig{
+				ClientIP: &corev1.ClientIPConfig{
+					TimeoutSeconds: &timeoutSeconds,
+				},
+			}
+			svc.Spec.Ports = []corev1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: corev1.ProtocolTCP,
+				NodePort: int32(svcNodePort),
+			}}
+		}),
+	)
+	makeEndpointsMap(fp)
+
+	fp.syncProxyRules()
+}

--- a/pkg/agent/proxy/service.go
+++ b/pkg/agent/proxy/service.go
@@ -1,0 +1,58 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/proxy/types"
+	k8sproxy "github.com/vmware-tanzu/antrea/third_party/proxy"
+)
+
+type serviceChangesTracker struct {
+	tracker *k8sproxy.ServiceChangeTracker
+
+	sync.Mutex
+	initialized bool
+}
+
+func newServiceChangesTracker(recorder record.EventRecorder) *serviceChangesTracker {
+	enableIPV6 := false
+	return &serviceChangesTracker{tracker: k8sproxy.NewServiceChangeTracker(types.NewServiceInfo, &enableIPV6, recorder)}
+}
+
+func (sh *serviceChangesTracker) OnServiceSynced() {
+	sh.Lock()
+	defer sh.Unlock()
+
+	sh.initialized = true
+}
+
+func (sh *serviceChangesTracker) OnServiceUpdate(previous, current *v1.Service) bool {
+	return sh.tracker.Update(previous, current)
+}
+
+func (sh *serviceChangesTracker) Synced() bool {
+	sh.Lock()
+	defer sh.Unlock()
+	return sh.initialized
+}
+
+func (sh *serviceChangesTracker) Update(serviceMap k8sproxy.ServiceMap) k8sproxy.UpdateServiceMapResult {
+	return k8sproxy.UpdateServiceMap(serviceMap, sh.tracker)
+}

--- a/pkg/agent/proxy/types/groupcounter.go
+++ b/pkg/agent/proxy/types/groupcounter.go
@@ -1,0 +1,75 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"sync"
+
+	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
+	k8sproxy "github.com/vmware-tanzu/antrea/third_party/proxy"
+)
+
+// GroupCounter generates and manages global unique group ID.
+type GroupCounter interface {
+	// Get generates a global unique group ID for a specific service.
+	// If the group ID of the service has been generated, then return the
+	// prior one. The bool return value indicates whether the groupID is newly
+	// generated.
+	Get(svcPortName k8sproxy.ServicePortName) (binding.GroupIDType, bool)
+	// Recycle removes a Service Group ID mapping. The recycled groupID can be
+	// reused.
+	Recycle(svcPortName k8sproxy.ServicePortName) bool
+}
+
+type groupCounter struct {
+	mu             sync.Mutex
+	groupIDCounter binding.GroupIDType
+	recycled       []binding.GroupIDType
+
+	groupMap map[k8sproxy.ServicePortName]binding.GroupIDType
+}
+
+func NewGroupCounter() *groupCounter {
+	return &groupCounter{groupMap: map[k8sproxy.ServicePortName]binding.GroupIDType{}}
+}
+
+func (c *groupCounter) Get(svcPortName k8sproxy.ServicePortName) (binding.GroupIDType, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if id, ok := c.groupMap[svcPortName]; ok {
+		return id, false
+	} else if len(c.recycled) != 0 {
+		id = c.recycled[len(c.recycled)-1]
+		c.recycled = c.recycled[:len(c.recycled)-1]
+		return id, true
+	} else {
+		c.groupIDCounter += 1
+		c.groupMap[svcPortName] = c.groupIDCounter
+		return c.groupIDCounter, true
+	}
+}
+
+func (c *groupCounter) Recycle(svcPortName k8sproxy.ServicePortName) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if id, ok := c.groupMap[svcPortName]; ok {
+		delete(c.groupMap, svcPortName)
+		c.recycled = append(c.recycled, id)
+		return true
+	}
+	return false
+}

--- a/pkg/agent/proxy/types/types.go
+++ b/pkg/agent/proxy/types/types.go
@@ -1,0 +1,55 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
+	k8sproxy "github.com/vmware-tanzu/antrea/third_party/proxy"
+)
+
+// ServiceInfo is the internal struct for caching service information.
+type ServiceInfo struct {
+	*k8sproxy.BaseServiceInfo
+	// cache for performance
+	OFProtocol openflow.Protocol
+}
+
+func (si *ServiceInfo) Equal(bSvcInfo *ServiceInfo) bool {
+	return si.SessionAffinityType() == bSvcInfo.SessionAffinityType() &&
+		si.StickyMaxAgeSeconds() == bSvcInfo.StickyMaxAgeSeconds() &&
+		si.OFProtocol == bSvcInfo.OFProtocol &&
+		si.Port() == bSvcInfo.Port()
+}
+
+// NewServiceInfo returns a new k8sproxy.ServicePort which abstracts a serviceInfo.
+func NewServiceInfo(port *corev1.ServicePort, service *corev1.Service, baseInfo *k8sproxy.BaseServiceInfo) k8sproxy.ServicePort {
+	info := &ServiceInfo{BaseServiceInfo: baseInfo}
+	info.OFProtocol = openflow.ProtocolTCP
+	if port.Protocol == corev1.ProtocolUDP {
+		info.OFProtocol = openflow.ProtocolUDP
+	} else if port.Protocol == corev1.ProtocolSCTP {
+		info.OFProtocol = openflow.ProtocolSCTP
+	}
+	return info
+}
+
+// NewEndpointInfo returns a new k8sproxy.Endpoint which abstracts an endpointsInfo.
+func NewEndpointInfo(baseInfo *k8sproxy.BaseEndpointInfo) k8sproxy.Endpoint {
+	return baseInfo
+}
+
+type EndpointsMap map[k8sproxy.ServicePortName]map[string]k8sproxy.Endpoint

--- a/pkg/cni/client_test.go
+++ b/pkg/cni/client_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build linux
+
 package cni
 
 import (

--- a/pkg/features/antrea_features.go
+++ b/pkg/features/antrea_features.go
@@ -29,6 +29,12 @@ const (
 	// alpha: v0.8
 	// Allows to apply cluster-wide NetworkPolicies.
 	ClusterNetworkPolicy featuregate.Feature = "ClusterNetworkPolicy"
+
+	// alpha: v0.8
+	// Enable antrea proxy which provides ServiceLB for in-cluster services in antrea agent.
+	// It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
+	// Service traffic.
+	AntreaProxy featuregate.Feature = "AntreaProxy"
 )
 
 var (
@@ -44,6 +50,7 @@ var (
 	// available throughout Antrea binaries.
 	defaultAntreaFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 		ClusterNetworkPolicy: {Default: false, PreRelease: featuregate.Alpha},
+		AntreaProxy:          {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -243,16 +243,19 @@ type LearnAction interface {
 	MatchTransportDst(protocol Protocol) LearnAction
 	MatchLearnedTCPDstPort() LearnAction
 	MatchLearnedUDPDstPort() LearnAction
+	MatchLearnedSCTPDstPort() LearnAction
 	MatchLearnedSrcIP() LearnAction
 	MatchLearnedDstIP() LearnAction
 	MatchReg(regID int, data uint32, rng Range) LearnAction
 	LoadReg(regID int, data uint32, rng Range) LearnAction
 	LoadRegToReg(fromRegID, toRegID int, fromRng, toRng Range) LearnAction
+	SetDstMAC(mac net.HardwareAddr) LearnAction
 	Done() FlowBuilder
 }
 
 type Group interface {
 	OFEntry
+	ResetBuckets() Group
 	Bucket() BucketBuilder
 }
 

--- a/pkg/ovs/openflow/ofctrl_bridge.go
+++ b/pkg/ovs/openflow/ofctrl_bridge.go
@@ -157,8 +157,11 @@ func (b *OFBridge) CreateGroup(id GroupIDType) Group {
 }
 
 func (b *OFBridge) DeleteGroup(id GroupIDType) bool {
-	err := b.ofSwitch.DeleteGroup(uint32(id))
-	if err != nil {
+	g := b.ofSwitch.GetGroup(uint32(id))
+	if g == nil {
+		return true
+	}
+	if err := g.Delete(); err != nil {
 		return false
 	}
 	return true

--- a/pkg/ovs/openflow/ofctrl_builder.go
+++ b/pkg/ovs/openflow/ofctrl_builder.go
@@ -59,13 +59,12 @@ func (b *ofFlowBuilder) MatchReg(regID int, data uint32) FlowBuilder {
 
 // MatchRegRange adds match condition for matching data in the target register at specified range.
 func (b *ofFlowBuilder) MatchRegRange(regID int, data uint32, rng Range) FlowBuilder {
-	var regData = data
 	if rng[0] > 0 {
-		regData = data << rng[0]
+		data <<= rng[0]
 	}
 	reg := &ofctrl.NXRegister{
 		ID:    regID,
-		Data:  regData,
+		Data:  data,
 		Range: rng.ToNXRange(),
 	}
 	b.Match.NxRegs = append(b.Match.NxRegs, reg)

--- a/pkg/ovs/openflow/ofctrl_flow.go
+++ b/pkg/ovs/openflow/ofctrl_flow.go
@@ -132,6 +132,6 @@ func (r *Range) ToNXRange() *openflow13.NXRange {
 	return openflow13.NewNXRange(int(r[0]), int(r[1]))
 }
 
-func (r *Range) length() uint32 {
+func (r *Range) Length() uint32 {
 	return r[1] - r[0] + 1
 }

--- a/pkg/ovs/openflow/ofctrl_group.go
+++ b/pkg/ovs/openflow/ofctrl_group.go
@@ -71,6 +71,11 @@ func (f *ofGroup) GetBundleMessage(entryOper OFOperation) (ofctrl.OpenFlowModMes
 	return message, nil
 }
 
+func (g *ofGroup) ResetBuckets() Group {
+	g.ofctrl.Buckets = nil
+	return g
+}
+
 type bucketBuilder struct {
 	group  *ofGroup
 	bucket *openflow13.Bucket

--- a/test/e2e/bandwidth_test.go
+++ b/test/e2e/bandwidth_test.go
@@ -60,7 +60,7 @@ func benchmarkBandwidthService(t *testing.T, endpointNode, clientNode string) {
 	}
 	defer teardownTest(t, data)
 
-	svc, err := data.createService("perftest-b", iperfPort, iperfPort, map[string]string{"antrea-e2e": "perftest-b"})
+	svc, err := data.createService("perftest-b", iperfPort, iperfPort, map[string]string{"antrea-e2e": "perftest-b"}, false)
 	if err != nil {
 		t.Fatalf("Error when creating perftest service: %v", err)
 	}

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -1,0 +1,176 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func skipIfProxyDisabled(t *testing.T, data *TestData) {
+	if enabled, err := proxyEnabled(data); err != nil {
+		t.Fatalf("Error when detecting proxy: %v", err)
+	} else if !enabled {
+		t.Skip()
+	}
+}
+
+func proxyEnabled(data *TestData) (bool, error) {
+	key := "resubmit(,40),resubmit(,41)"
+	agentName, err := data.getAntreaPodOnNode(masterNodeName())
+	if err != nil {
+		return false, err
+	}
+	table31Output, _, err := data.runCommandFromPod(metav1.NamespaceSystem, agentName, "antrea-agent", []string{"ovs-ofctl", "dump-flows", defaultBridgeName, "table=31"})
+	return strings.Contains(table31Output, key), err
+}
+
+func TestProxyServiceSessionAffinity(t *testing.T) {
+	skipIfProviderIs(t, "kind", "#881 Does not work in Kind, needs to be investigated.")
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	skipIfProxyDisabled(t, data)
+
+	nodeName := nodeName(1)
+	require.NoError(t, data.createNginxPod("nginx", nodeName))
+	nginxIP, err := data.podWaitForIP(defaultTimeout, "nginx", testNamespace)
+	require.NoError(t, err)
+	require.NoError(t, data.podWaitForRunning(defaultTimeout, "nginx", testNamespace))
+	svc, err := data.createNginxService(true)
+	require.NoError(t, err)
+	require.NoError(t, data.createBusyboxPodOnNode("busybox", nodeName))
+	require.NoError(t, data.podWaitForRunning(defaultTimeout, "busybox", testNamespace))
+	stdout, stderr, err := data.runCommandFromPod(testNamespace, "busybox", busyboxContainerName, []string{"wget", "-O", "-", svc.Spec.ClusterIP, "-T", "1"})
+	require.NoError(t, err, fmt.Sprintf("stdout: %s\n, stderr: %s", stdout, stderr))
+	agentName, err := data.getAntreaPodOnNode(nodeName)
+	require.NoError(t, err)
+	table40Output, _, err := data.runCommandFromPod(metav1.NamespaceSystem, agentName, "antrea-agent", []string{"ovs-ofctl", "dump-flows", defaultBridgeName, "table=40"})
+	require.NoError(t, err)
+	require.Contains(t, table40Output, fmt.Sprintf("nw_dst=%s,tp_dst=80", svc.Spec.ClusterIP))
+	require.Contains(t, table40Output, fmt.Sprintf("load:0x%s->NXM_NX_REG3[]", strings.TrimLeft(hex.EncodeToString(net.ParseIP(nginxIP).To4()), "0")))
+}
+
+func TestProxyHairpin(t *testing.T) {
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	skipIfProxyDisabled(t, data)
+
+	nodeName := nodeName(1)
+	err = data.createPodOnNode("busybox", nodeName, "busybox", []string{"nc", "-lk", "-p", "80"}, nil, nil, []v1.ContainerPort{{ContainerPort: 80, Protocol: v1.ProtocolTCP}})
+	require.NoError(t, err)
+	require.NoError(t, data.podWaitForRunning(defaultTimeout, "busybox", testNamespace))
+	svc, err := data.createService("busybox", 80, 80, map[string]string{"antrea-e2e": "busybox"}, false)
+	require.NoError(t, err)
+	stdout, stderr, err := data.runCommandFromPod(testNamespace, "busybox", busyboxContainerName, []string{"nc", svc.Spec.ClusterIP, "80", "-w", "1", "-e", "ls", "/"})
+	require.NoError(t, err, fmt.Sprintf("stdout: %s\n, stderr: %s", stdout, stderr))
+}
+
+func TestProxyEndpointLifeCycle(t *testing.T) {
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	skipIfProxyDisabled(t, data)
+
+	nodeName := nodeName(1)
+	require.NoError(t, data.createNginxPod("nginx", nodeName))
+	nginxIP, err := data.podWaitForIP(defaultTimeout, "nginx", testNamespace)
+	require.NoError(t, err)
+	_, err = data.createNginxService(false)
+	require.NoError(t, err)
+	agentName, err := data.getAntreaPodOnNode(nodeName)
+	require.NoError(t, err)
+
+	keywords := map[int]string{
+		42: fmt.Sprintf("nat(dst=%s:80)", nginxIP), // endpointNATTable
+	}
+
+	for tableID, keyword := range keywords {
+		tableOutput, _, err := data.runCommandFromPod(metav1.NamespaceSystem, agentName, "antrea-agent", []string{"ovs-ofctl", "dump-flows", defaultBridgeName, fmt.Sprintf("table=%d", tableID)})
+		require.NoError(t, err)
+		require.Contains(t, tableOutput, keyword)
+	}
+
+	require.NoError(t, data.deletePodAndWait(defaultTimeout, "nginx"))
+
+	for tableID, keyword := range keywords {
+		tableOutput, _, err := data.runCommandFromPod(metav1.NamespaceSystem, agentName, "antrea-agent", []string{"ovs-ofctl", "dump-flows", defaultBridgeName, fmt.Sprintf("table=%d", tableID)})
+		require.NoError(t, err)
+		require.NotContains(t, tableOutput, keyword)
+	}
+}
+
+func TestProxyServiceLifeCycle(t *testing.T) {
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	skipIfProxyDisabled(t, data)
+
+	nodeName := nodeName(1)
+	require.NoError(t, data.createNginxPod("nginx", nodeName))
+	nginxIP, err := data.podWaitForIP(defaultTimeout, "nginx", testNamespace)
+	require.NoError(t, err)
+	svc, err := data.createNginxService(false)
+	require.NoError(t, err)
+	agentName, err := data.getAntreaPodOnNode(nodeName)
+	require.NoError(t, err)
+
+	keywords := map[int]string{
+		41: fmt.Sprintf("nw_dst=%s,tp_dst=80", svc.Spec.ClusterIP), // serviceLBTable
+		42: fmt.Sprintf("nat(dst=%s:80)", nginxIP),                 // endpointNATTable
+	}
+	groupKeyword := fmt.Sprintf("load:0x%s->NXM_NX_REG3[],load:0x%x->NXM_NX_REG4[0..15],load:0x2->NXM_NX_REG4[16..18]", strings.TrimLeft(string(hex.EncodeToString(net.ParseIP(nginxIP).To4())), "0"), 80)
+	groupOutput, _, err := data.runCommandFromPod(metav1.NamespaceSystem, agentName, "antrea-agent", []string{"ovs-ofctl", "dump-groups", defaultBridgeName})
+	require.NoError(t, err)
+	require.Contains(t, groupOutput, groupKeyword)
+	for tableID, keyword := range keywords {
+		tableOutput, _, err := data.runCommandFromPod(metav1.NamespaceSystem, agentName, "antrea-agent", []string{"ovs-ofctl", "dump-flows", defaultBridgeName, fmt.Sprintf("table=%d", tableID)})
+		require.NoError(t, err)
+		require.Contains(t, tableOutput, keyword)
+	}
+
+	require.NoError(t, data.deleteService("nginx"))
+	time.Sleep(time.Second)
+
+	groupOutput, _, err = data.runCommandFromPod(metav1.NamespaceSystem, agentName, "antrea-agent", []string{"ovs-ofctl", "dump-groups", defaultBridgeName})
+	require.NoError(t, err)
+	require.NotContains(t, groupOutput, groupKeyword)
+	for tableID, keyword := range keywords {
+		tableOutput, _, err := data.runCommandFromPod(metav1.NamespaceSystem, agentName, "antrea-agent", []string{"ovs-ofctl", "dump-flows", defaultBridgeName, fmt.Sprintf("table=%d", tableID)})
+		require.NoError(t, err)
+		require.NotContains(t, tableOutput, keyword)
+	}
+}

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -83,7 +83,7 @@ type testConfig struct {
 }
 
 func TestConnectivityFlows(t *testing.T) {
-	c = ofClient.NewClient(br, bridgeMgmtAddr)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, true)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 	defer func() {
@@ -110,7 +110,7 @@ func TestConnectivityFlows(t *testing.T) {
 }
 
 func TestReplayFlowsConnectivityFlows(t *testing.T) {
-	c = ofClient.NewClient(br, bridgeMgmtAddr)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, true)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -137,7 +137,7 @@ func TestReplayFlowsConnectivityFlows(t *testing.T) {
 }
 
 func TestReplayFlowsNetworkPolicyFlows(t *testing.T) {
-	c = ofClient.NewClient(br, bridgeMgmtAddr)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, true)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -230,11 +230,11 @@ func testInstallTunnelFlows(t *testing.T, config *testConfig) {
 }
 
 func testInstallServiceFlows(t *testing.T, config *testConfig) {
-	err := c.InstallClusterServiceCIDRFlows(config.serviceCIDR, config.localGateway.mac, config.localGateway.ofPort)
+	err := c.InstallClusterServiceFlows()
 	if err != nil {
-		t.Fatalf("Failed to install Openflow entries to skip service CIDR from egress table")
+		t.Fatalf("Failed to install Openflow entries to skip service CIDR from egress table: %v", err)
 	}
-	for _, tableFlow := range prepareServiceHelperFlows(*config.serviceCIDR, config.localGateway.mac, config.localGateway.ofPort) {
+	for _, tableFlow := range prepareServiceHelperFlows() {
 		ofTestUtils.CheckFlowExists(t, ovsCtlClient, tableFlow.tableID, true, tableFlow.flows)
 	}
 }
@@ -288,7 +288,7 @@ func testUninstallPodFlows(t *testing.T, config *testConfig) {
 }
 
 func TestNetworkPolicyFlows(t *testing.T) {
-	c = ofClient.NewClient(br, bridgeMgmtAddr)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, true)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 
@@ -557,7 +557,7 @@ func preparePodFlows(podIP net.IP, podMAC net.HardwareAddr, podOFPort uint32, gw
 			uint8(10),
 			[]*ofTestUtils.ExpectFlow{
 				{fmt.Sprintf("priority=200,ip,in_port=%d,dl_src=%s,nw_src=%s", podOFPort, podMAC.String(), podIP.String()),
-					"goto_table:30"},
+					"goto_table:29"},
 				{
 					fmt.Sprintf("priority=200,arp,in_port=%d,arp_spa=%s,arp_sha=%s", podOFPort, podIP.String(), podMAC.String()),
 					"goto_table:20"},
@@ -567,7 +567,7 @@ func preparePodFlows(podIP net.IP, podMAC net.HardwareAddr, podOFPort uint32, gw
 			uint8(70),
 			[]*ofTestUtils.ExpectFlow{
 				{
-					fmt.Sprintf("priority=200,ip,dl_dst=%s,nw_dst=%s", vMAC.String(), podIP.String()),
+					fmt.Sprintf("priority=200,ip,reg0=0x80000/0x80000,nw_dst=%s", podIP.String()),
 					fmt.Sprintf("set_field:%s->eth_src,set_field:%s->eth_dst,dec_ttl,goto_table:80", gwMAC.String(), podMAC.String())},
 			},
 		},
@@ -595,14 +595,14 @@ func prepareGatewayFlows(gwIP net.IP, gwMAC net.HardwareAddr, gwOFPort uint32, v
 			uint8(31),
 			[]*ofTestUtils.ExpectFlow{
 				{"priority=200,ct_state=-new+trk,ct_mark=0x20,ip",
-					fmt.Sprintf("load:0x%s->NXM_OF_ETH_DST[],goto_table:40", strings.Replace(gwMAC.String(), ":", "", -1))},
+					fmt.Sprintf("load:0x%s->NXM_OF_ETH_DST[],goto_table:42", strings.Replace(gwMAC.String(), ":", "", -1))},
 			},
 		},
 		{
 			uint8(10),
 			[]*ofTestUtils.ExpectFlow{
 				{fmt.Sprintf("priority=200,arp,in_port=%d,arp_spa=%s,arp_sha=%s", gwOFPort, gwIP, gwMAC), "goto_table:20"},
-				{fmt.Sprintf("priority=200,ip,in_port=%d", gwOFPort), "goto_table:30"},
+				{fmt.Sprintf("priority=200,ip,in_port=%d", gwOFPort), "goto_table:29"},
 			},
 		},
 		{
@@ -637,7 +637,7 @@ func prepareTunnelFlows(tunnelPort uint32, vMAC net.HardwareAddr) []expectTableF
 		{
 			uint8(0),
 			[]*ofTestUtils.ExpectFlow{
-				{fmt.Sprintf("priority=200,in_port=%d", tunnelPort), "load:0->NXM_NX_REG0[0..15],goto_table:30"},
+				{fmt.Sprintf("priority=200,in_port=%d", tunnelPort), "load:0->NXM_NX_REG0[0..15],load:0x1->NXM_NX_REG0[19],goto_table:30"},
 			},
 		},
 	}
@@ -663,13 +663,13 @@ func prepareNodeFlows(tunnelPort uint32, peerSubnet net.IPNet, peerGwIP, peerNod
 	}
 }
 
-func prepareServiceHelperFlows(serviceCIDR net.IPNet, gwMAC net.HardwareAddr, gwOFPort uint32) []expectTableFlows {
+func prepareServiceHelperFlows() []expectTableFlows {
 	return []expectTableFlows{
 		{
 			uint8(40),
 			[]*ofTestUtils.ExpectFlow{
-				{fmt.Sprintf("priority=200,ip,nw_dst=%s", serviceCIDR.String()),
-					fmt.Sprintf("set_field:%s->eth_dst,load:0x%x->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],goto_table:105", gwMAC, gwOFPort),
+				{fmt.Sprint("priority=0"),
+					fmt.Sprint("load:0x1->NXM_NX_REG4[16..18]"),
 				},
 			},
 		},
@@ -696,20 +696,16 @@ func prepareDefaultFlows() []expectTableFlows {
 		{
 			uint8(30),
 			[]*ofTestUtils.ExpectFlow{
-				{"priority=200,ip", "ct(table=31,zone=65520)"},
+				{"priority=200,ip", "ct(table=31,zone=65520,nat)"},
 			},
 		},
 		{
 			uint8(31),
 			[]*ofTestUtils.ExpectFlow{
-				{"priority=210,ct_state=-new+trk,ct_mark=0x20,ip,reg0=0x1/0xffff", "goto_table:40"},
+				{"priority=210,ct_state=-new+trk,ct_mark=0x20,ip,reg0=0x1/0xffff", "goto_table:42"},
 				{"priority=190,ct_state=+inv+trk,ip", "drop"},
-				{"priority=0", "goto_table:40"},
+				{"priority=0", "resubmit(,40),resubmit(,41)"},
 			},
-		},
-		{
-			uint8(40),
-			[]*ofTestUtils.ExpectFlow{{"priority=0", "goto_table:50"}},
 		},
 		{
 			uint8(50),
@@ -738,9 +734,9 @@ func prepareDefaultFlows() []expectTableFlows {
 		{
 			uint8(105),
 			[]*ofTestUtils.ExpectFlow{
-				{"priority=200,ct_state=+new+trk,ip,reg0=0x1/0xffff", "ct(commit,table=110,zone=65520,exec(load:0x20->NXM_NX_CT_MARK[])"},
-				{"priority=190,ct_state=+new+trk,ip", "ct(commit,table=110,zone=65520)"},
-				{"priority=0", "goto_table:110"}},
+				{"priority=200,ct_state=+new+trk,ip,reg0=0x1/0xffff", "ct(commit,table=106,zone=65520,exec(load:0x20->NXM_NX_CT_MARK[])"},
+				{"priority=190,ct_state=+new+trk,ip", "ct(commit,table=106,zone=65520)"},
+				{"priority=0", "goto_table:106"}},
 		},
 		{
 			uint8(110),
@@ -797,11 +793,11 @@ func prepareExternalFlows(nodeIP net.IP, localSubnet *net.IPNet) []expectTableFl
 			[]*ofTestUtils.ExpectFlow{
 				{
 					"priority=210,ct_state=-new+trk,ct_mark=0x40,ip,reg0=0x4/0xffff",
-					"load:0xaabbccddeeff->NXM_OF_ETH_DST[],goto_table:40",
+					"load:0xaabbccddeeff->NXM_OF_ETH_DST[],load:0x1->NXM_NX_REG0[19],goto_table:42",
 				},
 				{
 					"priority=200,ct_state=-new+trk,ct_mark=0x40,ip",
-					"goto_table:40",
+					"goto_table:42",
 				},
 				{
 					fmt.Sprintf("priority=200,ip,in_port=%d", config1.UplinkOFPort),
@@ -814,10 +810,6 @@ func prepareExternalFlows(nodeIP net.IP, localSubnet *net.IPNet) []expectTableFl
 			[]*ofTestUtils.ExpectFlow{
 				{
 					"priority=200,ct_mark=0x20,ip,reg0=0x2/0xffff", "goto_table:80",
-				},
-				{
-					fmt.Sprintf("priority=190,ip,reg0=0x2/0xffff,nw_dst=%s", localSubnet.String()),
-					"goto_table:80",
 				},
 				{
 					fmt.Sprintf("priority=190,ip,reg0=0x2/0xffff,nw_dst=%s", nodeIP.String()),

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -641,6 +641,7 @@ func TestPacketOutIn(t *testing.T) {
 	err = bridge.AddFlowsInBundle([]binding.Flow{flow0, flow1}, nil, nil)
 	require.Nil(t, err)
 	err = bridge.SendPacketOut(pkt)
+	require.NoError(t, err)
 	<-stopCh
 }
 

--- a/third_party/proxy/LICENSE
+++ b/third_party/proxy/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third_party/proxy/README
+++ b/third_party/proxy/README
@@ -1,0 +1,1 @@
+Package proxy is copied from [k8s.io/kubernetes@/v1.17.6](https://github.com/kubernetes/kubernetes/tree/v1.17.6) to avoid importing the whole kubernetes repo.

--- a/third_party/proxy/config/config.go
+++ b/third_party/proxy/config/config.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Modifies:
+- Replace "k8s.io/kubernetes/pkg/controller" to "k8s.io/client-go/tools/cache"
+*/
+
+package config
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+// ServiceHandler is an abstract interface of objects which receive
+// notifications about service object changes.
+type ServiceHandler interface {
+	// OnServiceAdd is called whenever creation of new service object
+	// is observed.
+	OnServiceAdd(service *v1.Service)
+	// OnServiceUpdate is called whenever modification of an existing
+	// service object is observed.
+	OnServiceUpdate(oldService, service *v1.Service)
+	// OnServiceDelete is called whenever deletion of an existing service
+	// object is observed.
+	OnServiceDelete(service *v1.Service)
+	// OnServiceSynced is called once all the initial even handlers were
+	// called and the state is fully propagated to local cache.
+	OnServiceSynced()
+}
+
+// EndpointsHandler is an abstract interface of objects which receive
+// notifications about endpoints object changes.
+type EndpointsHandler interface {
+	// OnEndpointsAdd is called whenever creation of new endpoints object
+	// is observed.
+	OnEndpointsAdd(endpoints *v1.Endpoints)
+	// OnEndpointsUpdate is called whenever modification of an existing
+	// endpoints object is observed.
+	OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoints)
+	// OnEndpointsDelete is called whever deletion of an existing endpoints
+	// object is observed.
+	OnEndpointsDelete(endpoints *v1.Endpoints)
+	// OnEndpointsSynced is called once all the initial event handlers were
+	// called and the state is fully propagated to local cache.
+	OnEndpointsSynced()
+}
+
+// EndpointsConfig tracks a set of endpoints configurations.
+type EndpointsConfig struct {
+	listerSynced  cache.InformerSynced
+	eventHandlers []EndpointsHandler
+}
+
+// NewEndpointsConfig creates a new EndpointsConfig.
+func NewEndpointsConfig(endpointsInformer coreinformers.EndpointsInformer, resyncPeriod time.Duration) *EndpointsConfig {
+	result := &EndpointsConfig{
+		listerSynced: endpointsInformer.Informer().HasSynced,
+	}
+
+	endpointsInformer.Informer().AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    result.handleAddEndpoints,
+			UpdateFunc: result.handleUpdateEndpoints,
+			DeleteFunc: result.handleDeleteEndpoints,
+		},
+		resyncPeriod,
+	)
+
+	return result
+}
+
+// RegisterEventHandler registers a handler which is called on every endpoints change.
+func (c *EndpointsConfig) RegisterEventHandler(handler EndpointsHandler) {
+	c.eventHandlers = append(c.eventHandlers, handler)
+}
+
+// Run waits for cache synced and invokes handlers after syncing.
+func (c *EndpointsConfig) Run(stopCh <-chan struct{}) {
+	klog.Info("Starting endpoints config controller")
+
+	if !cache.WaitForCacheSync(stopCh, c.listerSynced) {
+		return
+	}
+
+	for i := range c.eventHandlers {
+		klog.V(3).Infof("Calling handler.OnEndpointsSynced()")
+		c.eventHandlers[i].OnEndpointsSynced()
+	}
+}
+
+func (c *EndpointsConfig) handleAddEndpoints(obj interface{}) {
+	endpoints, ok := obj.(*v1.Endpoints)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
+		return
+	}
+	for i := range c.eventHandlers {
+		klog.V(4).Infof("Calling handler.OnEndpointsAdd")
+		c.eventHandlers[i].OnEndpointsAdd(endpoints)
+	}
+}
+
+func (c *EndpointsConfig) handleUpdateEndpoints(oldObj, newObj interface{}) {
+	oldEndpoints, ok := oldObj.(*v1.Endpoints)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", oldObj))
+		return
+	}
+	endpoints, ok := newObj.(*v1.Endpoints)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", newObj))
+		return
+	}
+	for i := range c.eventHandlers {
+		klog.V(4).Infof("Calling handler.OnEndpointsUpdate")
+		c.eventHandlers[i].OnEndpointsUpdate(oldEndpoints, endpoints)
+	}
+}
+
+func (c *EndpointsConfig) handleDeleteEndpoints(obj interface{}) {
+	endpoints, ok := obj.(*v1.Endpoints)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
+			return
+		}
+		if endpoints, ok = tombstone.Obj.(*v1.Endpoints); !ok {
+			utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
+			return
+		}
+	}
+	for i := range c.eventHandlers {
+		klog.V(4).Infof("Calling handler.OnEndpointsDelete")
+		c.eventHandlers[i].OnEndpointsDelete(endpoints)
+	}
+}
+
+// ServiceConfig tracks a set of service configurations.
+type ServiceConfig struct {
+	listerSynced  cache.InformerSynced
+	eventHandlers []ServiceHandler
+}
+
+// NewServiceConfig creates a new ServiceConfig.
+func NewServiceConfig(serviceInformer coreinformers.ServiceInformer, resyncPeriod time.Duration) *ServiceConfig {
+	result := &ServiceConfig{
+		listerSynced: serviceInformer.Informer().HasSynced,
+	}
+
+	serviceInformer.Informer().AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    result.handleAddService,
+			UpdateFunc: result.handleUpdateService,
+			DeleteFunc: result.handleDeleteService,
+		},
+		resyncPeriod,
+	)
+
+	return result
+}
+
+// RegisterEventHandler registers a handler which is called on every service change.
+func (c *ServiceConfig) RegisterEventHandler(handler ServiceHandler) {
+	c.eventHandlers = append(c.eventHandlers, handler)
+}
+
+// Run waits for cache synced and invokes handlers after syncing.
+func (c *ServiceConfig) Run(stopCh <-chan struct{}) {
+	klog.Info("Starting service config controller")
+
+	if !cache.WaitForCacheSync(stopCh, c.listerSynced) {
+		return
+	}
+
+	for i := range c.eventHandlers {
+		klog.V(3).Info("Calling handler.OnServiceSynced()")
+		c.eventHandlers[i].OnServiceSynced()
+	}
+}
+
+func (c *ServiceConfig) handleAddService(obj interface{}) {
+	service, ok := obj.(*v1.Service)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
+		return
+	}
+	for i := range c.eventHandlers {
+		klog.V(4).Info("Calling handler.OnServiceAdd")
+		c.eventHandlers[i].OnServiceAdd(service)
+	}
+}
+
+func (c *ServiceConfig) handleUpdateService(oldObj, newObj interface{}) {
+	oldService, ok := oldObj.(*v1.Service)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", oldObj))
+		return
+	}
+	service, ok := newObj.(*v1.Service)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", newObj))
+		return
+	}
+	for i := range c.eventHandlers {
+		klog.V(4).Info("Calling handler.OnServiceUpdate")
+		c.eventHandlers[i].OnServiceUpdate(oldService, service)
+	}
+}
+
+func (c *ServiceConfig) handleDeleteService(obj interface{}) {
+	service, ok := obj.(*v1.Service)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
+			return
+		}
+		if service, ok = tombstone.Obj.(*v1.Service); !ok {
+			utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
+			return
+		}
+	}
+	for i := range c.eventHandlers {
+		klog.V(4).Info("Calling handler.OnServiceDelete")
+		c.eventHandlers[i].OnServiceDelete(service)
+	}
+}

--- a/third_party/proxy/config/doc.go
+++ b/third_party/proxy/config/doc.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Modifies:
+- Remove package import comment
+*/
+// Package config provides decoupling between various configuration sources (etcd, files,...) and
+// the pieces that actually care about them (loadbalancer, proxy). Config takes 1 or more
+// configuration sources and allows for incremental (add/remove) and full replace (set)
+// changes from each of the sources, then creates a union of the configuration and provides
+// a unified view for both service handlers as well as endpoint handlers. There is no attempt
+// to resolve conflicts of any sort. Basic idea is that each configuration source gets a channel
+// from the Config service and pushes updates to it via that channel. Config then keeps track of
+// incremental & replace changes and distributes them to listeners as appropriate.
+package config

--- a/third_party/proxy/doc.go
+++ b/third_party/proxy/doc.go
@@ -1,0 +1,22 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package proxy is copied from
+// k8s.io/kubernetes@/v1.17.6(https://github.com/kubernetes/kubernetes/tree/v1.17.6)
+// to avoid importing the whole kubernetes repo. Some unneeded functions are removed.
+
+package proxy
+
+// TODO: remove this package once the github.com/kubernetes/pkg/proxy becomes
+// an independent module

--- a/third_party/proxy/endpoints.go
+++ b/third_party/proxy/endpoints.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Modifies:
+- Remove imports: "net", "reflect", "strconv", "sync", "time", "k8s.io/api/core/v1",
+  "k8s.io/api/discovery/v1beta1", "k8s.io/apimachinery/pkg/util/sets",
+  "k8s.io/client-go/tools/record", "k8s.io/klog", "k8s.io/utils/net"
+- Remove vars: "supportedEndpointSliceAddressTypes"
+- Remove functions: "newBaseEndpointInfo", "makeEndpointFunc",
+  "NewEndpointChangeTracker", "detectStaleConnections"
+- Remove structs: "EndpointChangeTracker", "EndpointsMap"
+*/
+package proxy
+
+import (
+	utilproxy "github.com/vmware-tanzu/antrea/third_party/proxy/util"
+)
+
+// BaseEndpointInfo contains base information that defines an endpoint.
+// This could be used directly by proxier while processing endpoints,
+// or can be used for constructing a more specific EndpointInfo struct
+// defined by the proxier if needed.
+type BaseEndpointInfo struct {
+	Endpoint string // TODO: should be an endpointString type
+	// IsLocal indicates whether the endpoint is running in same host as kube-proxy.
+	IsLocal  bool
+	Topology map[string]string
+}
+
+var _ Endpoint = &BaseEndpointInfo{}
+
+// String is part of proxy.Endpoint interface.
+func (info *BaseEndpointInfo) String() string {
+	return info.Endpoint
+}
+
+// GetIsLocal is part of proxy.Endpoint interface.
+func (info *BaseEndpointInfo) GetIsLocal() bool {
+	return info.IsLocal
+}
+
+// GetTopology returns the topology information of the endpoint.
+func (info *BaseEndpointInfo) GetTopology() map[string]string {
+	return info.Topology
+}
+
+// IP returns just the IP part of the endpoint, it's a part of proxy.Endpoint interface.
+func (info *BaseEndpointInfo) IP() string {
+	return utilproxy.IPPart(info.Endpoint)
+}
+
+// Port returns just the Port part of the endpoint.
+func (info *BaseEndpointInfo) Port() (int, error) {
+	return utilproxy.PortPart(info.Endpoint)
+}
+
+// Equal is part of proxy.Endpoint interface.
+func (info *BaseEndpointInfo) Equal(other Endpoint) bool {
+	return info.String() == other.String() && info.GetIsLocal() == other.GetIsLocal()
+}

--- a/third_party/proxy/runner.go
+++ b/third_party/proxy/runner.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/klog"
+)
+
+// BoundedFrequencyRunner manages runs of a user-provided function.
+// See NewBoundedFrequencyRunner for examples.
+type BoundedFrequencyRunner struct {
+	name        string        // the name of this instance
+	minInterval time.Duration // the min time between runs, modulo bursts
+	maxInterval time.Duration // the max time between runs
+
+	run chan struct{} // try an async run
+
+	mu      sync.Mutex  // guards runs of fn and all mutations
+	fn      func()      // function to run
+	lastRun time.Time   // time of last run
+	timer   timer       // timer for deferred runs
+	limiter rateLimiter // rate limiter for on-demand runs
+}
+
+// designed so that flowcontrol.RateLimiter satisfies
+type rateLimiter interface {
+	TryAccept() bool
+	Stop()
+}
+
+type nullLimiter struct{}
+
+func (nullLimiter) TryAccept() bool {
+	return true
+}
+
+func (nullLimiter) Stop() {}
+
+var _ rateLimiter = nullLimiter{}
+
+// for testing
+type timer interface {
+	// C returns the timer's selectable channel.
+	C() <-chan time.Time
+
+	// See time.Timer.Reset.
+	Reset(d time.Duration) bool
+
+	// See time.Timer.Stop.
+	Stop() bool
+
+	// See time.Now.
+	Now() time.Time
+
+	// See time.Since.
+	Since(t time.Time) time.Duration
+
+	// See time.Sleep.
+	Sleep(d time.Duration)
+}
+
+// implement our timer in terms of std time.Timer.
+type realTimer struct {
+	*time.Timer
+}
+
+func (rt realTimer) C() <-chan time.Time {
+	return rt.Timer.C
+}
+
+func (rt realTimer) Now() time.Time {
+	return time.Now()
+}
+
+func (rt realTimer) Since(t time.Time) time.Duration {
+	return time.Since(t)
+}
+
+func (rt realTimer) Sleep(d time.Duration) {
+	time.Sleep(d)
+}
+
+var _ timer = realTimer{}
+
+// NewBoundedFrequencyRunner creates a new BoundedFrequencyRunner instance,
+// which will manage runs of the specified function.
+//
+// All runs will be async to the caller of BoundedFrequencyRunner.Run, but
+// multiple runs are serialized. If the function needs to hold locks, it must
+// take them internally.
+//
+// Runs of the function will have at least minInterval between them (from
+// completion to next start), except that up to bursts may be allowed.  Burst
+// runs are "accumulated" over time, one per minInterval up to burstRuns total.
+// This can be used, for example, to mitigate the impact of expensive operations
+// being called in response to user-initiated operations. Run requests that
+// would violate the minInterval are coallesced and run at the next opportunity.
+//
+// The function will be run at least once per maxInterval. For example, this can
+// force periodic refreshes of state in the absence of anyone calling Run.
+//
+// Examples:
+//
+// NewBoundedFrequencyRunner("name", fn, time.Second, 5*time.Second, 1)
+// - fn will have at least 1 second between runs
+// - fn will have no more than 5 seconds between runs
+//
+// NewBoundedFrequencyRunner("name", fn, 3*time.Second, 10*time.Second, 3)
+// - fn will have at least 3 seconds between runs, with up to 3 burst runs
+// - fn will have no more than 10 seconds between runs
+//
+// The maxInterval must be greater than or equal to the minInterval,  If the
+// caller passes a maxInterval less than minInterval, this function will panic.
+func NewBoundedFrequencyRunner(name string, fn func(), minInterval, maxInterval time.Duration, burstRuns int) *BoundedFrequencyRunner {
+	timer := realTimer{Timer: time.NewTimer(0)} // will tick immediately
+	<-timer.C()                                 // consume the first tick
+	return construct(name, fn, minInterval, maxInterval, burstRuns, timer)
+}
+
+// Make an instance with dependencies injected.
+func construct(name string, fn func(), minInterval, maxInterval time.Duration, burstRuns int, timer timer) *BoundedFrequencyRunner {
+	if maxInterval < minInterval {
+		panic(fmt.Sprintf("%s: maxInterval (%v) must be >= minInterval (%v)", name, minInterval, maxInterval))
+	}
+	if timer == nil {
+		panic(fmt.Sprintf("%s: timer must be non-nil", name))
+	}
+
+	bfr := &BoundedFrequencyRunner{
+		name:        name,
+		fn:          fn,
+		minInterval: minInterval,
+		maxInterval: maxInterval,
+		run:         make(chan struct{}, 1),
+		timer:       timer,
+	}
+	if minInterval == 0 {
+		bfr.limiter = nullLimiter{}
+	} else {
+		// allow burst updates in short succession
+		qps := float32(time.Second) / float32(minInterval)
+		bfr.limiter = flowcontrol.NewTokenBucketRateLimiterWithClock(qps, burstRuns, timer)
+	}
+	return bfr
+}
+
+// Loop handles the periodic timer and run requests.  This is expected to be
+// called as a goroutine.
+func (bfr *BoundedFrequencyRunner) Loop(stop <-chan struct{}) {
+	klog.V(3).Infof("%s Loop running", bfr.name)
+	bfr.timer.Reset(bfr.maxInterval)
+	for {
+		select {
+		case <-stop:
+			bfr.stop()
+			klog.V(3).Infof("%s Loop stopping", bfr.name)
+			return
+		case <-bfr.timer.C():
+			bfr.tryRun()
+		case <-bfr.run:
+			bfr.tryRun()
+		}
+	}
+}
+
+// Run the function as soon as possible.  If this is called while Loop is not
+// running, the call may be deferred indefinitely.
+// If there is already a queued request to call the underlying function, it
+// may be dropped - it is just guaranteed that we will try calling the
+// underlying function as soon as possible starting from now.
+func (bfr *BoundedFrequencyRunner) Run() {
+	// If it takes a lot of time to run the underlying function, noone is really
+	// processing elements from <run> channel. So to avoid blocking here on the
+	// putting element to it, we simply skip it if there is already an element
+	// in it.
+	select {
+	case bfr.run <- struct{}{}:
+	default:
+	}
+}
+
+// assumes the lock is not held
+func (bfr *BoundedFrequencyRunner) stop() {
+	bfr.mu.Lock()
+	defer bfr.mu.Unlock()
+	bfr.limiter.Stop()
+	bfr.timer.Stop()
+}
+
+// assumes the lock is not held
+func (bfr *BoundedFrequencyRunner) tryRun() {
+	bfr.mu.Lock()
+	defer bfr.mu.Unlock()
+
+	if bfr.limiter.TryAccept() {
+		// We're allowed to run the function right now.
+		bfr.fn()
+		bfr.lastRun = bfr.timer.Now()
+		bfr.timer.Stop()
+		bfr.timer.Reset(bfr.maxInterval)
+		klog.V(3).Infof("%s: ran, next possible in %v, periodic in %v", bfr.name, bfr.minInterval, bfr.maxInterval)
+		return
+	}
+
+	// It can't run right now, figure out when it can run next.
+
+	elapsed := bfr.timer.Since(bfr.lastRun)    // how long since last run
+	nextPossible := bfr.minInterval - elapsed  // time to next possible run
+	nextScheduled := bfr.maxInterval - elapsed // time to next periodic run
+	klog.V(4).Infof("%s: %v since last run, possible in %v, scheduled in %v", bfr.name, elapsed, nextPossible, nextScheduled)
+
+	if nextPossible < nextScheduled {
+		// Set the timer for ASAP, but don't drain here.  Assuming Loop is running,
+		// it might get a delivery in the mean time, but that is OK.
+		bfr.timer.Stop()
+		bfr.timer.Reset(nextPossible)
+		klog.V(3).Infof("%s: throttled, scheduling run in %v", bfr.name, nextPossible)
+	}
+}

--- a/third_party/proxy/service.go
+++ b/third_party/proxy/service.go
@@ -1,0 +1,427 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Modifies:
+- Replace import from "k8s.io/kubernetes/pkg/api/v1/service" to  "github.com/vmware-tanzu/antrea/pkg/agent/proxy/upstream/util"
+- Remove import "k8s.io/kubernetes/pkg/proxy/metrics" and related invokes
+*/
+
+package proxy
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"strings"
+	"sync"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
+	utilnet "k8s.io/utils/net"
+
+	utilproxy "github.com/vmware-tanzu/antrea/third_party/proxy/util"
+)
+
+// BaseServiceInfo contains base information that defines a service.
+// This could be used directly by proxier while processing services,
+// or can be used for constructing a more specific ServiceInfo struct
+// defined by the proxier if needed.
+type BaseServiceInfo struct {
+	clusterIP                net.IP
+	port                     int
+	protocol                 v1.Protocol
+	nodePort                 int
+	loadBalancerStatus       v1.LoadBalancerStatus
+	sessionAffinityType      v1.ServiceAffinity
+	stickyMaxAgeSeconds      int
+	externalIPs              []string
+	loadBalancerSourceRanges []string
+	healthCheckNodePort      int
+	onlyNodeLocalEndpoints   bool
+	topologyKeys             []string
+}
+
+var _ ServicePort = &BaseServiceInfo{}
+
+// String is part of ServicePort interface.
+func (info *BaseServiceInfo) String() string {
+	return fmt.Sprintf("%s:%d/%s", info.clusterIP, info.port, info.protocol)
+}
+
+// ClusterIP is part of ServicePort interface.
+func (info *BaseServiceInfo) ClusterIP() net.IP {
+	return info.clusterIP
+}
+
+// Port is part of ServicePort interface.
+func (info *BaseServiceInfo) Port() int {
+	return info.port
+}
+
+// SessionAffinityType is part of the ServicePort interface.
+func (info *BaseServiceInfo) SessionAffinityType() v1.ServiceAffinity {
+	return info.sessionAffinityType
+}
+
+// StickyMaxAgeSeconds is part of the ServicePort interface
+func (info *BaseServiceInfo) StickyMaxAgeSeconds() int {
+	return info.stickyMaxAgeSeconds
+}
+
+// Protocol is part of ServicePort interface.
+func (info *BaseServiceInfo) Protocol() v1.Protocol {
+	return info.protocol
+}
+
+// LoadBalancerSourceRanges is part of ServicePort interface
+func (info *BaseServiceInfo) LoadBalancerSourceRanges() []string {
+	return info.loadBalancerSourceRanges
+}
+
+// HealthCheckNodePort is part of ServicePort interface.
+func (info *BaseServiceInfo) HealthCheckNodePort() int {
+	return info.healthCheckNodePort
+}
+
+// NodePort is part of the ServicePort interface.
+func (info *BaseServiceInfo) NodePort() int {
+	return info.nodePort
+}
+
+// ExternalIPStrings is part of ServicePort interface.
+func (info *BaseServiceInfo) ExternalIPStrings() []string {
+	return info.externalIPs
+}
+
+// LoadBalancerIPStrings is part of ServicePort interface.
+func (info *BaseServiceInfo) LoadBalancerIPStrings() []string {
+	var ips []string
+	for _, ing := range info.loadBalancerStatus.Ingress {
+		ips = append(ips, ing.IP)
+	}
+	return ips
+}
+
+// OnlyNodeLocalEndpoints is part of ServicePort interface.
+func (info *BaseServiceInfo) OnlyNodeLocalEndpoints() bool {
+	return info.onlyNodeLocalEndpoints
+}
+
+// TopologyKeys is part of ServicePort interface.
+func (info *BaseServiceInfo) TopologyKeys() []string {
+	return info.topologyKeys
+}
+
+func (sct *ServiceChangeTracker) newBaseServiceInfo(port *v1.ServicePort, service *v1.Service) *BaseServiceInfo {
+	onlyNodeLocalEndpoints := false
+	if utilproxy.RequestsOnlyLocalTraffic(service) {
+		onlyNodeLocalEndpoints = true
+	}
+	var stickyMaxAgeSeconds int
+	if service.Spec.SessionAffinity == v1.ServiceAffinityClientIP {
+		// Kube-apiserver side guarantees SessionAffinityConfig won't be nil when session affinity type is ClientIP
+		stickyMaxAgeSeconds = int(*service.Spec.SessionAffinityConfig.ClientIP.TimeoutSeconds)
+	}
+	info := &BaseServiceInfo{
+		clusterIP:              net.ParseIP(service.Spec.ClusterIP),
+		port:                   int(port.Port),
+		protocol:               port.Protocol,
+		nodePort:               int(port.NodePort),
+		sessionAffinityType:    service.Spec.SessionAffinity,
+		stickyMaxAgeSeconds:    stickyMaxAgeSeconds,
+		onlyNodeLocalEndpoints: onlyNodeLocalEndpoints,
+		topologyKeys:           service.Spec.TopologyKeys,
+	}
+
+	if sct.isIPv6Mode == nil {
+		info.externalIPs = make([]string, len(service.Spec.ExternalIPs))
+		info.loadBalancerSourceRanges = make([]string, len(service.Spec.LoadBalancerSourceRanges))
+		copy(info.loadBalancerSourceRanges, service.Spec.LoadBalancerSourceRanges)
+		copy(info.externalIPs, service.Spec.ExternalIPs)
+		// Deep-copy in case the service instance changes
+		info.loadBalancerStatus = *service.Status.LoadBalancer.DeepCopy()
+	} else {
+		// Filter out the incorrect IP version case.
+		// If ExternalIPs, LoadBalancerSourceRanges and LoadBalancerStatus Ingress on service contains incorrect IP versions,
+		// only filter out the incorrect ones.
+		var incorrectIPs []string
+		info.externalIPs, incorrectIPs = utilproxy.FilterIncorrectIPVersion(service.Spec.ExternalIPs, *sct.isIPv6Mode)
+		if len(incorrectIPs) > 0 {
+			utilproxy.LogAndEmitIncorrectIPVersionEvent(sct.recorder, "externalIPs", strings.Join(incorrectIPs, ","), service.Namespace, service.Name, service.UID)
+		}
+		info.loadBalancerSourceRanges, incorrectIPs = utilproxy.FilterIncorrectCIDRVersion(service.Spec.LoadBalancerSourceRanges, *sct.isIPv6Mode)
+		if len(incorrectIPs) > 0 {
+			utilproxy.LogAndEmitIncorrectIPVersionEvent(sct.recorder, "loadBalancerSourceRanges", strings.Join(incorrectIPs, ","), service.Namespace, service.Name, service.UID)
+		}
+		// Obtain Load Balancer Ingress IPs
+		var ips []string
+		for _, ing := range service.Status.LoadBalancer.Ingress {
+			ips = append(ips, ing.IP)
+		}
+		if len(ips) > 0 {
+			correctIPs, incorrectIPs := utilproxy.FilterIncorrectIPVersion(ips, *sct.isIPv6Mode)
+			if len(incorrectIPs) > 0 {
+				utilproxy.LogAndEmitIncorrectIPVersionEvent(sct.recorder, "Load Balancer ingress IPs", strings.Join(incorrectIPs, ","), service.Namespace, service.Name, service.UID)
+			}
+			// Create the LoadBalancerStatus with the filtererd IPs
+			for _, ip := range correctIPs {
+				info.loadBalancerStatus.Ingress = append(info.loadBalancerStatus.Ingress, v1.LoadBalancerIngress{IP: ip})
+
+			}
+		}
+	}
+
+	if utilproxy.NeedsHealthCheck(service) {
+		p := service.Spec.HealthCheckNodePort
+		if p == 0 {
+			klog.Errorf("Service %s/%s has no healthcheck nodeport", service.Namespace, service.Name)
+		} else {
+			info.healthCheckNodePort = int(p)
+		}
+	}
+
+	return info
+}
+
+type makeServicePortFunc func(*v1.ServicePort, *v1.Service, *BaseServiceInfo) ServicePort
+
+// serviceChange contains all changes to services that happened since proxy rules were synced.  For a single object,
+// changes are accumulated, i.e. previous is state from before applying the changes,
+// current is state after applying all of the changes.
+type serviceChange struct {
+	previous ServiceMap
+	current  ServiceMap
+}
+
+// ServiceChangeTracker carries state about uncommitted changes to an arbitrary number of
+// Services, keyed by their namespace and name.
+type ServiceChangeTracker struct {
+	// lock protects items.
+	lock sync.Mutex
+	// items maps a service to its serviceChange.
+	items map[types.NamespacedName]*serviceChange
+	// makeServiceInfo allows proxier to inject customized information when processing service.
+	makeServiceInfo makeServicePortFunc
+	// isIPv6Mode indicates if change tracker is under IPv6/IPv4 mode. Nil means not applicable.
+	isIPv6Mode *bool
+	recorder   record.EventRecorder
+}
+
+// NewServiceChangeTracker initializes a ServiceChangeTracker
+func NewServiceChangeTracker(makeServiceInfo makeServicePortFunc, isIPv6Mode *bool, recorder record.EventRecorder) *ServiceChangeTracker {
+	return &ServiceChangeTracker{
+		items:           make(map[types.NamespacedName]*serviceChange),
+		makeServiceInfo: makeServiceInfo,
+		isIPv6Mode:      isIPv6Mode,
+		recorder:        recorder,
+	}
+}
+
+// Update updates given service's change map based on the <previous, current> service pair.  It returns true if items changed,
+// otherwise return false.  Update can be used to add/update/delete items of ServiceChangeMap.  For example,
+// Add item
+//   - pass <nil, service> as the <previous, current> pair.
+// Update item
+//   - pass <oldService, service> as the <previous, current> pair.
+// Delete item
+//   - pass <service, nil> as the <previous, current> pair.
+func (sct *ServiceChangeTracker) Update(previous, current *v1.Service) bool {
+	svc := current
+	if svc == nil {
+		svc = previous
+	}
+	// previous == nil && current == nil is unexpected, we should return false directly.
+	if svc == nil {
+		return false
+	}
+	namespacedName := types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
+
+	sct.lock.Lock()
+	defer sct.lock.Unlock()
+
+	change, exists := sct.items[namespacedName]
+	if !exists {
+		change = &serviceChange{}
+		change.previous = sct.serviceToServiceMap(previous)
+		sct.items[namespacedName] = change
+	}
+	change.current = sct.serviceToServiceMap(current)
+	// if change.previous equal to change.current, it means no change
+	if reflect.DeepEqual(change.previous, change.current) {
+		delete(sct.items, namespacedName)
+	}
+	return len(sct.items) > 0
+}
+
+// UpdateServiceMapResult is the updated results after applying service changes.
+type UpdateServiceMapResult struct {
+	// HCServiceNodePorts is a map of Service names to node port numbers which indicate the health of that Service on this Node.
+	// The value(uint16) of HCServices map is the service health check node port.
+	HCServiceNodePorts map[types.NamespacedName]uint16
+	// UDPStaleClusterIP holds stale (no longer assigned to a Service) Service IPs that had UDP ports.
+	// Callers can use this to abort timeout-waits or clear connection-tracking information.
+	UDPStaleClusterIP sets.String
+}
+
+// UpdateServiceMap updates ServiceMap based on the given changes.
+func UpdateServiceMap(serviceMap ServiceMap, changes *ServiceChangeTracker) (result UpdateServiceMapResult) {
+	result.UDPStaleClusterIP = sets.NewString()
+	serviceMap.apply(changes, result.UDPStaleClusterIP)
+
+	// TODO: If this will appear to be computationally expensive, consider
+	// computing this incrementally similarly to serviceMap.
+	result.HCServiceNodePorts = make(map[types.NamespacedName]uint16)
+	for svcPortName, info := range serviceMap {
+		if info.HealthCheckNodePort() != 0 {
+			result.HCServiceNodePorts[svcPortName.NamespacedName] = uint16(info.HealthCheckNodePort())
+		}
+	}
+
+	return result
+}
+
+// ServiceMap maps a service to its ServicePort.
+type ServiceMap map[ServicePortName]ServicePort
+
+// serviceToServiceMap translates a single Service object to a ServiceMap.
+//
+// NOTE: service object should NOT be modified.
+func (sct *ServiceChangeTracker) serviceToServiceMap(service *v1.Service) ServiceMap {
+	if service == nil {
+		return nil
+	}
+	svcName := types.NamespacedName{Namespace: service.Namespace, Name: service.Name}
+	if utilproxy.ShouldSkipService(svcName, service) {
+		return nil
+	}
+
+	if len(service.Spec.ClusterIP) != 0 {
+		// Filter out the incorrect IP version case.
+		// If ClusterIP on service has incorrect IP version, service itself will be ignored.
+		if sct.isIPv6Mode != nil && utilnet.IsIPv6String(service.Spec.ClusterIP) != *sct.isIPv6Mode {
+			utilproxy.LogAndEmitIncorrectIPVersionEvent(sct.recorder, "clusterIP", service.Spec.ClusterIP, service.Namespace, service.Name, service.UID)
+			return nil
+		}
+	}
+
+	serviceMap := make(ServiceMap)
+	for i := range service.Spec.Ports {
+		servicePort := &service.Spec.Ports[i]
+		svcPortName := ServicePortName{NamespacedName: svcName, Port: servicePort.Name, Protocol: servicePort.Protocol}
+		baseSvcInfo := sct.newBaseServiceInfo(servicePort, service)
+		if sct.makeServiceInfo != nil {
+			serviceMap[svcPortName] = sct.makeServiceInfo(servicePort, service, baseSvcInfo)
+		} else {
+			serviceMap[svcPortName] = baseSvcInfo
+		}
+	}
+	return serviceMap
+}
+
+// apply the changes to ServiceMap and update the stale udp cluster IP set. The UDPStaleClusterIP argument is passed in to store the
+// udp protocol service cluster ip when service is deleted from the ServiceMap.
+func (sm *ServiceMap) apply(changes *ServiceChangeTracker, UDPStaleClusterIP sets.String) {
+	changes.lock.Lock()
+	defer changes.lock.Unlock()
+	for _, change := range changes.items {
+		sm.merge(change.current)
+		// filter out the Update event of current changes from previous changes before calling unmerge() so that can
+		// skip deleting the Update events.
+		change.previous.filter(change.current)
+		sm.unmerge(change.previous, UDPStaleClusterIP)
+	}
+	// clear changes after applying them to ServiceMap.
+	changes.items = make(map[types.NamespacedName]*serviceChange)
+}
+
+// merge adds other ServiceMap's elements to current ServiceMap.
+// If collision, other ALWAYS win. Otherwise add the other to current.
+// In other words, if some elements in current collisions with other, update the current by other.
+// It returns a string type set which stores all the newly merged services' identifier, ServicePortName.String(), to help users
+// tell if a service is deleted or updated.
+// The returned value is one of the arguments of ServiceMap.unmerge().
+// ServiceMap A Merge ServiceMap B will do following 2 things:
+//   * update ServiceMap A.
+//   * produce a string set which stores all other ServiceMap's ServicePortName.String().
+// For example,
+//   - A{}
+//   - B{{"ns", "cluster-ip", "http"}: {"172.16.55.10", 1234, "TCP"}}
+//     - A updated to be {{"ns", "cluster-ip", "http"}: {"172.16.55.10", 1234, "TCP"}}
+//     - produce string set {"ns/cluster-ip:http"}
+//   - A{{"ns", "cluster-ip", "http"}: {"172.16.55.10", 345, "UDP"}}
+//   - B{{"ns", "cluster-ip", "http"}: {"172.16.55.10", 1234, "TCP"}}
+//     - A updated to be {{"ns", "cluster-ip", "http"}: {"172.16.55.10", 1234, "TCP"}}
+//     - produce string set {"ns/cluster-ip:http"}
+func (sm *ServiceMap) merge(other ServiceMap) sets.String {
+	// existingPorts is going to store all identifiers of all services in `other` ServiceMap.
+	existingPorts := sets.NewString()
+	for svcPortName, info := range other {
+		// Take ServicePortName.String() as the newly merged service's identifier and put it into existingPorts.
+		existingPorts.Insert(svcPortName.String())
+		_, exists := (*sm)[svcPortName]
+		if !exists {
+			klog.V(1).Infof("Adding new service port %q at %s", svcPortName, info.String())
+		} else {
+			klog.V(1).Infof("Updating existing service port %q at %s", svcPortName, info.String())
+		}
+		(*sm)[svcPortName] = info
+	}
+	return existingPorts
+}
+
+// filter filters out elements from ServiceMap base on given ports string sets.
+func (sm *ServiceMap) filter(other ServiceMap) {
+	for svcPortName := range *sm {
+		// skip the delete for Update event.
+		if _, ok := other[svcPortName]; ok {
+			delete(*sm, svcPortName)
+		}
+	}
+}
+
+// unmerge deletes all other ServiceMap's elements from current ServiceMap.  We pass in the UDPStaleClusterIP strings sets
+// for storing the stale udp service cluster IPs. We will clear stale udp connection base on UDPStaleClusterIP later
+func (sm *ServiceMap) unmerge(other ServiceMap, UDPStaleClusterIP sets.String) {
+	for svcPortName := range other {
+		info, exists := (*sm)[svcPortName]
+		if exists {
+			klog.V(1).Infof("Removing service port %q", svcPortName)
+			if info.Protocol() == v1.ProtocolUDP {
+				UDPStaleClusterIP.Insert(info.ClusterIP().String())
+			}
+			delete(*sm, svcPortName)
+		} else {
+			klog.Errorf("Service port %q doesn't exists", svcPortName)
+		}
+	}
+}

--- a/third_party/proxy/types.go
+++ b/third_party/proxy/types.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Modifies:
+- Remove interface "Provider"
+- Remove import "k8s.io/kubernetes/pkg/proxy/config"
+*/
+
+package proxy
+
+import (
+	"fmt"
+	"net"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ServicePortName carries a namespace + name + portname.  This is the unique
+// identifier for a load-balanced service.
+type ServicePortName struct {
+	types.NamespacedName
+	Port     string
+	Protocol v1.Protocol
+}
+
+func (spn ServicePortName) String() string {
+	return fmt.Sprintf("%s:%s", spn.NamespacedName.String(), spn.Port)
+}
+
+// ServicePort is an interface which abstracts information about a service.
+type ServicePort interface {
+	// String returns service string.  An example format can be: `IP:Port/Protocol`.
+	String() string
+	// GetClusterIP returns service cluster IP in net.IP format.
+	ClusterIP() net.IP
+	// GetPort returns service port if present. If return 0 means not present.
+	Port() int
+	// GetSessionAffinityType returns service session affinity type
+	SessionAffinityType() v1.ServiceAffinity
+	// GetStickyMaxAgeSeconds returns service max connection age
+	StickyMaxAgeSeconds() int
+	// ExternalIPStrings returns service ExternalIPs as a string array.
+	ExternalIPStrings() []string
+	// LoadBalancerIPStrings returns service LoadBalancerIPs as a string array.
+	LoadBalancerIPStrings() []string
+	// GetProtocol returns service protocol.
+	Protocol() v1.Protocol
+	// LoadBalancerSourceRanges returns service LoadBalancerSourceRanges if present empty array if not
+	LoadBalancerSourceRanges() []string
+	// GetHealthCheckNodePort returns service health check node port if present.  If return 0, it means not present.
+	HealthCheckNodePort() int
+	// GetNodePort returns a service Node port if present. If return 0, it means not present.
+	NodePort() int
+	// GetOnlyNodeLocalEndpoints returns if a service has only node local endpoints
+	OnlyNodeLocalEndpoints() bool
+	// TopologyKeys returns service TopologyKeys as a string array.
+	TopologyKeys() []string
+}
+
+// Endpoint in an interface which abstracts information about an endpoint.
+// TODO: Rename functions to be consistent with ServicePort.
+type Endpoint interface {
+	// String returns endpoint string.  An example format can be: `IP:Port`.
+	// We take the returned value as ServiceEndpoint.Endpoint.
+	String() string
+	// GetIsLocal returns true if the endpoint is running in same host as kube-proxy, otherwise returns false.
+	GetIsLocal() bool
+	// GetTopology returns the topology information of the endpoint.
+	GetTopology() map[string]string
+	// IP returns IP part of the endpoint.
+	IP() string
+	// Port returns the Port part of the endpoint.
+	Port() (int, error)
+	// Equal checks if two endpoints are equal.
+	Equal(Endpoint) bool
+}
+
+// ServiceEndpoint is used to identify a service and one of its endpoint pair.
+type ServiceEndpoint struct {
+	Endpoint        string
+	ServicePortName ServicePortName
+}

--- a/third_party/proxy/util/endpoints.go
+++ b/third_party/proxy/util/endpoints.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Modifies:
+- Remove function "ToCIDR"
+- Remove import "fmt"
+*/
+
+package util
+
+import (
+	"net"
+	"strconv"
+
+	"k8s.io/klog"
+)
+
+// IPPart returns just the IP part of an IP or IP:port or endpoint string. If the IP
+// part is an IPv6 address enclosed in brackets (e.g. "[fd00:1::5]:9999"),
+// then the brackets are stripped as well.
+func IPPart(s string) string {
+	if ip := net.ParseIP(s); ip != nil {
+		// IP address without port
+		return s
+	}
+	// Must be IP:port
+	host, _, err := net.SplitHostPort(s)
+	if err != nil {
+		klog.Errorf("Error parsing '%s': %v", s, err)
+		return ""
+	}
+	// Check if host string is a valid IP address
+	ip := net.ParseIP(host)
+	if ip == nil {
+		klog.Errorf("invalid IP part '%s'", host)
+		return ""
+	}
+	return ip.String()
+}
+
+// PortPart returns just the port part of an endpoint string.
+func PortPart(s string) (int, error) {
+	// Must be IP:port
+	_, port, err := net.SplitHostPort(s)
+	if err != nil {
+		klog.Errorf("Error parsing '%s': %v", s, err)
+		return -1, err
+	}
+	portNumber, err := strconv.Atoi(port)
+	if err != nil {
+		klog.Errorf("Error parsing '%s': %v", port, err)
+		return -1, err
+	}
+	return portNumber, nil
+}

--- a/third_party/proxy/util/service.go
+++ b/third_party/proxy/util/service.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Modifies:
+- Remove consts: "defaultLoadBalancerSourceRanges"
+- Remove functions: "IsAllowAll", "GetLoadBalancerSourceRanges", "GetServiceHealthCheckPathPort"
+*/
+
+package util
+
+import "k8s.io/api/core/v1"
+
+// RequestsOnlyLocalTraffic checks if service requests OnlyLocal traffic.
+func RequestsOnlyLocalTraffic(service *v1.Service) bool {
+	if service.Spec.Type != v1.ServiceTypeLoadBalancer &&
+		service.Spec.Type != v1.ServiceTypeNodePort {
+		return false
+	}
+	return service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal
+}
+
+// NeedsHealthCheck checks if service needs health check.
+func NeedsHealthCheck(service *v1.Service) bool {
+	if service.Spec.Type != v1.ServiceTypeLoadBalancer {
+		return false
+	}
+	return RequestsOnlyLocalTraffic(service)
+}

--- a/third_party/proxy/util/utils.go
+++ b/third_party/proxy/util/utils.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Modifies:
+- Remove imports: "errors", "strconv", "k8s.io/apimachinery/pkg/util/rand",
+  "k8s.io/apimachinery/pkg/util/sets", "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+- Remove consts: "IPv4ZeroCIDR", "IPv6ZeroCIDR"
+- Remove vars: "ErrAddressNotAllowed", "ErrNoAddresses"
+- Remove functions: "isValidEndpoint", "BuildPortsToEndpointsMap", "IsZeroCIDR",
+  "IsProxyableIP", "isProxyableIP", "IsProxyableHostname", "IsLocalIP", "GetNodeAddresses".
+*/
+package util
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	utilnet "k8s.io/utils/net"
+
+	"k8s.io/klog"
+)
+
+// Resolver is an interface for net.Resolver
+type Resolver interface {
+	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
+}
+
+// ShouldSkipService checks if a given service should skip proxying
+func ShouldSkipService(svcName types.NamespacedName, service *v1.Service) bool {
+	// if ClusterIP is "None" or empty, skip proxying
+	if service.Spec.ClusterIP == v1.ClusterIPNone || service.Spec.ClusterIP == "" {
+		klog.V(3).Infof("Skipping service %s due to clusterIP = %q", svcName, service.Spec.ClusterIP)
+		return true
+	}
+	// Even if ClusterIP is set, ServiceTypeExternalName services don't get proxied
+	if service.Spec.Type == v1.ServiceTypeExternalName {
+		klog.V(3).Infof("Skipping service %s due to Type=ExternalName", svcName)
+		return true
+	}
+	return false
+}
+
+// LogAndEmitIncorrectIPVersionEvent logs and emits incorrect IP version event.
+func LogAndEmitIncorrectIPVersionEvent(recorder record.EventRecorder, fieldName, fieldValue, svcNamespace, svcName string, svcUID types.UID) {
+	errMsg := fmt.Sprintf("%s in %s has incorrect IP version", fieldValue, fieldName)
+	klog.Errorf("%s (service %s/%s).", errMsg, svcNamespace, svcName)
+	if recorder != nil {
+		recorder.Eventf(
+			&v1.ObjectReference{
+				Kind:      "Service",
+				Name:      svcName,
+				Namespace: svcNamespace,
+				UID:       svcUID,
+			}, v1.EventTypeWarning, "KubeProxyIncorrectIPVersion", errMsg)
+	}
+}
+
+// FilterIncorrectIPVersion filters out the incorrect IP version case from a slice of IP strings.
+func FilterIncorrectIPVersion(ipStrings []string, isIPv6Mode bool) ([]string, []string) {
+	return filterWithCondition(ipStrings, isIPv6Mode, utilnet.IsIPv6String)
+}
+
+// FilterIncorrectCIDRVersion filters out the incorrect IP version case from a slice of CIDR strings.
+func FilterIncorrectCIDRVersion(ipStrings []string, isIPv6Mode bool) ([]string, []string) {
+	return filterWithCondition(ipStrings, isIPv6Mode, utilnet.IsIPv6CIDRString)
+}
+
+func filterWithCondition(strs []string, expectedCondition bool, conditionFunc func(string) bool) ([]string, []string) {
+	var corrects, incorrects []string
+	for _, str := range strs {
+		if conditionFunc(str) != expectedCondition {
+			incorrects = append(incorrects, str)
+		} else {
+			corrects = append(corrects, str)
+		}
+	}
+	return corrects, incorrects
+}


### PR DESCRIPTION
- Implement Antrea proxy for handling explicit ClusterIP services in OVS instead of using kube-proxy.
- Add unit tests and e2e tests for Antrea proxy.
- Add `AntreaProxy` option in FeatureGate for enabling Antrea proxy in the antrea agent. The default value for Linux is false while a Windows one is true.
- Enhance kind tests for running with Antrea proxy.
- Fix Windows service network policy not work issue.

Fixes #463.
Signed-off-by: Weiqiang TANG <weiqiangt@vmware.com>