### PR TITLE
Support running integration tests on macOS

### DIFF
--- a/test/integration/ovs/openflow_test_utils.go
+++ b/test/integration/ovs/openflow_test_utils.go
@@ -25,7 +25,10 @@ import (
 )
 
 func PrepareOVSBridge(brName string) error {
-	cmdStr := fmt.Sprintf("ovs-vsctl --may-exist add-br %s -- set Bridge %s protocols='OpenFlow10,OpenFlow13'", brName, brName)
+	// using the netdev datapath type does not impact test coverage but
+	// ensures that the integration tests can be run with Docker Desktop on
+	// macOS.
+	cmdStr := fmt.Sprintf("ovs-vsctl --may-exist add-br %s -- set Bridge %s protocols='OpenFlow10,OpenFlow13' datapath_type=netdev", brName, brName)
 	err := exec.Command("/bin/sh", "-c", cmdStr).Run()
 	if err != nil {
 		return err

--- a/test/integration/ovs/ovs_client_test.go
+++ b/test/integration/ovs/ovs_client_test.go
@@ -59,7 +59,10 @@ func (data *testData) setup(t *testing.T) {
 		t.Fatalf("Could not establish connection to %s after %s", UDSAddress, defaultConnectTimeout)
 	}
 
-	data.br = ovsconfig.NewOVSBridge(bridgeName, "system", data.ovsdb)
+	// using the netdev datapath type does not impact test coverage but
+	// ensures that the integration tests can be run with Docker Desktop on
+	// macOS.
+	data.br = ovsconfig.NewOVSBridge(bridgeName, "netdev", data.ovsdb)
 	err = data.br.Create()
 	require.Nil(t, err, "Failed to create bridge %s", bridgeName)
 }


### PR DESCRIPTION
Since `make docker-test-integration` runs the integration tests in a
Docker image, it is reasonnable to expect that one may be able to run
these tests on macOS (Docker Desktop). This required the following 2
changes:

 * OVS bridges should use the netdev datpath type, since the kernel
   datapath does not seem to be available in the KyperKit VM.
 * The HyperKit VM seems to enable ipip, which means that some extra
   tunnel interfaces are created in the network namepsaces that our
   tests create inside the Docker container. As a result our CNI
   integration tests need to be "relaxed" to accomodate for these.

Fixes #783