### PR TITLE
Create controller CA ConfigMap in the controller deployement Namespace

### DIFF
--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -428,17 +428,19 @@ data:
     #enablePrometheusMetrics: false
 
     # Indicates whether to use auto-generated self-signed TLS certificate.
-    # If false, A secret named "kube-system/antrea-controller-tls" must be provided with the following keys:
+    # If false, A Secret named "antrea-controller-tls" must be provided with the following keys:
     #   ca.crt: <CA certificate>
     #   tls.crt: <TLS certificate>
     #   tls.key: <TLS private key>
+    # And the Secret must be mounted to directory "/var/run/antrea/antrea-controller-tls" of the
+    # antrea-controller container.
     #selfSignedCert: true
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-fktddbgbt9
+  name: antrea-config-6kd8dg2mdc
   namespace: kube-system
 ---
 apiVersion: v1
@@ -543,7 +545,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-fktddbgbt9
+          name: antrea-config-6kd8dg2mdc
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -757,7 +759,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-fktddbgbt9
+          name: antrea-config-6kd8dg2mdc
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -428,17 +428,19 @@ data:
     #enablePrometheusMetrics: false
 
     # Indicates whether to use auto-generated self-signed TLS certificate.
-    # If false, A secret named "kube-system/antrea-controller-tls" must be provided with the following keys:
+    # If false, A Secret named "antrea-controller-tls" must be provided with the following keys:
     #   ca.crt: <CA certificate>
     #   tls.crt: <TLS certificate>
     #   tls.key: <TLS private key>
+    # And the Secret must be mounted to directory "/var/run/antrea/antrea-controller-tls" of the
+    # antrea-controller container.
     #selfSignedCert: true
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-9bkbtgd8tf
+  name: antrea-config-df75dft74m
   namespace: kube-system
 ---
 apiVersion: v1
@@ -543,7 +545,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-9bkbtgd8tf
+          name: antrea-config-df75dft74m
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -755,7 +757,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-9bkbtgd8tf
+          name: antrea-config-df75dft74m
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -428,17 +428,19 @@ data:
     #enablePrometheusMetrics: false
 
     # Indicates whether to use auto-generated self-signed TLS certificate.
-    # If false, A secret named "kube-system/antrea-controller-tls" must be provided with the following keys:
+    # If false, A Secret named "antrea-controller-tls" must be provided with the following keys:
     #   ca.crt: <CA certificate>
     #   tls.crt: <TLS certificate>
     #   tls.key: <TLS private key>
+    # And the Secret must be mounted to directory "/var/run/antrea/antrea-controller-tls" of the
+    # antrea-controller container.
     #selfSignedCert: true
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-576575d7g8
+  name: antrea-config-6fg7ftb7c2
   namespace: kube-system
 ---
 apiVersion: v1
@@ -552,7 +554,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-576575d7g8
+          name: antrea-config-6fg7ftb7c2
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -799,7 +801,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-576575d7g8
+          name: antrea-config-6fg7ftb7c2
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -428,17 +428,19 @@ data:
     #enablePrometheusMetrics: false
 
     # Indicates whether to use auto-generated self-signed TLS certificate.
-    # If false, A secret named "kube-system/antrea-controller-tls" must be provided with the following keys:
+    # If false, A Secret named "antrea-controller-tls" must be provided with the following keys:
     #   ca.crt: <CA certificate>
     #   tls.crt: <TLS certificate>
     #   tls.key: <TLS private key>
+    # And the Secret must be mounted to directory "/var/run/antrea/antrea-controller-tls" of the
+    # antrea-controller container.
     #selfSignedCert: true
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-d4b44mm2k6
+  name: antrea-config-g9c588t985
   namespace: kube-system
 ---
 apiVersion: v1
@@ -543,7 +545,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-d4b44mm2k6
+          name: antrea-config-g9c588t985
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -755,7 +757,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-d4b44mm2k6
+          name: antrea-config-g9c588t985
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-controller.conf
+++ b/build/yamls/base/conf/antrea-controller.conf
@@ -10,8 +10,10 @@
 #enablePrometheusMetrics: false
 
 # Indicates whether to use auto-generated self-signed TLS certificate.
-# If false, A secret named "kube-system/antrea-controller-tls" must be provided with the following keys:
+# If false, A Secret named "antrea-controller-tls" must be provided with the following keys:
 #   ca.crt: <CA certificate>
 #   tls.crt: <TLS certificate>
 #   tls.key: <TLS private key>
+# And the Secret must be mounted to directory "/var/run/antrea/antrea-controller-tls" of the
+# antrea-controller container.
 #selfSignedCert: true

