### PR TITLE
Add retries for cni conf file

### DIFF
--- a/build/images/scripts/install_cni_chaining
+++ b/build/images/scripts/install_cni_chaining
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 
+source logging
+
 # Find the cni conf file with lowest name
-cni_conf=$(ls /host/etc/cni/net.d | head -n1)
+while true; do
+  cni_conf=$(ls /host/etc/cni/net.d | head -n1)
+  if [[ ! -z $cni_conf ]]; then
+    break
+  fi
+  log_info "CNI conf file not found. Retrying after 2 secs"
+  sleep 2s
+done
 cni_conf="/host/etc/cni/net.d/$cni_conf"
 cat $cni_conf | jq '.plugins[] | .type' | grep antrea > /dev/null 2>&1
 if [[ $? != 0 ]]; then


### PR DESCRIPTION
In CNI chain option, add retry to look for primary
cni config file before adding antrea config in it

Fixes #863 