### PR TITLE
Remove function callbacks for tracking Antrea agent metrics 

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -64,6 +64,11 @@ func run(o *Options) error {
 		return fmt.Errorf("error creating Antrea client: %v", err)
 	}
 
+	// Register Antrea Agent metrics if EnablePrometheusMetrics is set
+	if o.config.EnablePrometheusMetrics {
+		metrics.InitializePrometheusMetrics()
+	}
+
 	// Create ovsdb and openflow clients.
 	ovsdbAddress := ovsconfig.GetConnAddress(o.config.OVSRunDir)
 	ovsdbConnection, err := ovsconfig.NewOVSDBConnectionUDS(ovsdbAddress)
@@ -172,10 +177,6 @@ func run(o *Options) error {
 		ovsBridgeClient,
 		networkPolicyController,
 		o.config.APIPort)
-
-	if o.config.EnablePrometheusMetrics {
-		metrics.InitializePrometheusMetrics(o.config.OVSBridge, ifaceStore, ofClient)
-	}
 
 	agentMonitor := monitor.NewAgentMonitor(crdClient, agentQuerier)
 

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/j-keck/arping v1.0.0
 	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd
-	github.com/prometheus/client_golang v1.0.0
 	github.com/prometheus/common v0.4.1
 	github.com/rakelkar/gonetsh v0.0.0-20190930180311-e5c5ffe4bdf0
 	github.com/satori/go.uuid v1.2.0

--- a/pkg/agent/interfacestore/interface_cache.go
+++ b/pkg/agent/interfacestore/interface_cache.go
@@ -17,6 +17,7 @@ package interfacestore
 import (
 	"sync"
 
+	"github.com/vmware-tanzu/antrea/pkg/agent/metrics"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"
 )
 
@@ -48,6 +49,9 @@ func (c *interfaceCache) Initialize(interfaces []*InterfaceConfig) {
 	for _, intf := range interfaces {
 		key := getInterfaceKey(intf)
 		c.cache[key] = intf
+		if intf.Type == ContainerInterface {
+			metrics.PodCount.Inc()
+		}
 	}
 }
 
@@ -72,6 +76,9 @@ func (c *interfaceCache) AddInterface(interfaceConfig *InterfaceConfig) {
 	c.Lock()
 	defer c.Unlock()
 	c.cache[key] = interfaceConfig
+	if interfaceConfig.Type == ContainerInterface {
+		metrics.PodCount.Inc()
+	}
 }
 
 // DeleteInterface deletes interface from local cache.
@@ -80,6 +87,9 @@ func (c *interfaceCache) DeleteInterface(interfaceConfig *InterfaceConfig) {
 	c.Lock()
 	defer c.Unlock()
 	delete(c.cache, key)
+	if interfaceConfig.Type == ContainerInterface {
+		metrics.PodCount.Dec()
+	}
 }
 
 // GetInterface retrieves interface from local cache given the interface key.

--- a/pkg/agent/metrics/prometheus.go
+++ b/pkg/agent/metrics/prometheus.go
@@ -15,78 +15,40 @@
 package metrics
 
 import (
-	"strconv"
-
-	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog"
 
-	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
-	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
 	"github.com/vmware-tanzu/antrea/pkg/util/env"
 )
 
