### PR TITLE
[Windows] Support OVS commands in antctl

### DIFF
--- a/pkg/ovs/ovsctl/ofctl.go
+++ b/pkg/ovs/ovsctl/ofctl.go
@@ -17,7 +17,6 @@ package ovsctl
 import (
 	"bufio"
 	"fmt"
-	"os/exec"
 	"strings"
 )
 
@@ -91,7 +90,7 @@ func (c *ovsCtlClient) DumpGroups(args ...string) ([][]string, error) {
 func (c *ovsCtlClient) RunOfctlCmd(cmd string, args ...string) ([]byte, error) {
 	cmdStr := fmt.Sprintf("ovs-ofctl -O Openflow13 %s %s", cmd, c.bridge)
 	cmdStr = cmdStr + " " + strings.Join(args, " ")
-	out, err := exec.Command("/bin/sh", "-c", cmdStr).Output()
+	out, err := getOVSCommand(cmdStr).Output()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ovs/ovsctl/ovsctl_others.go
+++ b/pkg/ovs/ovsctl/ovsctl_others.go
@@ -1,0 +1,26 @@
+// +build linux darwin
+
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovsctl
+
+import "os/exec"
+
+// File path of the ovs-vswitchd control UNIX domain socket.
+const ovsVSwitchdUDS = "/var/run/openvswitch/ovs-vswitchd.*.ctl"
+
+func getOVSCommand(cmdStr string) *exec.Cmd {
+	return exec.Command("/bin/sh", "-c", cmdStr)
+}

--- a/pkg/ovs/ovsctl/ovsctl_windows.go
+++ b/pkg/ovs/ovsctl/ovsctl_windows.go
@@ -1,0 +1,26 @@
+// +build windows
+
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovsctl
+
+import "os/exec"
+
+// File path of the ovs-vswitchd control named pipe.
+const ovsVSwitchdUDS = "c:/openvswitch/var/run/openvswitch/ovs-vswitchd.ctl"
+
+func getOVSCommand(cmdStr string) *exec.Cmd {
+	return exec.Command("cmd.exe", "/c", cmdStr)
+}


### PR DESCRIPTION
Use "cmd.exe" on Windows when executing OVS commands.
Use the named pipe file for ovs-vswitchd control socket in ovs-appctl command.