### PR TITLE
Change default tunnel type from VXLAN to Geneve

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Also check out [@ProjectAntrea](https://twitter.com/ProjectAntrea) on Twitter!
 ## Features
 
 Antrea currently supports the following features:
-* IPv4 overlay network for a Kubernetes cluster. VXLAN, Geneve, GRE, or STT can
+* IPv4 overlay network for a Kubernetes cluster. Geneve, VXLAN, GRE, or STT can
 be used as the encapsulation protocol.
 * [Kubernetes Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies)
 implementation.

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -363,11 +363,11 @@ data:
     #hostGateway: gw0
 
     # Encapsulation mode for communication between Pods across Nodes, supported values:
-    # - vxlan (default)
-    # - geneve
+    # - geneve (default)
+    # - vxlan
     # - gre
     # - stt
-    #tunnelType: vxlan
+    #tunnelType: geneve
 
     # Default MTU to use for the host gateway interface and the network interface of each Pod. If
     # omitted, antrea-agent will default this value to 1450 to accommodate for tunnel encapsulate
@@ -438,7 +438,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-2k49hdb86m
+  name: antrea-config-fktddbgbt9
   namespace: kube-system
 ---
 apiVersion: v1
@@ -543,7 +543,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-2k49hdb86m
+          name: antrea-config-fktddbgbt9
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -757,7 +757,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-2k49hdb86m
+          name: antrea-config-fktddbgbt9
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -363,11 +363,11 @@ data:
     #hostGateway: gw0
 
     # Encapsulation mode for communication between Pods across Nodes, supported values:
-    # - vxlan (default)
-    # - geneve
+    # - geneve (default)
+    # - vxlan
     # - gre
     # - stt
-    #tunnelType: vxlan
+    #tunnelType: geneve
 
     # Default MTU to use for the host gateway interface and the network interface of each Pod. If
     # omitted, antrea-agent will default this value to 1450 to accommodate for tunnel encapsulate
@@ -438,7 +438,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-cfhgb2tt48
+  name: antrea-config-9bkbtgd8tf
   namespace: kube-system
 ---
 apiVersion: v1
@@ -543,7 +543,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-cfhgb2tt48
+          name: antrea-config-9bkbtgd8tf
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -755,7 +755,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-cfhgb2tt48
+          name: antrea-config-9bkbtgd8tf
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -363,8 +363,8 @@ data:
     #hostGateway: gw0
 
     # Encapsulation mode for communication between Pods across Nodes, supported values:
-    # - vxlan (default)
-    # - geneve
+    # - geneve (default)
+    # - vxlan
     # - gre
     # - stt
     tunnelType: gre
@@ -438,7 +438,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-57kg4gbmk6
+  name: antrea-config-576575d7g8
   namespace: kube-system
 ---
 apiVersion: v1
@@ -552,7 +552,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-57kg4gbmk6
+          name: antrea-config-576575d7g8
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -799,7 +799,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-57kg4gbmk6
+          name: antrea-config-576575d7g8
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -25,10 +25,10 @@ data:
     #hostGateway: gw0
 
     # Encapsulation mode for communication between Pods across Nodes, supported values:
-    # - vxlan (default)
-    # - geneve
+    # - geneve (default)
+    # - vxlan
     # - stt
-    #tunnelType: vxlan
+    #tunnelType: geneve
 
     # Default MTU to use for the host gateway interface and the network interface of each Pod. If
     # omitted, antrea-agent will default this value to 1450 to accommodate for tunnel encapsulate
@@ -62,7 +62,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-windows-config-mthfbgb569
+  name: antrea-windows-config-kc69htmck4
   namespace: kube-system
 ---
 apiVersion: apps/v1
@@ -150,7 +150,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-windows-config-mthfbgb569
+          name: antrea-windows-config-kc69htmck4
         name: antrea-windows-config
       - configMap:
           defaultMode: 420

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -363,11 +363,11 @@ data:
     #hostGateway: gw0
 
     # Encapsulation mode for communication between Pods across Nodes, supported values:
-    # - vxlan (default)
-    # - geneve
+    # - geneve (default)
+    # - vxlan
     # - gre
     # - stt
-    #tunnelType: vxlan
+    #tunnelType: geneve
 
     # Default MTU to use for the host gateway interface and the network interface of each Pod. If
     # omitted, antrea-agent will default this value to 1450 to accommodate for tunnel encapsulate
@@ -438,7 +438,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-cd7tt4t2f8
+  name: antrea-config-d4b44mm2k6
   namespace: kube-system
 ---
 apiVersion: v1
@@ -543,7 +543,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-cd7tt4t2f8
+          name: antrea-config-d4b44mm2k6
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -755,7 +755,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-cd7tt4t2f8
+          name: antrea-config-d4b44mm2k6
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -17,11 +17,11 @@
 #hostGateway: gw0
 
 # Encapsulation mode for communication between Pods across Nodes, supported values:
-# - vxlan (default)
-# - geneve
+# - geneve (default)
+# - vxlan
 # - gre
 # - stt
-#tunnelType: vxlan
+#tunnelType: geneve
 
 # Default MTU to use for the host gateway interface and the network interface of each Pod. If
 # omitted, antrea-agent will default this value to 1450 to accommodate for tunnel encapsulate

--- a/build/yamls/windows/base/conf/antrea-agent.conf
+++ b/build/yamls/windows/base/conf/antrea-agent.conf
@@ -7,10 +7,10 @@
 #hostGateway: gw0
 
 # Encapsulation mode for communication between Pods across Nodes, supported values:
-# - vxlan (default)
-# - geneve
+# - geneve (default)
+# - vxlan
 # - stt
-#tunnelType: vxlan
+#tunnelType: geneve
 
 # Default MTU to use for the host gateway interface and the network interface of each Pod. If
 # omitted, antrea-agent will default this value to 1450 to accommodate for tunnel encapsulate

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -49,8 +49,8 @@ type AgentConfig struct {
 	// Defaults to gw0.
 	HostGateway string `yaml:"hostGateway,omitempty"`
 	// Encapsulation mode for communication between Pods across Nodes, supported values:
-	// - vxlan (default)
-	// - geneve
+	// - geneve (default)
+	// - vxlan
 	// - gre
 	// - stt
 	TunnelType string `yaml:"tunnelType,omitempty"`

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -34,8 +34,8 @@ const (
 	defaultHostGateway        = "gw0"
 	defaultHostProcPathPrefix = "/host"
 	defaultServiceCIDR        = "10.96.0.0/12"
-	defaultMTUVXLAN           = 1450
 	defaultMTUGeneve          = 1450
+	defaultMTUVXLAN           = 1450
 	defaultMTUGRE             = 1462
 	defaultMTUSTT             = 1500
 	defaultMTU                = 1500

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,7 @@ OVS flows check out the [OVS pipeline doc](/docs/ovs-pipeline.md).
 
 Antrea Agent includes two Kubernetes controllers:
 - The Node controller watches the Kubernetes API server for new Nodes, and
-creates an OVS (VXLAN / Geneve / GRE / STT) tunnel to each remote Node.
+creates an OVS (Geneve / VXLAN / GRE / STT) tunnel to each remote Node.
 - The NetworkPolicy controller watches the computed NetworkPolicies from the
 Antrea Controller API, and installs OVS flows to implement the NetworkPolicies
 for the local Pods.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,11 +41,11 @@ Use `antrea-agent -h` to see complete options.
 #hostGateway: gw0
 
 # Encapsulation mode for communication between Pods across Nodes, supported values:
-# - vxlan (default)
-# - geneve
+# - geneve (default)
+# - vxlan
 # - gre
 # - stt
-#tunnelType: vxlan
+#tunnelType: geneve
 
 # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
 # for the GRE tunnel type.

--- a/docs/ipsec-tunnel.md
+++ b/docs/ipsec-tunnel.md
@@ -1,7 +1,7 @@
 # IPsec Encryption of Tunnel Traffic with Antrea
 
 Antrea supports encrypting tunnel traffic across Nodes with IPsec ESP. At this
-moment, IPsec encyption works only for GRE tunnel (but not VXLAN, Geneve, and
+moment, IPsec encyption works only for GRE tunnel (but not Geneve, VXLAN, and
 STT tunnel types).
 
 ## Prerequisites

--- a/docs/os-issues.md
+++ b/docs/os-issues.md
@@ -47,7 +47,7 @@ Unmanaged=yes
 ```
 # /etc/systemd/network/90-antrea-tun.network
 [Match]
-Name=vxlan_sys_* genev_sys_* gre_sys stt_sys_*
+Name=genev_sys_* vxlan_sys_* gre_sys stt_sys_*
 
 [Link]
 Unmanaged=yes

--- a/docs/ovs-pipeline.md
+++ b/docs/ovs-pipeline.md
@@ -9,7 +9,7 @@
   the tunnel to the new Node). When a Node is deleted, it performs the necessary
   clean-ups.
 * *peer Node*: this is how we refer to other Nodes in the cluster, to which the
-  local Node is connected through a VXLAN or Geneve tunnel.
+  local Node is connected through a Geneve, VXLAN, GRE, or STT tunnel.
 * *Global Virtual MAC*: a virtual MAC address which is used as the destination
   MAC for all tunnelled traffic across all Nodes. This simplifies networking by
   enabling all Nodes to use this MAC address instead of the actual MAC address
@@ -143,8 +143,8 @@ If you dump the flows for this table, you may see the following:
 ```
 
 Flow 1 is for traffic coming in on the local gateway. Flow 2 is for traffic
-coming in through a VXLAN or Geneve tunnel (i.e. from another Node). The next
-two flows (3 and 4) are for local Pods (in this case Pods from the coredns
+coming in through an overlay tunnel (i.e. from another Node). The next two
+flows (3 and 4) are for local Pods (in this case Pods from the coredns
 deployment).
 
 Local traffic then goes to [SpoofGuardTable], while tunnel traffic

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -3,7 +3,7 @@
 ## Overview
 Antrea supports Windows worker Node. On Windows Node, Antrea sets up an overlay
 network to forward packets between Nodes and implements NetworkPolicies. Currently
-VXLAN, Geneve and STT tunnels are supported.
+Geneve, VXLAN, and STT tunnels are supported.
 
 This page shows how to install antrea-agent on Windows Nodes and register the
 Node to an existing Kubernetes cluster.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -151,9 +151,9 @@ func (i *Initializer) initInterfaceStore() error {
 				InterfaceName: port.Name,
 				OVSPortConfig: ovsPort,
 			}
-		case port.IFType == ovsconfig.VXLANTunnel:
-			fallthrough
 		case port.IFType == ovsconfig.GeneveTunnel:
+			fallthrough
+		case port.IFType == ovsconfig.VXLANTunnel:
 			fallthrough
 		case port.IFType == ovsconfig.GRETunnel:
 			fallthrough

--- a/pkg/ovs/ovsconfig/interfaces.go
+++ b/pkg/ovs/ovsconfig/interfaces.go
@@ -17,8 +17,8 @@ package ovsconfig
 type TunnelType string
 
 const (
-	VXLANTunnel  = "vxlan"
 	GeneveTunnel = "geneve"
+	VXLANTunnel  = "vxlan"
 	GRETunnel    = "gre"
 	STTTunnel    = "stt"
 


### PR DESCRIPTION
Geneve supports extensible encapsulation headers which allow Antrea to
add extra contexts to the encapsulated packets across Nodes. This is
required by the Antrea Traceflow feature (see issue #631) which is
expected to be released in Antrea 0.8.0.

When upgrading an existing K8s cluster that configured Antrea to use
VXLAN tunnel type, there are two options to handle the default tunnel
type change:
1) Edit the Antrea deployment YAML and explicitly set the
'tunnel_type" config option to 'vxlan` in 'antrea-agent.conf' of the
'antrea-config' ConfigMap. Then Antrea will keep using the VXLAN
tunnel type after upgrade.
2) Swtich to the new default tunnel type. Then after the new version
of Antrea agent starts, it will delete the old VXLAN tunnel port on the
OVS bridge and create a new tunnel port of the Geneve type. So, before
agents on all Nodes are upgraded and recreate the tunnel port, it is
possible some Nodes are using the VXLAN tunnel type, while some others
are using the Geneve tunnel type, and the traffic between the two sides
will be dropped.