### PR TITLE
Add Github workflow for issue / PR lifecycle management

### DIFF
--- a/.github/workflows/lifecycle_management.yml
+++ b/.github/workflows/lifecycle_management.yml
@@ -1,0 +1,31 @@
+name: "Issues and PRs lifecycle management"
+on:
+  schedule:
+    # every day at midnight
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    if: github.repository == 'vmware-tanzu/antrea'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment, or this will be closed in 180 days'
+          stale-pr-message: 'This PR is stale because it has been open 180 days with no activity. Remove stale label or comment, or this will be closed in 180 days'
+          stale-issue-label: 'lifecycle/stale'
+          stale-pr-label: 'lifecycle/stale'
+          days-before-stale: 180
+          days-before-close: 180
+          exempt-issue-labels: 'lifecycle/frozen'
+          exempt-pr-labels: 'lifecycle/frozen'
+          remove-stale-when-updated: true
+          debug-only: false
+  skip:
+    if: github.repository != 'vmware-tanzu/antrea'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip
+        run: |
+          echo "Skipping lifecyle management because workflow cannot be run from fork"

--- a/docs/github-labels.md
+++ b/docs/github-labels.md
@@ -78,7 +78,6 @@ https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md.
 | kind/support                       | Categorizes issue or PR as related to a support question. | Any |
 | lifecycle/active                   | Indicates that an issue or PR is actively being worked on by a contributor. | Any |
 | lifecycle/frozen                   | Indicates that an issue or PR should not be auto-closed due to staleness. | Any |
-| lifecycle/rotten                   | Denotes an issue or PR that has aged beyond stale and will be auto-closed. | Any |
 | lifecycle/stale                    | Denotes an issue or PR has remained open with no activity and has become stale. | Any |
 | priority/awaiting-more-evidence    | Lowest priority. Possibly useful, but not yet enough support to actually get it done. | Any |
 | priority/backlog                   | Higher priority than priority/awaiting-more-evidence. | Any |

--- a/docs/issue-management.md
+++ b/docs/issue-management.md
@@ -358,19 +358,15 @@ To track the state of an issue, the following labels will be assigned.
 
 * `lifecycle/active` -- indicates that an issue or PR is actively being worked on by a contributor
 * `lifecycle/frozen` -- indicates that an issue or PR should not be auto-closed due to staleness
-* `lifecycle/rotten` -- denotes an issue or PR that has aged beyond stale and will be auto-closed
 * `lifecycle/stale` -- denotes an issue or PR has remained open with no activity and has become stale
 
 The following schedule will be used to determine an issue's lifecycle:
 
-* after 90 days of inactivity, an issue will be automatically marked as `lifecycle/stale`
-* after 180 days of inactivity, an issue will be automatically marked as
-  `lifecycle/rotten` and can then be scheduled for auto closure
+* after 180 days of inactivity, an issue will be automatically marked as `lifecycle/stale`
+* after an extra 180 days of inactivity, an issue will be automatically closed
 * any issue marked as `lifecycle/frozen` will prevent automatic transitions to
-  stale or rotten state.
-* an issue marked as `lifecycle/active` adds an additional 30 days to the
-  scheduled stale and rotten transitions above. If no activity is present, the
-  issue can be automatically closed.
+  stale and prevent auto-closure
+* commenting on an issue will remove the `lifecycle/stale` label
 
 Issue lifecycle management ensures that the project backlog remains fresh and
 relevant. Project maintainers and contributors will need to revisit issues to


### PR DESCRIPTION
We use the stale action (https://github.com/actions/stale) to take care
of issue / PR state transitions and labelling.

The action is not quite as configurable as what we had in mind when we
wrote the issue management document, so we got rid of the
`lifecycle/rotten` label. But this label was only used to indicate that
the issue was being automatically closed.

Since we do not have a very high volume of new issues at this time, or a
very large backlog, I chose some more conservative time intervals for
transitions (issue becomes stale after 180 days, and is closed after an
extra 180 days of inactivity). These can be tuned in the future.