### PR TITLE
Update capv csi syncer

### DIFF
--- a/ci/cluster-api/vsphere/templates/cluster.yaml
+++ b/ci/cluster-api/vsphere/templates/cluster.yaml
@@ -69,7 +69,7 @@ spec:
         attacherImage: quay.io/k8scsi/csi-attacher:v1.1.1
         controllerImage: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.2
         livenessProbeImage: quay.io/k8scsi/livenessprobe:v1.1.0
-        metadataSyncerImage: gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.2
+        metadataSyncerImage: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.0.0
         nodeDriverImage: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.2
         provisionerImage: quay.io/k8scsi/csi-provisioner:v1.2.1
         registrarImage: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0


### PR DESCRIPTION
This may solve vsphere-csi-controller crash issue.
e.g.
https://jenkins.antrea-ci.rocks/view/antrea-for-pull-request/job/antrea-conformance-for-pull-request/634/console

It can be seen that in conformance test, e2e plugin only tests 2 cases and fails. It fails at BeforeSuite. On workload cluster, there is a pod called vsphere-csi-controller which keeps crashing. The root cause is this syncer container failure.