### PR TITLE
Change gateway and tunnel interface names to antrea-gw0 and antrea-tun0

### DIFF
--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -530,7 +530,7 @@ data:
 
     # Name of the interface antrea-agent will create and use for host <--> pod communication.
     # Make sure it doesn't conflict with your existing interfaces.
-    #hostGateway: gw0
+    #hostGateway: antrea-gw0
 
     # Encapsulation mode for communication between Pods across Nodes, supported values:
     # - geneve (default)
@@ -616,7 +616,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-mc5ccdc4g2
+  name: antrea-config-56mbbtb474
   namespace: kube-system
 ---
 apiVersion: v1
@@ -721,7 +721,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-mc5ccdc4g2
+          name: antrea-config-56mbbtb474
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -937,7 +937,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-mc5ccdc4g2
+          name: antrea-config-56mbbtb474
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -530,7 +530,7 @@ data:
 
     # Name of the interface antrea-agent will create and use for host <--> pod communication.
     # Make sure it doesn't conflict with your existing interfaces.
-    #hostGateway: gw0
+    #hostGateway: antrea-gw0
 
     # Encapsulation mode for communication between Pods across Nodes, supported values:
     # - geneve (default)
@@ -616,7 +616,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-6t2d49gm87
+  name: antrea-config-96mc77fdk8
   namespace: kube-system
 ---
 apiVersion: v1
@@ -721,7 +721,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-6t2d49gm87
+          name: antrea-config-96mc77fdk8
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -935,7 +935,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-6t2d49gm87
+          name: antrea-config-96mc77fdk8
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -530,7 +530,7 @@ data:
 
     # Name of the interface antrea-agent will create and use for host <--> pod communication.
     # Make sure it doesn't conflict with your existing interfaces.
-    #hostGateway: gw0
+    #hostGateway: antrea-gw0
 
     # Encapsulation mode for communication between Pods across Nodes, supported values:
     # - geneve (default)
@@ -616,7 +616,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-887cmc44kc
+  name: antrea-config-tkd7g2g7d4
   namespace: kube-system
 ---
 apiVersion: v1
@@ -730,7 +730,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-887cmc44kc
+          name: antrea-config-tkd7g2g7d4
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -979,7 +979,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-887cmc44kc
+          name: antrea-config-tkd7g2g7d4
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -29,7 +29,7 @@ data:
 
     # Name of the interface antrea-agent will create and use for host <--> pod communication.
     # Make sure it doesn't conflict with your existing interfaces.
-    #hostGateway: gw0
+    #hostGateway: antrea-gw0
 
     # Encapsulation mode for communication between Pods across Nodes, supported values:
     # - geneve (default)
@@ -69,7 +69,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-windows-config-8ktf86t8d5
+  name: antrea-windows-config-2b4h888dt2
   namespace: kube-system
 ---
 apiVersion: apps/v1
@@ -157,7 +157,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-windows-config-8ktf86t8d5
+          name: antrea-windows-config-2b4h888dt2
         name: antrea-windows-config
       - configMap:
           defaultMode: 420

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -530,7 +530,7 @@ data:
 
     # Name of the interface antrea-agent will create and use for host <--> pod communication.
     # Make sure it doesn't conflict with your existing interfaces.
-    #hostGateway: gw0
+    #hostGateway: antrea-gw0
 
     # Encapsulation mode for communication between Pods across Nodes, supported values:
     # - geneve (default)
@@ -616,7 +616,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-d42ht2g25g
+  name: antrea-config-5g4h62mc5t
   namespace: kube-system
 ---
 apiVersion: v1
@@ -721,7 +721,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-d42ht2g25g
+          name: antrea-config-5g4h62mc5t
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -935,7 +935,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-d42ht2g25g
+          name: antrea-config-5g4h62mc5t
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -20,7 +20,7 @@ featureGates:
 
 # Name of the interface antrea-agent will create and use for host <--> pod communication.
 # Make sure it doesn't conflict with your existing interfaces.
-#hostGateway: gw0
+#hostGateway: antrea-gw0
 
 # Encapsulation mode for communication between Pods across Nodes, supported values:
 # - geneve (default)

