### PR TITLE
Improve liveness probe for antrea-ovs container

### DIFF
--- a/build/images/scripts/daemon_status
+++ b/build/images/scripts/daemon_status
@@ -18,7 +18,7 @@ function is_process_running() {
 }
 
 function check_ovs_status {
-    /usr/share/openvswitch/scripts/ovs-ctl status > /dev/null
+    /usr/share/openvswitch/scripts/ovs-ctl status
     return $?
 }
 

--- a/build/images/scripts/start_ovs
+++ b/build/images/scripts/start_ovs
@@ -61,7 +61,7 @@ while true; do
     SLEEP_PID=$!
     wait $SLEEP_PID
 
-    if ! check_ovs_status ; then
+    if ! check_ovs_status > /dev/null ; then
         # OVS was stopped in the container.
         log_warning $CONTAINER_NAME "OVS was stopped. Starting it again"
 

--- a/build/images/scripts/start_ovs_netdev
+++ b/build/images/scripts/start_ovs_netdev
@@ -94,7 +94,7 @@ while true; do
     SLEEP_PID=$!
     wait $SLEEP_PID
 
-    if ! check_ovs_status ; then
+    if ! check_ovs_status > /dev/null; then
         # OVS was stopped in the container.
         log_warning $CONTAINER_NAME "OVS was stopped. Starting it again"
 

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -694,9 +694,11 @@ spec:
             command:
             - /bin/sh
             - -c
-            - timeout 5 container_liveness_probe ovs
+            - timeout 10 container_liveness_probe ovs
+          failureThreshold: 5
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 10
         name: antrea-ovs
         resources:
           requests:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -692,9 +692,11 @@ spec:
             command:
             - /bin/sh
             - -c
-            - timeout 5 container_liveness_probe ovs
+            - timeout 10 container_liveness_probe ovs
+          failureThreshold: 5
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 10
         name: antrea-ovs
         resources:
           requests:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -736,9 +736,11 @@ spec:
             command:
             - /bin/sh
             - -c
-            - timeout 5 container_liveness_probe ovs
+            - timeout 10 container_liveness_probe ovs
+          failureThreshold: 5
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 10
         name: antrea-ovs
         resources:
           requests:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -692,9 +692,11 @@ spec:
             command:
             - /bin/sh
             - -c
-            - timeout 5 container_liveness_probe ovs
+            - timeout 10 container_liveness_probe ovs
+          failureThreshold: 5
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 10
         name: antrea-ovs
         resources:
           requests:

--- a/build/yamls/base/agent.yml
+++ b/build/yamls/base/agent.yml
@@ -159,12 +159,16 @@ spec:
                 - IPC_LOCK
           livenessProbe:
             exec:
+              # docker CRI doesn't honor timeoutSeconds, add "timeout" to the command as a workaround.
+              # https://github.com/kubernetes/kubernetes/issues/51901
               command:
                 - /bin/sh
                 - -c
-                - timeout 5 container_liveness_probe ovs
+                - timeout 10 container_liveness_probe ovs
             initialDelaySeconds: 5
-            periodSeconds: 5
+            timeoutSeconds: 10
+            periodSeconds: 10
+            failureThreshold: 5
           volumeMounts:
           - name: host-var-run-antrea
             mountPath: /var/run/openvswitch


### PR DESCRIPTION
* Increase failureThreshold to 5 and timeout to 10 seconds to avoid
  frequent restarts when the node is overloaded.

* Set timeoutSeconds explicitly otherwise it's defaulted to 1 second,
  though it's not honored by docker CRI.

* Keep the output of probe script so that it will be appended to the
  message of liveness failure event and be helpful to see the actual
  problem.

For #833