### PR TITLE
Update antrea cni to work with 0.4.0 version

### DIFF
--- a/build/images/Dockerfile.build.ubuntu
+++ b/build/images/Dockerfile.build.ubuntu
@@ -7,7 +7,7 @@ RUN apt-get update && \
 ENV CNI_PLUGINS="./host-local ./loopback ./portmap"
 
 RUN mkdir -p /opt/cni/bin && \
-    wget -q -O - https://dl.k8s.io/network-plugins/cni-plugins-amd64-v0.7.5.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
+    wget -q -O - https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
 
 
 FROM golang:1.13 as antrea-build

--- a/build/images/Dockerfile.ubuntu
+++ b/build/images/Dockerfile.ubuntu
@@ -7,7 +7,7 @@ RUN apt-get update && \
 ENV CNI_PLUGINS="./host-local ./loopback ./portmap"
 
 RUN mkdir -p /opt/cni/bin && \
-    wget -q -O - https://dl.k8s.io/network-plugins/cni-plugins-amd64-v0.7.5.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
+    wget -q -O - https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
 
 
 FROM antrea/openvswitch:2.13.0

--- a/cmd/antrea-cni/main.go
+++ b/cmd/antrea-cni/main.go
@@ -29,7 +29,7 @@ func main() {
 		cni.ActionAdd.Request,
 		cni.ActionCheck.Request,
 		cni.ActionDel.Request,
-		cni_version.PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1"),
+		cni_version.All,
 		fmt.Sprintf("Antrea CNI %s", version.GetFullVersionWithRuntimeInfo()),
 	)
 }

--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -103,10 +103,6 @@ type CNIServer struct {
 	routeClient route.Interface
 }
 
-const (
-	supportedCNIVersions = "0.1.0,0.2.0,0.3.0,0.3.1,0.4.0"
-)
-
 var supportedCNIVersionSet map[string]bool
 
 type RuntimeDNS struct {
@@ -206,7 +202,7 @@ func (s *CNIServer) checkRequestMessage(request *cnipb.CniCmdRequest) (*CNIConfi
 	cniVersion := cniConfig.CNIVersion
 	// Check if CNI version in the request is supported
 	if !s.isCNIVersionSupported(cniVersion) {
-		klog.Errorf(fmt.Sprintf("Unsupported CNI version [%s], supported CNI versions [%s]", cniVersion, supportedCNIVersions))
+		klog.Errorf(fmt.Sprintf("Unsupported CNI version [%s], supported CNI versions %s", cniVersion, version.All.SupportedVersions()))
 		return cniConfig, s.incompatibleCniVersionResponse(cniVersion)
 	}
 	if s.isChaining {
@@ -246,7 +242,7 @@ func (s *CNIServer) decodingFailureResponse(what string) *cnipb.CniCmdResponse {
 
 func (s *CNIServer) incompatibleCniVersionResponse(cniVersion string) *cnipb.CniCmdResponse {
 	cniErrorCode := cnipb.ErrorCode_INCOMPATIBLE_CNI_VERSION
-	cniErrorMsg := fmt.Sprintf("Unsupported CNI version [%s], supported versions [%s]", cniVersion, supportedCNIVersions)
+	cniErrorMsg := fmt.Sprintf("Unsupported CNI version [%s], supported versions %s", cniVersion, version.All.SupportedVersions())
 	return s.generateCNIErrorResponse(cniErrorCode, cniErrorMsg)
 }
 
@@ -293,9 +289,9 @@ func (s *CNIServer) invalidNetworkConfigResponse(msg string) *cnipb.CniCmdRespon
 	)
 }
 
-func buildVersionSet(versions string) map[string]bool {
+func buildVersionSet() map[string]bool {
 	versionSet := make(map[string]bool)
-	for _, ver := range strings.Split(versions, ",") {
+	for _, ver := range version.All.SupportedVersions() {
 		versionSet[strings.Trim(ver, " ")] = true
 	}
 	return versionSet
@@ -625,5 +621,5 @@ func (s *CNIServer) reconcile() error {
 }
 
 func init() {
-	supportedCNIVersionSet = buildVersionSet(supportedCNIVersions)
+	supportedCNIVersionSet = buildVersionSet()
 }

--- a/pkg/agent/cniserver/server_test.go
+++ b/pkg/agent/cniserver/server_test.go
@@ -494,14 +494,13 @@ func translateRawPrevResult(prevResult *current.Result, cniVersion string) (map[
 }
 
 func newCNIServer(t *testing.T) *CNIServer {
-	supportedVersions := "0.3.0,0.3.1,0.4.0"
 	cniServer := &CNIServer{
 		cniSocket:       testSocket,
 		nodeConfig:      testNodeConfig,
 		serverVersion:   cni.AntreaCNIVersion,
 		containerAccess: newContainerAccessArbitrator(),
 	}
-	cniServer.supportedCNIVersions = buildVersionSet(supportedVersions)
+	cniServer.supportedCNIVersions = buildVersionSet()
 	return cniServer
 }
 


### PR DESCRIPTION
This patch update the antrea cni to get the supported version
for the cni pkg. It also update the host-local plugin in the Ubunut
image with version that support cni spec 0.4.0