### PR TITLE
Fix kubeconfig not found issue for jenkins gc job.

### DIFF
--- a/ci/jenkins/jobs/job-templates.yaml
+++ b/ci/jenkins/jobs/job-templates.yaml
@@ -101,6 +101,7 @@
 
 - job-template:
     name: '{name}-{test_name}-for-period'
+    node: '{node}'
     block-downstream: false
     block-upstream: false
     builders: '{builders}'
@@ -129,6 +130,7 @@
 
 - job-template:
     name: '{name}-{test_name}-for-gc'
+    node: '{node}'
     builders: '{builders}'
     description: '{description}'
     properties:

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -7,6 +7,7 @@
     jobs:
       - '{name}-{test_name}-for-period':
           test_name: job-updater
+          node: 'antrea-test-node'
           description: 'This is for updating all antrea jobs.'
           builders:
             - builder-job-updater
@@ -18,6 +19,7 @@
           ignore_post_commit_hooks: false
       - '{name}-{test_name}-for-gc':
           test_name: workload-cluster
+          node: 'antrea-test-node'
           description: 'This is for deleting useless workload clusters.'
           builders:
             - builder-workload-cluster-gc


### PR DESCRIPTION
Jenkins gc job must run on the same node like e2e, conformance jobs, so it can find the same kubeconfig. This also applies to job-updater job.