### PR TITLE
Support for batch OVS flow updates

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -334,11 +334,11 @@ func (i *Initializer) initOpenFlowPipeline() error {
 		// the time required for convergence may be large and there is no simple way to
 		// determine when is a right time to perform the cleanup task.
 		// TODO: introduce a deterministic mechanism through which the different entities
-		// responsible for installing flows can notify the agent that this deletion
-		// operation can take place.
-		// TODO: As a deterministic mechanism, a waitGroup can be created here and notified when
-		//  restartFullSyncWaitGroup in agent networkpolicy controller is unblocked. This would signal
-		//  NP flows have been synced once. Other mechanisms are needed for node flows fullSync check though.
+		//  responsible for installing flows can notify the agent that this deletion
+		//  operation can take place. A waitGroup can be created here and notified when
+		//  full sync in agent networkpolicy controller is complete. This would signal NP
+		//  flows have been synced once. Other mechanisms are still needed for node flows
+		//  fullSync check.
 		time.Sleep(10 * time.Second)
 		klog.Info("Deleting stale flows from previous round if any")
 		if err := i.ofClient.DeleteStaleFlows(); err != nil {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -336,6 +336,9 @@ func (i *Initializer) initOpenFlowPipeline() error {
 		// TODO: introduce a deterministic mechanism through which the different entities
 		// responsible for installing flows can notify the agent that this deletion
 		// operation can take place.
+		// TODO: As a deterministic mechanism, a waitGroup can be created here and notified when
+		//  restartFullSyncWaitGroup in agent networkpolicy controller is unblocked. This would signal
+		//  NP flows have been synced once. Other mechanisms are needed for node flows fullSync check though.
 		time.Sleep(10 * time.Second)
 		klog.Info("Deleting stale flows from previous round if any")
 		if err := i.ofClient.DeleteStaleFlows(); err != nil {

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -73,6 +73,9 @@ type Controller struct {
 	networkPolicyWatcher  *watcher
 	appliedToGroupWatcher *watcher
 	addressGroupWatcher   *watcher
+	appliedToSyncGroup    sync.WaitGroup
+	addressSyncGroup      sync.WaitGroup
+	internalNPSyncGroup   sync.WaitGroup
 }
 
 // NewNetworkPolicyController returns a new *Controller.
@@ -87,6 +90,13 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 		reconciler:           newReconciler(ofClient, ifaceStore),
 	}
 	c.ruleCache = newRuleCache(c.enqueueRule, podUpdates)
+	// Create a WaitGroup that is used to block network policy workers from asynchronously processing
+	// NP rules until the events preceding bookmark are synced. It can also be used as part of the
+	// solution to a deterministic mechanism for when to cleanup flows from previous round.
+	// Wait until appliedToGroupWatcher, addressGroupWatcher and networkPolicyWatcher to receive bookmark event.
+	c.appliedToSyncGroup.Add(1)
+	c.addressSyncGroup.Add(1)
+	c.internalNPSyncGroup.Add(1)
 
 	// Use nodeName to filter resources when watching resources.
 	options := metav1.ListOptions{
@@ -141,6 +151,8 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 			c.ruleCache.ReplaceNetworkPolicies(policies)
 			return nil
 		},
+		restartFullSyncGroup: &c.internalNPSyncGroup,
+		restartSynced:        false,
 	}
 
 	c.appliedToGroupWatcher = &watcher{
@@ -188,6 +200,8 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 			c.ruleCache.ReplaceAppliedToGroups(groups)
 			return nil
 		},
+		restartFullSyncGroup: &c.appliedToSyncGroup,
+		restartSynced:        false,
 	}
 
 	c.addressGroupWatcher = &watcher{
@@ -235,6 +249,8 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 			c.ruleCache.ReplaceAddressGroups(groups)
 			return nil
 		},
+		restartFullSyncGroup: &c.addressSyncGroup,
+		restartSynced:        false,
 	}
 	return c
 }
@@ -294,6 +310,15 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 	go wait.NonSlidingUntil(c.addressGroupWatcher.watch, 5*time.Second, stopCh)
 	go wait.NonSlidingUntil(c.networkPolicyWatcher.watch, 5*time.Second, stopCh)
 
+	klog.Infof("Waiting for all watchers to receive bookmark event")
+	c.appliedToSyncGroup.Wait()
+	c.addressSyncGroup.Wait()
+	c.internalNPSyncGroup.Wait()
+	klog.Infof("All watchers have received bookmark event")
+	// Batch install all rules in queue after fullSync is finished.
+	c.processAllItemsInQueue()
+
+	klog.Infof("Starting NetworkPolicy workers now")
 	for i := 0; i < defaultWorkers; i++ {
 		go wait.Until(c.worker, time.Second, stopCh)
 	}
@@ -328,6 +353,25 @@ func (c *Controller) processNextWorkItem() bool {
 	return true
 }
 
