### PR TITLE
E2E tests for ClusterNetworkPolicy

### DIFF
--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -44,7 +44,7 @@ function run_test {
 
   $YML_CMD --kind --encap-mode $mode $proxy | docker exec -i kind-control-plane dd of=/root/antrea.yml
   sleep 1
-  go test -v -timeout=20m github.com/vmware-tanzu/antrea/test/e2e -provider=kind
+  go test -v -timeout=30m github.com/vmware-tanzu/antrea/test/e2e -provider=kind
   $TESTBED_CMD destroy kind
 }
 

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/j-keck/arping v1.0.0
 	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd
+	github.com/pkg/errors v0.8.1
 	github.com/prometheus/common v0.4.1
 	github.com/rakelkar/gonetsh v0.0.0-20190930180311-e5c5ffe4bdf0
 	github.com/satori/go.uuid v1.2.0

--- a/pkg/agent/controller/networkpolicy/priority.go
+++ b/pkg/agent/controller/networkpolicy/priority.go
@@ -123,7 +123,7 @@ func (pa *priorityAssigner) syncPriorityZone(p types.Priority) (*uint16, map[uin
 		computedPriority := pa.getPriorityZoneStart(p) - uint16(offset)
 		oldOFPriority, updateExisting := pa.priorityMap[priority]
 		if updateExisting && computedPriority != oldOFPriority {
-			klog.V(2).Infof("Original priority %d needs to be reassigned %d now.", oldOFPriority, computedPriority)
+			klog.V(2).Infof("Original priority %d needs to be reassigned %d now", oldOFPriority, computedPriority)
 			priorityUpdates[oldOFPriority] = computedPriority
 		} else if !updateExisting {
 			// A new Priority has been added to priorityMap
@@ -152,6 +152,6 @@ func (pa *priorityAssigner) Release(priorityNum uint16) error {
 			return nil
 		}
 	}
-	klog.V(2).Infof("OF priority %v not stored in priorityMap, skip releasing priority.", priorityNum)
+	klog.V(2).Infof("OF priority %v not stored in priorityMap, skip releasing priority", priorityNum)
 	return nil
 }

--- a/pkg/agent/openflow/network_policy.go
+++ b/pkg/agent/openflow/network_policy.go
@@ -734,7 +734,7 @@ func (c *client) InstallPolicyRuleFlows(ruleID uint32, rule *types.PolicyRule, n
 	if nClause > 1 {
 		// Install action flows.
 		var actionFlows []binding.Flow
-		if rule.Action != nil && *rule.Action == secv1alpha1.RuleActionDrop {
+		if rule.IsAntreaNetworkPolicyRule() && *rule.Action == secv1alpha1.RuleActionDrop {
 			actionFlows = append(actionFlows, c.conjunctionActionDropFlow(ruleID, ruleTable.GetID(), rule.Priority))
 		} else {
 			actionFlows = append(actionFlows, c.conjunctionActionFlow(ruleID, ruleTable.GetID(), dropTable.GetNext(), rule.Priority))

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -386,11 +386,11 @@ func (n *NetworkPolicyController) labelsMatchGroupSelector(pod *v1.Pod, podNS *v
 // match the Namespace's labels.
 func (n *NetworkPolicyController) filterAddressGroupsForNamespace(namespace *v1.Namespace) sets.String {
 	matchingKeys := sets.String{}
-	// Only cluster scoped groups can possibly select this Namespace.
+	// Only cluster scoped groups or AddressGroups created by CNP can possibly select this Namespace.
 	addressGroups, _ := n.addressGroupStore.GetByIndex(cache.NamespaceIndex, "")
 	for _, group := range addressGroups {
 		addrGroup := group.(*antreatypes.AddressGroup)
-		// Cluster scoped AddressGroup will not have NamespaceSelector.
+		// AddressGroup created by CNP might not have NamespaceSelector.
 		if addrGroup.Selector.NamespaceSelector != nil && addrGroup.Selector.NamespaceSelector.Matches(labels.Set(namespace.Labels)) {
 			matchingKeys.Insert(addrGroup.Name)
 			klog.V(2).Infof("Namespace %s matched AddressGroup %s", namespace.Name, addrGroup.Name)

--- a/test/e2e/clusternetworkpolicy_test.go
+++ b/test/e2e/clusternetworkpolicy_test.go
@@ -1,0 +1,558 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	secv1alpha1 "github.com/vmware-tanzu/antrea/pkg/apis/security/v1alpha1"
+	. "github.com/vmware-tanzu/antrea/test/e2e/utils"
+)
+
+// common for all tests.
+var (
+	allPods          []Pod
+	k8s              *Kubernetes
+	allTestList      []*TestCase
+	pods, namespaces []string
+	podIPs           map[string]string
+	p80, p81         int
+)
+
+const (
+	// provide enough time for policies to be enforced & deleted by the CNI plugin.
+	networkPolicyDelay = 2 * time.Second
+)
+
+func failOnError(err error, t *testing.T) {
+	if err != nil {
+		log.Errorf("%+v", err)
+		k8s.Cleanup(namespaces)
+		t.Fatalf("test failed: %v", err)
+	}
+}
+
+// TestCase is a collection of TestSteps to be tested against.
+type TestCase struct {
+	Name  string
+	Steps []*TestStep
+}
+
+// TestStep is a single unit of testing spec. It includes the CNP specs that need to be
+// applied for this test, the port to test traffic on and the expected Reachability matrix.
+type TestStep struct {
+	Name         string
+	Reachability *Reachability
+	CNPs         []*secv1alpha1.ClusterNetworkPolicy
+	Port         int
+	Duration     time.Duration
+}
+
+func initialize(t *testing.T, data *TestData) {
+	p80 = 80
+	p81 = 81
+	pods = []string{"a", "b", "c"}
+	namespaces = []string{"x", "y", "z"}
+
+	for _, podName := range pods {
+		for _, ns := range namespaces {
+			allPods = append(allPods, NewPod(ns, podName))
+		}
+	}
+	err := enableCNP(data)
+	failOnError(err, t)
+	k8s, err = NewKubernetes(data)
+	failOnError(err, t)
+	ips, err := k8s.Bootstrap(namespaces, pods)
+	failOnError(err, t)
+	podIPs = *ips
+}
+
+func enableCNP(data *TestData) error {
+	configMap, err := data.GetAntreaConfigMap(antreaNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to get ConfigMap: %v", err)
+	}
+	antreaControllerConf, _ := configMap.Data["antrea-controller.conf"]
+	antreaAgentConf, _ := configMap.Data["antrea-agent.conf"]
+	antreaControllerConf = strings.Replace(antreaControllerConf, "#featureGates:", "featureGates:\n   ClusterNetworkPolicy: true", 1)
+	antreaAgentConf = strings.Replace(antreaAgentConf, "#featureGates:", "featureGates:\n   ClusterNetworkPolicy: true", 1)
+	configMap.Data["antrea-controller.conf"] = antreaControllerConf
+	configMap.Data["antrea-agent.conf"] = antreaAgentConf
+	if _, err := data.clientset.CoreV1().ConfigMaps(antreaNamespace).Update(context.TODO(), configMap, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("failed to update ConfigMap %s: %v", configMap.Name, err)
+	}
+	_, err = data.restartAntreaControllerPod(defaultTimeout)
+	if err != nil {
+		return fmt.Errorf("error when restarting antrea-controller Pod: %v", err)
+	}
+	// TODO: restart agent pods as well if featureGate affects agent
+	return nil
+}
+
+func applyDefaultDenyToAllNamespaces(k8s *Kubernetes, namespaces []string) error {
+	if err := k8s.CleanNetworkPolicies(namespaces); err != nil {
+		return err
+	}
+	for _, ns := range namespaces {
+		builder := &NetworkPolicySpecBuilder{}
+		builder = builder.SetName(ns, "default-deny-namespace")
+		builder.SetTypeIngress()
+		if _, err := k8s.CreateOrUpdateNetworkPolicy(ns, builder.Get()); err != nil {
+			return err
+		}
+	}
+	time.Sleep(networkPolicyDelay)
+	r := NewReachability(allPods, false)
+	k8s.Validate(allPods, r, p80)
+	_, wrong, _ := r.Summary()
+	if wrong != 0 {
+		return fmt.Errorf("error when creating default deny k8s network policies")
+	}
+	return nil
+}
+
+func cleanupDefaultDenyNPs(k8s *Kubernetes, namespaces []string) error {
+	if err := k8s.CleanNetworkPolicies(namespaces); err != nil {
+		return err
+	}
+	time.Sleep(networkPolicyDelay)
+	r := NewReachability(allPods, true)
+	k8s.Validate(allPods, r, p80)
+	_, wrong, _ := r.Summary()
+	if wrong != 0 {
+		return fmt.Errorf("error when cleaning default deny k8s network policies")
+	}
+	return nil
+}
+
+// testCNPAllowXBtoA tests traffic from X/B to pods with label A, after applying the default deny
+// k8s NetworkPolicies in all namespaces and CNP to allow X/B to A.
+func testCNPAllowXBtoA(t *testing.T) {
+	builder := &ClusterNetworkPolicySpecBuilder{}
+	builder = builder.SetName("cnp-allow-xb-to-a").
+		SetPriority(1.0).
+		SetAppliedToGroup(map[string]string{"pod": "a"}, nil, nil, nil)
+	builder.AddIngress(v1.ProtocolTCP, &p80, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "x"},
+		nil, nil, secv1alpha1.RuleActionAllow)
+
+	reachability := NewReachability(allPods, false)
+	reachability.Expect(Pod("x/b"), Pod("x/a"), true)
+	reachability.Expect(Pod("x/b"), Pod("y/a"), true)
+	reachability.Expect(Pod("x/b"), Pod("z/a"), true)
+	reachability.ExpectSelf(allPods, true)
+
+	testStep := []*TestStep{
+		{
+			"Port 80",
+			reachability,
+			[]*secv1alpha1.ClusterNetworkPolicy{builder.Get()},
+			80,
+			0,
+		},
+	}
+	testCase := []*TestCase{
+		{"CNP Allow X/B to A", testStep},
+	}
+	executeTests(t, testCase)
+}
+
+// testCNPAllowXBtoYA tests traffic from X/B to Y/A on named port 81, after applying the default deny
+// k8s NetworkPolicies in all namespaces and CNP to allow X/B to Y/A.
+func testCNPAllowXBtoYA(t *testing.T) {
+	port81Name := "serve-81"
+	builder := &ClusterNetworkPolicySpecBuilder{}
+	builder = builder.SetName("cnp-allow-xb-to-ya").
+		SetPriority(2.0).
+		SetAppliedToGroup(map[string]string{"pod": "a"}, map[string]string{"ns": "y"}, nil, nil)
+	builder.AddIngress(v1.ProtocolTCP, nil, &port81Name, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "x"},
+		nil, nil, secv1alpha1.RuleActionAllow)
+
+	reachability := NewReachability(allPods, false)
+	reachability.Expect(Pod("x/b"), Pod("y/a"), true)
+	reachability.ExpectSelf(allPods, true)
+
+	testStep := []*TestStep{
+		{
+			"NamedPort 81",
+			reachability,
+			[]*secv1alpha1.ClusterNetworkPolicy{builder.Get()},
+			81,
+			0,
+		},
+	}
+	testCase := []*TestCase{
+		{"CNP Allow X/B to Y/A", testStep},
+	}
+	executeTests(t, testCase)
+}
+
+// testCNPPriorityOverrideDefaultDeny tests priority override in CNP. It applies a higher priority CNP to drop
+// traffic from namespace Z to X/A, and in the meantime applies a lower priority CNP to allow traffic from Z to X.
+// It is tested with default deny k8s NetworkPolicies in all namespaces.
+func testCNPPriorityOverrideDefaultDeny(t *testing.T) {
+	builder1 := &ClusterNetworkPolicySpecBuilder{}
+	builder1 = builder1.SetName("cnp-priority2").
+		SetPriority(2).
+		SetAppliedToGroup(nil, map[string]string{"ns": "x"}, nil, nil)
+	builder1.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"ns": "z"},
+		nil, nil, secv1alpha1.RuleActionAllow)
+
+	builder2 := &ClusterNetworkPolicySpecBuilder{}
+	builder2 = builder2.SetName("cnp-priority1").
+		SetPriority(1).
+		SetAppliedToGroup(map[string]string{"pod": "a"}, map[string]string{"ns": "x"}, nil, nil)
+	builder2.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"ns": "z"},
+		nil, nil, secv1alpha1.RuleActionDrop)
+
+	// Ingress from ns:z to x/a will be dropped since cnp-priority1 has higher precedence.
+	reachabilityBothCNP := NewReachability(allPods, false)
+	reachabilityBothCNP.Expect(Pod("z/a"), Pod("x/b"), true)
+	reachabilityBothCNP.Expect(Pod("z/a"), Pod("x/c"), true)
+	reachabilityBothCNP.Expect(Pod("z/b"), Pod("x/b"), true)
+	reachabilityBothCNP.Expect(Pod("z/b"), Pod("x/c"), true)
+	reachabilityBothCNP.Expect(Pod("z/c"), Pod("x/b"), true)
+	reachabilityBothCNP.Expect(Pod("z/c"), Pod("x/c"), true)
+	reachabilityBothCNP.ExpectSelf(allPods, true)
+
+	testStep := []*TestStep{
+		{
+			"Both CNP",
+			reachabilityBothCNP,
+			[]*secv1alpha1.ClusterNetworkPolicy{builder1.Get(), builder2.Get()},
+			80,
+			0,
+		},
+	}
+	testCase := []*TestCase{
+		{"CNP PriorityOverride Default Deny", testStep},
+	}
+	executeTests(t, testCase)
+}
+
+// testCNPAllowNoDefaultIsolation tests that no default isolation rules are created for CNPs.
+func testCNPAllowNoDefaultIsolation(t *testing.T) {
+	builder := &ClusterNetworkPolicySpecBuilder{}
+	builder = builder.SetName("cnp-allow-x-ingress-y-egress-z").
+		SetPriority(1.1).
+		SetAppliedToGroup(nil, map[string]string{"ns": "x"}, nil, nil)
+	builder.AddIngress(v1.ProtocolTCP, &p81, nil, nil, nil, map[string]string{"ns": "y"},
+		nil, nil, secv1alpha1.RuleActionAllow)
+	builder.AddEgress(v1.ProtocolTCP, &p81, nil, nil, nil, map[string]string{"ns": "z"},
+		nil, nil, secv1alpha1.RuleActionAllow)
+
+	reachability := NewReachability(allPods, true)
+	testStep := []*TestStep{
+		{
+			"Port 81",
+			reachability,
+			[]*secv1alpha1.ClusterNetworkPolicy{builder.Get()},
+			81,
+			0,
+		},
+	}
+	testCase := []*TestCase{
+		{"CNP Allow No Default Isolation", testStep},
+	}
+	executeTests(t, testCase)
+}
+
+// testCNPDropEgress tests that a CNP is able to drop egress traffic from pods labelled A to namespace Z.
+func testCNPDropEgress(t *testing.T) {
+	builder := &ClusterNetworkPolicySpecBuilder{}
+	builder = builder.SetName("cnp-deny-a-to-z-egress").
+		SetPriority(1.0).
+		SetAppliedToGroup(map[string]string{"pod": "a"}, nil, nil, nil)
+	builder.AddEgress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"ns": "z"},
+		nil, nil, secv1alpha1.RuleActionDrop)
+
+	reachability := NewReachability(allPods, true)
+	reachability.Expect(Pod("x/a"), Pod("z/a"), false)
+	reachability.Expect(Pod("x/a"), Pod("z/b"), false)
+	reachability.Expect(Pod("x/a"), Pod("z/c"), false)
+	reachability.Expect(Pod("y/a"), Pod("z/a"), false)
+	reachability.Expect(Pod("y/a"), Pod("z/b"), false)
+	reachability.Expect(Pod("y/a"), Pod("z/c"), false)
+	reachability.Expect(Pod("z/a"), Pod("z/b"), false)
+	reachability.Expect(Pod("z/a"), Pod("z/c"), false)
+
+	testStep := []*TestStep{
+		{
+			"Port 80",
+			reachability,
+			[]*secv1alpha1.ClusterNetworkPolicy{builder.Get()},
+			80,
+			0,
+		},
+	}
+	testCase := []*TestCase{
+		{"CNP Drop Egress From All Pod:a to NS:z", testStep},
+	}
+	executeTests(t, testCase)
+}
+
+// testCNPPriorityOverride tests priority overriding in three CNPs. Those three CNPs are applied in the
+// reverse order in terms of priority, and each controls a smaller set of traffic patterns.
+func testCNPPriorityOverride(t *testing.T) {
+	builder1 := &ClusterNetworkPolicySpecBuilder{}
+	builder1 = builder1.SetName("cnp-priority1").
+		SetPriority(1.1).
+		SetAppliedToGroup(map[string]string{"pod": "a"}, map[string]string{"ns": "x"}, nil, nil)
+	podZBIP, _ := podIPs["z/b"]
+	cidr := podZBIP + "/32"
+	// Highest priority. Drops traffic from z/b to x/a.
+	builder1.AddIngress(v1.ProtocolTCP, &p80, nil, &cidr, nil, nil,
+		nil, nil, secv1alpha1.RuleActionDrop)
+
+	builder2 := &ClusterNetworkPolicySpecBuilder{}
+	builder2 = builder2.SetName("cnp-priority2").
+		SetPriority(1.2).
+		SetAppliedToGroup(map[string]string{"pod": "a"}, map[string]string{"ns": "x"}, nil, nil)
+	// Medium priority. Allows traffic from z to x/a.
+	builder2.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"ns": "z"},
+		nil, nil, secv1alpha1.RuleActionAllow)
+
+	builder3 := &ClusterNetworkPolicySpecBuilder{}
+	builder3 = builder3.SetName("cnp-priority3").
+		SetPriority(1.3).
+		SetAppliedToGroup(nil, map[string]string{"ns": "x"}, nil, nil)
+	// Lowest priority. Drops traffic from z to x.
+	builder3.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"ns": "z"},
+		nil, nil, secv1alpha1.RuleActionDrop)
+
+	reachabilityBothCNP := NewReachability(allPods, true)
+	reachabilityBothCNP.Expect(Pod("z/a"), Pod("x/b"), false)
+	reachabilityBothCNP.Expect(Pod("z/a"), Pod("x/c"), false)
+	reachabilityBothCNP.Expect(Pod("z/b"), Pod("x/a"), false)
+	reachabilityBothCNP.Expect(Pod("z/b"), Pod("x/b"), false)
+	reachabilityBothCNP.Expect(Pod("z/b"), Pod("x/c"), false)
+	reachabilityBothCNP.Expect(Pod("z/c"), Pod("x/b"), false)
+	reachabilityBothCNP.Expect(Pod("z/c"), Pod("x/c"), false)
+
+	// Create the CNPs in reverse priority order to make sure that priority re-assignments work as expected.
+	testStep := []*TestStep{
+		{
+			"Both CNP",
+			reachabilityBothCNP,
+			[]*secv1alpha1.ClusterNetworkPolicy{builder3.Get(), builder2.Get(), builder1.Get()},
+			80,
+			0,
+		},
+	}
+	testCase := []*TestCase{
+		{"CNP PriorityOverride", testStep},
+	}
+	executeTests(t, testCase)
+}
+
+// testCNPPriorityConflictingRule tests that if there are two CNPs in the cluster with rules that conflicts with
+// each other, the CNP with higher priority will prevail.
+func testCNPPriorityConflictingRule(t *testing.T) {
+	builder1 := &ClusterNetworkPolicySpecBuilder{}
+	builder1 = builder1.SetName("cnp-drop").
+		SetPriority(1).
+		SetAppliedToGroup(nil, map[string]string{"ns": "x"}, nil, nil)
+	builder1.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"ns": "z"},
+		nil, nil, secv1alpha1.RuleActionDrop)
+
+	builder2 := &ClusterNetworkPolicySpecBuilder{}
+	builder2 = builder2.SetName("cnp-allow").
+		SetPriority(2).
+		SetAppliedToGroup(nil, map[string]string{"ns": "x"}, nil, nil)
+	// The following ingress rule will take no effect as it is exactly the same as ingress rule of cnp-drop,
+	// but cnp-allow has lower priority.
+	builder2.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"ns": "z"},
+		nil, nil, secv1alpha1.RuleActionAllow)
+
+	reachabilityBothCNP := NewReachability(allPods, true)
+	reachabilityBothCNP.Expect(Pod("z/a"), Pod("x/a"), false)
+	reachabilityBothCNP.Expect(Pod("z/a"), Pod("x/b"), false)
+	reachabilityBothCNP.Expect(Pod("z/a"), Pod("x/c"), false)
+	reachabilityBothCNP.Expect(Pod("z/b"), Pod("x/a"), false)
+	reachabilityBothCNP.Expect(Pod("z/b"), Pod("x/b"), false)
+	reachabilityBothCNP.Expect(Pod("z/b"), Pod("x/c"), false)
+	reachabilityBothCNP.Expect(Pod("z/c"), Pod("x/a"), false)
+	reachabilityBothCNP.Expect(Pod("z/c"), Pod("x/b"), false)
+	reachabilityBothCNP.Expect(Pod("z/c"), Pod("x/c"), false)
+
+	testStep := []*TestStep{
+		{
+			"Both CNP",
+			reachabilityBothCNP,
+			[]*secv1alpha1.ClusterNetworkPolicy{builder1.Get(), builder2.Get()},
+			80,
+			0,
+		},
+	}
+	testCase := []*TestCase{
+		{"CNP Priority Conflicting Rule", testStep},
+	}
+	executeTests(t, testCase)
+}
+
+// testCNPPriorityConflictingRule tests that if there are two rules in the cluster that conflicts with
+// each other, the rule with higher precedence will prevail.
+func testCNPRulePrioirty(t *testing.T) {
+	builder1 := &ClusterNetworkPolicySpecBuilder{}
+	// cnp-deny will apply to all pods in namespace x
+	builder1 = builder1.SetName("cnp-deny").
+		SetPriority(5).
+		SetAppliedToGroup(nil, map[string]string{"ns": "x"}, nil, nil)
+	builder1.AddEgress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"ns": "y"},
+		nil, nil, secv1alpha1.RuleActionDrop)
+	// This rule should take no effect as it will be overridden by the first rule of cnp-allow
+	builder1.AddEgress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"ns": "z"},
+		nil, nil, secv1alpha1.RuleActionDrop)
+
+	builder2 := &ClusterNetworkPolicySpecBuilder{}
+	// cnp-allow will also apply to all pods in namespace x
+	builder2 = builder2.SetName("cnp-allow").
+		SetPriority(5).
+		SetAppliedToGroup(nil, map[string]string{"ns": "x"}, nil, nil)
+	builder2.AddEgress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"ns": "z"},
+		nil, nil, secv1alpha1.RuleActionAllow)
+	// This rule should take no effect as it will be overridden by the first rule of cnp-drop
+	builder2.AddEgress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"ns": "y"},
+		nil, nil, secv1alpha1.RuleActionAllow)
+
+	// Only egress from pods in namespace x to namespace y should be denied
+	reachabilityBothCNP := NewReachability(allPods, true)
+	reachabilityBothCNP.Expect(Pod("x/a"), Pod("y/a"), false)
+	reachabilityBothCNP.Expect(Pod("x/b"), Pod("y/a"), false)
+	reachabilityBothCNP.Expect(Pod("x/c"), Pod("y/a"), false)
+	reachabilityBothCNP.Expect(Pod("x/a"), Pod("y/b"), false)
+	reachabilityBothCNP.Expect(Pod("x/b"), Pod("y/b"), false)
+	reachabilityBothCNP.Expect(Pod("x/c"), Pod("y/b"), false)
+	reachabilityBothCNP.Expect(Pod("x/a"), Pod("y/c"), false)
+	reachabilityBothCNP.Expect(Pod("x/b"), Pod("y/c"), false)
+	reachabilityBothCNP.Expect(Pod("x/c"), Pod("y/c"), false)
+
+	testStep := []*TestStep{
+		{
+			"Both CNP",
+			reachabilityBothCNP,
+			[]*secv1alpha1.ClusterNetworkPolicy{builder2.Get(), builder1.Get()},
+			80,
+			0,
+		},
+	}
+	testCase := []*TestCase{
+		{"CNP Rule Priority", testStep},
+	}
+	executeTests(t, testCase)
+}
+
+// executeTests runs all the tests in testList and print results
+func executeTests(t *testing.T, testList []*TestCase) {
+	for _, testCase := range testList {
+		log.Infof("running test case %s", testCase.Name)
+		log.Debugf("cleaning-up previous policies and sleeping for %v", networkPolicyDelay)
+		err := k8s.CleanCNPs()
+		time.Sleep(networkPolicyDelay)
+		failOnError(err, t)
+		for _, step := range testCase.Steps {
+			log.Infof("running step %s of test case %s", step.Name, testCase.Name)
+			reachability := step.Reachability
+			for _, cnp := range step.CNPs {
+				if cnp != nil {
+					log.Debugf("creating CNP %v", cnp.Name)
+					_, err := k8s.CreateOrUpdateCNP(cnp)
+					failOnError(err, t)
+				}
+			}
+			if len(step.CNPs) > 0 {
+				log.Debugf("Sleeping for %v for all CNPs to take effect", networkPolicyDelay)
+				time.Sleep(networkPolicyDelay)
+			}
+			start := time.Now()
+			k8s.Validate(allPods, reachability, step.Port)
+			step.Duration = time.Now().Sub(start)
+			reachability.PrintSummary(true, true, true)
+
+			_, wrong, _ := step.Reachability.Summary()
+			if wrong != 0 {
+				t.Errorf("failure -- %d wrong results", wrong)
+			}
+		}
+	}
+	allTestList = append(allTestList, testList...)
+}
+
+// printResults summarizes test results for all the testcases
+func printResults() {
+	fmt.Printf("\n\n---------------- Test Results ------------------\n\n")
+	failCount := 0
+	for _, testCase := range allTestList {
+		fmt.Printf("Test %s:\n", testCase.Name)
+		testFailed := false
+		for _, step := range testCase.Steps {
+			_, wrong, comparison := step.Reachability.Summary()
+			var result string
+			if wrong == 0 {
+				result = "success"
+			} else {
+				result = fmt.Sprintf("failure -- %d wrong results", wrong)
+				testFailed = true
+			}
+			fmt.Printf("\tStep %s on port %d, duration %d seconds, result: %s\n",
+				step.Name, step.Port, int(step.Duration.Seconds()), result)
+			fmt.Printf("\n%s\n", comparison.PrettyPrint("\t\t"))
+		}
+		if testFailed {
+			failCount++
+		}
+		fmt.Printf("\n\n")
+	}
+	fmt.Printf("=== TEST FAILURES: %d/%d ===\n", failCount, len(allTestList))
+	fmt.Printf("\n\n")
+}
+
+func TestClusterNetworkPolicy(t *testing.T) {
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+	initialize(t, data)
+
+	t.Run("TestGroupDefaultDENY", func(t *testing.T) {
+		// CNP testcases below require default deny k8s network policies to work
+		applyDefaultDenyToAllNamespaces(k8s, namespaces)
+		t.Run("Case=CNPAllowXBtoA", func(t *testing.T) { testCNPAllowXBtoA(t) })
+		t.Run("Case=CNPAllowXBtoYA", func(t *testing.T) { testCNPAllowXBtoYA(t) })
+		t.Run("Case=CNPPrioirtyOverrideDefaultDeny", func(t *testing.T) { testCNPPriorityOverrideDefaultDeny(t) })
+		cleanupDefaultDenyNPs(k8s, namespaces)
+	})
+
+	t.Run("TestGroupNoK8sNP", func(t *testing.T) {
+		// CNP testcases below do not depend on underlying k8s network policies
+		t.Run("Case=CNPAllowNoDefaultIsolation", func(t *testing.T) { testCNPAllowNoDefaultIsolation(t) })
+		t.Run("Case=CNPDropEgress", func(t *testing.T) { testCNPDropEgress(t) })
+		t.Run("Case=CNPPrioirtyOverride", func(t *testing.T) { testCNPPriorityOverride(t) })
+		t.Run("Case=CNPPriorityConflictingRule", func(t *testing.T) { testCNPPriorityConflictingRule(t) })
+		t.Run("Case=CNPRulePriority", func(t *testing.T) { testCNPRulePrioirty(t) })
+	})
+
+	printResults()
+	k8s.Cleanup(namespaces)
+}

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -413,10 +413,6 @@ func (data *TestData) createClient() error {
 	return nil
 }
 
