### PR TITLE
Fix flaky test TestUserProvidedCert

### DIFF
--- a/test/e2e/security_test.go
+++ b/test/e2e/security_test.go
@@ -146,6 +146,9 @@ func testCert(t *testing.T, data *TestData, expectedCABundle string, restartPod 
 		}
 	} else {
 		antreaController, err = data.getAntreaController()
+		if err != nil {
+			t.Fatalf("Error when getting antrea-controller Pod: %v", err)
+		}
 		timeout += 2 * time.Minute
 	}
 


### PR DESCRIPTION
Even though the strategy of the antrea-controller deployment is
"Recreate", the old Pod might still be in terminating state when the new
Pod is running after deleting a Pod manually[1]. We should ensure
there's only 1 Pod and it's running after restarting antrea-controller
Pod.

[1] https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#recreate-deployment.

Fixes #823