+func (c *Controller) processAllItemsInQueue() {
+	klog.Infof("Installing all network policy flows before bookmark event")
+	numRules := c.queue.Len()
+	batchSyncRuleKeys := make([]string, numRules)
+	for i := 0; i < numRules; i++ {
+		ruleKey, _ := c.queue.Get()
+		batchSyncRuleKeys[i] = ruleKey.(string)
+		// set key to done to prevent missing watched updates between here and fullSync finish.
+		c.queue.Done(ruleKey)
+	}
+	// Reconcile all rule keys at once.
+	if err := c.syncRules(batchSyncRuleKeys); err != nil {
+		klog.Errorf("Error occurred when reconciling all rules before bookmark event %v", err)
+		for _, k := range batchSyncRuleKeys {
+			c.queue.AddRateLimited(k)
+		}
+	}
+}
+
 func (c *Controller) syncRule(key string) error {
 	startTime := time.Now()
 	defer func() {
@@ -349,6 +393,27 @@ func (c *Controller) syncRule(key string) error {
 		return nil
 	}
 	if err := c.reconciler.Reconcile(rule); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) syncRules(keys []string) error {
+	startTime := time.Now()
+	defer func() {
+		klog.V(4).Infof("Finished syncing all rules before bookmark event (%v)", time.Since(startTime))
+	}()
+
+	var allRules []*CompletedRule
+	for _, key := range keys {
+		rule, exists, completed := c.ruleCache.GetCompletedRule(key)
+		if !exists || !completed {
+			klog.Errorf("Rule %v is not complete or does not exist in cache", key)
+		} else {
+			allRules = append(allRules, rule)
+		}
+	}
+	if err := c.reconciler.BatchReconcile(allRules); err != nil {
 		return err
 	}
 	return nil
@@ -383,6 +448,10 @@ type watcher struct {
 	connected bool
 	// lock protects connected.
 	lock sync.RWMutex
+	// group to be notified when each watcher receives bookmark event
+	restartFullSyncGroup *sync.WaitGroup
+	// restartSynced indicates if the resource has been synced at list once since agent started.
+	restartSynced bool
 }
 
 func (w *watcher) isConnected() bool {
@@ -441,6 +510,11 @@ loop:
 	if err := w.ReplaceFunc(initObjects); err != nil {
 		klog.Errorf("Failed to handle init events: %v", err)
 		return
+	}
+	if !w.restartSynced {
+		w.restartSynced = true
+		// Notify restartFullSyncGroup that all events before bookmark is handled
+		w.restartFullSyncGroup.Done()
 	}
 
 	for {

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -76,6 +76,16 @@ func (r *mockReconciler) Reconcile(rule *CompletedRule) error {
 	return nil
 }
 
+func (r *mockReconciler) BatchReconcile(rules []*CompletedRule) error {
+	r.Lock()
+	defer r.Unlock()
+	for _, rule := range rules {
+		r.lastRealized[rule.ID] = rule
+		r.updated <- rule.ID
+	}
+	return nil
+}
+
 func (r *mockReconciler) Forget(ruleID string) error {
 	r.Lock()
 	defer r.Unlock()

--- a/pkg/agent/controller/networkpolicy/priority.go
+++ b/pkg/agent/controller/networkpolicy/priority.go
@@ -144,6 +144,17 @@ func (pa *priorityAssigner) GetOFPriority(p types.Priority) (*uint16, map[uint16
 	return &ofPriority, map[uint16]uint16{}, nil
 }
 
+// RegisterPriorities registers a list of Priorities to be created with priorityMap.
+// It is used to populate the priorityMap in case of batch rule adds.
+func (pa *priorityAssigner) RegisterPriorities(priorities []types.Priority) error {
+	for _, p := range priorities {
+		if _, _, err := pa.GetOFPriority(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Release removes the priority that currently corresponds to the input OFPriority from the priorityMap.
 func (pa *priorityAssigner) Release(priorityNum uint16) error {
 	for priorityKey, p := range pa.priorityMap {

--- a/pkg/agent/controller/networkpolicy/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/reconciler_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -542,18 +543,19 @@ func TestReconcilerBatchReconcile(t *testing.T) {
 			}
 			// TODO: mock idAllocator and priorityAssigner
 			mockOFClient.EXPECT().BatchInstallPolicyRuleFlows(gomock.Any()).
-				Do(func(rules []types.OFPolicyRule) {
-					if tt.numInstalledRules == 0 && len(rules) != len(tt.expectedOFRules) {
-						t.Fatalf("Expect to install %v flows while %v flows were installed",
+				Do(func(rules []*types.PolicyRule) {
+					if tt.numInstalledRules == 0 {
+						assert.Equalf(t, len(rules), len(tt.expectedOFRules),
+							"Expect to install %v flows while %v flows were installed",
 							len(tt.expectedOFRules), len(rules))
-					} else if tt.numInstalledRules > 0 && len(rules) != len(tt.expectedOFRules)-tt.numInstalledRules {
-						t.Fatalf("Expect to install %v flows while %v flows were installed",
+					} else if tt.numInstalledRules > 0 {
+						assert.Equalf(t, len(rules), len(tt.expectedOFRules)-tt.numInstalledRules,
+							"Expect to install %v flows while %v flows were installed",
 							len(tt.expectedOFRules)-tt.numInstalledRules, len(rules))
 					}
 				})
-			if err := r.BatchReconcile(tt.args); (err != nil) != tt.wantErr {
-				t.Fatalf("BatchReconcile() error = %v, wantErr %v", err, tt.wantErr)
-			}
+			err := r.BatchReconcile(tt.args)
+			assert.Equalf(t, err != nil, tt.wantErr, "BatchReconcile() error = %v, wantErr %v", err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/agent/controller/networkpolicy/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/reconciler_test.go
@@ -428,12 +428,131 @@ func TestReconcilerReconcile(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 			mockOFClient := openflowtest.NewMockClient(controller)
-			for _, ofRule := range tt.expectedOFRules {
-				mockOFClient.EXPECT().InstallPolicyRuleFlows(gomock.Any(), gomock.Eq(ofRule), "", "")
+			// TODO: mock idAllocator and priorityAssigner
+			for i := 0; i < len(tt.expectedOFRules); i++ {
+				mockOFClient.EXPECT().InstallPolicyRuleFlows(gomock.Any())
 			}
 			r := newReconciler(mockOFClient, ifaceStore)
 			if err := r.Reconcile(tt.args); (err != nil) != tt.wantErr {
 				t.Fatalf("Reconcile() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestReconcilerBatchReconcile(t *testing.T) {
+	ifaceStore := interfacestore.NewInterfaceStore()
+	ifaceStore.AddInterface(&interfacestore.InterfaceConfig{
+		InterfaceName:            util.GenerateContainerInterfaceName("pod1", "ns1", "container1"),
+		IP:                       net.ParseIP("2.2.2.2"),
+		ContainerInterfaceConfig: &interfacestore.ContainerInterfaceConfig{PodName: "pod1", PodNamespace: "ns1", ContainerID: "container1"},
+		OVSPortConfig:            &interfacestore.OVSPortConfig{OFPort: 1},
+	})
+	ifaceStore.AddInterface(&interfacestore.InterfaceConfig{
+		InterfaceName:            util.GenerateContainerInterfaceName("pod3", "ns1", "container3"),
+		IP:                       net.ParseIP("3.3.3.3"),
+		ContainerInterfaceConfig: &interfacestore.ContainerInterfaceConfig{PodName: "pod3", PodNamespace: "ns1", ContainerID: "container3"},
+		OVSPortConfig:            &interfacestore.OVSPortConfig{OFPort: 3},
+	})
+	completedRules := []*CompletedRule{
+		{
+			rule:          &rule{ID: "ingress-rule", Direction: v1beta1.DirectionIn, Services: []v1beta1.Service{serviceTCP80, serviceTCP}},
+			FromAddresses: addressGroup1,
+			ToAddresses:   nil,
+			Pods:          appliedToGroup1,
+		},
+		{
+			rule: &rule{ID: "ingress-rule-no-ports", Direction: v1beta1.DirectionIn, Services: []v1beta1.Service{}},
+			Pods: appliedToGroup1,
+		},
+		{
+			rule: &rule{ID: "ingress-rule-diff-named-port", Direction: v1beta1.DirectionIn, Services: []v1beta1.Service{serviceHTTP}},
+			Pods: appliedToGroupWithDiffContainerPort,
+		},
+		{
+			rule:          &rule{ID: "egress-rule", Direction: v1beta1.DirectionOut},
+			FromAddresses: nil,
+			ToAddresses:   addressGroup1,
+			Pods:          appliedToGroup1,
+		},
+	}
+	expectedOFRules := []*types.PolicyRule{
+		{
+			Direction: v1beta1.DirectionIn,
+			From:      ipsToOFAddresses(sets.NewString("1.1.1.1")),
+			To:        ofPortsToOFAddresses(sets.NewInt32(1)),
+			Service:   []v1beta1.Service{serviceTCP80, serviceTCP},
+		},
+		{
+			Direction: v1beta1.DirectionIn,
+			From:      []types.Address{},
+			To:        ofPortsToOFAddresses(sets.NewInt32(1)),
+			Service:   nil,
+		},
+		{
+			Direction: v1beta1.DirectionIn,
+			From:      []types.Address{},
+			To:        ofPortsToOFAddresses(sets.NewInt32(1)),
+			Service:   []v1beta1.Service{serviceTCP80},
+		},
+		{
+			Direction: v1beta1.DirectionIn,
+			From:      []types.Address{},
+			To:        ofPortsToOFAddresses(sets.NewInt32(3)),
+			Service:   []v1beta1.Service{serviceTCP443},
+		},
+		{
+			Direction: v1beta1.DirectionOut,
+			From:      ipsToOFAddresses(sets.NewString("2.2.2.2")),
+			To:        ipsToOFAddresses(sets.NewString("1.1.1.1")),
+			Service:   nil,
+		},
+	}
+	tests := []struct {
+		name              string
+		args              []*CompletedRule
+		expectedOFRules   []*types.PolicyRule
+		numInstalledRules int
+		wantErr           bool
+	}{
+		{
+			"batch-install",
+			completedRules,
+			expectedOFRules,
+			0,
+			false,
+		},
+		{
+			"batch-install-partial",
+			completedRules,
+			expectedOFRules,
+			1,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+			mockOFClient := openflowtest.NewMockClient(controller)
+			r := newReconciler(mockOFClient, ifaceStore)
+			if tt.numInstalledRules > 0 {
+				// BatchInstall should skip rules already installed
+				r.lastRealizeds.Store(tt.args[0].ID, newLastRealized(tt.args[0]))
+			}
+			// TODO: mock idAllocator and priorityAssigner
+			mockOFClient.EXPECT().BatchInstallPolicyRuleFlows(gomock.Any()).
+				Do(func(rules []types.OFPolicyRule) {
+					if tt.numInstalledRules == 0 && len(rules) != len(tt.expectedOFRules) {
+						t.Fatalf("Expect to install %v flows while %v flows were installed",
+							len(tt.expectedOFRules), len(rules))
+					} else if tt.numInstalledRules > 0 && len(rules) != len(tt.expectedOFRules)-tt.numInstalledRules {
+						t.Fatalf("Expect to install %v flows while %v flows were installed",
+							len(tt.expectedOFRules)-tt.numInstalledRules, len(rules))
+					}
+				})
+			if err := r.BatchReconcile(tt.args); (err != nil) != tt.wantErr {
+				t.Fatalf("BatchReconcile() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
@@ -559,7 +678,7 @@ func TestReconcilerUpdate(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 			mockOFClient := openflowtest.NewMockClient(controller)
-			mockOFClient.EXPECT().InstallPolicyRuleFlows(gomock.Any(), gomock.Any(), "", "")
+			mockOFClient.EXPECT().InstallPolicyRuleFlows(gomock.Any())
 			if len(tt.expectedAddedFrom) > 0 {
 				mockOFClient.EXPECT().AddPolicyRuleAddress(gomock.Any(), types.SrcAddress, gomock.Eq(tt.expectedAddedFrom), nil)
 			}

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -127,10 +127,10 @@ type Client interface {
 	// NetworkPolicy rule. Each ingress/egress policy rule installs Openflow entries on two tables, one for
 	// ruleTable and the other for dropTable. If a packet does not pass the ruleTable, it will be dropped by the
 	// dropTable.
-	InstallPolicyRuleFlows(ofPolicyRule types.OFPolicyRule) error
+	InstallPolicyRuleFlows(ofPolicyRule *types.PolicyRule) error
 
 	// BatchInstallPolicyRuleFlows installs multiple flows for NetworkPolicy rules in batch.
-	BatchInstallPolicyRuleFlows(ofPolicyRules []types.OFPolicyRule) error
+	BatchInstallPolicyRuleFlows(ofPolicyRules []*types.PolicyRule) error
 
 	// UninstallPolicyRuleFlows removes the Openflow entry relevant to the specified NetworkPolicy rule.
 	// It also returns a slice of stale ofPriorities used by ClusterNetworkPolicies.

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -127,7 +127,10 @@ type Client interface {
 	// NetworkPolicy rule. Each ingress/egress policy rule installs Openflow entries on two tables, one for
 	// ruleTable and the other for dropTable. If a packet does not pass the ruleTable, it will be dropped by the
 	// dropTable.
-	InstallPolicyRuleFlows(ruleID uint32, rule *types.PolicyRule, npName, npNamespace string) error
+	InstallPolicyRuleFlows(ofPolicyRule types.OFPolicyRule) error
+
+	// BatchInstallPolicyRuleFlows installs multiple flows for NetworkPolicy rules in batch.
+	BatchInstallPolicyRuleFlows(ofPolicyRules []types.OFPolicyRule) error
 
 	// UninstallPolicyRuleFlows removes the Openflow entry relevant to the specified NetworkPolicy rule.
 	// It also returns a slice of stale ofPriorities used by ClusterNetworkPolicies.

--- a/pkg/agent/openflow/network_policy.go
+++ b/pkg/agent/openflow/network_policy.go
@@ -711,21 +711,41 @@ func (c *policyRuleConjunction) getAddressClause(addrType types.AddressType) *cl
 // If there is an error in any clause's addAddrFlows or addServiceFlows, the conjunction action flow will never be hit.
 // If the default drop flow is already installed before this error, all packets will be dropped by the default drop flow,
 // Otherwise all packets will be allowed.
-func (c *client) InstallPolicyRuleFlows(ruleID uint32, rule *types.PolicyRule, npName, npNamespace string) error {
+func (c *client) InstallPolicyRuleFlows(ofPolicyRule types.OFPolicyRule) error {
 	c.replayMutex.RLock()
 	defer c.replayMutex.RUnlock()
 
+	conj := c.calculateActionFlowChangesForRule(ofPolicyRule)
+
+	c.conjMatchFlowLock.Lock()
+	defer c.conjMatchFlowLock.Unlock()
+	ctxChanges := c.calculateMatchFlowChangesForRule(conj, ofPolicyRule.OfRule, false)
+
+	if err := c.ofEntryOperations.AddAll(conj.actionFlows); err != nil {
+		return err
+	}
+	if err := c.applyConjunctiveMatchFlows(ctxChanges); err != nil {
+		return err
+	}
+	// Add the policyRuleConjunction into policyCache
+	c.policyCache.Add(conj)
+	return nil
+}
+
+// calculateActionFlowChangesForRule calculates and updates the actionFlows for the conjunction corresponded to the ofPolicyRule.
+func (c *client) calculateActionFlowChangesForRule(ofPolicyRule types.OFPolicyRule) *policyRuleConjunction {
+	rule := ofPolicyRule.OfRule
+	ruleID := ofPolicyRule.OfID
 	// Check if the policyRuleConjunction is added into cache or not. If yes, return nil.
 	conj := c.getPolicyRuleConjunction(ruleID)
 	if conj != nil {
 		klog.V(2).Infof("PolicyRuleConjunction %d is already added in cache", ruleID)
 		return nil
 	}
-
 	conj = &policyRuleConjunction{
 		id:          ruleID,
-		npName:      npName,
-		npNamespace: npNamespace}
+		npName:      ofPolicyRule.NpName,
+		npNamespace: ofPolicyRule.NpNamespace}
 	nClause, ruleTable, dropTable := conj.calculateClauses(rule, c)
 
 	// Conjunction action flows are installed only if the number of clauses in the conjunction is > 1. It should be a rule
@@ -739,31 +759,61 @@ func (c *client) InstallPolicyRuleFlows(ruleID uint32, rule *types.PolicyRule, n
 		} else {
 			actionFlows = append(actionFlows, c.conjunctionActionFlow(ruleID, ruleTable.GetID(), dropTable.GetNext(), rule.Priority))
 		}
-		if err := c.ofEntryOperations.AddAll(actionFlows); err != nil {
-			return nil
-		}
-		// Add the action flows after the Openflow entries are installed on the OVS bridge successfully.
 		conj.actionFlows = actionFlows
 	}
-	c.conjMatchFlowLock.Lock()
-	defer c.conjMatchFlowLock.Unlock()
+	return conj
+}
 
+// calculateMatchFlowChangesForRule calculates the contextChanges for the policyRule, and updates the context status in case of batch install.
+func (c *client) calculateMatchFlowChangesForRule(conj *policyRuleConjunction, rule *types.PolicyRule, isBatchInstall bool) []*conjMatchFlowContextChange {
 	// Calculate the conjMatchFlowContext changes. The changed Openflow entries are included in the conjMatchFlowContext change.
 	ctxChanges := conj.calculateChangesForRuleCreation(c, rule)
+	// Update conjunctiveMatchContext if during batch flow install, otherwise the subsequent contextChange
+	// calculations will not be based on the previous flowChanges that have not been sent to OVS bridge.
+	// TODO: roll back if batch flow install fails?
+	if isBatchInstall {
+		for _, ctxChange := range ctxChanges {
+			ctxChange.updateContextStatus()
+		}
+	}
+	return ctxChanges
+}
 
-	// Send the changed Openflow entries to the OVS bridge, and then update the conjMatchFlowContext as the expected status.
-	if err := c.applyConjunctiveMatchFlows(ctxChanges); err != nil {
+// BatchInstallPolicyRuleFlows installs flows for NetworkPolicy rules in case of agent restart. It calculates and
+// accumulates all Openflow entry updates required and installs all of them on OVS bridge in one bundle.
+func (c *client) BatchInstallPolicyRuleFlows(ofPolicyRules []types.OFPolicyRule) error {
+	c.replayMutex.RLock()
+	defer c.replayMutex.RUnlock()
+
+	var allCtxChanges []*conjMatchFlowContextChange
+	var allActionFlowChanges []*binding.Flow
+	var updatedConjunctions []*policyRuleConjunction
+
+	for _, rule := range ofPolicyRules {
+		conj := c.calculateActionFlowChangesForRule(rule)
+		ctxChanges := c.calculateMatchFlowChangesForRule(conj, rule.OfRule, true)
+		for _, actionFlow := range conj.actionFlows {
+			allActionFlowChanges = append(allActionFlowChanges, &actionFlow)
+		}
+		allCtxChanges = append(allCtxChanges, ctxChanges...)
+		updatedConjunctions = append(updatedConjunctions, conj)
+	}
+	// Send the changed Openflow entries to the OVS bridge.
+	if err := c.sendConjunctiveFlows(allCtxChanges, allActionFlowChanges); err != nil {
 		return err
 	}
-	// Add the policyRuleConjunction into policyCache.
-	c.policyCache.Add(conj)
+	// Update conjMatchFlowContexts as the expected status.
+	for _, conj := range updatedConjunctions {
+		// Add the policyRuleConjunction into policyCache
+		c.policyCache.Add(conj)
+	}
 	return nil
 }
 
 // applyConjunctiveMatchFlows installs OpenFlow entries on the OVS bridge, and then updates the conjMatchFlowContext.
 func (c *client) applyConjunctiveMatchFlows(flowChanges []*conjMatchFlowContextChange) error {
 	// Send the OpenFlow entries to the OVS bridge.
-	if err := c.sendConjunctiveMatchFlows(flowChanges); err != nil {
+	if err := c.sendConjunctiveFlows(flowChanges, nil); err != nil {
 		return err
 	}
 	// Update conjunctiveMatchContext.
@@ -773,9 +823,12 @@ func (c *client) applyConjunctiveMatchFlows(flowChanges []*conjMatchFlowContextC
 	return nil
 }
 
-// sendConjunctiveMatchFlows sends all the changed OpenFlow entries to the OVS bridge in a single Bundle.
-func (c *client) sendConjunctiveMatchFlows(changes []*conjMatchFlowContextChange) error {
+// sendConjunctiveFlows sends all the changed OpenFlow entries to the OVS bridge in a single Bundle.
+func (c *client) sendConjunctiveFlows(changes []*conjMatchFlowContextChange, actionFlows []*binding.Flow) error {
 	var addFlows, modifyFlows, deleteFlows []binding.Flow
+	for _, actionFlow := range actionFlows {
+		addFlows = append(addFlows, *actionFlow)
+	}
 	var flowChanges []*flowChange
 	for _, flowChange := range changes {
 		if flowChange.matchFlow != nil {

--- a/pkg/agent/openflow/network_policy.go
+++ b/pkg/agent/openflow/network_policy.go
@@ -791,9 +791,7 @@ func (c *client) BatchInstallPolicyRuleFlows(ofPolicyRules []*types.PolicyRule) 
 	for _, rule := range ofPolicyRules {
 		conj := c.calculateActionFlowChangesForRule(rule)
 		ctxChanges := c.calculateMatchFlowChangesForRule(conj, rule, true)
-		for _, actionFlow := range conj.actionFlows {
-			allActionFlowChanges = append(allActionFlowChanges, actionFlow)
-		}
+		allActionFlowChanges = append(allActionFlowChanges, conj.actionFlows...)
 		allCtxChanges = append(allCtxChanges, ctxChanges...)
 		updatedConjunctions = append(updatedConjunctions, conj)
 	}
@@ -825,10 +823,8 @@ func (c *client) applyConjunctiveMatchFlows(flowChanges []*conjMatchFlowContextC
 // sendConjunctiveFlows sends all the changed OpenFlow entries to the OVS bridge in a single Bundle.
 func (c *client) sendConjunctiveFlows(changes []*conjMatchFlowContextChange, actionFlows []binding.Flow) error {
 	var addFlows, modifyFlows, deleteFlows []binding.Flow
-	for _, actionFlow := range actionFlows {
-		addFlows = append(addFlows, actionFlow)
-	}
 	var flowChanges []*flowChange
+	addFlows = actionFlows
 	for _, flowChange := range changes {
 		if flowChange.matchFlow != nil {
 			flowChanges = append(flowChanges, flowChange.matchFlow)

--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -168,7 +168,13 @@ func TestInstallPolicyRuleFlows(t *testing.T) {
 	require.Nil(t, err)
 
 	assert.Equal(t, 0, len(c.GetNetworkPolicyFlowKeys("np1", "ns1")))
-	err = c.InstallPolicyRuleFlows(ruleID2, rule2, "np1", "ns1")
+	ofPolicyRule2 := types.OFPolicyRule{
+		OfID:        ruleID2,
+		OfRule:      rule2,
+		NpName:      "np1",
+		NpNamespace: "ns1",
+	}
+	err = c.InstallPolicyRuleFlows(ofPolicyRule2)
 	require.Nil(t, err)
 	checkConjunctionConfig(t, ruleID2, 1, 2, 1, 0)
 	assert.Equal(t, 6, len(c.GetNetworkPolicyFlowKeys("np1", "ns1")))
@@ -203,7 +209,13 @@ func TestInstallPolicyRuleFlows(t *testing.T) {
 	err = c.applyConjunctiveMatchFlows(ctxChanges3)
 	require.Nil(t, err)
 
-	err = c.InstallPolicyRuleFlows(ruleID3, rule3, "np1", "ns1")
+	ofPolicyRule3 := types.OFPolicyRule{
+		OfID:        ruleID3,
+		OfRule:      rule3,
+		NpName:      "np1",
+		NpNamespace: "ns1",
+	}
+	err = c.InstallPolicyRuleFlows(ofPolicyRule3)
 	require.Nil(t, err, "Failed to invoke InstallPolicyRuleFlows")
 	checkConjunctionConfig(t, ruleID3, 1, 2, 1, 2)
 	assert.Equal(t, 14, len(c.GetNetworkPolicyFlowKeys("np1", "ns1")))

--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -24,6 +24,7 @@ import (
 
 var (
 	c             *client
+	cnpOutTable   *mocks.MockTable
 	outTable      *mocks.MockTable
 	outDropTable  *mocks.MockTable
 	outAllowTable *mocks.MockTable
@@ -122,10 +123,13 @@ func TestInstallPolicyRuleFlows(t *testing.T) {
 	defaultAction := secv1alpha1.RuleActionAllow
 	ruleID1 := uint32(101)
 	rule1 := &types.PolicyRule{
-		Direction: v1beta1.DirectionOut,
-		From:      parseAddresses([]string{"192.168.1.30", "192.168.1.50"}),
-		Action:    &defaultAction,
-		Priority:  nil,
+		Direction:       v1beta1.DirectionOut,
+		From:            parseAddresses([]string{"192.168.1.30", "192.168.1.50"}),
+		Action:          &defaultAction,
+		Priority:        nil,
+		FlowID:          ruleID1,
+		PolicyName:      "np1",
+		PolicyNamespace: "ns1",
 	}
 
 	outDropTable.EXPECT().BuildFlow(gomock.Any()).Return(newMockDropFlowBuilder(ctrl)).AnyTimes()
@@ -146,10 +150,13 @@ func TestInstallPolicyRuleFlows(t *testing.T) {
 
 	ruleID2 := uint32(102)
 	rule2 := &types.PolicyRule{
-		Direction: v1beta1.DirectionOut,
-		From:      parseAddresses([]string{"192.168.1.40", "192.168.1.50"}),
-		Action:    &defaultAction,
-		To:        parseAddresses([]string{"0.0.0.0/0"}),
+		Direction:       v1beta1.DirectionOut,
+		From:            parseAddresses([]string{"192.168.1.40", "192.168.1.50"}),
+		Action:          &defaultAction,
+		To:              parseAddresses([]string{"0.0.0.0/0"}),
+		FlowID:          ruleID2,
+		PolicyName:      "np1",
+		PolicyNamespace: "ns1",
 	}
 	conj2 := &policyRuleConjunction{id: ruleID2}
 	conj2.calculateClauses(rule2, c)
@@ -168,13 +175,7 @@ func TestInstallPolicyRuleFlows(t *testing.T) {
 	require.Nil(t, err)
 
 	assert.Equal(t, 0, len(c.GetNetworkPolicyFlowKeys("np1", "ns1")))
-	ofPolicyRule2 := types.OFPolicyRule{
-		OfID:        ruleID2,
-		OfRule:      rule2,
-		NpName:      "np1",
-		NpNamespace: "ns1",
-	}
-	err = c.InstallPolicyRuleFlows(ofPolicyRule2)
+	err = c.InstallPolicyRuleFlows(rule2)
 	require.Nil(t, err)
 	checkConjunctionConfig(t, ruleID2, 1, 2, 1, 0)
 	assert.Equal(t, 6, len(c.GetNetworkPolicyFlowKeys("np1", "ns1")))
@@ -186,11 +187,14 @@ func TestInstallPolicyRuleFlows(t *testing.T) {
 	npPort1 := v1beta1.Service{Protocol: &tcpProtocol, Port: &port1}
 	npPort2 := v1beta1.Service{Protocol: &tcpProtocol, Port: &port2}
 	rule3 := &types.PolicyRule{
-		Direction: v1beta1.DirectionOut,
-		From:      parseAddresses([]string{"192.168.1.40", "192.168.1.60"}),
-		To:        parseAddresses([]string{"192.168.2.0/24"}),
-		Action:    &defaultAction,
-		Service:   []v1beta1.Service{npPort1, npPort2},
+		Direction:       v1beta1.DirectionOut,
+		From:            parseAddresses([]string{"192.168.1.40", "192.168.1.60"}),
+		To:              parseAddresses([]string{"192.168.2.0/24"}),
+		Action:          &defaultAction,
+		Service:         []v1beta1.Service{npPort1, npPort2},
+		FlowID:          ruleID3,
+		PolicyName:      "np1",
+		PolicyNamespace: "ns1",
 	}
 	conj3 := &policyRuleConjunction{id: ruleID3}
 	conj3.calculateClauses(rule3, c)
@@ -209,13 +213,7 @@ func TestInstallPolicyRuleFlows(t *testing.T) {
 	err = c.applyConjunctiveMatchFlows(ctxChanges3)
 	require.Nil(t, err)
 
-	ofPolicyRule3 := types.OFPolicyRule{
-		OfID:        ruleID3,
-		OfRule:      rule3,
-		NpName:      "np1",
-		NpNamespace: "ns1",
-	}
-	err = c.InstallPolicyRuleFlows(ofPolicyRule3)
+	err = c.InstallPolicyRuleFlows(rule3)
 	require.Nil(t, err, "Failed to invoke InstallPolicyRuleFlows")
 	checkConjunctionConfig(t, ruleID3, 1, 2, 1, 2)
 	assert.Equal(t, 14, len(c.GetNetworkPolicyFlowKeys("np1", "ns1")))
@@ -237,6 +235,81 @@ func TestInstallPolicyRuleFlows(t *testing.T) {
 	err = c.applyConjunctiveMatchFlows(ctxChanges5)
 	assert.Equal(t, 11, len(c.GetNetworkPolicyFlowKeys("np1", "ns1")))
 	require.Nil(t, err)
+}
+
+func TestBatchInstallPolicyRuleFlows(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	c = prepareClient(ctrl)
+	defaultAction := secv1alpha1.RuleActionAllow
+	priorityRule2 := uint16(10000)
+
+	ruleID1 := uint32(10)
+	rule1 := &types.PolicyRule{
+		Direction:       v1beta1.DirectionOut,
+		From:            parseAddresses([]string{"192.168.1.40", "192.168.1.50"}),
+		Action:          &defaultAction,
+		To:              parseAddresses([]string{"0.0.0.0/0"}),
+		FlowID:          ruleID1,
+		PolicyName:      "np1",
+		PolicyNamespace: "ns1",
+	}
+	outDropTable.EXPECT().BuildFlow(gomock.Any()).Return(newMockDropFlowBuilder(ctrl)).AnyTimes()
+	ruleFlowBuilder := newMockRuleFlowBuilder(ctrl)
+	outTable.EXPECT().BuildFlow(gomock.Any()).Return(ruleFlowBuilder).AnyTimes()
+	cnpOutTable.EXPECT().BuildFlow(gomock.Any()).Return(ruleFlowBuilder).AnyTimes()
+
+	conj := &policyRuleConjunction{id: ruleID1}
+	conj.calculateClauses(rule1, c)
+	require.NotNil(t, conj.toClause)
+	require.Nil(t, conj.serviceClause)
+	ruleFlowBuilder.EXPECT().MatchConjID(ruleID1).MaxTimes(1)
+	ruleFlowBuilder.EXPECT().MatchPriority(priorityLow).MaxTimes(1)
+	expectConjunctionsCount([]*expectConjunctionTimes{{1, ruleID1, 2, 2}})
+	expectConjunctionsCount([]*expectConjunctionTimes{{2, ruleID1, 1, 2}})
+	ctxChanges1 := conj.calculateChangesForRuleCreation(c, rule1)
+	matchFlows1, dropFlows1 := getChangedFlows(ctxChanges1)
+	assert.Equal(t, 2, getChangedFlowCount(dropFlows1))
+	assert.Equal(t, 3, getChangedFlowCount(matchFlows1))
+	assert.Equal(t, 3, getChangedFlowOPCount(matchFlows1, insertion))
+
+	ruleID2 := uint32(20)
+	rule2 := &types.PolicyRule{
+		Direction:       v1beta1.DirectionOut,
+		From:            parseAddresses([]string{"192.168.1.60"}),
+		Action:          &defaultAction,
+		Priority:        &priorityRule2,
+		To:              parseAddresses([]string{"192.168.1.70"}),
+		FlowID:          ruleID2,
+		PolicyName:      "np2",
+		PolicyNamespace: "ns1",
+	}
+
+	conj2 := &policyRuleConjunction{id: ruleID2}
+	conj2.calculateClauses(rule2, c)
+	require.NotNil(t, conj2.toClause)
+	require.Nil(t, conj2.serviceClause)
+	ruleFlowBuilder.EXPECT().MatchConjID(ruleID2).MaxTimes(1)
+	ruleFlowBuilder.EXPECT().MatchPriority(priorityRule2).MaxTimes(1)
+	ruleAction.EXPECT().Conjunction(ruleID2, gomock.Any(), gomock.Any()).Return(ruleFlowBuilder).MaxTimes(1)
+	ruleAction.EXPECT().Conjunction(ruleID2, gomock.Any(), gomock.Any()).Return(ruleFlowBuilder).MaxTimes(1)
+	ctxChanges2 := conj2.calculateChangesForRuleCreation(c, rule2)
+	matchFlows2, dropFlows2 := getChangedFlows(ctxChanges2)
+	assert.Equal(t, 0, getChangedFlowCount(dropFlows2))
+	assert.Equal(t, 2, getChangedFlowCount(matchFlows2))
+	assert.Equal(t, 2, getChangedFlowOPCount(matchFlows2, insertion))
+
+	err := c.applyConjunctiveMatchFlows(append(ctxChanges1, ctxChanges2...))
+	require.Nil(t, err)
+
+	err = c.BatchInstallPolicyRuleFlows([]*types.PolicyRule{rule1, rule2})
+	require.Nil(t, err)
+	checkConjunctionConfig(t, ruleID1, 1, 2, 1, 0)
+	checkActionFlowPriority(t, ruleID1, priorityNormal)
+	checkConjunctionConfig(t, ruleID2, 1, 1, 1, 0)
+	assert.Equal(t, 6, len(c.GetNetworkPolicyFlowKeys("np1", "ns1")))
+	assert.Equal(t, 3, len(c.GetNetworkPolicyFlowKeys("np2", "ns1")))
 }
 
 func TestConjMatchFlowContextKeyConflict(t *testing.T) {
@@ -338,6 +411,15 @@ func checkConjunctionConfig(t *testing.T, ruleID uint32, actionFlowCount, fromMa
 	}
 }
 
+func checkActionFlowPriority(t *testing.T, ruleID uint32, priority uint16) {
+	conj := c.getPolicyRuleConjunction(ruleID)
+	require.NotNil(t, conj, "Failed to add policyRuleConjunction into client cache")
+	actionFlowPriorities := conj.ActionFlowPriorities()
+	for _, p := range actionFlowPriorities {
+		assert.Equal(t, strconv.Itoa(int(priority)), p, fmt.Sprintf("Action flow for rule %d installed at wrong priority, expect: %s, actual: %s", ruleID, strconv.Itoa(int(priority)), p))
+	}
+}
+
 func checkFlowCount(t *testing.T, expectCount int) {
 	actualCount := len(c.globalConjMatchFlowCache)
 	assert.Equal(t, expectCount, actualCount, fmt.Sprintf("Incorrect count of conjunctive match flow context into global cache, expect: %d, actual: %d", expectCount, actualCount))
@@ -366,6 +448,8 @@ func newMockDropFlowBuilder(ctrl *gomock.Controller) *mocks.MockFlowBuilder {
 	dropFlowBuilder.EXPECT().MatchDstIP(gomock.Any()).Return(dropFlowBuilder).AnyTimes()
 	dropFlowBuilder.EXPECT().MatchSrcIP(gomock.Any()).Return(dropFlowBuilder).AnyTimes()
 	dropFlowBuilder.EXPECT().MatchInPort(gomock.Any()).Return(dropFlowBuilder).AnyTimes()
+	dropFlowBuilder.EXPECT().MatchConjID(gomock.Any()).Return(ruleFlowBuilder).AnyTimes()
+	dropFlowBuilder.EXPECT().MatchPriority(gomock.Any()).Return(ruleFlowBuilder).AnyTimes()
 	dropFlowBuilder.EXPECT().MatchRegRange(gomock.Any(), gomock.Any(), gomock.Any()).Return(dropFlowBuilder).AnyTimes()
 	action := mocks.NewMockAction(ctrl)
 	action.EXPECT().Drop().Return(dropFlowBuilder).AnyTimes()
@@ -435,11 +519,13 @@ func prepareClient(ctrl *gomock.Controller) *client {
 	)
 	bridge := mocks.NewMockBridge(ctrl)
 	bridge.EXPECT().AddFlowsInBundle(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	cnpOutTable = createMockTable(ctrl, cnpEgressRuleTable, EgressRuleTable, binding.TableMissActionNext)
 	outTable = createMockTable(ctrl, EgressRuleTable, EgressDefaultTable, binding.TableMissActionNext)
 	outDropTable = createMockTable(ctrl, EgressDefaultTable, l3ForwardingTable, binding.TableMissActionNext)
 	outAllowTable = createMockTable(ctrl, l3ForwardingTable, l2ForwardingCalcTable, binding.TableMissActionNext)
 	c = &client{
 		pipeline: map[binding.TableIDType]binding.Table{
+			cnpEgressRuleTable: cnpOutTable,
 			EgressRuleTable:    outTable,
 			EgressDefaultTable: outDropTable,
 			l3ForwardingTable:  outAllowTable,

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -67,6 +67,20 @@ func (mr *MockClientMockRecorder) AddPolicyRuleAddress(arg0, arg1, arg2, arg3 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPolicyRuleAddress", reflect.TypeOf((*MockClient)(nil).AddPolicyRuleAddress), arg0, arg1, arg2, arg3)
 }
 
+// BatchInstallPolicyRuleFlows mocks base method
+func (m *MockClient) BatchInstallPolicyRuleFlows(arg0 []types.OFPolicyRule) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchInstallPolicyRuleFlows", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BatchInstallPolicyRuleFlows indicates an expected call of BatchInstallPolicyRuleFlows
+func (mr *MockClientMockRecorder) BatchInstallPolicyRuleFlows(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchInstallPolicyRuleFlows", reflect.TypeOf((*MockClient)(nil).BatchInstallPolicyRuleFlows), arg0)
+}
+
 // DeletePolicyRuleAddress mocks base method
 func (m *MockClient) DeletePolicyRuleAddress(arg0 uint32, arg1 types.AddressType, arg2 []types.Address, arg3 *uint16) error {
 	m.ctrl.T.Helper()
@@ -350,17 +364,17 @@ func (mr *MockClientMockRecorder) InstallPodFlows(arg0, arg1, arg2, arg3, arg4 i
 }
 
 // InstallPolicyRuleFlows mocks base method
-func (m *MockClient) InstallPolicyRuleFlows(arg0 uint32, arg1 *types.PolicyRule, arg2, arg3 string) error {
+func (m *MockClient) InstallPolicyRuleFlows(arg0 types.OFPolicyRule) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallPolicyRuleFlows", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "InstallPolicyRuleFlows", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallPolicyRuleFlows indicates an expected call of InstallPolicyRuleFlows
-func (mr *MockClientMockRecorder) InstallPolicyRuleFlows(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallPolicyRuleFlows(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPolicyRuleFlows", reflect.TypeOf((*MockClient)(nil).InstallPolicyRuleFlows), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPolicyRuleFlows", reflect.TypeOf((*MockClient)(nil).InstallPolicyRuleFlows), arg0)
 }
 
 // InstallServiceFlows mocks base method

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -68,7 +68,7 @@ func (mr *MockClientMockRecorder) AddPolicyRuleAddress(arg0, arg1, arg2, arg3 in
 }
 
 // BatchInstallPolicyRuleFlows mocks base method
-func (m *MockClient) BatchInstallPolicyRuleFlows(arg0 []types.OFPolicyRule) error {
+func (m *MockClient) BatchInstallPolicyRuleFlows(arg0 []*types.PolicyRule) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BatchInstallPolicyRuleFlows", arg0)
 	ret0, _ := ret[0].(error)
@@ -364,7 +364,7 @@ func (mr *MockClientMockRecorder) InstallPodFlows(arg0, arg1, arg2, arg3, arg4 i
 }
 
 // InstallPolicyRuleFlows mocks base method
-func (m *MockClient) InstallPolicyRuleFlows(arg0 types.OFPolicyRule) error {
+func (m *MockClient) InstallPolicyRuleFlows(arg0 *types.PolicyRule) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstallPolicyRuleFlows", arg0)
 	ret0, _ := ret[0].(error)

--- a/pkg/agent/types/networkpolicy.go
+++ b/pkg/agent/types/networkpolicy.go
@@ -42,14 +42,18 @@ type Address interface {
 
 // PolicyRule groups configurations to set up conjunctive match for egress/ingress policy rules.
 type PolicyRule struct {
-	Direction v1beta1.Direction
-	From      []Address
-	To        []Address
-	Service   []v1beta1.Service
-	Action    *secv1alpha1.RuleAction
-	Priority  *uint16
+	Direction       v1beta1.Direction
+	From            []Address
+	To              []Address
+	Service         []v1beta1.Service
+	Action          *secv1alpha1.RuleAction
+	Priority        *uint16
+	FlowID          uint32
+	PolicyName      string
+	PolicyNamespace string
 }
 
+// IsAntreaNetworkPolicyRule returns if a PolicyRule is created for Antrea NetworkPolicy types.
 func (r *PolicyRule) IsAntreaNetworkPolicyRule() bool {
 	return r.Priority != nil
 }
@@ -60,12 +64,4 @@ func (r *PolicyRule) IsAntreaNetworkPolicyRule() bool {
 type Priority struct {
 	PolicyPriority float64
 	RulePriority   int32
-}
-
-// OFPolicyRule groups all configurations that the openflow module needs to install flow for PolicyRule.
-type OFPolicyRule struct {
-	OfID        uint32
-	OfRule      *PolicyRule
-	NpName      string
-	NpNamespace string
 }

--- a/pkg/agent/types/networkpolicy.go
+++ b/pkg/agent/types/networkpolicy.go
@@ -61,3 +61,11 @@ type Priority struct {
 	PolicyPriority float64
 	RulePriority   int32
 }
+
+// OFPolicyRule groups all configurations that the openflow module needs to install flow for PolicyRule.
+type OFPolicyRule struct {
+	OfID        uint32
+	OfRule      *PolicyRule
+	NpName      string
+	NpNamespace string
+}

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -168,20 +168,17 @@ func TestReplayFlowsNetworkPolicyFlows(t *testing.T) {
 	npPort1 := v1beta1.Service{Protocol: &tcpProtocol, Port: &port2}
 	toIPList := prepareIPAddresses(toList)
 	rule := &types.PolicyRule{
-		Direction: v1beta1.DirectionIn,
-		From:      prepareIPAddresses(fromList),
-		To:        toIPList,
-		Service:   []v1beta1.Service{npPort1},
-		Action:    &defaultAction,
+		Direction:       v1beta1.DirectionIn,
+		From:            prepareIPAddresses(fromList),
+		To:              toIPList,
+		Service:         []v1beta1.Service{npPort1},
+		Action:          &defaultAction,
+		FlowID:          ruleID,
+		PolicyName:      "np1",
+		PolicyNamespace: "ns1",
 	}
 
-	ofPolicyRule := types.OFPolicyRule{
-		OfID:        ruleID,
-		OfRule:      rule,
-		NpName:      "np1",
-		NpNamespace: "ns1",
-	}
-	err = c.InstallPolicyRuleFlows(ofPolicyRule)
+	err = c.InstallPolicyRuleFlows(rule)
 	require.Nil(t, err, "Failed to InstallPolicyRuleFlows")
 
 	err = c.AddPolicyRuleAddress(ruleID, types.SrcAddress, prepareIPNetAddresses([]string{"192.168.5.0/24", "192.169.1.0/24"}), nil)
@@ -335,19 +332,16 @@ func TestNetworkPolicyFlows(t *testing.T) {
 	npPort1 := v1beta1.Service{Protocol: &tcpProtocol, Port: &port2}
 	toIPList := prepareIPAddresses(toList)
 	rule := &types.PolicyRule{
-		Direction: v1beta1.DirectionIn,
-		From:      prepareIPAddresses(fromList),
-		To:        toIPList,
-		Service:   []v1beta1.Service{npPort1},
-		Action:    &defaultAction,
+		Direction:       v1beta1.DirectionIn,
+		From:            prepareIPAddresses(fromList),
+		To:              toIPList,
+		Service:         []v1beta1.Service{npPort1},
+		Action:          &defaultAction,
+		FlowID:          ruleID,
+		PolicyName:      "np1",
+		PolicyNamespace: "ns1",
 	}
-	ofPolicyRule := types.OFPolicyRule{
-		OfID:        ruleID,
-		OfRule:      rule,
-		NpName:      "np1",
-		NpNamespace: "ns1",
-	}
-	err = c.InstallPolicyRuleFlows(ofPolicyRule)
+	err = c.InstallPolicyRuleFlows(rule)
 	require.Nil(t, err, "Failed to InstallPolicyRuleFlows")
 	checkConjunctionFlows(t, ingressRuleTable, ingressDefaultTable, contrackCommitTable, priorityNormal, ruleID, rule, assert.True)
 	checkDefaultDropFlows(t, ingressDefaultTable, priorityNormal, types.DstAddress, toIPList, true)
@@ -377,18 +371,15 @@ func TestNetworkPolicyFlows(t *testing.T) {
 	udpProtocol := v1beta1.ProtocolUDP
 	npPort2 := v1beta1.Service{Protocol: &udpProtocol}
 	rule2 := &types.PolicyRule{
-		Direction: v1beta1.DirectionIn,
-		To:        toIPList2,
-		Service:   []v1beta1.Service{npPort2},
-		Action:    &defaultAction,
+		Direction:       v1beta1.DirectionIn,
+		To:              toIPList2,
+		Service:         []v1beta1.Service{npPort2},
+		Action:          &defaultAction,
+		FlowID:          ruleID2,
+		PolicyName:      "np1",
+		PolicyNamespace: "ns1",
 	}
-	ofPolicyRule2 := types.OFPolicyRule{
-		OfID:        ruleID2,
-		OfRule:      rule2,
-		NpName:      "np1",
-		NpNamespace: "ns1",
-	}
-	err = c.InstallPolicyRuleFlows(ofPolicyRule2)
+	err = c.InstallPolicyRuleFlows(rule2)
 	require.Nil(t, err, "Failed to InstallPolicyRuleFlows")
 
 	// Dump flows

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -175,7 +175,13 @@ func TestReplayFlowsNetworkPolicyFlows(t *testing.T) {
 		Action:    &defaultAction,
 	}
 
-	err = c.InstallPolicyRuleFlows(ruleID, rule, "np1", "ns1")
+	ofPolicyRule := types.OFPolicyRule{
+		OfID:        ruleID,
+		OfRule:      rule,
+		NpName:      "np1",
+		NpNamespace: "ns1",
+	}
+	err = c.InstallPolicyRuleFlows(ofPolicyRule)
 	require.Nil(t, err, "Failed to InstallPolicyRuleFlows")
 
 	err = c.AddPolicyRuleAddress(ruleID, types.SrcAddress, prepareIPNetAddresses([]string{"192.168.5.0/24", "192.169.1.0/24"}), nil)
@@ -335,8 +341,13 @@ func TestNetworkPolicyFlows(t *testing.T) {
 		Service:   []v1beta1.Service{npPort1},
 		Action:    &defaultAction,
 	}
-
-	err = c.InstallPolicyRuleFlows(ruleID, rule, "np1", "ns1")
+	ofPolicyRule := types.OFPolicyRule{
+		OfID:        ruleID,
+		OfRule:      rule,
+		NpName:      "np1",
+		NpNamespace: "ns1",
+	}
+	err = c.InstallPolicyRuleFlows(ofPolicyRule)
 	require.Nil(t, err, "Failed to InstallPolicyRuleFlows")
 	checkConjunctionFlows(t, ingressRuleTable, ingressDefaultTable, contrackCommitTable, priorityNormal, ruleID, rule, assert.True)
 	checkDefaultDropFlows(t, ingressDefaultTable, priorityNormal, types.DstAddress, toIPList, true)
@@ -371,7 +382,13 @@ func TestNetworkPolicyFlows(t *testing.T) {
 		Service:   []v1beta1.Service{npPort2},
 		Action:    &defaultAction,
 	}
-	err = c.InstallPolicyRuleFlows(ruleID2, rule2, "np1", "ns1")
+	ofPolicyRule2 := types.OFPolicyRule{
+		OfID:        ruleID2,
+		OfRule:      rule2,
+		NpName:      "np1",
+		NpNamespace: "ns1",
+	}
+	err = c.InstallPolicyRuleFlows(ofPolicyRule2)
 	require.Nil(t, err, "Failed to InstallPolicyRuleFlows")
 
 	// Dump flows


### PR DESCRIPTION
Currently in Antrea, OVS flows for NetworkPolicies are installed asynchronously. For agent restart cases however, the initial NetworkPolicy events before the Bookmark (https://github.com/vmware-tanzu/antrea/pull/704) can be processed in batch and be sent to OVS bridge in a single bundle. This PR implements this methodology.