--- a/cmd/antrea-controller/config.go
+++ b/cmd/antrea-controller/config.go
@@ -31,10 +31,12 @@ type ControllerConfig struct {
 	// Defaults to false.
 	EnablePrometheusMetrics bool `yaml:"enablePrometheusMetrics,omitempty"`
 	// Indicates whether to use auto-generated self-signed TLS certificate.
-	// If false, A secret named "kube-system/antrea-controller-tls" must be provided with the following keys:
+	// If false, A Secret named "antrea-controller-tls" must be provided with the following keys:
 	//   ca.crt: <CA certificate>
 	//   tls.crt: <TLS certificate>
 	//   tls.key: <TLS private key>
+	// And the Secret must be mounted to directory "/var/run/antrea/antrea-controller-tls" of the
+	// antrea-controller container.
 	// Defaults to true.
 	SelfSignedCert bool `yaml:"selfSignedCert,omitempty"`
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,10 +92,12 @@ clientConnection:
 #apiPort: 10349
 
 # Indicates whether to use auto-generated self-signed TLS certificate.
-# If false, A secret named "kube-system/antrea-controller-tls" must be provided with the following keys:
+# If false, A Secret named "antrea-controller-tls" must be provided with the following keys:
 #   ca.crt: <CA certificate>
 #   tls.crt: <TLS certificate>
 #   tls.key: <TLS private key>
+# And the Secret must be mounted to directory "/var/run/antrea/antrea-controller-tls" of the
+# antrea-controller container.
 #selfSignedCert: true
 ```
 

--- a/docs/securing-control-plane.md
+++ b/docs/securing-control-plane.md
@@ -33,20 +33,23 @@ for client authentication.
 By default, antrea-controller generates a self-signed certificate. You can
 override the behavior by [providing your own certificates](#providing-your-own-certificates).
 Either way, the antrea-controller will distribute the CA certificate as a
-ConfigMap named `antrea-ca` in the `kube-system` Namespace and inject it into
-the APIServices resources created by Antrea in order to allow its clients (i.e.
-antrea-agent, kube-apiserver) to perform authentication.
+ConfigMap named `antrea-ca` in the Antrea deployment Namespace and inject it
+into the APIServices resources created by Antrea in order to allow its clients
+(i.e. antrea-agent, kube-apiserver) to perform authentication.
 
 Typically, clients that wish to access the antrea-controller API can
 authenticate the server by validating against the CA certificate published in
-the `kube-system/antrea-ca` ConfigMap.
+the `antrea-ca` ConfigMap.
 
 ## Providing your own certificates
 
 Since Antrea v0.7.0, you can provide your own certificates to Antrea. To do so,
 you must set the `selfSignedCert` field of `antrea-controller.conf` to `false`,
 so that the antrea-controller will read the certificate key pair from the
-`kube-system/antrea-controller-tls` Secret.
+`antrea-controller-tls` Secret. The example manifests and descriptions below
+assume Antrea is deployed in the `kube-system` Namespace. If you deploy Antrea
+in a different Namepace, please update the Namespace name in the manifests
+accordingly.
 
 ```yaml
 apiVersion: v1
@@ -77,8 +80,8 @@ DNS names:
 **Note: It assumes you are using `cluster.local` as the cluster domain, you
 should replace it with the actual one of your Kubernetes cluster.**
 
-You can then create the `kube-system/antrea-controller-tls` Secret with the
-certificate key pair and the CA certificate in the following form:
+You can then create the `antrea-controller-tls` Secret with the certificate key
+pair and the CA certificate in the following form:
 ```yaml
 apiVersion: v1
 kind: Secret
@@ -147,7 +150,7 @@ to the antrea-controller Pod if the Pod starts before the Secret is created.**
 ## Certificate rotation
 
 Antrea v0.7.0 and higher supports certificate rotation. It can be achieved by
-simply updating the `kube-system/antrea-controller-tls` Secret. The
+simply updating the `antrea-controller-tls` Secret. The
 antrea-controller will react to the change, updating its serving certificate and
 re-distributing the latest CA certificate (if applicable).
 

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -54,7 +54,12 @@ func NewAntreaClientProvider(config config.ClientConnectionConfiguration, kubeCl
 	// The key "ca.crt" may not exist at the beginning, no need to fail as the CA provider will watch the ConfigMap
 	// and notify antreaClientProvider of any update. The consumers of antreaClientProvider are supposed to always
 	// call GetAntreaClient() to get a client and not cache it.
-	antreaCAProvider, _ := dynamiccertificates.NewDynamicCAFromConfigMapController("antrea-ca", cert.CAConfigMapNamespace, cert.CAConfigMapName, cert.CAConfigMapKey, kubeClient)
+	antreaCAProvider, _ := dynamiccertificates.NewDynamicCAFromConfigMapController(
+		"antrea-ca",
+		cert.GetCAConfigMapNamespace(),
+		cert.CAConfigMapName,
+		cert.CAConfigMapKey,
+		kubeClient)
 	antreaClientProvider := &antreaClientProvider{
 		config:            config,
 		caContentProvider: antreaCAProvider,
@@ -145,7 +150,7 @@ func inClusterConfig(caBundle []byte) (*rest.Config, error) {
 
 	tlsClientConfig := rest.TLSClientConfig{
 		CAData:     caBundle,
-		ServerName: cert.AntreaServerNames[0],
+		ServerName: cert.GetAntreaServerNames()[0],
 	}
 
 	return &rest.Config{

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -15,18 +15,11 @@
 package querier
 
 import (
-	"os"
-
 	v1 "k8s.io/api/core/v1"
 
 	networkingv1beta1 "github.com/vmware-tanzu/antrea/pkg/apis/networking/v1beta1"
+	"github.com/vmware-tanzu/antrea/pkg/util/env"
 	"github.com/vmware-tanzu/antrea/pkg/version"
-)
-
-const (
-	podName      = "POD_NAME"
-	podNamespace = "POD_NAMESPACE"
-	nodeName     = "NODE_NAME"
 )
 
 type NetworkPolicyInfoQuerier interface {
@@ -52,10 +45,12 @@ type ControllerNetworkPolicyInfoQuerier interface {
 
 // GetSelfPod gets current pod.
 func GetSelfPod() v1.ObjectReference {
-	if os.Getenv(podName) == "" || os.Getenv(podNamespace) == "" {
+	podName := env.GetPodName()
+	podNamespace := env.GetPodNamespace()
+	if podName == "" || podNamespace == "" {
 		return v1.ObjectReference{}
 	}
-	return v1.ObjectReference{Kind: "Pod", Name: os.Getenv(podName), Namespace: os.Getenv(podNamespace)}
+	return v1.ObjectReference{Kind: "Pod", Name: podName, Namespace: podNamespace}
 }
 
 // GetSelfNode gets current node.
@@ -66,10 +61,11 @@ func GetSelfNode(isAgent bool, node string) v1.ObjectReference {
 		}
 		return v1.ObjectReference{Kind: "Node", Name: node}
 	}
-	if os.Getenv(nodeName) == "" {
+	nodeName, _ := env.GetNodeName()
+	if nodeName == "" {
 		return v1.ObjectReference{}
 	}
-	return v1.ObjectReference{Kind: "Node", Name: os.Getenv(nodeName)}
+	return v1.ObjectReference{Kind: "Node", Name: nodeName}
 }
 
 // GetVersion gets current version.

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -23,8 +23,9 @@ import (
 
 // nodeNameEnvKey is environment variable.
 const (
-	nodeNameEnvKey = "NODE_NAME"
-	podNameEnvKey  = "POD_NAME"
+	nodeNameEnvKey     = "NODE_NAME"
+	podNameEnvKey      = "POD_NAME"
+	podNamespaceEnvKey = "POD_NAMESPACE"
 
 	antreaCloudEKSEnvKey = "ANTREA_CLOUD_EKS"
 )
@@ -47,13 +48,22 @@ func GetNodeName() (string, error) {
 	return nodeName, nil
 }
 
-// GetPodName returns the pod name where the code executes
+// GetPodName returns name of the Pod where the code executes.
 func GetPodName() string {
 	podName := os.Getenv(podNameEnvKey)
 	if podName == "" {
 		klog.Warningf("Environment variable %s not found", podNameEnvKey)
 	}
 	return podName
+}
+
+// GetPodNamespace returns Namespace of the Pod where the code executes.
+func GetPodNamespace() string {
+	podNamespace := os.Getenv(podNamespaceEnvKey)
+	if podNamespace == "" {
+		klog.Warningf("Environment variable %s not found", podNamespaceEnvKey)
+	}
+	return podNamespace
 }
 
 func getBoolEnvVar(name string, defaultValue bool) bool {


### PR DESCRIPTION
Stop using the fixed "kube-system" Namespace for the CA ConfigMap.
Also update the deployment YAML and docs/securing-control-plane.md
about the descriptions about CA ConfigMap and TLS Secret Namespace.

Fixes: #876