### PR TITLE
Fix statefulset Pod recreate case

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -89,13 +89,13 @@ func TestInitstore(t *testing.T) {
 	if store.Len() != 2 {
 		t.Errorf("Failed to load OVS port in store")
 	}
-	container1, found1 := store.GetContainerInterface("pod1", "ns1")
+	container1, found1 := store.GetContainerInterface(uuid1)
 	if !found1 {
 		t.Errorf("Failed to load OVS port into local store")
 	} else if container1.OFPort != 1 || container1.IP.String() != p1IP || container1.MAC.String() != p1MAC || container1.InterfaceName != "p1" {
 		t.Errorf("Failed to load OVS port configuration into local store")
 	}
-	_, found2 := store.GetContainerInterface("pod2", "ns2")
+	_, found2 := store.GetContainerInterface(uuid2)
 	if !found2 {
 		t.Errorf("Failed to load OVS port into local store")
 	}

--- a/pkg/agent/apiserver/handlers/networkpolicy/handler.go
+++ b/pkg/agent/apiserver/handlers/networkpolicy/handler.go
@@ -46,8 +46,8 @@ func HandleFunc(aq querier.AgentQuerier) http.HandlerFunc {
 			}
 		} else if pod != "" {
 			// Query NetworkPolicies applied to the Pod
-			_, ok := aq.GetInterfaceStore().GetContainerInterface(pod, ns)
-			if ok {
+			interfaces := aq.GetInterfaceStore().GetContainerInterfacesByPod(pod, ns)
+			if len(interfaces) > 0 {
 				nps := npq.GetAppliedNetworkPolicies(pod, ns)
 				obj = networkingv1beta1.NetworkPolicyList{Items: nps}
 			}

--- a/pkg/agent/apiserver/handlers/ovsflows/handler.go
+++ b/pkg/agent/apiserver/handlers/ovsflows/handler.go
@@ -86,12 +86,12 @@ func getTableFlows(aq querier.AgentQuerier, table string) ([]Response, error) {
 }
 
 func getPodFlows(aq querier.AgentQuerier, podName, namespace string) ([]Response, error) {
-	intf, ok := aq.GetInterfaceStore().GetContainerInterface(podName, namespace)
-	if !ok {
+	interfaces := aq.GetInterfaceStore().GetContainerInterfacesByPod(podName, namespace)
+	if len(interfaces) == 0 {
 		return nil, nil
 	}
 
-	flowKeys := aq.GetOpenflowClient().GetPodFlowKeys(intf.InterfaceName)
+	flowKeys := aq.GetOpenflowClient().GetPodFlowKeys(interfaces[0].InterfaceName)
 	return dumpMatchedFlows(aq, flowKeys)
 
 }

--- a/pkg/agent/apiserver/handlers/ovsflows/handler_test.go
+++ b/pkg/agent/apiserver/handlers/ovsflows/handler_test.go
@@ -101,7 +101,7 @@ func TestPodFlows(t *testing.T) {
 		if tc.expectedStatus != http.StatusNotFound {
 			ofc := oftest.NewMockClient(ctrl)
 			ovsctl := ovsctltest.NewMockOVSCtlClient(ctrl)
-			i.EXPECT().GetContainerInterface(tc.name, tc.namespace).Return(testInterface, true).Times(1)
+			i.EXPECT().GetContainerInterfacesByPod(tc.name, tc.namespace).Return([]*interfacestore.InterfaceConfig{testInterface}).Times(1)
 			ofc.EXPECT().GetPodFlowKeys(testInterface.InterfaceName).Return(testFlowKeys).Times(1)
 			q.EXPECT().GetOpenflowClient().Return(ofc).Times(1)
 			q.EXPECT().GetOVSCtlClient().Return(ovsctl).Times(len(testFlowKeys))
@@ -109,7 +109,7 @@ func TestPodFlows(t *testing.T) {
 				ovsctl.EXPECT().DumpMatchedFlow(testFlowKeys[i]).Return(testDumpResults[i], nil).Times(1)
 			}
 		} else {
-			i.EXPECT().GetContainerInterface(tc.name, tc.namespace).Return(nil, false).Times(1)
+			i.EXPECT().GetContainerInterfacesByPod(tc.name, tc.namespace).Return(nil).Times(1)
 		}
 
 		runHTTPTest(t, &tc, q)

--- a/pkg/agent/apiserver/handlers/ovstracing/handler_test.go
+++ b/pkg/agent/apiserver/handlers/ovstracing/handler_test.go
@@ -185,7 +185,7 @@ func TestPodFlows(t *testing.T) {
 		if tc.expectedStatus == http.StatusNotFound {
 			q.EXPECT().GetInterfaceStore().Return(i).Times(1)
 			if tc.port == "pod" {
-				i.EXPECT().GetContainerInterface("inPod", "inNS").Return(nil, false).Times(1)
+				i.EXPECT().GetContainerInterfacesByPod("inPod", "inNS").Return(nil).Times(1)
 			} else {
 				i.EXPECT().GetInterfaceByName(tc.port).Return(nil, false).Times(1)
 			}
@@ -201,12 +201,12 @@ func TestPodFlows(t *testing.T) {
 				q.EXPECT().GetOpenflowClient().Return(ofc).Times(1)
 				ofc.EXPECT().GetTunnelVirtualMAC().Return(tunnelVirtualMAC).Times(1)
 			} else if tc.port == "pod" {
-				i.EXPECT().GetContainerInterface("inPod", "inNS").Return(inPodInterface, true).Times(1)
+				i.EXPECT().GetContainerInterfacesByPod("inPod", "inNS").Return([]*interfacestore.InterfaceConfig{inPodInterface}).Times(1)
 			} else if tc.port != "" {
 				i.EXPECT().GetInterfaceByName(tc.port).Return(inPodInterface, true).Times(1)
 			}
-			i.EXPECT().GetContainerInterface("srcPod", "srcNS").Return(srcPodInterface, true).MaxTimes(1)
-			i.EXPECT().GetContainerInterface("dstPod", "dstNS").Return(dstPodInterface, true).MaxTimes(1)
+			i.EXPECT().GetContainerInterfacesByPod("srcPod", "srcNS").Return([]*interfacestore.InterfaceConfig{srcPodInterface}).MaxTimes(1)
+			i.EXPECT().GetContainerInterfacesByPod("dstPod", "dstNS").Return([]*interfacestore.InterfaceConfig{dstPodInterface}).MaxTimes(1)
 
 			if tc.expectedStatus == http.StatusBadRequest {
 				// "ovs-appctl" won't be executed. OVSCtlClient.Trace() will just

--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -320,8 +320,6 @@ func (s *CNIServer) parsePrevResultFromRequest(networkConfig *NetworkConfig) (*c
 func (s *CNIServer) validatePrevResult(cfgArgs *cnipb.CniCmdArgs, k8sCNIArgs *k8sArgs, prevResult *current.Result) (*cnipb.CniCmdResponse, error) {
 	containerID := cfgArgs.ContainerId
 	netNS := s.hostNetNsPath(cfgArgs.Netns)
-	podName := string(k8sCNIArgs.K8S_POD_NAME)
-	podNamespace := string(k8sCNIArgs.K8S_POD_NAMESPACE)
 
 	// Find interfaces from previous configuration
 	containerIntf := parseContainerIfaceFromResults(cfgArgs, prevResult)
@@ -333,8 +331,6 @@ func (s *CNIServer) validatePrevResult(cfgArgs *cnipb.CniCmdArgs, k8sCNIArgs *k8
 	if err := s.podConfigurator.checkInterfaces(
 		containerID,
 		netNS,
-		podName,
-		podNamespace,
 		containerIntf,
 		prevResult); err != nil {
 		return s.checkInterfaceFailureResponse(err), nil
@@ -370,8 +366,9 @@ func (s *CNIServer) CmdAdd(ctx context.Context, request *cnipb.CniCmdRequest) (*
 		}
 	}()
 
-	s.containerAccess.lockContainer(cniConfig.getContainerKey())
-	defer s.containerAccess.unlockContainer(cniConfig.getContainerKey())
+	infraContainer := cniConfig.getInfraContainer()
+	s.containerAccess.lockContainer(infraContainer)
+	defer s.containerAccess.unlockContainer(infraContainer)
 
 	if s.isChaining {
 		resp, err := s.interceptAdd(cniConfig)
@@ -381,18 +378,17 @@ func (s *CNIServer) CmdAdd(ctx context.Context, request *cnipb.CniCmdRequest) (*
 		return resp, err
 	}
 
-	podKey := util.GenerateContainerInterfaceName(string(cniConfig.K8S_POD_NAME), string(cniConfig.K8S_POD_NAMESPACE))
 	var ipamResult *current.Result
 	var err error
 	// Only allocate IP when handling CNI request from infra container.
 	// On windows platform, CNI plugin is called for all containers in a Pod.
 	if !isInfraContainer {
-		if ipamResult, _ = ipam.GetIPFromCache(podKey); ipamResult == nil {
+		if ipamResult, _ = ipam.GetIPFromCache(infraContainer); ipamResult == nil {
 			return nil, fmt.Errorf("allocated IP address not found")
 		}
 	} else {
 		// Request IP Address from IPAM driver.
-		ipamResult, err = ipam.ExecIPAMAdd(cniConfig.CniCmdArgs, cniConfig.IPAM.Type, podKey)
+		ipamResult, err = ipam.ExecIPAMAdd(cniConfig.CniCmdArgs, cniConfig.IPAM.Type, infraContainer)
 		if err != nil {
 			klog.Errorf("Failed to add IP addresses from IPAM driver: %v", err)
 			return s.ipamFailureResponse(err), nil
@@ -441,23 +437,21 @@ func (s *CNIServer) CmdDel(_ context.Context, request *cnipb.CniCmdRequest) (
 		return response, nil
 	}
 
-	s.containerAccess.lockContainer(cniConfig.getContainerKey())
-	defer s.containerAccess.unlockContainer(cniConfig.getContainerKey())
+	infraContainer := cniConfig.getInfraContainer()
+	s.containerAccess.lockContainer(infraContainer)
+	defer s.containerAccess.unlockContainer(infraContainer)
 
 	if s.isChaining {
 		return s.interceptDel(cniConfig)
 	}
-	podKey := util.GenerateContainerInterfaceName(string(cniConfig.K8S_POD_NAME), string(cniConfig.K8S_POD_NAMESPACE))
 	// Release IP to IPAM driver
-	if err := ipam.ExecIPAMDelete(cniConfig.CniCmdArgs, cniConfig.IPAM.Type, podKey); err != nil {
+	if err := ipam.ExecIPAMDelete(cniConfig.CniCmdArgs, cniConfig.IPAM.Type, infraContainer); err != nil {
 		klog.Errorf("Failed to delete IP addresses by IPAM driver: %v", err)
 		return s.ipamFailureResponse(err), nil
 	}
 	klog.Info("Deleted IP addresses by IPAM driver")
 	// Remove host interface and OVS configuration
-	podName := string(cniConfig.K8S_POD_NAME)
-	podNamespace := string(cniConfig.K8S_POD_NAMESPACE)
-	if err := s.podConfigurator.removeInterfaces(podName, podNamespace, cniConfig.ContainerId); err != nil {
+	if err := s.podConfigurator.removeInterfaces(cniConfig.ContainerId); err != nil {
 		klog.Errorf("Failed to remove interfaces for container %s: %v", cniConfig.ContainerId, err)
 		return s.configInterfaceFailureResponse(err), nil
 	}
@@ -473,8 +467,9 @@ func (s *CNIServer) CmdCheck(_ context.Context, request *cnipb.CniCmdRequest) (
 		return response, nil
 	}
 
-	s.containerAccess.lockContainer(cniConfig.getContainerKey())
-	defer s.containerAccess.unlockContainer(cniConfig.getContainerKey())
+	infraContainer := cniConfig.getInfraContainer()
+	s.containerAccess.lockContainer(infraContainer)
+	defer s.containerAccess.unlockContainer(infraContainer)
 
 	if s.isChaining {
 		return s.interceptCheck(cniConfig)
@@ -495,11 +490,6 @@ func (s *CNIServer) CmdCheck(_ context.Context, request *cnipb.CniCmdRequest) (
 	}
 	klog.Info("Succeed to check network configuration")
 	return &cnipb.CniCmdResponse{CniResult: []byte("")}, nil
-}
-
-// getContainerKey returns the key of a Pod, which is a string with format "$K8S_POD_NAMESPACE/$K8S_POD_NAME".
-func (c *CNIConfig) getContainerKey() string {
-	return fmt.Sprintf("%s/%s", string(c.K8S_POD_NAMESPACE), string(c.K8S_POD_NAME))
 }
 
 func New(

--- a/pkg/agent/cniserver/server_linux.go
+++ b/pkg/agent/cniserver/server_linux.go
@@ -36,3 +36,9 @@ func (s *CNIServer) hostNetNsPath(netNS string) string {
 func isInfraContainer(netNS string) bool {
 	return true
 }
+
+// getInfraContainer returns the sandbox container ID of a Pod.
+// On Linux, it's always the ContainerID in the request.
+func (c *CNIConfig) getInfraContainer() string {
+	return c.ContainerId
+}

--- a/pkg/agent/cniserver/server_windows.go
+++ b/pkg/agent/cniserver/server_windows.go
@@ -17,6 +17,8 @@
 package cniserver
 
 import (
+	"strings"
+
 	"github.com/containernetworking/cni/pkg/types/current"
 	"k8s.io/klog"
 )
@@ -48,4 +50,29 @@ func (s *CNIServer) hostNetNsPath(netNS string) string {
 // On Windows platform, the network namespace of infra container is "none".
 func isInfraContainer(netNS string) bool {
 	return netNS == infraContainerNetNS
+}
+
+func getInfraContainer(containerID, netNS string) string {
+	if isInfraContainer(netNS) {
+		return containerID
+	}
+	parts := strings.Split(netNS, ":")
+	if len(parts) != 2 {
+		klog.Errorf("Cannot get infra container ID, unexpected netNS: %v, fallback to containerID", netNS)
+		return containerID
+	}
+	return strings.TrimSpace(parts[1])
+}
+
+// getInfraContainer returns the infra (sandbox) container ID of a Pod.
+// On Windows, kubelet sends two kinds of CNI ADD requests for each Pod:
+// 1. <container_id:"067e66fa59ade9c36552aeedac4f1420fe8efe0d2a4061ecdac45f67c5ef035c" netns:"none" ifname:"eth0"
+// args:"IgnoreUnknown=1;K8S_POD_NAMESPACE=default;K8S_POD_NAME=win-webserver-6c7bdbf9fc-lswt2;K8S_POD_INFRA_CONTAINER_ID=067e66fa59ade9c36552aeedac4f1420fe8efe0d2a4061ecdac45f67c5ef035c" >
+// 2. <container_id:"0cd7ab3df88aa15f6a9b7f5fc2008ef4cb5740e9ded8ede3633dca7344fd58ca" netns:"container:067e66fa59ade9c36552aeedac4f1420fe8efe0d2a4061ecdac45f67c5ef035c" ifname:"eth0"
+// args:"IgnoreUnknown=1;K8S_POD_NAMESPACE=default;K8S_POD_NAME=win-webserver-6c7bdbf9fc-lswt2;K8S_POD_INFRA_CONTAINER_ID=0cd7ab3df88aa15f6a9b7f5fc2008ef4cb5740e9ded8ede3633dca7344fd58ca" >
+//
+// The first request uses infra container ID as "container_id", while subsequent requests use workload container ID as
+// "container_id" and have infra container ID in "netns" in the form of "container:<INFRA CONTAINER ID>".
+func (c *CNIConfig) getInfraContainer() string {
+	return getInfraContainer(c.ContainerId, c.Netns)
 }

--- a/pkg/agent/controller/networkpolicy/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/reconciler.go
@@ -452,14 +452,16 @@ func (r *reconciler) Forget(ruleID string) error {
 func (r *reconciler) getPodOFPorts(pods v1beta1.GroupMemberPodSet) sets.Int32 {
 	ofPorts := sets.NewInt32()
 	for _, pod := range pods {
-		iface, found := r.ifaceStore.GetContainerInterface(pod.Pod.Name, pod.Pod.Namespace)
-		if !found {
+		ifaces := r.ifaceStore.GetContainerInterfacesByPod(pod.Pod.Name, pod.Pod.Namespace)
+		if len(ifaces) == 0 {
 			// This might be because the container has been deleted during realization or hasn't been set up yet.
 			klog.Infof("Can't find interface for Pod %s/%s, skipping", pod.Pod.Namespace, pod.Pod.Name)
 			continue
 		}
-		klog.V(2).Infof("Got OFPort %v for Pod %s/%s", iface.OFPort, pod.Pod.Namespace, pod.Pod.Name)
-		ofPorts.Insert(iface.OFPort)
+		for _, iface := range ifaces {
+			klog.V(2).Infof("Got OFPort %v for Pod %s/%s", iface.OFPort, pod.Pod.Namespace, pod.Pod.Name)
+			ofPorts.Insert(iface.OFPort)
+		}
 	}
 	return ofPorts
 }
@@ -467,14 +469,16 @@ func (r *reconciler) getPodOFPorts(pods v1beta1.GroupMemberPodSet) sets.Int32 {
 func (r *reconciler) getPodIPs(pods v1beta1.GroupMemberPodSet) sets.String {
 	ips := sets.NewString()
 	for _, pod := range pods {
-		iface, found := r.ifaceStore.GetContainerInterface(pod.Pod.Name, pod.Pod.Namespace)
-		if !found {
+		ifaces := r.ifaceStore.GetContainerInterfacesByPod(pod.Pod.Name, pod.Pod.Namespace)
+		if len(ifaces) == 0 {
 			// This might be because the container has been deleted during realization or hasn't been set up yet.
 			klog.Infof("Can't find interface for Pod %s/%s, skipping", pod.Pod.Namespace, pod.Pod.Name)
 			continue
 		}
-		klog.V(2).Infof("Got IP %v for Pod %s/%s", iface.IP, pod.Pod.Namespace, pod.Pod.Name)
-		ips.Insert(iface.IP.String())
+		for _, iface := range ifaces {
+			klog.V(2).Infof("Got IP %v for Pod %s/%s", iface.IP, pod.Pod.Namespace, pod.Pod.Name)
+			ips.Insert(iface.IP.String())
+		}
 	}
 	return ips
 }

--- a/pkg/agent/controller/networkpolicy/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/reconciler_test.go
@@ -123,15 +123,15 @@ func TestReconcilerForget(t *testing.T) {
 func TestReconcilerReconcile(t *testing.T) {
 	ifaceStore := interfacestore.NewInterfaceStore()
 	ifaceStore.AddInterface(&interfacestore.InterfaceConfig{
-		InterfaceName:            util.GenerateContainerInterfaceName("pod1", "ns1"),
+		InterfaceName:            util.GenerateContainerInterfaceName("pod1", "ns1", "container1"),
 		IP:                       net.ParseIP("2.2.2.2"),
-		ContainerInterfaceConfig: &interfacestore.ContainerInterfaceConfig{PodName: "pod1", PodNamespace: "ns1"},
+		ContainerInterfaceConfig: &interfacestore.ContainerInterfaceConfig{PodName: "pod1", PodNamespace: "ns1", ContainerID: "container1"},
 		OVSPortConfig:            &interfacestore.OVSPortConfig{OFPort: 1},
 	})
 	ifaceStore.AddInterface(&interfacestore.InterfaceConfig{
-		InterfaceName:            util.GenerateContainerInterfaceName("pod3", "ns1"),
+		InterfaceName:            util.GenerateContainerInterfaceName("pod3", "ns1", "container3"),
 		IP:                       net.ParseIP("3.3.3.3"),
-		ContainerInterfaceConfig: &interfacestore.ContainerInterfaceConfig{PodName: "pod3", PodNamespace: "ns1"},
+		ContainerInterfaceConfig: &interfacestore.ContainerInterfaceConfig{PodName: "pod3", PodNamespace: "ns1", ContainerID: "container3"},
 		OVSPortConfig:            &interfacestore.OVSPortConfig{OFPort: 3},
 	})
 	ipNet1 := newCIDR("10.10.0.0/16")
@@ -443,15 +443,15 @@ func TestReconcilerUpdate(t *testing.T) {
 	ifaceStore := interfacestore.NewInterfaceStore()
 	ifaceStore.AddInterface(
 		&interfacestore.InterfaceConfig{
-			InterfaceName:            util.GenerateContainerInterfaceName("pod1", "ns1"),
+			InterfaceName:            util.GenerateContainerInterfaceName("pod1", "ns1", "container1"),
 			IP:                       net.ParseIP("2.2.2.2"),
-			ContainerInterfaceConfig: &interfacestore.ContainerInterfaceConfig{PodName: "pod1", PodNamespace: "ns1"},
+			ContainerInterfaceConfig: &interfacestore.ContainerInterfaceConfig{PodName: "pod1", PodNamespace: "ns1", ContainerID: "container1"},
 			OVSPortConfig:            &interfacestore.OVSPortConfig{OFPort: 1}})
 	ifaceStore.AddInterface(
 		&interfacestore.InterfaceConfig{
-			InterfaceName:            util.GenerateContainerInterfaceName("pod2", "ns1"),
+			InterfaceName:            util.GenerateContainerInterfaceName("pod2", "ns1", "container2"),
 			IP:                       net.ParseIP("3.3.3.3"),
-			ContainerInterfaceConfig: &interfacestore.ContainerInterfaceConfig{PodName: "pod2", PodNamespace: "ns1"},
+			ContainerInterfaceConfig: &interfacestore.ContainerInterfaceConfig{PodName: "pod2", PodNamespace: "ns1", ContainerID: "container2"},
 			OVSPortConfig:            &interfacestore.OVSPortConfig{OFPort: 2}})
 	tests := []struct {
 		name                string

--- a/pkg/agent/interfacestore/interface_cache.go
+++ b/pkg/agent/interfacestore/interface_cache.go
@@ -17,8 +17,26 @@ package interfacestore
 import (
 	"sync"
 
+	"k8s.io/client-go/tools/cache"
+
 	"github.com/vmware-tanzu/antrea/pkg/agent/metrics"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"
+	"github.com/vmware-tanzu/antrea/pkg/k8s"
+)
+
+const (
+	// interfaceNameIndex is the index built with InterfaceConfig.InterfaceName.
+	interfaceNameIndex = "interfaceName"
+	// interfaceTypeIndex is the index built with InterfaceConfig.Type.
+	interfaceTypeIndex = "interfaceType"
+	// containerIDIndex is the index built with InterfaceConfig.ContainerID.
+	// Only container interfaces will be indexed.
+	// One containerID should get at most one interface in theory.
+	containerIDIndex = "containerID"
+	// podIndex is the index built with InterfaceConfig.PodNamespace + Podname.
+	// Only container interfaces will be indexed.
+	// One Pod may get more than one interface.
+	podIndex = "pod"
 )
 
 // Local cache for interfaces created on node, including container, host gateway, and tunnel
@@ -42,13 +60,12 @@ import (
 
 type interfaceCache struct {
 	sync.RWMutex
-	cache map[string]*InterfaceConfig
+	cache cache.Indexer
 }
 
 func (c *interfaceCache) Initialize(interfaces []*InterfaceConfig) {
 	for _, intf := range interfaces {
-		key := getInterfaceKey(intf)
-		c.cache[key] = intf
+		c.cache.Add(intf)
 		if intf.Type == ContainerInterface {
 			metrics.PodCount.Inc()
 		}
@@ -56,10 +73,12 @@ func (c *interfaceCache) Initialize(interfaces []*InterfaceConfig) {
 }
 
 // getInterfaceKey returns the key to access interfaceConfig from the cache.
-func getInterfaceKey(interfaceConfig *InterfaceConfig) string {
+// It implements cache.KeyFunc.
+func getInterfaceKey(obj interface{}) (string, error) {
+	interfaceConfig := obj.(*InterfaceConfig)
 	var key string
 	if interfaceConfig.Type == ContainerInterface {
-		key = util.GenerateContainerInterfaceKey(interfaceConfig.PodName, interfaceConfig.PodNamespace)
+		key = util.GenerateContainerInterfaceKey(interfaceConfig.ContainerID)
 	} else if interfaceConfig.Type == TunnelInterface && interfaceConfig.NodeName != "" {
 		// Tunnel interface for a Node.
 		key = util.GenerateNodeTunnelInterfaceKey(interfaceConfig.NodeName)
@@ -67,15 +86,14 @@ func getInterfaceKey(interfaceConfig *InterfaceConfig) string {
 		// Use the interface name as the key by default.
 		key = interfaceConfig.InterfaceName
 	}
-	return key
+	return key, nil
 }
 
 // AddInterface adds interfaceConfig into local cache.
 func (c *interfaceCache) AddInterface(interfaceConfig *InterfaceConfig) {
-	key := getInterfaceKey(interfaceConfig)
 	c.Lock()
 	defer c.Unlock()
-	c.cache[key] = interfaceConfig
+	c.cache.Add(interfaceConfig)
 	if interfaceConfig.Type == ContainerInterface {
 		metrics.PodCount.Inc()
 	}
@@ -83,10 +101,9 @@ func (c *interfaceCache) AddInterface(interfaceConfig *InterfaceConfig) {
 
 // DeleteInterface deletes interface from local cache.
 func (c *interfaceCache) DeleteInterface(interfaceConfig *InterfaceConfig) {
-	key := getInterfaceKey(interfaceConfig)
 	c.Lock()
 	defer c.Unlock()
-	delete(c.cache, key)
+	c.cache.Delete(interfaceConfig)
 	if interfaceConfig.Type == ContainerInterface {
 		metrics.PodCount.Dec()
 	}
@@ -96,8 +113,11 @@ func (c *interfaceCache) DeleteInterface(interfaceConfig *InterfaceConfig) {
 func (c *interfaceCache) GetInterface(interfaceKey string) (*InterfaceConfig, bool) {
 	c.RLock()
 	defer c.RUnlock()
-	iface, found := c.cache[interfaceKey]
-	return iface, found
+	iface, found, _ := c.cache.GetByKey(interfaceKey)
+	if !found {
+		return nil, false
+	}
+	return iface.(*InterfaceConfig), found
 }
 
 // GetInterfaceByName retrieves interface from local cache given the interface
@@ -105,34 +125,27 @@ func (c *interfaceCache) GetInterface(interfaceKey string) (*InterfaceConfig, bo
 func (c *interfaceCache) GetInterfaceByName(interfaceName string) (*InterfaceConfig, bool) {
 	c.RLock()
 	defer c.RUnlock()
-	for _, v := range c.cache {
-		if v.InterfaceName == interfaceName {
-			return v, true
-		}
+	interfaceConfigs, _ := c.cache.ByIndex(interfaceNameIndex, interfaceName)
+	if len(interfaceConfigs) == 0 {
+		return nil, false
 	}
-	return nil, false
+	return interfaceConfigs[0].(*InterfaceConfig), true
 }
 
 func (c *interfaceCache) GetContainerInterfaceNum() int {
-	num := 0
 	c.RLock()
 	defer c.RUnlock()
-	for _, v := range c.cache {
-		if v.Type == ContainerInterface {
-			num++
-		}
-	}
-	return num
+	keys, _ := c.cache.IndexKeys(interfaceTypeIndex, ContainerInterface.String())
+	return len(keys)
 }
 
 func (c *interfaceCache) GetInterfacesByType(interfaceType InterfaceType) []*InterfaceConfig {
 	c.RLock()
 	defer c.RUnlock()
-	var interfaces []*InterfaceConfig
-	for _, v := range c.cache {
-		if v.Type == interfaceType {
-			interfaces = append(interfaces, v)
-		}
+	objs, _ := c.cache.ByIndex(interfaceTypeIndex, interfaceType.String())
+	interfaces := make([]*InterfaceConfig, len(objs))
+	for i := range objs {
+		interfaces[i] = objs[i].(*InterfaceConfig)
 	}
 	return interfaces
 }
@@ -140,39 +153,40 @@ func (c *interfaceCache) GetInterfacesByType(interfaceType InterfaceType) []*Int
 func (c *interfaceCache) Len() int {
 	c.RLock()
 	defer c.RUnlock()
-	return len(c.cache)
-}
-
-func (c *interfaceCache) GetInterfaceKeys() []string {
-	c.RLock()
-	defer c.RUnlock()
-	keys := make([]string, 0, len(c.cache))
-	for key := range c.cache {
-		keys = append(keys, key)
-	}
-	return keys
+	return len(c.cache.ListKeys())
 }
 
 func (c *interfaceCache) GetInterfaceKeysByType(interfaceType InterfaceType) []string {
 	c.RLock()
 	defer c.RUnlock()
-	keys := make([]string, 0, len(c.cache))
-	for key, v := range c.cache {
-		if v.Type != interfaceType {
-			continue
-		}
-		keys = append(keys, key)
-	}
+	keys, _ := c.cache.IndexKeys(interfaceTypeIndex, interfaceType.String())
 	return keys
 }
 
-// GetPodInterface retrieves InterfaceConfig for the Pod.
-func (c *interfaceCache) GetContainerInterface(podName string, podNamespace string) (*InterfaceConfig, bool) {
-	key := util.GenerateContainerInterfaceKey(podName, podNamespace)
+// GetContainerInterface retrieves InterfaceConfig by the given container ID.
+func (c *interfaceCache) GetContainerInterface(containerID string) (*InterfaceConfig, bool) {
 	c.RLock()
 	defer c.RUnlock()
-	iface, ok := c.cache[key]
-	return iface, ok
+	objs, _ := c.cache.ByIndex(containerIDIndex, containerID)
+	if len(objs) == 0 {
+		return nil, false
+	}
+	return objs[0].(*InterfaceConfig), true
+}
+
+// GetContainerInterfacesByPod retrieves InterfaceConfigs for the Pod.
+// It's possible that more than one container interface (with different containerIDs) has the same Pod namespace and
+// name temporarily when the previous Pod is being deleted and the new Pod is being created almost simultaneously.
+// https://github.com/vmware-tanzu/antrea/issues/785#issuecomment-642051884
+func (c *interfaceCache) GetContainerInterfacesByPod(podName string, podNamespace string) []*InterfaceConfig {
+	c.RLock()
+	defer c.RUnlock()
+	objs, _ := c.cache.ByIndex(podIndex, k8s.NamespacedName(podNamespace, podName))
+	interfaces := make([]*InterfaceConfig, len(objs))
+	for i := range objs {
+		interfaces[i] = objs[i].(*InterfaceConfig)
+	}
+	return interfaces
 }
 
 // GetNodeTunnelInterface retrieves InterfaceConfig for the tunnel to the Node.
@@ -180,10 +194,46 @@ func (c *interfaceCache) GetNodeTunnelInterface(nodeName string) (*InterfaceConf
 	key := util.GenerateNodeTunnelInterfaceKey(nodeName)
 	c.RLock()
 	defer c.RUnlock()
-	iface, ok := c.cache[key]
-	return iface, ok
+	obj, ok, _ := c.cache.GetByKey(key)
+	if !ok {
+		return nil, false
+	}
+	return obj.(*InterfaceConfig), true
+}
+
+func interfaceNameIndexFunc(obj interface{}) ([]string, error) {
+	interfaceConfig := obj.(*InterfaceConfig)
+	return []string{interfaceConfig.InterfaceName}, nil
+}
+
+func interfaceTypeIndexFunc(obj interface{}) ([]string, error) {
+	interfaceConfig := obj.(*InterfaceConfig)
+	return []string{interfaceConfig.Type.String()}, nil
+}
+
+func containerIDIndexFunc(obj interface{}) ([]string, error) {
+	interfaceConfig := obj.(*InterfaceConfig)
+	if interfaceConfig.Type != ContainerInterface {
+		return []string{}, nil
+	}
+	return []string{interfaceConfig.ContainerID}, nil
+}
+
+func podIndexFunc(obj interface{}) ([]string, error) {
+	interfaceConfig := obj.(*InterfaceConfig)
+	if interfaceConfig.Type != ContainerInterface {
+		return []string{}, nil
+	}
+	return []string{k8s.NamespacedName(interfaceConfig.PodNamespace, interfaceConfig.PodName)}, nil
 }
 
 func NewInterfaceStore() InterfaceStore {
-	return &interfaceCache{cache: map[string]*InterfaceConfig{}}
+	return &interfaceCache{
+		cache: cache.NewIndexer(getInterfaceKey, cache.Indexers{
+			interfaceNameIndex: interfaceNameIndexFunc,
+			interfaceTypeIndex: interfaceTypeIndexFunc,
+			containerIDIndex:   containerIDIndexFunc,
+			podIndex:           podIndexFunc,
+		}),
+	}
 }

--- a/pkg/agent/interfacestore/testing/mock_interfacestore.go
+++ b/pkg/agent/interfacestore/testing/mock_interfacestore.go
@@ -73,18 +73,18 @@ func (mr *MockInterfaceStoreMockRecorder) DeleteInterface(arg0 interface{}) *gom
 }
 
 // GetContainerInterface mocks base method
-func (m *MockInterfaceStore) GetContainerInterface(arg0, arg1 string) (*interfacestore.InterfaceConfig, bool) {
+func (m *MockInterfaceStore) GetContainerInterface(arg0 string) (*interfacestore.InterfaceConfig, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetContainerInterface", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetContainerInterface", arg0)
 	ret0, _ := ret[0].(*interfacestore.InterfaceConfig)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // GetContainerInterface indicates an expected call of GetContainerInterface
-func (mr *MockInterfaceStoreMockRecorder) GetContainerInterface(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockInterfaceStoreMockRecorder) GetContainerInterface(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerInterface", reflect.TypeOf((*MockInterfaceStore)(nil).GetContainerInterface), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerInterface", reflect.TypeOf((*MockInterfaceStore)(nil).GetContainerInterface), arg0)
 }
 
 // GetContainerInterfaceNum mocks base method
@@ -99,6 +99,20 @@ func (m *MockInterfaceStore) GetContainerInterfaceNum() int {
 func (mr *MockInterfaceStoreMockRecorder) GetContainerInterfaceNum() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerInterfaceNum", reflect.TypeOf((*MockInterfaceStore)(nil).GetContainerInterfaceNum))
+}
+
+// GetContainerInterfacesByPod mocks base method
+func (m *MockInterfaceStore) GetContainerInterfacesByPod(arg0, arg1 string) []*interfacestore.InterfaceConfig {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetContainerInterfacesByPod", arg0, arg1)
+	ret0, _ := ret[0].([]*interfacestore.InterfaceConfig)
+	return ret0
+}
+
+// GetContainerInterfacesByPod indicates an expected call of GetContainerInterfacesByPod
+func (mr *MockInterfaceStoreMockRecorder) GetContainerInterfacesByPod(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerInterfacesByPod", reflect.TypeOf((*MockInterfaceStore)(nil).GetContainerInterfacesByPod), arg0, arg1)
 }
 
 // GetInterface mocks base method
@@ -129,20 +143,6 @@ func (m *MockInterfaceStore) GetInterfaceByName(arg0 string) (*interfacestore.In
 func (mr *MockInterfaceStoreMockRecorder) GetInterfaceByName(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInterfaceByName", reflect.TypeOf((*MockInterfaceStore)(nil).GetInterfaceByName), arg0)
-}
-
-// GetInterfaceKeys mocks base method
-func (m *MockInterfaceStore) GetInterfaceKeys() []string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetInterfaceKeys")
-	ret0, _ := ret[0].([]string)
-	return ret0
-}
-
-// GetInterfaceKeys indicates an expected call of GetInterfaceKeys
-func (mr *MockInterfaceStoreMockRecorder) GetInterfaceKeys() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInterfaceKeys", reflect.TypeOf((*MockInterfaceStore)(nil).GetInterfaceKeys))
 }
 
 // GetInterfaceKeysByType mocks base method

--- a/pkg/agent/interfacestore/types.go
+++ b/pkg/agent/interfacestore/types.go
@@ -16,6 +16,7 @@ package interfacestore
 
 import (
 	"net"
+	"strconv"
 
 	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 )
@@ -32,6 +33,10 @@ const (
 )
 
 type InterfaceType uint8
+
+func (t InterfaceType) String() string {
+	return strconv.Itoa(int(t))
+}
 
 type OVSPortConfig struct {
 	PortUUID string
@@ -74,12 +79,12 @@ type InterfaceStore interface {
 	DeleteInterface(interfaceConfig *InterfaceConfig)
 	GetInterface(interfaceKey string) (*InterfaceConfig, bool)
 	GetInterfaceByName(interfaceName string) (*InterfaceConfig, bool)
-	GetContainerInterface(podName string, podNamespace string) (*InterfaceConfig, bool)
+	GetContainerInterface(containerID string) (*InterfaceConfig, bool)
+	GetContainerInterfacesByPod(podName string, podNamespace string) []*InterfaceConfig
 	GetNodeTunnelInterface(nodeName string) (*InterfaceConfig, bool)
 	GetContainerInterfaceNum() int
 	GetInterfacesByType(interfaceType InterfaceType) []*InterfaceConfig
 	Len() int
-	GetInterfaceKeys() []string
 	GetInterfaceKeysByType(interfaceType InterfaceType) []string
 }
 

--- a/pkg/agent/util/net_test.go
+++ b/pkg/agent/util/net_test.go
@@ -24,7 +24,8 @@ import (
 func TestGenerateContainerInterfaceName(t *testing.T) {
 	podNamespace := "namespace1"
 	podName0 := "pod0"
-	iface0 := GenerateContainerInterfaceName(podName0, podNamespace)
+	containerID0 := "container0"
+	iface0 := GenerateContainerInterfaceName(podName0, podNamespace, containerID0)
 	if len(iface0) > interfaceNameLength {
 		t.Errorf("Failed to ensure length of interface name %s <= %d", iface0, interfaceNameLength)
 	}
@@ -32,17 +33,17 @@ func TestGenerateContainerInterfaceName(t *testing.T) {
 		t.Errorf("failed to use podName as prefix: %s", iface0)
 	}
 	podName1 := "pod1-abcde-12345"
-	iface1 := GenerateContainerInterfaceName(podName1, podNamespace)
+	iface1 := GenerateContainerInterfaceName(podName1, podNamespace, containerID0)
 	if len(iface1) != interfaceNameLength {
 		t.Errorf("Failed to ensure length of interface name as %d", interfaceNameLength)
 	}
 	if !strings.HasPrefix(iface1, "pod1-abc") {
 		t.Errorf("failed to use first 8 valid characters")
 	}
-	podName2 := "pod1-abcde-54321"
-	iface2 := GenerateContainerInterfaceName(podName2, podNamespace)
+	containerID1 := "container1"
+	iface2 := GenerateContainerInterfaceName(podName1, podNamespace, containerID1)
 	if iface1 == iface2 {
-		t.Errorf("failed to differentiate interfaces with pods has the same prefix")
+		t.Errorf("failed to differentiate interfaces with pods that have the same pod namespace and name")
 	}
 }
 

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -399,7 +399,7 @@ func (tester *cmdAddDelTester) cmdAddTest(tc testCase, dataDir string) (*current
 	testRequire.Equal(tester.targetNS.Path(), result.Interfaces[1].Sandbox)
 
 	// Check for the veth link in the test namespace.
-	hostIfaceName := util.GenerateContainerInterfaceName(testPod, testPodNamespace)
+	hostIfaceName := util.GenerateContainerInterfaceName(testPod, testPodNamespace, ContainerID)
 	testRequire.Equal(hostIfaceName, result.Interfaces[0].Name)
 	testRequire.Len(result.Interfaces[0].Mac, 17)
 
@@ -574,7 +574,7 @@ func cmdAddDelCheckTest(testNS ns.NetNS, tc testCase, dataDir string) {
 	ipamMock.EXPECT().Add(mock.Any(), mock.Any()).Return(ipamResult, nil).AnyTimes()
 
 	// Mock ovs output while get ovs port external configuration
-	ovsPortname := util.GenerateContainerInterfaceName(testPod, testPodNamespace)
+	ovsPortname := util.GenerateContainerInterfaceName(testPod, testPodNamespace, ContainerID)
 	ovsPortUUID := uuid.New().String()
 	ovsServiceMock.EXPECT().CreatePort(ovsPortname, ovsPortname, mock.Any()).Return(ovsPortUUID, nil).AnyTimes()
 	ovsServiceMock.EXPECT().GetOFPort(ovsPortname).Return(int32(10), nil).AnyTimes()


### PR DESCRIPTION
When deleting a StatefulSet Pod with 0 second graceful period, the Pod
might be removed from the Kubernetes API very quickly and a new Pod is
created immediately, leading to kubelet processing the deletion of the
previous Pod and the add of the new Pod simultaneously, so CNI cannot
assume PodNamespace+PodName must be unique.

Previously antrea-agent computes the network device name by hashing
PodNamespace and PodName, the CNI DEL of the previous Pod could destroy
the network device of the new Pod if it's executed after the new one's
CNI ADD.

To fix it, antrea-agent must no longer use PodNamespace+PodName as the
identifier of the Pod's network device. This patches uses (sandbox)
container ID as part of the network device name, and uses container ID
as the key when caching interfaceConfig, then multiple Pods that have
the name will be handled individually without interfering with each
other.

To be compatible with network devices created by previous versions, CNI
DEL handler doesn't assume how the network device name is computed and
always look up network config by container ID.

For #785