### PR TITLE
Merge apt install instructions of dockerfile

### DIFF
--- a/build/images/Dockerfile.build.ubuntu
+++ b/build/images/Dockerfile.build.ubuntu
@@ -25,9 +25,6 @@ RUN make antrea-agent antrea-controller antrea-cni antctl-ubuntu
 
 FROM antrea/openvswitch:2.13.0
 
-RUN apt-get update && apt-get install -y --no-install-recommends jq && \
-    rm -rf /var/cache/apt/* /var/lib/apt/lists/*
-
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A Docker image to deploy the Antrea CNI. Takes care of building the Antrea binaries as part of building the image."
 
@@ -35,6 +32,7 @@ USER root
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ipset \
+    jq \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=cni-binaries /opt/cni/bin /opt/cni/bin

--- a/build/images/Dockerfile.ubuntu
+++ b/build/images/Dockerfile.ubuntu
@@ -12,9 +12,6 @@ RUN mkdir -p /opt/cni/bin && \
 
 FROM antrea/openvswitch:2.13.0
 
-RUN apt-get update && apt-get install -y --no-install-recommends jq && \
-    rm -rf /var/cache/apt/* /var/lib/apt/lists/*
-
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A Docker image to deploy the Antrea CNI. Requires the Antrea binaries to be built prior to building the image."
 
@@ -22,6 +19,7 @@ USER root
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ipset \
+    jq \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=cni-binaries /opt/cni/bin /opt/cni/bin


### PR DESCRIPTION
To avoid unnecessary layer and time spent on apt-get update, merge apt
install instructions into one.

Ubuntu image automatically cleans up apt cache after every install, no
need to remove "/var/cache/apt" explicitly.