### PR TITLE
Wait for 5 seconds when getting of_port number

### DIFF
--- a/pkg/ovs/ovsconfig/default.go
+++ b/pkg/ovs/ovsconfig/default.go
@@ -25,8 +25,8 @@ const (
 	DefaultOVSRunDir = "/var/run/openvswitch"
 
 	defaultConnNetwork = "unix"
-	// Wait up to 1 second when get port.
-	defaultGetPortTimeout = 1 * time.Second
+	// Wait up to 5 seconds when getting port.
+	defaultGetPortTimeout = 5 * time.Second
 )
 
 func GetConnAddress(ovsRunDir string) string {

--- a/pkg/ovs/ovsconfig/default_windows.go
+++ b/pkg/ovs/ovsconfig/default_windows.go
@@ -25,9 +25,8 @@ const (
 
 	defaultConnNetwork = "winpipe"
 	namedPipePrefix    = `\\.\pipe\`
-	// Wait up to 2 seconds when get port, the operation of port creation
-	// takes longer on Windows platform than on Linux.
-	defaultGetPortTimeout = 2 * time.Second
+	// Wait up to 5 seconds when getting port.
+	defaultGetPortTimeout = 5 * time.Second
 )
 
 func GetConnAddress(ovsRunDir string) string {


### PR DESCRIPTION
Instead of 1 second on Linux. We have observed on some production
clusters that it sometimes takes more second for ovs-vswitch to report
the port number to OVSDB, although we are not yet sure why. Because the
wait operation actually returns when the port is available, this does
not increase execution time of CNI Add in the general case.