### PR TITLE
Add workaround for Agent readiness probe issue in Kind clusters

### DIFF
--- a/build/yamls/patches/kind/startAgent.yml
+++ b/build/yamls/patches/kind/startAgent.yml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: antrea-agent
+spec:
+  template:
+    spec:
+      containers:
+      - name: antrea-agent
+        command: ["/bin/sh"]
+        args: ["-c", "sleep 2; exec antrea-agent --config /etc/antrea/antrea-agent.conf"]

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -235,9 +235,13 @@ if $KIND; then
 
     # add tun device to antrea OVS container
     $KUSTOMIZE edit add patch tunDevice.yml
-    # antrea-ovs should use start_ovs_netdev instead of start_ovs to ensure that the br_phy bridge
+    # antrea-ovs should use start_ovs_netdev instead of start_ovs to ensure that the br-phy bridge
     # is created.
     $KUSTOMIZE edit add patch startOvs.yml
+    # this adds a small delay before running the antrea-agent process, to give the antrea-ovs
+    # container enough time to set up the br-phy bridge.
+    # workaround for https://github.com/vmware-tanzu/antrea/issues/801
+    $KUSTOMIZE edit add patch startAgent.yml
     # change initContainer script and remove SYS_MODULE capability
     $KUSTOMIZE edit add patch installCni.yml
 


### PR DESCRIPTION
When deploying Antrea in Kind clusters, we sometimes observe that the
antrea-agent container does not become ready for a few minutes. This
seems to happen specifically when the antrea-agent starts and
establishes connections to the k8s apiserver or the Antrea Controller
before the br-phy bridge has been created. When this happens, the
creation of the br-phy bridge seems to break the existing connections,
and the container is eventually re-started after the TCP keepalive
timeout (~5 minutes with the Go HTTP library), which fixes the
issue. However, by this time, a few e2e tests have timed out and failed.

This workaround adds a small sleep (2 seconds) before starting the
antrea-agent process, which ensures that the antrea-ovs container has
enough time to create the br-phy bridge.

Fixes #801