### PR TITLE
Update default labels in Github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: kind/bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: enhancement
+labels: kind/feature
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -2,7 +2,7 @@
 name: Proposal
 about: Describe a feature you are planning to implement
 title: ''
-labels: proposal
+labels: kind/design
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -2,7 +2,7 @@
 name: Support request
 about: You are trying to use Antrea and need help
 title: ''
-labels: support
+labels: kind/support
 assignees: ''
 
 ---

--- a/docs/issue-management.md
+++ b/docs/issue-management.md
@@ -260,9 +260,6 @@ could include some of the following:
 * this is desirable but we need help completing other issues or PRs first; then we will
   consider this design
 
-_Note this was previously called `proposal`. We will add the `kind/design` label
-to all issues currently labeled with `proposal`._
-
 #### Documentation
 
 A `kind/documentation` label categorizes issue or PR as related to a
@@ -303,9 +300,6 @@ To create a support issue or PR:
   to a publicly-accessible location. **Be aware that the generated support
   bundle includes a lot of information, including logs, so please ensure that
   you do not share anything sensitive.**
-
-_Note this was previously called `support`. We will add the `kind/support` label
-to all issues currently labeled with `support`._
 
 ### Area
 


### PR DESCRIPTION
The "kind/*" labels which are described in the contributor docs should
be used instead of the legacy ones.