-// ovsStatManager implements prometheus.Collector
-type ovsStatManager struct {
-	ofClient     openflow.Client
-	ovsBridge    string
-	ovsTableDesc *prometheus.Desc
-}
-
-func (c *ovsStatManager) getOVSStatistics() (ovsFlowsByTable map[string]float64) {
-	ovsFlowsByTable = make(map[string]float64)
-	flowTableStatus := c.ofClient.GetFlowTableStatus()
-	for _, tableStatus := range flowTableStatus {
-		ovsFlowsByTable[strconv.Itoa(int(tableStatus.ID))] = float64(tableStatus.FlowCount)
-	}
-	return
-}
-
-func (c *ovsStatManager) Describe(ch chan<- *prometheus.Desc) {
-	ch <- c.ovsTableDesc
-}
-
-func (c *ovsStatManager) Collect(ch chan<- prometheus.Metric) {
-	ovsFlowsByTable := c.getOVSStatistics()
-	for tableId, tableFlowCount := range ovsFlowsByTable {
-		ch <- prometheus.MustNewConstMetric(
-			c.ovsTableDesc,
-			prometheus.GaugeValue,
-			tableFlowCount,
-			tableId,
-		)
-	}
-}
-
-func newOVSStatManager(ovsBridge string, ofClient openflow.Client) *ovsStatManager {
-	return &ovsStatManager{
-		ofClient:  ofClient,
-		ovsBridge: ovsBridge,
-		ovsTableDesc: prometheus.NewDesc(
-			"antrea_agent_ovs_flow_table",
-			"OVS flow table flow count.",
-			[]string{"table_id"},
-			prometheus.Labels{"bridge": ovsBridge},
-		),
-	}
-}
-
-func InitializePrometheusMetrics(
-	ovsBridge string,
-	ifaceStore interfacestore.InterfaceStore,
-	ofClient openflow.Client) {
-
-	klog.Info("Initializing prometheus metrics")
-	podCount := metrics.NewGaugeFunc(
-		metrics.GaugeOpts{
+var (
+	PodCount = metrics.NewGauge(
+		&metrics.GaugeOpts{
 			Name:           "antrea_agent_local_pod_count",
 			Help:           "Number of pods on local node which are managed by the Antrea Agent.",
 			StabilityLevel: metrics.STABLE,
 		},
-		func() float64 { return float64(ifaceStore.GetContainerInterfaceNum()) },
 	)
-	if err := legacyregistry.RawRegister(podCount); err != nil {
+
+	OVSTotalFlowCount = metrics.NewGauge(&metrics.GaugeOpts{
+		Name:           "antrea_agent_ovs_total_flow_count",
+		Help:           "Total flow count of all OVS flow tables.",
+		StabilityLevel: metrics.STABLE,
+	},
+	)
+
+	OVSFlowCount = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Name:           "antrea_agent_ovs_flow_count",
+		Help:           "Flow count for each OVS flow table. Table IDs are labels.",
+		StabilityLevel: metrics.STABLE,
+	}, []string{"table_id"})
+)
+
+func InitializePrometheusMetrics() {
+	klog.Info("Initializing prometheus metrics")
+
+	if err := legacyregistry.Register(PodCount); err != nil {
 		klog.Error("Failed to register antrea_agent_local_pod_count with Prometheus")
 	}
 
@@ -108,8 +70,10 @@ func InitializePrometheusMetrics(
 	// and will not measure anything unless the collector is first registered.
 	gaugeHost.Set(1)
 
-	ovsStats := newOVSStatManager(ovsBridge, ofClient)
-	if err := legacyregistry.RawRegister(ovsStats); err != nil {
-		klog.Error("Failed to register antrea_agent_ovs_flow_table with Prometheus")
+	if err := legacyregistry.Register(OVSTotalFlowCount); err != nil {
+		klog.Error("Failed to register antrea_agent_ovs_total_flow_count with Prometheus")
+	}
+	if err := legacyregistry.Register(OVSFlowCount); err != nil {
+		klog.Error("Failed to register antrea_agent_ovs_flow_count with Prometheus")
 	}
 }

--- a/pkg/agent/metrics/prometheus.go
+++ b/pkg/agent/metrics/prometheus.go
@@ -40,7 +40,7 @@ var (
 
 	OVSFlowCount = metrics.NewGaugeVec(&metrics.GaugeOpts{
 		Name:           "antrea_agent_ovs_flow_count",
-		Help:           "Flow count for each OVS flow table. Table IDs are labels.",
+		Help:           "Flow count for each OVS flow table. The TableID is used as a label.",
 		StabilityLevel: metrics.STABLE,
 	}, []string{"table_id"})
 )

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -35,7 +35,8 @@ const monitoringNamespace string = "monitoring"
 // Agent metrics to validate
 var antreaAgentMetrics = []string{
 	"antrea_agent_local_pod_count",
-	"antrea_agent_ovs_flow_table",
+	"antrea_agent_ovs_total_flow_count",
+	"antrea_agent_ovs_flow_count",
 	"antrea_agent_runtime_info",
 }
 


### PR DESCRIPTION
Track Antrea agent metrics when the corresponding events happen rather
than through a callback. This is for optimizing scraping ([comment in PR#321](https://github.com/vmware-tanzu/antrea/pull/321#discussion_r402425060)) to cut down the cost of calling function callbacks for every scrape. This also removes
dependencies on certain packages that are introduced by callbacks; the latter
becomes critical in adding new metrics.
In addition, it fixes the dependency on metric types such as
NewCounterFunc, NewGuageFunc etc. and there by RawRegister, which is
being deprecated soon.

Tested locally and through existing e2e test.

Fix #752