### PR TITLE
Add support for the number of networkpolicies per node

### DIFF
--- a/pkg/agent/controller/networkpolicy/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/reconciler.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
-	"github.com/vmware-tanzu/antrea/pkg/agent/metrics"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
 	"github.com/vmware-tanzu/antrea/pkg/agent/types"
 	"github.com/vmware-tanzu/antrea/pkg/apis/networking/v1beta1"
@@ -255,13 +254,6 @@ func (r *reconciler) add(rule *CompletedRule) error {
 		lastRealized.ofIDs[svcHash] = ofID
 	}
 
-	// Count up antrea_agent_ingress_networkpolicy_rule_count or antrea_agent_egress_networkpolicy_rule_count
-	if rule.Direction == v1beta1.DirectionIn {
-		metrics.IngressNetworkPolicyCount.Inc()
-	} else if rule.Direction == v1beta1.DirectionOut {
-		metrics.EgressNetworkPolicyCount.Inc()
-	}
-
 	return nil
 }
 
@@ -436,13 +428,6 @@ func (r *reconciler) Forget(ruleID string) error {
 			return err
 		}
 		delete(lastRealized.ofIDs, svcHash)
-	}
-
-	// Decrement antrea_agent_ingress_networkpolicy_rule_count or antrea_agent_egress_networkpolicy_rule_count
-	if lastRealized.Direction == v1beta1.DirectionIn {
-		metrics.IngressNetworkPolicyCount.Dec()
-	} else if lastRealized.Direction == v1beta1.DirectionOut {
-		metrics.EgressNetworkPolicyCount.Dec()
 	}
 
 	r.lastRealizeds.Delete(ruleID)

--- a/pkg/agent/controller/networkpolicy/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/reconciler_test.go
@@ -83,14 +83,14 @@ func TestReconcilerForget(t *testing.T) {
 		},
 		{
 			"known-single-ofrule",
-			map[string]*lastRealized{"foo": {ofIDs: map[servicesHash]uint32{servicesHash1: 8}, CompletedRule: &CompletedRule{rule: &rule{Direction: v1beta1.DirectionIn}}}},
+			map[string]*lastRealized{"foo": {ofIDs: map[servicesHash]uint32{servicesHash1: 8}}},
 			"foo",
 			[]uint32{8},
 			false,
 		},
 		{
 			"known-multiple-ofrule",
-			map[string]*lastRealized{"foo": {ofIDs: map[servicesHash]uint32{servicesHash1: 8, servicesHash2: 9}, CompletedRule: &CompletedRule{rule: &rule{Direction: v1beta1.DirectionOut}}}},
+			map[string]*lastRealized{"foo": {ofIDs: map[servicesHash]uint32{servicesHash1: 8, servicesHash2: 9}}},
 			"foo",
 			[]uint32{8, 9},
 			false,

--- a/pkg/agent/metrics/prometheus.go
+++ b/pkg/agent/metrics/prometheus.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	EgressNetworkPolicyCount = metrics.NewGauge(
+	EgressNetworkPolicyRuleCount = metrics.NewGauge(
 		&metrics.GaugeOpts{
 			Name:           "antrea_agent_egress_networkpolicy_rule_count",
 			Help:           "Number of egress networkpolicy rules on local node which are managed by the Antrea Agent.",
@@ -31,7 +31,7 @@ var (
 		},
 	)
 
-	IngressNetworkPolicyCount = metrics.NewGauge(
+	IngressNetworkPolicyRuleCount = metrics.NewGauge(
 		&metrics.GaugeOpts{
 			Name:           "antrea_agent_ingress_networkpolicy_rule_count",
 			Help:           "Number of ingress networkpolicy rules on local node which are managed by the Antrea Agent.",
@@ -43,6 +43,14 @@ var (
 		&metrics.GaugeOpts{
 			Name:           "antrea_agent_local_pod_count",
 			Help:           "Number of pods on local node which are managed by the Antrea Agent.",
+			StabilityLevel: metrics.STABLE,
+		},
+	)
+
+	NetworkPolicyCount = metrics.NewGauge(
+		&metrics.GaugeOpts{
+			Name:           "antrea_agent_networkpolicy_count",
+			Help:           "Number of networkpolicies on local node which are managed by the Antrea Agent.",
 			StabilityLevel: metrics.STABLE,
 		},
 	)
@@ -86,12 +94,16 @@ func InitializePrometheusMetrics() {
 	// and will not measure anything unless the collector is first registered.
 	gaugeHost.Set(1)
 
-	if err := legacyregistry.Register(EgressNetworkPolicyCount); err != nil {
+	if err := legacyregistry.Register(EgressNetworkPolicyRuleCount); err != nil {
 		klog.Error("Failed to register antrea_agent_egress_networkpolicy_rule_count with Prometheus")
 	}
 
-	if err := legacyregistry.Register(IngressNetworkPolicyCount); err != nil {
+	if err := legacyregistry.Register(IngressNetworkPolicyRuleCount); err != nil {
 		klog.Error("Failed to register antrea_agent_ingress_networkpolicy_rule_count with Prometheus")
+	}
+
+	if err := legacyregistry.Register(NetworkPolicyCount); err != nil {
+		klog.Error("Failed to register antrea_agent_networkpolicy_count with Prometheus")
 	}
 
 	if err := legacyregistry.Register(OVSTotalFlowCount); err != nil {

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -37,6 +37,7 @@ var antreaAgentMetrics = []string{
 	"antrea_agent_egress_networkpolicy_rule_count",
 	"antrea_agent_ingress_networkpolicy_rule_count",
 	"antrea_agent_local_pod_count",
+	"antrea_agent_networkpolicy_count",
 	"antrea_agent_ovs_total_flow_count",
 	"antrea_agent_ovs_flow_count",
 	"antrea_agent_runtime_info",


### PR DESCRIPTION
- Change name of networkpolicy rule metric variable
- Add support the number of networkpolicies per node

This PR is a part of #713 feature request

Signed-off-by: Yuki Tsuboi <ytsuboi@vmware.com>