-func (data *TestData) getClients() (kubernetes.Interface, secv1alpha1.SecurityV1alpha1Interface) {
-	return data.clientset, data.securityClient
-}
-
 // deleteAntrea deletes the Antrea DaemonSet; we use cascading deletion, which means all the Pods created
 // by Antrea will be deleted. After issuing the deletion request, we poll the K8s apiserver to ensure
 // that the DaemonSet does not exist any more. This function is a no-op if the Antrea DaemonSet does

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -39,6 +39,7 @@ import (
 	aggregatorclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
+	secv1alpha1 "github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned/typed/security/v1alpha1"
 	"github.com/vmware-tanzu/antrea/test/e2e/providers"
 )
 
@@ -94,6 +95,7 @@ type TestData struct {
 	kubeConfig       *restclient.Config
 	clientset        kubernetes.Interface
 	aggregatorClient aggregatorclientset.Interface
+	securityClient   secv1alpha1.SecurityV1alpha1Interface
 }
 
 // workerNodeName returns an empty string if there is no worker Node with the provided idx
@@ -400,10 +402,19 @@ func (data *TestData) createClient() error {
 	if err != nil {
 		return fmt.Errorf("error when creating kubernetes aggregatorClient: %v", err)
 	}
+	securityClient, err := secv1alpha1.NewForConfig(kubeConfig)
+	if err != nil {
+		return fmt.Errorf("error when creating Antrea securityClient: %v", err)
+	}
 	data.kubeConfig = kubeConfig
 	data.clientset = clientset
 	data.aggregatorClient = aggregatorClient
+	data.securityClient = securityClient
 	return nil
+}
+
+func (data *TestData) getClients() (kubernetes.Interface, secv1alpha1.SecurityV1alpha1Interface) {
+	return data.clientset, data.securityClient
 }
 
 // deleteAntrea deletes the Antrea DaemonSet; we use cascading deletion, which means all the Pods created

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -1,0 +1,454 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	v1net "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/remotecommand"
+
+	secv1alpha1 "github.com/vmware-tanzu/antrea/pkg/apis/security/v1alpha1"
+	secClient "github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned/typed/security/v1alpha1"
+)
+
+type Kubernetes struct {
+	data           *TestData
+	podCache       map[string][]v1.Pod
+	ClientSet      *kubernetes.Clientset
+	SecurityClient *secClient.SecurityV1alpha1Client
+}
+
+func NewKubernetes(data *TestData) (*Kubernetes, error) {
+	clientSet, secClienSet := data.getClients()
+	return &Kubernetes{
+		data:           data,
+		podCache:       map[string][]v1.Pod{},
+		ClientSet:      clientSet.(*kubernetes.Clientset),
+		SecurityClient: secClienSet.(*secClient.SecurityV1alpha1Client),
+	}, nil
+}
+
+// GetPod returns a pod with the matching namespace and name
+func (k *Kubernetes) GetPod(ns string, name string) (*v1.Pod, error) {
+	pods, err := k.getPodsUncached(ns, "pod", name)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "unable to get pod %s/%s", ns, name)
+	}
+	if len(pods) == 0 {
+		return nil, nil
+	}
+	return &pods[0], nil
+}
+
+func (k *Kubernetes) getPodsUncached(ns string, key, val string) ([]v1.Pod, error) {
+	v1PodList, err := k.ClientSet.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%v=%v", key, val),
+	})
+	if err != nil {
+		return nil, errors.WithMessage(err, "unable to list pods")
+	}
+	return v1PodList.Items, nil
+}
+
+// GetPods returns an array of all pods in the given namespace having a k/v label pair.
+func (k *Kubernetes) GetPods(ns string, key string, val string) ([]v1.Pod, error) {
+	if p, ok := k.podCache[fmt.Sprintf("%v_%v_%v", ns, key, val)]; ok {
+		return p, nil
+	}
+
+	v1PodList, err := k.getPodsUncached(ns, key, val)
+	if err != nil {
+		return nil, errors.WithMessage(err, "unable to list pods")
+	}
+	k.podCache[fmt.Sprintf("%v_%v_%v", ns, key, val)] = v1PodList
+	return v1PodList, nil
+}
+
+// Probe execs into a pod and checks its connectivity to another pod.  Of course it assumes
+// that the target pod is serving on the input port, and also that wget is installed.  For perf it uses
+// spider rather then actually getting the full contents.
+func (k *Kubernetes) Probe(ns1, pod1, ns2, pod2 string, port int) (bool, error) {
+	fromPods, err := k.GetPods(ns1, "pod", pod1)
+	if err != nil {
+		return false, errors.WithMessagef(err, "unable to get pods from ns %s", ns1)
+	}
+	if len(fromPods) == 0 {
+		return false, errors.New(fmt.Sprintf("no pod of name %s in namespace %s found", pod1, ns1))
+	}
+	fromPod := fromPods[0]
+
+	toPods, err := k.GetPods(ns2, "pod", pod2)
+	if err != nil {
+		return false, errors.WithMessagef(err, "unable to get pods from ns %s", ns2)
+	}
+	if len(toPods) == 0 {
+		return false, errors.New(fmt.Sprintf("no pod of name %s in namespace %s found", pod2, ns2))
+	}
+	toPod := toPods[0]
+
+	toIP := toPod.Status.PodIP
+
+	// There seems to be an issue when running Antrea in Kind where tunnel traffic is dropped at
+	// first. This leads to the first test being run consistently failing. To avoid this issue
+	// until it is resolved, we try to connect 3 times.
+	// See https://github.com/vmware-tanzu/antrea/issues/467.
+	cmd := []string{
+		"/bin/sh",
+		"-c",
+		// 3 tries, timeout is 1 second
+		fmt.Sprintf("for i in $(seq 1 3); do ncat -vz -w 1 %s %d && exit 0 || true; done; exit 1", toIP, port),
+	}
+	// HACK: inferring container name as c80, c81, etc, for simplicity.
+	containerName := fmt.Sprintf("c%v", port)
+	log.Tracef("Running: kubectl exec %s -c %s -n %s -- %s", fromPod.Name, containerName, fromPod.Namespace, strings.Join(cmd, " "))
+	stdout, stderr, err := k.data.runCommandFromPod(fromPod.Namespace, fromPod.Name, containerName, cmd)
+	if err != nil {
+		// log this error as trace since may be an expected failure
+		log.Tracef("%s/%s -> %s/%s: error when running command: err - %v /// stdout - %s /// stderr - %s", ns1, pod1, ns2, pod2, err, stdout, stderr)
+		// do not return an error
+		return false, nil
+	}
+	return true, nil
+}
+
+// ExecuteRemoteCommand executes a remote shell command on the given pod
+// returns the output from stdout and stderr
+func (k *Kubernetes) ExecuteRemoteCommand(pod v1.Pod, cname string, command []string) (string, string, error) {
+	kubeCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{},
+	)
+	restCfg, err := kubeCfg.ClientConfig()
+	if err != nil {
+		return "", "", errors.WithMessagef(err, "unable to get rest config from kube config")
+	}
+	buf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	request := k.ClientSet.CoreV1().RESTClient().Post().Namespace(pod.Namespace).Resource("pods").
+		Name(pod.Name).SubResource("exec").VersionedParams(&v1.PodExecOptions{
+		Container: cname,
+		Command:   command,
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false},
+		scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(restCfg, "POST", request.URL())
+	if err != nil {
+		return "", "", errors.Wrapf(err, "failed to create SPDYExecutor")
+	}
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdout: buf,
+		Stderr: errBuf,
+	})
+	if err != nil {
+		return buf.String(), errBuf.String(), err
+	}
+	return buf.String(), errBuf.String(), nil
+}
+
+// CreateOrUpdateNamespace is a convenience function for idempotent setup of namespaces
+func (k *Kubernetes) CreateOrUpdateNamespace(n string, labels map[string]string) (*v1.Namespace, error) {
+	ns := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   n,
+			Labels: labels,
+		},
+	}
+	nsr, err := k.ClientSet.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	if err == nil {
+		log.Infof("created namespace %s", n)
+		return nsr, nil
+	}
+
+	log.Debugf("unable to create namespace %s, let's try updating it instead (error: %s)", ns.Name, err)
+	nsr, err = k.ClientSet.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
+	if err != nil {
+		log.Debugf("unable to update namespace %s: %s", ns, err)
+	}
+
+	return nsr, err
+}
+
+// CreateOrUpdateDeployment is a convenience function for idempotent setup of deployments
+func (k *Kubernetes) CreateOrUpdateDeployment(ns, deploymentName string, replicas int32, labels map[string]string) (*appsv1.Deployment, error) {
+	zero := int64(0)
+	log.Infof("creating/updating deployment %s in ns %s", deploymentName, ns)
+	makeContainerSpec := func(port int32) v1.Container {
+		return v1.Container{
+			Name:            fmt.Sprintf("c%d", port),
+			ImagePullPolicy: v1.PullIfNotPresent,
+			Image:           "antrea/netpol-test:latest",
+			// "-k" for persistent server
+			Command:         []string{"ncat", "-lk", "-p", fmt.Sprintf("%d", port)},
+			SecurityContext: &v1.SecurityContext{},
+			Ports: []v1.ContainerPort{
+				{
+					ContainerPort: port,
+					Name:          fmt.Sprintf("serve-%d", port),
+				},
+			},
+		}
+	}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName,
+			Labels:    labels,
+			Namespace: ns,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:    labels,
+					Namespace: ns,
+				},
+				Spec: v1.PodSpec{
+					TerminationGracePeriodSeconds: &zero,
+					Containers: []v1.Container{
+						makeContainerSpec(80), makeContainerSpec(81),
+					},
+				},
+			},
+		},
+	}
+
+	d, err := k.ClientSet.AppsV1().Deployments(ns).Create(context.TODO(), deployment, metav1.CreateOptions{})
+	if err == nil {
+		log.Infof("created deployment %s in namespace %s", d.Name, ns)
+		return d, nil
+	}
+
+	log.Debugf("unable to create deployment %s in ns %s, let's try update instead", deployment.Name, ns)
+	d, err = k.ClientSet.AppsV1().Deployments(ns).Update(context.TODO(), d, metav1.UpdateOptions{})
+	if err != nil {
+		log.Debugf("unable to update deployment %s in ns %s: %s", deployment.Name, ns, err)
+	}
+	return d, err
+}
+
+// CleanNetworkPolicies is a convenience function for deleting network policies before startup of any new test.
+func (k *Kubernetes) CleanNetworkPolicies(namespaces []string) error {
+	for _, ns := range namespaces {
+		l, err := k.ClientSet.NetworkingV1().NetworkPolicies(ns).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "unable to list network policies in ns %s", ns)
+		}
+		for _, np := range l.Items {
+			log.Infof("deleting network policy %s in ns %s", np.Name, ns)
+			err = k.ClientSet.NetworkingV1().NetworkPolicies(np.Namespace).Delete(context.TODO(), np.Name, metav1.DeleteOptions{})
+			if err != nil {
+				return errors.Wrapf(err, "unable to delete network policy %s", np.Name)
+			}
+		}
+	}
+	return nil
+}
+
+// CreateOrUpdateNetworkPolicy is a convenience function for updating/creating netpols. Updating is important since
+// some tests update a network policy to confirm that mutation works with a CNI.
+func (k *Kubernetes) CreateOrUpdateNetworkPolicy(ns string, netpol *v1net.NetworkPolicy) (*v1net.NetworkPolicy, error) {
+	log.Infof("creating/updating network policy %s in ns %s", netpol.Name, ns)
+	netpol.ObjectMeta.Namespace = ns
+	np, err := k.ClientSet.NetworkingV1().NetworkPolicies(ns).Update(context.TODO(), netpol, metav1.UpdateOptions{})
+	if err == nil {
+		return np, err
+	}
+
+	log.Debugf("unable to update network policy %s in ns %s, let's try creating it instead (error: %s)", netpol.Name, ns, err)
+	np, err = k.ClientSet.NetworkingV1().NetworkPolicies(ns).Create(context.TODO(), netpol, metav1.CreateOptions{})
+	if err != nil {
+		log.Debugf("unable to create network policy: %s", err)
+	}
+	return np, err
+}
+
+// CleanCNPs is a convenience function for deleting ClusterNetworkPolicies before startup of any new test.
+func (k *Kubernetes) CleanCNPs() error {
+	l, err := k.SecurityClient.ClusterNetworkPolicies().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "unable to list ClusterNetworkPolicies")
+	}
+	for _, cnp := range l.Items {
+		log.Infof("deleting ClusterNetworkPolicies %s", cnp.Name)
+		err = k.SecurityClient.ClusterNetworkPolicies().Delete(context.TODO(), cnp.Name, metav1.DeleteOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "unable to delete ClusterNetworkPolicy %s", cnp.Name)
+		}
+	}
+	return nil
+}
+
+// CreateOrUpdateCNP is a convenience function for updating/creating ClusterNetworkPolicies.
+func (k *Kubernetes) CreateOrUpdateCNP(cnp *secv1alpha1.ClusterNetworkPolicy) (*secv1alpha1.ClusterNetworkPolicy, error) {
+	log.Infof("creating/updating ClusterNetworkPolicy %s", cnp.Name)
+	cnpReturned, err := k.SecurityClient.ClusterNetworkPolicies().Get(context.TODO(), cnp.Name, metav1.GetOptions{})
+	if err != nil {
+		log.Debugf("creating ClusterNetworkPolicy %s", cnp.Name)
+		cnp, err = k.SecurityClient.ClusterNetworkPolicies().Create(context.TODO(), cnp, metav1.CreateOptions{})
+		if err != nil {
+			log.Debugf("unable to create ClusterNetworkPolicy: %s", err)
+		}
+		return cnp, err
+	} else if cnpReturned.Name != "" {
+		log.Debugf("ClusterNetworkPolicy with name %s already exists, updating", cnp.Name)
+		cnp, err = k.SecurityClient.ClusterNetworkPolicies().Update(context.TODO(), cnp, metav1.UpdateOptions{})
+		return cnp, err
+	}
+	return nil, fmt.Errorf("error occurred in creating/updating ClusterNetworkPolicy %s", cnp.Name)
+}
+
+func (k *Kubernetes) waitForPodInNamespace(ns string, pod string) (*string, error) {
+	log.Infof("waiting for pod %s/%s", ns, pod)
+	for {
+		k8sPod, err := k.GetPod(ns, pod)
+		if err != nil {
+			return nil, errors.WithMessagef(err, "unable to get pod %s/%s", ns, pod)
+		}
+
+		if k8sPod != nil && k8sPod.Status.Phase == v1.PodRunning {
+			if k8sPod.Status.PodIP == "" {
+				return nil, errors.WithMessagef(err, "unable to get IP of pod %s/%s", ns, pod)
+			} else {
+				log.Debugf("IP of pod %s/%s is: %s", ns, pod, k8sPod.Status.PodIP)
+			}
+
+			log.Debugf("pod running: %s/%s", ns, pod)
+			podIP := k8sPod.Status.PodIP
+			return &podIP, nil
+		}
+		log.Infof("pod %s/%s not ready, waiting ...", ns, pod)
+		time.Sleep(2 * time.Second)
+	}
+}
+
+func (k *Kubernetes) waitForHTTPServers(allPods []Pod) error {
+	const maxTries = 10
+	const sleepInterval = 1 * time.Second
+	log.Infof("waiting for HTTP servers (ports 80 and 81) to become ready")
+	var wrong int
+	for i := 0; i < maxTries; i++ {
+		reachability := NewReachability(allPods, true)
+		k.Validate(allPods, reachability, 80)
+		k.Validate(allPods, reachability, 81)
+		_, wrong, _ = reachability.Summary()
+		if wrong == 0 {
+			log.Infof("all HTTP servers are ready")
+			return nil
+		}
+		log.Debugf("%d HTTP servers not ready", wrong)
+		time.Sleep(sleepInterval)
+	}
+	return errors.Errorf("after %d tries, %d HTTP servers are not ready", maxTries, wrong)
+}
+
+func (k *Kubernetes) Validate(allPods []Pod, reachability *Reachability, port int) {
+	type probeResult struct {
+		podFrom   Pod
+		podTo     Pod
+		connected bool
+		err       error
+	}
+	numProbes := len(allPods) * len(allPods)
+	resultsCh := make(chan *probeResult, numProbes)
+	// TODO: find better metrics, this is only for POC.
+	oneProbe := func(podFrom, podTo Pod) {
+		log.Tracef("Probing: %s -> %s", podFrom, podTo)
+		connected, err := k.Probe(podFrom.Namespace(), podFrom.PodName(), podTo.Namespace(), podTo.PodName(), port)
+		resultsCh <- &probeResult{podFrom, podTo, connected, err}
+	}
+	for _, pod1 := range allPods {
+		for _, pod2 := range allPods {
+			go oneProbe(pod1, pod2)
+		}
+	}
+	for i := 0; i < numProbes; i++ {
+		r := <-resultsCh
+		if r.err != nil {
+			log.Errorf("unable to perform probe %s -> %s: %v", r.podFrom, r.podTo, r.err)
+		}
+		reachability.Observe(r.podFrom, r.podTo, r.connected)
+		if !r.connected && reachability.Expected.Get(r.podFrom.String(), r.podTo.String()) {
+			log.Warnf("FAILED CONNECTION FOR WHITELISTED PODS %s -> %s !!!! ", r.podFrom, r.podTo)
+		}
+	}
+}
+
+func (k *Kubernetes) Bootstrap(namespaces, pods []string) (*map[string]string, error) {
+	for _, ns := range namespaces {
+		_, err := k.CreateOrUpdateNamespace(ns, map[string]string{"ns": ns})
+		if err != nil {
+			return nil, errors.WithMessagef(err, "unable to create/update ns %s", ns)
+		}
+		for _, pod := range pods {
+			log.Infof("creating/updating pod %s/%s", ns, pod)
+			_, err := k.CreateOrUpdateDeployment(ns, ns+pod, 1, map[string]string{"pod": pod})
+			if err != nil {
+				return nil, errors.WithMessagef(err, "unable to create/update deployment %s/%s", ns, pod)
+			}
+		}
+	}
+	var allPods []Pod
+	podIPs := make(map[string]string, len(pods)*len(namespaces))
+	for _, podName := range pods {
+		for _, ns := range namespaces {
+			allPods = append(allPods, NewPod(ns, podName))
+		}
+	}
+	for _, pod := range allPods {
+		ip, err := k.waitForPodInNamespace(pod.Namespace(), pod.PodName())
+		if ip == nil || err != nil {
+			return nil, errors.WithMessagef(err, "unable to wait for pod %s/%s", pod.Namespace(), pod.PodName())
+		}
+		podIPs[pod.String()] = *ip
+	}
+
+	// Ensure that all the HTTP servers have time to start properly.
+	// See https://github.com/vmware-tanzu/antrea/issues/472.
+	if err := k.waitForHTTPServers(allPods); err != nil {
+		return nil, err
+	}
+
+	return &podIPs, nil
+}
+
+func (k *Kubernetes) Cleanup(namespaces []string) error {
+	if err := k.CleanCNPs(); err != nil {
+		return err
+	}
+	for _, ns := range namespaces {
+		log.Infof("Deleting test namespace %s", ns)
+		if err := k.ClientSet.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/test/e2e/reachability.go
+++ b/test/e2e/reachability.go
@@ -1,0 +1,268 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"strings"
+)
+
+type Pod string
+
+func NewPod(namespace string, podName string) Pod {
+	return Pod(fmt.Sprintf("%s/%s", namespace, podName))
+}
+
+func (pod Pod) String() string {
+	return string(pod)
+}
+
+func (pod Pod) split() (string, string) {
+	pieces := strings.Split(string(pod), "/")
+	if len(pieces) != 2 {
+		panic(errors.New(fmt.Sprintf("expected ns/pod, found %+v", pieces)))
+	}
+	return pieces[0], pieces[1]
+}
+
+func (pod Pod) Namespace() string {
+	ns, _ := pod.split()
+	return ns
+}
+
+func (pod Pod) PodName() string {
+	_, podName := pod.split()
+	return podName
+}
+
+type Connectivity struct {
+	From        Pod
+	To          Pod
+	IsConnected bool
+}
+
+type TruthTable struct {
+	Items   []string
+	itemSet map[string]bool
+	Values  map[string]map[string]bool
+}
+
+func NewTruthTable(items []string, defaultValue *bool) *TruthTable {
+	itemSet := map[string]bool{}
+	values := map[string]map[string]bool{}
+	for _, from := range items {
+		itemSet[from] = true
+		values[from] = map[string]bool{}
+		if defaultValue != nil {
+			for _, to := range items {
+				values[from][to] = *defaultValue
+			}
+		}
+	}
+	return &TruthTable{
+		Items:   items,
+		itemSet: itemSet,
+		Values:  values,
+	}
+}
+
+// IsComplete returns true if there's a value set for every single pair of items, otherwise it returns false.
+func (tt *TruthTable) IsComplete() bool {
+	for _, from := range tt.Items {
+		for _, to := range tt.Items {
+			if _, ok := tt.Values[from][to]; !ok {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (tt *TruthTable) Set(from string, to string, value bool) {
+	dict, ok := tt.Values[from]
+	if !ok {
+		panic(errors.New(fmt.Sprintf("key %s not found in map", from)))
+	}
+	if _, ok := tt.itemSet[to]; !ok {
+		panic(errors.New(fmt.Sprintf("key %s not allowed", to)))
+	}
+	dict[to] = value
+}
+
+func (tt *TruthTable) SetAllFrom(from string, value bool) {
+	dict, ok := tt.Values[from]
+	if !ok {
+		panic(errors.New(fmt.Sprintf("key %s not found in map", from)))
+	}
+	for _, to := range tt.Items {
+		dict[to] = value
+	}
+}
+
+func (tt *TruthTable) SetAllTo(to string, value bool) {
+	if _, ok := tt.itemSet[to]; !ok {
+		panic(errors.New(fmt.Sprintf("key %s not found", to)))
+	}
+	for _, from := range tt.Items {
+		tt.Values[from][to] = value
+	}
+}
+
+func (tt *TruthTable) Get(from string, to string) bool {
+	dict, ok := tt.Values[from]
+	if !ok {
+		panic(errors.New(fmt.Sprintf("key %s not found in map", from)))
+	}
+	val, ok := dict[to]
+	if !ok {
+		panic(errors.New(fmt.Sprintf("key %s not found in map (%+v)", to, dict)))
+	}
+	return val
+}
+
+func (tt *TruthTable) Compare(other *TruthTable) *TruthTable {
+	// TODO set equality
+	//if tt.itemSet != other.itemSet {
+	//	panic()
+	//}
+	values := map[string]map[string]bool{}
+	for from, dict := range tt.Values {
+		values[from] = map[string]bool{}
+		for to, val := range dict {
+			values[from][to] = val == other.Values[from][to] // TODO other.Get(from, to) ?
+		}
+	}
+	// TODO check for equality from both sides
+	return &TruthTable{
+		Items:   tt.Items,
+		itemSet: tt.itemSet,
+		Values:  values,
+	}
+}
+
+func (tt *TruthTable) PrettyPrint(indent string) string {
+	header := indent + strings.Join(append([]string{"-"}, tt.Items...), "\t")
+	lines := []string{header}
+	for _, from := range tt.Items {
+		line := []string{from}
+		for _, to := range tt.Items {
+			val := "X"
+			if tt.Values[from][to] {
+				val = "."
+			}
+			line = append(line, val)
+		}
+		lines = append(lines, indent+strings.Join(line, "\t"))
+	}
+	return strings.Join(lines, "\n")
+}
+
+type Reachability struct {
+	Expected *TruthTable
+	Observed *TruthTable
+	Pods     []Pod
+}
+
+func NewReachability(pods []Pod, defaultExpectation bool) *Reachability {
+	items := []string{}
+	for _, pod := range pods {
+		items = append(items, string(pod))
+	}
+	r := &Reachability{
+		Expected: NewTruthTable(items, &defaultExpectation),
+		Observed: NewTruthTable(items, nil),
+		Pods:     pods,
+	}
+	return r
+}
+
+// ExpectConn is an experimental way to describe connectivity with named fields
+func (r *Reachability) ExpectConn(spec *Connectivity) {
+	if spec.From == "" && spec.To == "" {
+		panic("at most one of From and To may be empty, but both are empty")
+	}
+	if spec.From == "" {
+		r.ExpectAllIngress(spec.To, spec.IsConnected)
+	} else if spec.To == "" {
+		r.ExpectAllEgress(spec.From, spec.IsConnected)
+	} else {
+		r.Expect(spec.From, spec.To, spec.IsConnected)
+	}
+}
+
+func (r *Reachability) Expect(pod1 Pod, pod2 Pod, isConnected bool) {
+	r.Expected.Set(string(pod1), string(pod2), isConnected)
+}
+
+func (r *Reachability) ExpectSelf(allPods []Pod, isConnected bool) {
+	for _, p := range allPods {
+		r.Expected.Set(string(p), string(p), isConnected)
+	}
+}
+
+// ExpectAllIngress defines that any traffic going into the pod will be allowed/denied (true/false)
+func (r *Reachability) ExpectAllIngress(pod Pod, connected bool) {
+	r.Expected.SetAllTo(string(pod), connected)
+	if !connected {
+		log.Infof("Blacklisting all traffic *to* %s", pod)
+	}
+}
+
+// ExpectAllEgress defines that any traffic going out of the pod will be allowed/denied (true/false)
+func (r *Reachability) ExpectAllEgress(pod Pod, connected bool) {
+	r.Expected.SetAllFrom(string(pod), connected)
+	if !connected {
+		log.Infof("Blacklisting all traffic *from* %s", pod)
+	}
+}
+
+func (r *Reachability) Observe(pod1 Pod, pod2 Pod, isConnected bool) {
+	r.Observed.Set(string(pod1), string(pod2), isConnected)
+}
+
+func (r *Reachability) Summary() (trueObs int, falseObs int, comparison *TruthTable) {
+	comparison = r.Expected.Compare(r.Observed)
+	if !comparison.IsComplete() {
+		panic("observations not complete!")
+	}
+	falseObs = 0
+	trueObs = 0
+	for _, dict := range comparison.Values {
+		for _, val := range dict {
+			if val {
+				trueObs++
+			} else {
+				falseObs++
+			}
+		}
+	}
+	return trueObs, falseObs, comparison
+}
+
+func (r *Reachability) PrintSummary(printExpected bool, printObserved bool, printComparison bool) {
+	right, wrong, comparison := r.Summary()
+	fmt.Printf("reachability: correct:%v, incorrect:%v, result=%t\n\n", right, wrong, wrong == 0)
+	if printExpected {
+		fmt.Printf("expected:\n\n%s\n\n\n", r.Expected.PrettyPrint(""))
+	}
+	if printObserved {
+		fmt.Printf("observed:\n\n%s\n\n\n", r.Observed.PrettyPrint(""))
+	}
+	if printComparison {
+		fmt.Printf("comparison:\n\n%s\n\n\n", comparison.PrettyPrint(""))
+	}
+}

--- a/test/e2e/utils/cnpspecbuilder.go
+++ b/test/e2e/utils/cnpspecbuilder.go
@@ -1,0 +1,214 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	v1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	secv1alpha1 "github.com/vmware-tanzu/antrea/pkg/apis/security/v1alpha1"
+)
+
+type ClusterNetworkPolicySpecBuilder struct {
+	Spec secv1alpha1.ClusterNetworkPolicySpec
+	Name string
+}
+
+func (b *ClusterNetworkPolicySpecBuilder) Get() *secv1alpha1.ClusterNetworkPolicy {
+	if b.Spec.Ingress == nil {
+		b.Spec.Ingress = []secv1alpha1.Rule{}
+	}
+	if b.Spec.Egress == nil {
+		b.Spec.Egress = []secv1alpha1.Rule{}
+	}
+	return &secv1alpha1.ClusterNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: b.Name,
+		},
+		Spec: b.Spec,
+	}
+}
+
+func (b *ClusterNetworkPolicySpecBuilder) SetName(name string) *ClusterNetworkPolicySpecBuilder {
+	b.Name = name
+	return b
+}
+
+func (b *ClusterNetworkPolicySpecBuilder) SetPriority(p float64) *ClusterNetworkPolicySpecBuilder {
+	b.Spec.Priority = p
+	return b
+}
+
+func (b *ClusterNetworkPolicySpecBuilder) SetAppliedToGroup(podSelector map[string]string,
+	nsSelector map[string]string,
+	podSelectorMatchExp *[]metav1.LabelSelectorRequirement,
+	nsSelectorMatchExp *[]metav1.LabelSelectorRequirement) *ClusterNetworkPolicySpecBuilder {
+
+	var ps *metav1.LabelSelector
+	var ns *metav1.LabelSelector
+
+	if podSelector != nil {
+		ps = &metav1.LabelSelector{
+			MatchLabels: podSelector,
+		}
+		if podSelectorMatchExp != nil {
+			ps.MatchExpressions = *podSelectorMatchExp
+		}
+	}
+	if podSelectorMatchExp != nil {
+		ps = &metav1.LabelSelector{
+			MatchExpressions: *podSelectorMatchExp,
+		}
+	}
+	if nsSelector != nil {
+		ns = &metav1.LabelSelector{
+			MatchLabels: nsSelector,
+		}
+		if nsSelectorMatchExp != nil {
+			ns.MatchExpressions = *nsSelectorMatchExp
+		}
+	}
+
+	if nsSelectorMatchExp != nil {
+		ns = &metav1.LabelSelector{
+			MatchExpressions: *nsSelectorMatchExp,
+		}
+	}
+
+	appliedToPeer := secv1alpha1.NetworkPolicyPeer{
+		PodSelector:       ps,
+		NamespaceSelector: ns,
+	}
+	b.Spec.AppliedTo = append(b.Spec.AppliedTo, appliedToPeer)
+	return b
+}
+
+func (b *ClusterNetworkPolicySpecBuilder) AddIngress(protoc v1.Protocol,
+	port *int, portName *string, cidr *string,
+	podSelector map[string]string, nsSelector map[string]string,
+	podSelectorMatchExp *[]metav1.LabelSelectorRequirement, nsSelectorMatchExp *[]metav1.LabelSelectorRequirement,
+	action secv1alpha1.RuleAction) *ClusterNetworkPolicySpecBuilder {
+
+	var ps *metav1.LabelSelector
+	var ns *metav1.LabelSelector
+	if b.Spec.Ingress == nil {
+		b.Spec.Ingress = []secv1alpha1.Rule{}
+	}
+
+	if podSelector != nil {
+		ps = &metav1.LabelSelector{
+			MatchLabels: podSelector,
+		}
+		if podSelectorMatchExp != nil {
+			ps.MatchExpressions = *podSelectorMatchExp
+		}
+	}
+	if podSelectorMatchExp != nil {
+		ps = &metav1.LabelSelector{
+			MatchExpressions: *podSelectorMatchExp,
+		}
+	}
+	if nsSelector != nil {
+		ns = &metav1.LabelSelector{
+			MatchLabels: nsSelector,
+		}
+		if nsSelectorMatchExp != nil {
+			ns.MatchExpressions = *nsSelectorMatchExp
+		}
+	}
+	if nsSelectorMatchExp != nil {
+		ns = &metav1.LabelSelector{
+			MatchExpressions: *nsSelectorMatchExp,
+		}
+	}
+	var ipBlock *secv1alpha1.IPBlock
+	if cidr != nil {
+		ipBlock = &secv1alpha1.IPBlock{
+			CIDR: *cidr,
+		}
+	}
+	var policyPeer []secv1alpha1.NetworkPolicyPeer
+	if ps != nil || ns != nil || ipBlock != nil {
+		policyPeer = []secv1alpha1.NetworkPolicyPeer{{
+			PodSelector:       ps,
+			NamespaceSelector: ns,
+			IPBlock:           ipBlock,
+		}}
+	}
+
+	var ports []secv1alpha1.NetworkPolicyPort
+	if port != nil && portName != nil {
+		panic("specify portname or port, not both")
+	}
+	if port != nil {
+		ports = []secv1alpha1.NetworkPolicyPort{
+			{
+				Port:     &intstr.IntOrString{IntVal: int32(*port)},
+				Protocol: &protoc,
+			},
+		}
+	}
+	if portName != nil {
+		ports = []secv1alpha1.NetworkPolicyPort{
+			{
+				Port:     &intstr.IntOrString{Type: intstr.String, StrVal: *portName},
+				Protocol: &protoc,
+			},
+		}
+	}
+	newRule := secv1alpha1.Rule{
+		From:   policyPeer,
+		Ports:  ports,
+		Action: &action,
+	}
+	b.Spec.Ingress = append(b.Spec.Ingress, newRule)
+	return b
+}
+
+func (b *ClusterNetworkPolicySpecBuilder) AddEgress(protoc v1.Protocol,
+	port *int, portName *string, cidr *string,
+	podSelector map[string]string, nsSelector map[string]string,
+	podSelectorMatchExp *[]metav1.LabelSelectorRequirement, nsSelectorMatchExp *[]metav1.LabelSelectorRequirement,
+	action secv1alpha1.RuleAction) *ClusterNetworkPolicySpecBuilder {
+
+	// For simplicity, we just reuse the Ingress code here.  The underlying data model for ingress/egress is identical
+	// With the exception of calling the rule `To` vs. `From`.
+	c := &ClusterNetworkPolicySpecBuilder{}
+	c.AddIngress(protoc, port, portName, cidr, podSelector, nsSelector, podSelectorMatchExp, nsSelectorMatchExp, action)
+	theRule := c.Get().Spec.Ingress[0]
+
+	b.Spec.Egress = append(b.Spec.Egress, secv1alpha1.Rule{
+		To:     theRule.From,
+		Ports:  theRule.Ports,
+		Action: theRule.Action,
+	})
+	return b
+}
+
+// AddEgressDNS mutates the nth policy rule to allow DNS, convenience method
+func (b *ClusterNetworkPolicySpecBuilder) WithEgressDNS() *ClusterNetworkPolicySpecBuilder {
+	protocolUDP := v1.ProtocolUDP
+	route53 := secv1alpha1.NetworkPolicyPort{
+		Protocol: &protocolUDP,
+		Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 53},
+	}
+
+	for _, e := range b.Spec.Egress {
+		e.Ports = append(e.Ports, route53)
+	}
+	return b
+}

--- a/test/e2e/utils/networkpolicyspecbuilder.go
+++ b/test/e2e/utils/networkpolicyspecbuilder.go
@@ -1,0 +1,179 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+type NetworkPolicySpecBuilder struct {
+	Spec      networkingv1.NetworkPolicySpec
+	Name      string
+	Namespace string
+}
+
+func (n *NetworkPolicySpecBuilder) Get() *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      n.Name,
+			Namespace: n.Namespace,
+		},
+		Spec: n.Spec,
+	}
+}
+
+func (n *NetworkPolicySpecBuilder) SetPodSelector(labels map[string]string) *NetworkPolicySpecBuilder {
+	ps := metav1.LabelSelector{
+		MatchLabels: labels,
+	}
+	n.Spec.PodSelector = ps
+	return n
+}
+
+func (n *NetworkPolicySpecBuilder) SetName(namespace string, name string) *NetworkPolicySpecBuilder {
+	n.Namespace = namespace
+	n.Name = name
+	return n
+}
+
+// TODO: Add tests to match expressions
+func (n *NetworkPolicySpecBuilder) AddIngress(protoc v1.Protocol, port *int, portName *string, cidr *string, exceptCIDRs []string, podSelector map[string]string, nsSelector map[string]string, podSelectorMatchExp *[]metav1.LabelSelectorRequirement, nsSelectorMatchExp *[]metav1.LabelSelectorRequirement) *NetworkPolicySpecBuilder {
+
+	var ps *metav1.LabelSelector
+	var ns *metav1.LabelSelector
+	if n.Spec.Ingress == nil {
+		n.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{}
+	}
+
+	if podSelector != nil {
+		ps = &metav1.LabelSelector{
+			MatchLabels: podSelector,
+		}
+		if podSelectorMatchExp != nil {
+			ps.MatchExpressions = *podSelectorMatchExp
+		}
+	}
+
+	if podSelectorMatchExp != nil {
+		ps = &metav1.LabelSelector{
+			MatchExpressions: *podSelectorMatchExp,
+		}
+	}
+
+	if nsSelector != nil {
+		ns = &metav1.LabelSelector{
+			MatchLabels: nsSelector,
+		}
+		if nsSelectorMatchExp != nil {
+			ns.MatchExpressions = *nsSelectorMatchExp
+		}
+	}
+
+	if nsSelectorMatchExp != nil {
+		ns = &metav1.LabelSelector{
+			MatchExpressions: *nsSelectorMatchExp,
+		}
+	}
+
+	var ipBlock *networkingv1.IPBlock
+	if cidr != nil {
+		ipBlock = &networkingv1.IPBlock{
+			CIDR:   *cidr,
+			Except: exceptCIDRs,
+		}
+	}
+
+	var policyPeer []networkingv1.NetworkPolicyPeer
+	if ps != nil || ns != nil || ipBlock != nil {
+		policyPeer = []networkingv1.NetworkPolicyPeer{{
+			PodSelector:       ps,
+			NamespaceSelector: ns,
+			IPBlock:           ipBlock,
+		}}
+	}
+
+	var ports []networkingv1.NetworkPolicyPort
+	if port != nil && portName != nil {
+		panic("specify portname or port, not both")
+	}
+	if port != nil {
+		ports = []networkingv1.NetworkPolicyPort{
+			{
+				Port:     &intstr.IntOrString{IntVal: int32(*port)},
+				Protocol: &protoc,
+			},
+		}
+	}
+	if portName != nil {
+		ports = []networkingv1.NetworkPolicyPort{
+			{
+				Port:     &intstr.IntOrString{Type: intstr.String, StrVal: *portName},
+				Protocol: &protoc,
+			},
+		}
+	}
+	newRule := networkingv1.NetworkPolicyIngressRule{
+		From:  policyPeer,
+		Ports: ports,
+	}
+	n.Spec.Ingress = append(n.Spec.Ingress, newRule)
+	return n
+}
+
+// AddEgressDNS mutates the nth policy rule to allow DNS, convenience method
+func (n *NetworkPolicySpecBuilder) WithEgressDNS() *NetworkPolicySpecBuilder {
+	protocolUDP := v1.ProtocolUDP
+	route53 := networkingv1.NetworkPolicyPort{
+		Protocol: &protocolUDP,
+		Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 53},
+	}
+
+	for _, e := range n.Spec.Egress {
+		e.Ports = append(e.Ports, route53)
+	}
+	return n
+}
+
+func (n *NetworkPolicySpecBuilder) AddEgress(protoc v1.Protocol, port *int, portName *string, cidr *string, exceptCIDRs []string, podSelector map[string]string, nsSelector map[string]string, podSelectorMatchExp *[]metav1.LabelSelectorRequirement, nsSelectorMatchExp *[]metav1.LabelSelectorRequirement) *NetworkPolicySpecBuilder {
+	// For simplicity, we just reuse the Ingress code here.  The underlying data model for ingress/egress is identical
+	// With the exception of calling the rule `To` vs. `From`.
+	i := &NetworkPolicySpecBuilder{}
+	i.AddIngress(protoc, port, portName, cidr, exceptCIDRs, podSelector, nsSelector, podSelectorMatchExp, nsSelectorMatchExp)
+	theRule := i.Get().Spec.Ingress[0]
+
+	n.Spec.Egress = append(n.Spec.Egress, networkingv1.NetworkPolicyEgressRule{
+		To:    theRule.From,
+		Ports: theRule.Ports,
+	})
+
+	return n
+}
+
+func (n *NetworkPolicySpecBuilder) SetTypeIngress() *NetworkPolicySpecBuilder {
+	n.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}
+	return n
+}
+func (n *NetworkPolicySpecBuilder) SetTypeEgress() *NetworkPolicySpecBuilder {
+	n.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}
+	return n
+}
+func (n *NetworkPolicySpecBuilder) SetTypeBoth() *NetworkPolicySpecBuilder {
+	n.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeEgress, networkingv1.PolicyTypeIngress}
+	return n
+}


### PR DESCRIPTION
This PR adds 8 E2E testcases for ClusterNetworkPolicy:
#### GroupDefaultDeny 
Tests in this group will be performed with DEFAULT-DENY k8s network policies applied to all underlying pods. This is to verify the ALLOW action for CNP.
- testCNPAllowXBtoA (basic)
- testCNPAllowXBtoYA (tests namedPort)
- testCNPPrioirtyOverrideDefaultDeny (tests priority precedence)

#### TestGroupNoK8sNP
Tests below will be performed without any underlying k8s network policies.
- testCNPAllowNoDefaultIsolation (basic)
- testCNPDropEgress (tests DROP action)
- testCNPPrioirtyOverride (tests ipBlock and priority reassignments/precedence)
- testCNPPriorityConflictingRule (tests priority precedence)
- testCNPRulePrioirty  (tests rule priority precedence)