--- a/build/yamls/windows/base/conf/antrea-agent.conf
+++ b/build/yamls/windows/base/conf/antrea-agent.conf
@@ -11,7 +11,7 @@ featureGates:
 
 # Name of the interface antrea-agent will create and use for host <--> pod communication.
 # Make sure it doesn't conflict with your existing interfaces.
-#hostGateway: gw0
+#hostGateway: antrea-gw0
 
 # Encapsulation mode for communication between Pods across Nodes, supported values:
 # - geneve (default)

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -95,7 +95,7 @@ func run(o *Options) error {
 		TrafficEncapMode:  encapMode,
 		EnableIPSecTunnel: o.config.EnableIPSecTunnel}
 
-	routeClient, err := route.NewClient(o.config.HostGateway, serviceCIDRNet, encapMode)
+	routeClient, err := route.NewClient(serviceCIDRNet, encapMode)
 	if err != nil {
 		return fmt.Errorf("error creating route client: %v", err)
 	}

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -46,7 +46,7 @@ type AgentConfig struct {
 	OVSRunDir string `yaml:"ovsRunDir,omitempty"`
 	// Name of the interface antrea-agent will create and use for host <--> pod communication.
 	// Make sure it doesn't conflict with your existing interfaces.
-	// Defaults to gw0.
+	// Defaults to antrea-gw0.
 	HostGateway string `yaml:"hostGateway,omitempty"`
 	// Encapsulation mode for communication between Pods across Nodes, supported values:
 	// - geneve (default)

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -31,9 +31,10 @@ import (
 
 const (
 	defaultOVSBridge          = "br-int"
-	defaultHostGateway        = "gw0"
+	defaultHostGateway        = "antrea-gw0"
 	defaultHostProcPathPrefix = "/host"
 	defaultServiceCIDR        = "10.96.0.0/12"
+	defaultTunnelType         = ovsconfig.VXLANTunnel
 	defaultMTUGeneve          = 1450
 	defaultMTUVXLAN           = 1450
 	defaultMTUGRE             = 1462
@@ -136,7 +137,7 @@ func (o *Options) setDefaults() {
 		o.config.HostGateway = defaultHostGateway
 	}
 	if o.config.TunnelType == "" {
-		o.config.TunnelType = ovsconfig.VXLANTunnel
+		o.config.TunnelType = defaultTunnelType
 	}
 	if o.config.HostProcPathPrefix == "" {
 		o.config.HostProcPathPrefix = defaultHostProcPathPrefix

--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -224,7 +224,7 @@ antctl trace-packet -S ns1/pod1 -D ns2/srv2 -f "tcp,tcp_dst=80"
 # Trace the Service reply packet (assuming "ns2/pod2" is the Service backend Pod)
 antctl trace-packet -D ns1/pod1 -S ns2/pod2 -f "tcp,tcp_src=80"
 # Trace an IP packet from a Pod to gateway port
-antctl trace-packet -S ns1/pod1 -D gw0
+antctl trace-packet -S ns1/pod1 -D antrea-gw0
 # Trace a UDP packet from a Pod to an IP address
 antctl trace-packet -S ns1/pod1 -D 10.1.2.3 -f udp,udp_dst=1234
 # Trace a UDP packet from an IP address to a Pod

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -149,8 +149,8 @@ their health and runtime information.
 On every Node, Antrea Agent creates an OVS bridge (named `br-int` by default),
 and creates a veth pair for each Pod, with one end being in the Pod's network
 namespace and the other connected to the OVS bridge. On the OVS bridge, Antrea
-Agent also creates an internal port - `gw0` by default - to be the gateway of
-the Node's subnet, and a tunnel port `tun0` which is for creating overlay
+Agent also creates an internal port - `antrea-gw0` by default - to be the gateway of
+the Node's subnet, and a tunnel port `antrea-tun0` which is for creating overlay
 tunnels to other Nodes.
 
 <img src="/docs/assets/node.svg.png" width="300" alt="Antrea Node Network">
@@ -160,7 +160,7 @@ the subnet. Antrea leverages Kubernetes' `NodeIPAMController` for the Node
 subnet allocation, which sets the `podCIDR` field of the Kubernetes Node spec
 to the allocated subnet. Antrea Agent retrieves the subnets of Nodes from the
 `podCIDR` field. It reserves the first IP of the local Node's subnet to be the
-gateway IP and assigns it to the `gw0` port, and invokes the
+gateway IP and assigns it to the `antrea-gw0` port, and invokes the
 [host-local IPAM plugin](https://github.com/containernetworking/plugins/tree/master/plugins/ipam/host-local)
 to allocate IPs from the subnet to all local Pods. A local Pod is assigned an IP
 when the CNI ADD command is received for that Pod.
@@ -177,12 +177,12 @@ IP against each Node's subnet.
 the OVS bridge directly.
 
 * ***Inter-node traffic*** Packets to a Pod on another Node will be first
-forwarded to the `tun0` port, encapsulated, and sent to the destination Node
-through the tunnel; then they will be decapsulated, injected through the `tun0`
+forwarded to the `antrea-tun0` port, encapsulated, and sent to the destination Node
+through the tunnel; then they will be decapsulated, injected through the `antrea-tun0`
 port to the OVS bridge, and finally forwarded to the destination Pod.
 
 * ***Pod to external traffic*** Packets sent to an external IP or the Nodes'
-network will be forwarded to the `gw0` port (as it is the gateway of the local
+network will be forwarded to the `antrea-gw0` port (as it is the gateway of the local
 Pod subnet), and will be routed (based on routes configured on the Node) to the
 appropriate network interface of the Node (e.g. a physical network interface for
 a baremetal Node) and sent out to the Node network from there. Antrea Agent
@@ -195,7 +195,7 @@ so their source IP will be rewritten to the Node's IP before going out.
 
 At the moment, Antrea leverages `kube-proxy` to serve traffic for ClusterIP and
 NodePort type Services. The packets from a Pod to a Service's ClusterIP will be
-forwarded through the `gw0` port, then `kube-proxy` will select one Service
+forwarded through the `antrea-gw0` port, then `kube-proxy` will select one Service
 backend Pod to be the connection's destination and DNAT the packets to the Pod's
 IP and port. If the destination Pod is on the local Node the packets will be
 forwarded to the Pod directly; if it is on another Node the packets will be sent
@@ -267,7 +267,7 @@ IP address to two OVS interface options of the tunnel interface. Then
 with PSK for the remote Node, and strongSwan can create the IPsec Security
 Associations based on the Security Policies. These additional tunnel ports are
 not used to send traffic to a remote Node - the tunnel traffic is still output
-to the default tunnel port (`tun0`) with OVS flow based tunneling. However, the
+to the default tunnel port (`antrea-tun0`) with OVS flow based tunneling. However, the
 traffic from a remote Node will be received from the Node's IPsec tunnel port.
 
 ### Hybrid, NoEncap, NetworkPolicyOnly TrafficEncapMode

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,7 @@ Use `antrea-agent -h` to see complete options.
 
 # Name of the gateway interface for the local Pod subnet. antrea-agent will create the interface on the OVS bridge.
 # Make sure it doesn't conflict with your existing interfaces.
-#hostGateway: gw0
+#hostGateway: antrea-gw0
 
 # Encapsulation mode for communication between Pods across Nodes, supported values:
 # - geneve (default)

--- a/docs/os-issues.md
+++ b/docs/os-issues.md
@@ -20,7 +20,7 @@ for network configuration. By default, all interfaces are managed by networkd
 because of the [configuration
 files](https://github.com/coreos/init/tree/master/systemd/network) that ship
 with CoreOS. Unfortunately, that includes the gateway interface created by
-Antrea (`gw0` by default). Most of the time, this is not an issue, but if
+Antrea (`antrea-gw0` by default). Most of the time, this is not an issue, but if
 networkd is restarted for any reason, it will cause the interface to lose its IP
 configuration, and all the routes associated with the interface will be
 deleted. To avoid this issue, we recommend that you create the following
@@ -29,7 +29,7 @@ configuration files:
 # /etc/systemd/network/90-antrea-ovs.network
 [Match]
 # use the correct name for the gateway if you changed the Antrea configuration
-Name=gw0 ovs-system
+Name=antrea-gw0 ovs-system
 Driver=openvswitch
 
 [Link]
@@ -89,8 +89,8 @@ experience connectivity issues, it may be because of Photon's default firewall
 rules, which are quite strict by
 [default](https://vmware.github.io/photon/assets/files/html/3.0/photon_admin/default-firewall-settings.html). The
 easiest workaround is to accept all traffic on the gateway interface created by
-Antrea (`gw0` by default), which enables traffic to flow between the Node and
+Antrea (`antrea-gw0` by default), which enables traffic to flow between the Node and
 the Pod network:
 ```
-iptables -A INPUT -i gw0 -j ACCEPT
+iptables -A INPUT -i antrea-gw0 -j ACCEPT
 ```

--- a/docs/ovs-pipeline.md
+++ b/docs/ovs-pipeline.md
@@ -135,8 +135,8 @@ local Pod. This information is used by matches in subsequent tables.
 
 If you dump the flows for this table, you may see the following:
 ```
-1. table=0, priority=200,in_port=gw0 actions=load:0x1->NXM_NX_REG0[0..15],goto_table:10
-2. table=0, priority=200,in_port=tun0 actions=load:0->NXM_NX_REG0[0..15],goto_table:30
+1. table=0, priority=200,in_port=antrea-gw0 actions=load:0x1->NXM_NX_REG0[0..15],goto_table:10
+2. table=0, priority=200,in_port=antrea-tun0 actions=load:0->NXM_NX_REG0[0..15],goto_table:30
 3. table=0, priority=190,in_port="coredns5-8ec607" actions=load:0x2->NXM_NX_REG0[0..15],goto_table:10
 4. table=0, priority=190,in_port="coredns5-9d9530" actions=load:0x2->NXM_NX_REG0[0..15],goto_table:10
 5. table=0, priority=0 actions=drop
@@ -172,12 +172,12 @@ traffic can be received on the gateway port with a source IP belonging to a
 local Pod. We may add some fine-grained rules in the future to accommodate for
 this, but for now we just allow all IP traffic received from the gateway. We do
 have an ARP spoofing check for the gateway however, since there is no reason for
-the host to advertise a different MAC address on gw0.
+the host to advertise a different MAC address on antrea-gw0.
 
 If you dump the flows for this table, you may see the following:
 ```
-1. table=10, priority=200,ip,in_port=gw0 actions=goto_table:30
-2. table=10, priority=200,arp,in_port=gw0,arp_spa=10.10.0.1,arp_sha=e2:e5:a4:9b:1c:b1 actions=goto_table:20
+1. table=10, priority=200,ip,in_port=antrea-gw0 actions=goto_table:30
+2. table=10, priority=200,arp,in_port=antrea-gw0,arp_spa=10.10.0.1,arp_sha=e2:e5:a4:9b:1c:b1 actions=goto_table:20
 3. table=10, priority=200,ip,in_port="coredns5-8ec607",dl_src=12:9e:a6:47:d0:70,nw_src=10.10.0.2 actions=goto_table:30
 4. table=10, priority=200,ip,in_port="coredns5-9d9530",dl_src=ba:a8:13:ca:ed:cf,nw_src=10.10.0.3 actions=goto_table:30
 5. table=10, priority=200,arp,in_port="coredns5-8ec607",arp_spa=10.10.0.2,arp_sha=12:9e:a6:47:d0:70 actions=goto_table:20
@@ -214,9 +214,9 @@ Flow 1 is the "ARP responder" for the peer Node whose local Pod subnet is
 10.10.1.0/24. If we were to look at the routing table for the local Node, we
 would see the following "onlink" route:
 ```
-10.10.1.0/24 via 10.10.1.1 dev gw0 onlink
+10.10.1.0/24 via 10.10.1.1 dev antrea-gw0 onlink
 ```
-A similar route is installed on the gateway (gw0) interface every time the
+A similar route is installed on the gateway (antrea-gw0) interface every time the
 Antrea Node Route Controller is notified that a new Node has joined the
 cluster. The route must be marked as "onlink" since the kernel does not have a
 route to the peer gateway 10.10.1.1: we trick the kernel into believing that

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func newAgentInitializer(ovsBridgeClient ovsconfig.OVSBridgeClient, ifaceStore interfacestore.InterfaceStore) *Initializer {
-	return &Initializer{ovsBridgeClient: ovsBridgeClient, ifaceStore: ifaceStore, hostGateway: "gw0"}
+	return &Initializer{ovsBridgeClient: ovsBridgeClient, ifaceStore: ifaceStore, hostGateway: "antrea-gw0"}
 }
 
 func convertExternalIDMap(in map[string]interface{}) map[string]string {
@@ -70,10 +70,10 @@ func TestInitstore(t *testing.T) {
 	p2NetMAC, _ := net.ParseMAC(p2MAC)
 	p2NetIP := net.ParseIP(p2IP)
 
-	ovsPort1 := ovsconfig.OVSPortData{UUID: uuid1, Name: "p1", IFName: "p1", OFPort: 1,
+	ovsPort1 := ovsconfig.OVSPortData{UUID: uuid1, Name: "p1", IFName: "p1", OFPort: 11,
 		ExternalIDs: convertExternalIDMap(cniserver.BuildOVSPortExternalIDs(
 			interfacestore.NewContainerInterface("p1", uuid1, "pod1", "ns1", p1NetMAC, p1NetIP)))}
-	ovsPort2 := ovsconfig.OVSPortData{UUID: uuid2, Name: "p2", IFName: "p2", OFPort: 2,
+	ovsPort2 := ovsconfig.OVSPortData{UUID: uuid2, Name: "p2", IFName: "p2", OFPort: 12,
 		ExternalIDs: convertExternalIDMap(cniserver.BuildOVSPortExternalIDs(
 			interfacestore.NewContainerInterface("p2", uuid2, "pod2", "ns2", p2NetMAC, p2NetIP)))}
 	initOVSPorts := []ovsconfig.OVSPortData{ovsPort1, ovsPort2}
@@ -92,7 +92,7 @@ func TestInitstore(t *testing.T) {
 	container1, found1 := store.GetContainerInterface(uuid1)
 	if !found1 {
 		t.Errorf("Failed to load OVS port into local store")
-	} else if container1.OFPort != 1 || container1.IP.String() != p1IP || container1.MAC.String() != p1MAC || container1.InterfaceName != "p1" {
+	} else if container1.OFPort != 11 || container1.IP.String() != p1IP || container1.MAC.String() != p1MAC || container1.InterfaceName != "p1" {
 		t.Errorf("Failed to load OVS port configuration into local store")
 	}
 	_, found2 := store.GetContainerInterface(uuid2)

--- a/pkg/agent/apiserver/handlers/ovstracing/handler.go
+++ b/pkg/agent/apiserver/handlers/ovstracing/handler.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver/handlers"
-	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
 	"github.com/vmware-tanzu/antrea/pkg/agent/querier"
 	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsctl"
@@ -176,7 +175,7 @@ func prepareTracingRequest(aq querier.AgentQuerier, req *request) (*ovsctl.Traci
 			// Source is a remote Pod. Use the default tunnel port as the input port.
 			// For hybrid TrafficEncapMode, even the remote Node is in the same subnet
 			// as the source Node, the tunnel port is still used as the input port.
-			intf, ok := aq.GetInterfaceStore().GetInterface(config.DefaultTunPortName)
+			intf, ok := aq.GetInterfaceStore().GetInterface(aq.GetNodeConfig().DefaultTunName)
 			// If the default tunnel port is not found, it might be NoEncap or
 			// NetworkPolicyOnly mode. Use gateway port as the input port then.
 			if ok {

--- a/pkg/agent/apiserver/handlers/ovstracing/handler_test.go
+++ b/pkg/agent/apiserver/handlers/ovstracing/handler_test.go
@@ -45,13 +45,13 @@ var (
 
 	testNodeConfig = &config.NodeConfig{
 		GatewayConfig: &config.GatewayConfig{
-			Name: "gw0",
+			Name: "antrea-gw0",
 			IP:   net.ParseIP("10.1.1.1"),
 			MAC:  gatewayMAC},
 	}
 
-	gatewayInterface = &interfacestore.InterfaceConfig{Type: interfacestore.GatewayInterface, InterfaceName: "gw0"}
-	tunnelInterface  = &interfacestore.InterfaceConfig{Type: interfacestore.TunnelInterface, InterfaceName: "tun0"}
+	gatewayInterface = &interfacestore.InterfaceConfig{Type: interfacestore.GatewayInterface, InterfaceName: "antrea-gw0"}
+	tunnelInterface  = &interfacestore.InterfaceConfig{Type: interfacestore.TunnelInterface, InterfaceName: "antrea-tun0"}
 	inPodInterface   = &interfacestore.InterfaceConfig{
 		Type:          interfacestore.ContainerInterface,
 		InterfaceName: "inPod",
@@ -162,15 +162,15 @@ func TestPodFlows(t *testing.T) {
 		},
 		{
 			test:           "Tunnel traffic",
-			port:           "tun0",
-			query:          "?port=tun0&&source=10.1.1.123&&destination=dstNS/dstPod",
+			port:           "antrea-tun0",
+			query:          "?port=antrea-tun0&&source=10.1.1.123&&destination=dstNS/dstPod",
 			calledTrace:    true,
 			expectedStatus: http.StatusOK,
 		},
 		{
-			test:           "gw0 port",
-			port:           "gw0",
-			query:          "?port=gw0&&destination=dstNS/dstPod",
+			test:           "antrea-gw0 port",
+			port:           "antrea-gw0",
+			query:          "?port=antrea-gw0&&destination=dstNS/dstPod",
 			calledTrace:    true,
 			expectedStatus: http.StatusOK,
 		},
@@ -194,9 +194,9 @@ func TestPodFlows(t *testing.T) {
 			assert.False(t, tc.expectedStatus == http.StatusNotFound)
 
 			q.EXPECT().GetInterfaceStore().Return(i).MaxTimes(3)
-			if tc.port == "gw0" {
+			if tc.port == "antrea-gw0" {
 				i.EXPECT().GetInterfaceByName(tc.port).Return(gatewayInterface, true).Times(1)
-			} else if tc.port == "tun0" {
+			} else if tc.port == "antrea-tun0" {
 				i.EXPECT().GetInterfaceByName(tc.port).Return(tunnelInterface, true).Times(1)
 				q.EXPECT().GetOpenflowClient().Return(ofc).Times(1)
 				ofc.EXPECT().GetTunnelVirtualMAC().Return(tunnelVirtualMAC).Times(1)

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -22,7 +22,6 @@ import (
 )
 
 const (
-	DefaultTunPortName = "tun0"
 	// Invalid ofport_request number is in range 1 to 65,279. For ofport_request number not in the range, OVS
 	// ignore the it and automatically assign a port number.
 	// Here we use an invalid port number "0" to request for automatically port allocation.
@@ -35,12 +34,12 @@ const (
 )
 
 type GatewayConfig struct {
-	IP  net.IP
-	MAC net.HardwareAddr
+	// Name is the name of host gateway, e.g. antrea-gw0.
+	Name string
+	IP   net.IP
+	MAC  net.HardwareAddr
 	// LinkIndex is the link index of host gateway.
 	LinkIndex int
-	// Name is the name of host gateway, e.g. gw0.
-	Name string
 }
 
 func (g *GatewayConfig) String() string {
@@ -62,13 +61,17 @@ type NodeConfig struct {
 	Name string
 	// The name of the OpenVSwitch bridge antrea-agent uses.
 	OVSBridge string
+	// The name of the default tunnel interface. Defaults to "antrea-tun0", but can
+	// be overridden by the discovered tunnel interface name from the OVS bridge.
+	DefaultTunName string
 	// The CIDR block to allocate Pod IPs out of.
 	// It's nil for the networkPolicyOnly trafficEncapMode which doesn't do IPAM.
 	PodCIDR *net.IPNet
 	// The Node's IP used in Kubernetes. It has the network mask information.
 	NodeIPAddr *net.IPNet
-	// The config of the gateway network device, i.e. gw0 by default.
-	GatewayConfig   *GatewayConfig
+	// The config of the gateway interface on the OVS bridge.
+	GatewayConfig *GatewayConfig
+	// The config of the OVS bridge uplink interface. Only for Windows Node.
 	UplinkNetConfig *AdapterNetConfig
 }
 

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -220,7 +220,7 @@ func (c *Controller) removeStaleTunnelPorts() error {
 			klog.Errorf("Interface %s can no longer be found in the interface store", ifaceID)
 			continue
 		}
-		if interfaceConfig.InterfaceName == config.DefaultTunPortName {
+		if interfaceConfig.InterfaceName == c.nodeConfig.DefaultTunName {
 			continue
 		}
 		if err := c.ovsBridgeClient.DeletePort(interfaceConfig.PortUUID); err != nil {
@@ -328,7 +328,7 @@ func (c *Controller) processNextWorkItem() bool {
 // If we have not established connectivity to the Node yet:
 //   * we install the appropriate Linux route:
 // Destination     Gateway         Use Iface
-// peerPodCIDR     peerGatewayIP   localGatewayIface (e.g gw0)
+// peerPodCIDR     peerGatewayIP   localGatewayIface (e.g antrea-gw0)
 //   * we install the appropriate OpenFlow flows to ensure that all the traffic destined to
 //   peerPodCIDR goes through the correct L3 tunnel.
 // If the Node no longer exists (cannot be retrieved by name from nodeLister) we delete the route

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -521,7 +521,7 @@ func (c *client) traceflowL2ForwardOutputFlow(dataplaneTag uint8, category cooki
 		Done()
 }
 
-// l2ForwardOutputReentInPortFlow generates the flow that forward re-entrance peer Node traffic via gw0.
+// l2ForwardOutputReentInPortFlow generates the flow that forwards re-entrance peer Node traffic via antrea-gw0.
 // This flow supersedes default output flow because ovs by default auto-skips packets with output = input port.
 func (c *client) l2ForwardOutputReentInPortFlow(gwPort uint32, category cookie.Category) binding.Flow {
 	return c.pipeline[l2ForwardingOutTable].BuildFlow(priorityHigh).MatchProtocol(binding.ProtocolIP).
@@ -1036,8 +1036,8 @@ func (c *client) l3ToExternalFlows(nodeIP net.IP, localSubnet net.IPNet, outputP
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done(),
 		// Forward the packet to L2ForwardingCalc table if it is sent to the Node IP(not to the host gateway). Since
-		// the packet is using the host gateway's MAC as dst MAC, it will be sent out from "gw0". This flow entry is to
-		// avoid SNAT on such packet, otherwise the source and destination IP are the same.
+		// the packet is using the host gateway's MAC as dst MAC, it will be sent out from "antrea-gw0". This flow
+		// entry is to avoid SNAT on such packet, otherwise the source and destination IP are the same.
 		c.pipeline[l3ForwardingTable].BuildFlow(priorityLow).
 			MatchProtocol(binding.ProtocolIP).
 			MatchRegRange(int(marksReg), markTrafficFromLocal, binding.Range{0, 15}).

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -44,7 +44,7 @@ type Client struct {
 }
 
 // NewClient returns a route client.
-func NewClient(hostGateway string, serviceCIDR *net.IPNet, encapMode config.TrafficEncapModeType) (*Client, error) {
+func NewClient(serviceCIDR *net.IPNet, encapMode config.TrafficEncapModeType) (*Client, error) {
 	nr := netroute.New()
 	return &Client{
 		nr:          nr,
@@ -63,10 +63,10 @@ func (c *Client) Initialize(nodeConfig *config.NodeConfig) error {
 	}
 	// Enable IP-Forwarding on the host gateway interface, thus the host networking stack can be used to forward the
 	// SNAT packet from local Pods. The SNAT packet is leaving the OVS pipeline with the Node's IP as the source IP,
-	// the external address as the destination IP, and the gw0's MAC as the dst MAC. Then it will be forwarded to the
-	// host network stack from the host gateway interface, and its dst MAC could be resolved to the right one. At last,
-	// the packet is sent back to OVS from the bridge Interface, and the OpenFlow entries will output it to the uplink
-	// interface directly.
+	// the external address as the destination IP, and the antrea-gw0's MAC as the dst MAC. Then it will be forwarded
+	// to the host network stack from the host gateway interface, and its dst MAC could be resolved to the right one.
+	// At last, the packet is sent back to OVS from the bridge Interface, and the OpenFlow entries will output it to
+	// the uplink interface directly.
 	if err := util.EnableIPForwarding(nodeConfig.GatewayConfig.Name); err != nil {
 		return err
 	}

--- a/pkg/agent/route/route_windows_test.go
+++ b/pkg/agent/route/route_windows_test.go
@@ -39,13 +39,12 @@ func getNetLinkIndex(dev string) int {
 func TestRouteOperation(t *testing.T) {
 	// Leverage loopback interface for testing.
 	hostGateway := "Loopback Pseudo-Interface 1"
-	_, serviceCIDR, _ := net.ParseCIDR("1.1.0.0/16")
 	gwLink := getNetLinkIndex("Loopback Pseudo-Interface 1")
 
+	_, serviceCIDR, _ := net.ParseCIDR("1.1.0.0/16")
 	peerNodeIP := net.ParseIP("10.0.0.2")
 	gwIP1 := net.ParseIP("192.168.2.1")
 	_, destCIDR1, _ := net.ParseCIDR("192.168.2.0/24")
-
 	dest2 := "192.168.3.0/24"
 	gwIP2 := net.ParseIP("192.168.3.1")
 	_, destCIDR2, _ := net.ParseCIDR(dest2)
@@ -53,10 +52,11 @@ func TestRouteOperation(t *testing.T) {
 	nr := netroute.New()
 	defer nr.Exit()
 
-	client, err := NewClient(hostGateway, serviceCIDR, 0)
+	client, err := NewClient(serviceCIDR, 0)
 	require.Nil(t, err)
 	nodeConfig := &config.NodeConfig{
 		GatewayConfig: &config.GatewayConfig{
+			Name:      hostGateway,
 			LinkIndex: gwLink,
 		},
 	}

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -279,7 +279,7 @@ var CommandList = &commandList{
   Trace a UDP packet from a Pod to an IP address
   $ antctl trace-packet -S ns1/pod1 -D 10.1.2.3 -f udp,udp_dst=1234
   Trace an IP packet from a Pod to gateway port
-  $ antctl trace-packet -S ns1/pod1 -D gw0
+  $ antctl trace-packet -S ns1/pod1 -D antrea-gw0
   Trace a UDP packet from an IP to a Pod
   $ antctl trace-packet -D ns1/pod1 -S 10.1.2.3 -f udp,udp_src=1234
   Trace an IP packet from OVS port using a specified source IP

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -51,7 +51,7 @@ const (
 	antreaConfigVolume   string = "antrea-config"
 	antreaDaemonSet      string = "antrea-agent"
 	antreaDeployment     string = "antrea-controller"
-	antreaDefaultGW      string = "gw0"
+	antreaDefaultGW      string = "antrea-gw0"
 	testNamespace        string = "antrea-test"
 	busyboxContainerName string = "busybox"
 	ovsContainerName     string = "antrea-ovs"

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -717,7 +717,7 @@ func TestCNIServerChaining(t *testing.T) {
 	defer controller.Finish()
 	var server *cniserver.CNIServer
 	testContainerOFPort := int32(1234)
-	testPatchPortName := "gw0"
+	testPatchPortName := "antrea-gw0"
 	ctx, _ := context.WithCancel(context.Background())
 
 	tc := testCase{


### PR DESCRIPTION
Add "antrea-" prefix to the default names of host gateway and tunnel
interfaces.
To handle interface name changes after Antrea upgrade, or name changes
due to agent configuration changes, antrea-agent will use the discovered
interface names (from the OVS bridge) as the gateway and tunnel
interface names.