### PR TITLE
[CI] Add cloud support matrix in Jenkins readme

### DIFF
--- a/ci/jenkins/README.md
+++ b/ci/jenkins/README.md
@@ -15,20 +15,37 @@ by this management cluster. As soon as the build finishes, the cluster
 should be deleted. This ensures that all tests are run on a clean testbed.
 
 ### List of Jenkins jobs
-* [e2e](https://jenkins.antrea-ci.rocks/job/antrea-e2e-for-pull-request/):
+[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-eks-conformance-test-native&subject=EKS%20Conformance/NetworkPolicy)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-eks-conformance-test-native/) [![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-gke-conformance-native&subject=GKE%20Conformance/NetworkPolicy%20)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-gke-conformance-native/)
+* [e2e [gated check-in]](https://jenkins.antrea-ci.rocks/job/antrea-e2e-for-pull-request/):
   [end-to-end tests](/test/e2e) for Antrea.
-* [conformance](https://jenkins.antrea-ci.rocks/job/antrea-conformance-for-pull-request/):
+* [conformance [gated check-in]](https://jenkins.antrea-ci.rocks/job/antrea-conformance-for-pull-request/):
   community tests using sonobuoy, focusing on "Conformance", and skipping "Slow",
   "Serial", "Disruptive", "Flaky", "Feature", "sig-cli",
-  "sig-storage", "sig-auth", "sig-api-machinery", "sig-apps" and "sig-node".
-* [network policy](https://jenkins.antrea-ci.rocks/job/antrea-networkpolicy-for-pull-request/):
+  "sig-storage", "sig-auth", "sig-api-machinery", "sig-apps" and "sig-node". [gated check-in]
+* [network policy [gated check-in]](https://jenkins.antrea-ci.rocks/job/antrea-networkpolicy-for-pull-request/):
   community tests using sonobuoy, focusing on "Feature:NetworkPolicy".
 * Microsoft Windows conformance: community tests related to Microsoft Windows.
   It focuses on: "[sig-network].+[Conformance]|[sig-windows]".
   It skips: "[LinuxOnly]|[Slow]|[Serial]|[Disruptive]|[Flaky]|[Feature:.+]|[sig-cli]|[sig-storage]|[sig-auth]|[sig-api-machinery]|[sig-apps]|[sig-node]|[Privileged]|should be able to change the type from|[sig-network] Services should be able to create a functioning NodePort service [Conformance]".
-* jenkins jobs validator: this job only executes for PRs that include changes to
+* jenkins jobs validator [gated check-in]: this job only executes for PRs that include changes to
   [ci/jenkins/jobs](/ci/jenkins/jobs). It validates the syntax of the jenkins jobs'
   configuration.
+* [EKS conformance/network policy [bi-daily]](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-eks-conformance-test-native/)
+  community tests on EKS cluster using sonobuoy, focusing on "Conformance" and "Feature:NetworkPolicy", skipping the same regexes as in job __conformance__ above, as well as "NodePort" (See [#690](https://github.com/vmware-tanzu/antrea/issues/690)).\
+  Current test environment matrix:
+  
+  |  K8s version |    Node type    |  Node AMI Family |  Status  |
+  | :----------: | :-------------: | :--------------: | :------: |
+  |     1.15     |  EC2 t3.medium  |   AmazonLinux2   |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-eks-conformance-test-native)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-eks-conformance-test-native/)|
+  
+* [GKE conformance/network policy [bi-daily]](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-gke-conformance-native/)
+  community tests on GKE cluster using sonobuoy, focusing on "Conformance" and "Feature:NetworkPolicy", skipping the same regexes as in job __conformance__ above.\
+  Current test environment matrix:
+    
+  |  K8s version   |     Node OS     | VPC Native Mode (on by default) |  Status  | 
+  | :------------: | :-------------: | :-----------------------------: |:-------: |
+  | 1.15.11-gke.11 |     Ubuntu      |  On                             |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-gke-conformance-native)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-gke-conformance-native/)|
+  
 
 If you need to run the K8s community tests locally, you may use the
 [ci/run-k8s-e2e-tests.sh](/ci/run-k8s-e2e-tests.sh) script. It takes care of


### PR DESCRIPTION
Fixes #729 
- Add cloud jenkins CI job status in ci/jenkins/README.md
- Add current test matrix