### PR TITLE
Make antrea-agent tolerant of NoExecute taints

### DIFF
--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -727,6 +727,8 @@ spec:
         operator: Exists
       - effect: NoSchedule
         operator: Exists
+      - effect: NoExecute
+        operator: Exists
       volumes:
       - configMap:
           name: antrea-config-hmd2mdhg89

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -725,6 +725,8 @@ spec:
         operator: Exists
       - effect: NoSchedule
         operator: Exists
+      - effect: NoExecute
+        operator: Exists
       volumes:
       - configMap:
           name: antrea-config-ff5ff2btgc

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -769,6 +769,8 @@ spec:
         operator: Exists
       - effect: NoSchedule
         operator: Exists
+      - effect: NoExecute
+        operator: Exists
       volumes:
       - configMap:
           name: antrea-config-fggkd66d2h

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -725,6 +725,8 @@ spec:
         operator: Exists
       - effect: NoSchedule
         operator: Exists
+      - effect: NoExecute
+        operator: Exists
       volumes:
       - configMap:
           name: antrea-config-mf4t8c67c8

--- a/build/yamls/base/agent.yml
+++ b/build/yamls/base/agent.yml
@@ -25,6 +25,9 @@ spec:
         # Make sure it gets scheduled on all nodes.
         - effect: NoSchedule
           operator: Exists
+        # Make sure it doesn't get evicted.
+        - effect: NoExecute
+          operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: antrea-agent


### PR DESCRIPTION
As a node-critical Pod, antrea-agent should be tolerant of all NoExecute
taints regardless of their keys like kube-proxy and other CNIs do,
otherwise workload Pods' network won't work once antrea-agent is evicted.

Fixes #814