### PR TITLE
Support log file size and number limits

### DIFF
--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -662,9 +662,10 @@ spec:
         - --config
         - /etc/antrea/antrea-controller.conf
         - --logtostderr=false
-        - --log_dir
-        - /var/log/antrea
+        - --log_dir=/var/log/antrea
         - --alsologtostderr
+        - --log_file_max_size=100
+        - --log_file_max_num=4
         command:
         - antrea-controller
         env:
@@ -787,9 +788,10 @@ spec:
         - --config
         - /etc/antrea/antrea-agent.conf
         - --logtostderr=false
-        - --log_dir
-        - /var/log/antrea
+        - --log_dir=/var/log/antrea
         - --alsologtostderr
+        - --log_file_max_size=100
+        - --log_file_max_num=4
         command:
         - antrea-agent
         env:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -662,9 +662,10 @@ spec:
         - --config
         - /etc/antrea/antrea-controller.conf
         - --logtostderr=false
-        - --log_dir
-        - /var/log/antrea
+        - --log_dir=/var/log/antrea
         - --alsologtostderr
+        - --log_file_max_size=100
+        - --log_file_max_num=4
         command:
         - antrea-controller
         env:
@@ -787,9 +788,10 @@ spec:
         - --config
         - /etc/antrea/antrea-agent.conf
         - --logtostderr=false
-        - --log_dir
-        - /var/log/antrea
+        - --log_dir=/var/log/antrea
         - --alsologtostderr
+        - --log_file_max_size=100
+        - --log_file_max_num=4
         command:
         - antrea-agent
         env:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -671,9 +671,10 @@ spec:
         - --config
         - /etc/antrea/antrea-controller.conf
         - --logtostderr=false
-        - --log_dir
-        - /var/log/antrea
+        - --log_dir=/var/log/antrea
         - --alsologtostderr
+        - --log_file_max_size=100
+        - --log_file_max_num=4
         command:
         - antrea-controller
         env:
@@ -826,9 +827,10 @@ spec:
         - --config
         - /etc/antrea/antrea-agent.conf
         - --logtostderr=false
-        - --log_dir
-        - /var/log/antrea
+        - --log_dir=/var/log/antrea
         - --alsologtostderr
+        - --log_file_max_size=100
+        - --log_file_max_num=4
         command:
         - antrea-agent
         env:

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -1,16 +1,16 @@
 apiVersion: v1
 data:
-  Run-AntreaAgent.ps1: |-
+  Run-AntreaAgent.ps1: |
     $ErrorActionPreference = "Stop"
     # wins will rename the binary when executing it. So we need to copy the binary everytime before running it.
     mkdir -force /host/k/antrea/bin
     cp /k/antrea/bin/* /host/k/antrea/bin/
-    C:/k/antrea/utils/wins.exe cli process run --path /k/antrea/bin/antrea-agent.exe --args "--config=/k/antrea/etc/antrea-agent.conf --logtostderr=false --log_dir=/k/antrea/logs/ --alsologtostderr" --envs "KUBERNETES_SERVICE_HOST=$env:KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT=$env:KUBERNETES_SERVICE_PORT ANTREA_SERVICE_HOST=$env:ANTREA_SERVICE_HOST ANTREA_SERVICE_PORT=$env:ANTREA_SERVICE_PORT NODE_NAME=$env:NODE_NAME"
+    C:/k/antrea/utils/wins.exe cli process run --path /k/antrea/bin/antrea-agent.exe --args "--config=/k/antrea/etc/antrea-agent.conf --logtostderr=false --log_dir=/k/antrea/logs/ --alsologtostderr --log_file_max_size=100 --log_file_max_num=4" --envs "KUBERNETES_SERVICE_HOST=$env:KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT=$env:KUBERNETES_SERVICE_PORT ANTREA_SERVICE_HOST=$env:ANTREA_SERVICE_HOST ANTREA_SERVICE_PORT=$env:ANTREA_SERVICE_PORT NODE_NAME=$env:NODE_NAME"
 kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-agent-windows-9ffbt88hmc
+  name: antrea-agent-windows-59cc7mmd6h
   namespace: kube-system
 ---
 apiVersion: v1
@@ -161,7 +161,7 @@ spec:
         name: antrea-windows-config
       - configMap:
           defaultMode: 420
-          name: antrea-agent-windows-9ffbt88hmc
+          name: antrea-agent-windows-59cc7mmd6h
         name: antrea-agent-windows
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -662,9 +662,10 @@ spec:
         - --config
         - /etc/antrea/antrea-controller.conf
         - --logtostderr=false
-        - --log_dir
-        - /var/log/antrea
+        - --log_dir=/var/log/antrea
         - --alsologtostderr
+        - --log_file_max_size=100
+        - --log_file_max_num=4
         command:
         - antrea-controller
         env:
@@ -787,9 +788,10 @@ spec:
         - --config
         - /etc/antrea/antrea-agent.conf
         - --logtostderr=false
-        - --log_dir
-        - /var/log/antrea
+        - --log_dir=/var/log/antrea
         - --alsologtostderr
+        - --log_file_max_size=100
+        - --log_file_max_num=4
         command:
         - antrea-agent
         env:

--- a/build/yamls/base/agent.yml
+++ b/build/yamls/base/agent.yml
@@ -69,7 +69,7 @@ spec:
               cpu: "200m"
           command: ["antrea-agent"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).
-          args: ["--config", "/etc/antrea/antrea-agent.conf", "--logtostderr=false", "--log_dir", "/var/log/antrea", "--alsologtostderr"]
+          args: ["--config", "/etc/antrea/antrea-agent.conf", "--logtostderr=false", "--log_dir=/var/log/antrea", "--alsologtostderr", "--log_file_max_size=100", "--log_file_max_num=4"]
           env:
             # Provide pod and node information for clusterinformation CRD.
             - name: POD_NAME

--- a/build/yamls/base/controller.yml
+++ b/build/yamls/base/controller.yml
@@ -80,7 +80,7 @@ spec:
               cpu: "200m"
           command: ["antrea-controller"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).
-          args: ["--config", "/etc/antrea/antrea-controller.conf", "--logtostderr=false", "--log_dir", "/var/log/antrea", "--alsologtostderr"]
+          args: ["--config", "/etc/antrea/antrea-controller.conf", "--logtostderr=false", "--log_dir=/var/log/antrea", "--alsologtostderr", "--log_file_max_size=100", "--log_file_max_num=4"]
           env:
             # Provide pod and node information for clusterinformation CRD.
             - name: POD_NAME

--- a/build/yamls/windows/base/conf/Run-AntreaAgent.ps1
+++ b/build/yamls/windows/base/conf/Run-AntreaAgent.ps1
@@ -2,4 +2,4 @@ $ErrorActionPreference = "Stop"
 # wins will rename the binary when executing it. So we need to copy the binary everytime before running it.
 mkdir -force /host/k/antrea/bin
 cp /k/antrea/bin/* /host/k/antrea/bin/
-C:/k/antrea/utils/wins.exe cli process run --path /k/antrea/bin/antrea-agent.exe --args "--config=/k/antrea/etc/antrea-agent.conf --logtostderr=false --log_dir=/k/antrea/logs/ --alsologtostderr" --envs "KUBERNETES_SERVICE_HOST=$env:KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT=$env:KUBERNETES_SERVICE_PORT ANTREA_SERVICE_HOST=$env:ANTREA_SERVICE_HOST ANTREA_SERVICE_PORT=$env:ANTREA_SERVICE_PORT NODE_NAME=$env:NODE_NAME"
+C:/k/antrea/utils/wins.exe cli process run --path /k/antrea/bin/antrea-agent.exe --args "--config=/k/antrea/etc/antrea-agent.conf --logtostderr=false --log_dir=/k/antrea/logs/ --alsologtostderr --log_file_max_size=100 --log_file_max_num=4" --envs "KUBERNETES_SERVICE_HOST=$env:KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT=$env:KUBERNETES_SERVICE_PORT ANTREA_SERVICE_HOST=$env:ANTREA_SERVICE_HOST ANTREA_SERVICE_PORT=$env:ANTREA_SERVICE_PORT NODE_NAME=$env:NODE_NAME"

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -40,6 +40,7 @@ import (
 	crdinformers "github.com/vmware-tanzu/antrea/pkg/client/informers/externalversions"
 	"github.com/vmware-tanzu/antrea/pkg/features"
 	"github.com/vmware-tanzu/antrea/pkg/k8s"
+	"github.com/vmware-tanzu/antrea/pkg/log"
 	"github.com/vmware-tanzu/antrea/pkg/monitor"
 	ofconfig "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
 	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
@@ -185,6 +186,8 @@ func run(o *Options) error {
 	// cause the stopCh channel to be closed; if another signal is received before the program
 	// exits, we will force exit.
 	stopCh := signals.RegisterSignalHandlers()
+
+	log.StartLogFileNumberMonitor(stopCh)
 
 	go cniServer.Run(stopCh)
 

--- a/cmd/antrea-agent/main.go
+++ b/cmd/antrea-agent/main.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/component-base/logs"
 	"k8s.io/klog"
 
+	"github.com/vmware-tanzu/antrea/pkg/log"
 	"github.com/vmware-tanzu/antrea/pkg/version"
 )
 
@@ -33,7 +34,6 @@ func main() {
 	defer logs.FlushLogs()
 
 	command := newAgentCommand()
-
 	if err := command.Execute(); err != nil {
 		logs.FlushLogs()
 		os.Exit(1)
@@ -47,6 +47,7 @@ func newAgentCommand() *cobra.Command {
 		Use:  "antrea-agent",
 		Long: "The Antrea agent runs on each node.",
 		Run: func(cmd *cobra.Command, args []string) {
+			log.InitLogFileLimits(cmd.Flags())
 			if err := opts.complete(args); err != nil {
 				klog.Fatalf("Failed to complete: %v", err)
 			}
@@ -62,6 +63,7 @@ func newAgentCommand() *cobra.Command {
 
 	flags := cmd.Flags()
 	opts.addFlags(flags)
+	log.AddFlags(flags)
 	// Install log flags
 	flags.AddGoFlagSet(flag.CommandLine)
 	return cmd

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -42,6 +42,7 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/controller/traceflow"
 	"github.com/vmware-tanzu/antrea/pkg/features"
 	"github.com/vmware-tanzu/antrea/pkg/k8s"
+	"github.com/vmware-tanzu/antrea/pkg/log"
 	"github.com/vmware-tanzu/antrea/pkg/monitor"
 	"github.com/vmware-tanzu/antrea/pkg/signals"
 	"github.com/vmware-tanzu/antrea/pkg/version"
@@ -117,6 +118,8 @@ func run(o *Options) error {
 	// cause the stopCh channel to be closed; if another signal is received before the program
 	// exits, we will force exit.
 	stopCh := signals.RegisterSignalHandlers()
+
+	log.StartLogFileNumberMonitor(stopCh)
 
 	informerFactory.Start(stopCh)
 

--- a/cmd/antrea-controller/main.go
+++ b/cmd/antrea-controller/main.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/component-base/logs"
 	"k8s.io/klog"
 
+	"github.com/vmware-tanzu/antrea/pkg/log"
 	"github.com/vmware-tanzu/antrea/pkg/version"
 )
 
@@ -47,6 +48,7 @@ func newControllerCommand() *cobra.Command {
 		Use:  "antrea-controller",
 		Long: "The Antrea Controller.",
 		Run: func(cmd *cobra.Command, args []string) {
+			log.InitLogFileLimits(cmd.Flags())
 			if err := opts.complete(args); err != nil {
 				klog.Fatalf("Failed to complete: %v", err)
 			}
@@ -62,6 +64,7 @@ func newControllerCommand() *cobra.Command {
 
 	flags := cmd.Flags()
 	opts.addFlags(flags)
+	log.AddFlags(flags)
 	// Install log flags
 	flags.AddGoFlagSet(flag.CommandLine)
 	return cmd

--- a/pkg/log/log_file.go
+++ b/pkg/log/log_file.go
@@ -1,0 +1,192 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package log processes the klog flags, and enforces the maximum log file
+// size and maximum log file number limits.
+package log
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
+)
+
+const (
+	logToStdErrFlag = "logtostderr"
+	logDirFlag      = "log_dir"
+	logFileFlag     = "log_file"
+	maxSizeFlag     = "log_file_max_size"
+	maxNumFlag      = "log_file_max_num"
+
+	// Check log file number every 10 mins.
+	logFileCheckInterval = time.Minute * 10
+	// Allowed maximum value for the maximum file size limit.
+	maxMaxSizeMB = 1024 * 100
+)
+
+var (
+	maxNumArg     = uint16(0)
+	logFileMaxNum = uint16(0)
+	logDir        = ""
+
+	executableName = filepath.Base(os.Args[0])
+)
+
+func AddFlags(fs *pflag.FlagSet) {
+	fs.Uint16Var(&maxNumArg, maxNumFlag, maxNumArg, "Maximum number of log files per severity level to be kept. Value 0 means unlimited.")
+}
+
+// InitLogFileLimits initializes log file maximum size and maximum number limits based on the
+// command line flags.
+func InitLogFileLimits(fs *pflag.FlagSet) {
+	var err error
+	var logToStdErr bool
+	var logFile string
+	var maxSize uint64
+
+	logToStdErr, err = fs.GetBool(logToStdErrFlag)
+	if err != nil {
+		// Should not happen. Return for safety.
+		return
+	}
+	if logToStdErr {
+		// Logging to files is not enabled.
+		return
+	}
+
+	logFile, err = fs.GetString(logFileFlag)
+	if err != nil {
+		return
+	}
+	if logFile != "" {
+		// Log to a single file. klog will take care of the max size limit.
+		return
+	}
+
+	// Max log file size in MB.
+	maxSize, err = fs.GetUint64(maxSizeFlag)
+	if err != nil {
+		return
+	}
+	if maxSize > maxMaxSizeMB {
+		klog.Errorf("The specified log file max size %d is too big (maximum: %d), ignored", maxSize, maxMaxSizeMB)
+	} else {
+		maxSize = maxSize * 1024 * 1024
+
+		// klog does not respect the max file size specified by --log_file_max_size
+		// when --log_file is not used. Here as a workaround, we directly set the
+		// specified max size to klog.MaxSize.
+		if klog.MaxSize != maxSize {
+			klog.MaxSize = maxSize
+			klog.Infof("Set log file max size to %d", maxSize)
+		}
+	}
+
+	if maxNumArg > 0 {
+		logDir, err = fs.GetString(logDirFlag)
+		if err != nil {
+			return
+		}
+
+		logFileMaxNum = maxNumArg
+		if logDir == "" {
+			// Log to the tmp dir.
+			logDir = os.TempDir()
+		}
+	}
+}
+
+// StartLogFileNumberMonitor starts monitoring the log files to make sure the
+// number of log files does not exceed the maximum limit, when the log file
+// number limit is configured.
+func StartLogFileNumberMonitor(stopCh <-chan struct{}) {
+	if logFileMaxNum == 0 {
+		// The maximum log file number limit is not configured.
+		return
+	}
+
+	go func() {
+		klog.Infof("Starting log file monitoring. Maximum log file number is %d", logFileMaxNum)
+		wait.Until(checkLogFiles, logFileCheckInterval, stopCh)
+	}()
+}
+
+func checkLogFiles() {
+	f, err := os.Open(logDir)
+	if err != nil {
+		klog.Errorf("Failed to open log directory %s: %v", logDir, err)
+		return
+	}
+	allFiles, err := f.Readdir(-1)
+	f.Close()
+	if err != nil {
+		klog.Errorf("Failed to read log directory %s: %v", logDir, err)
+		return
+	}
+
+	maxNum := int(logFileMaxNum)
+	if len(allFiles) <= maxNum {
+		return
+	}
+
+	infoLogFiles := []os.FileInfo{}
+	warningLogFiles := []os.FileInfo{}
+	errorLogFiles := []os.FileInfo{}
+	for _, file := range allFiles {
+		if !file.Mode().IsRegular() {
+			// Skip dir, symbol link, etc.
+			continue
+		}
+		if !strings.HasPrefix(file.Name(), executableName) {
+			continue
+		}
+		if strings.Contains(file.Name(), ".log.INFO.") {
+			infoLogFiles = append(infoLogFiles, file)
+		} else if strings.Contains(file.Name(), ".log.WARNING.") {
+			warningLogFiles = append(warningLogFiles, file)
+		} else if strings.Contains(file.Name(), ".log.ERROR.") {
+			errorLogFiles = append(errorLogFiles, file)
+		}
+	}
+
+	checkFilesFn := func(files []os.FileInfo) {
+		if len(files) <= maxNum {
+			return
+		}
+		// Sort files by modification time.
+		sort.Slice(files, func(i, j int) bool {
+			return files[i].ModTime().After(files[j].ModTime())
+		})
+		// Remove the oldest files.
+		for _, file := range files[maxNum:] {
+			err := os.Remove(logDir + "/" + file.Name())
+			if err != nil {
+				klog.Errorf("Failed to delete log file %s: %v", file.Name(), err)
+			} else {
+				klog.Infof("Deleted log file %s", file.Name())
+			}
+		}
+	}
+
+	checkFilesFn(infoLogFiles)
+	checkFilesFn(warningLogFiles)
+	checkFilesFn(errorLogFiles)
+}

--- a/pkg/log/log_file_test.go
+++ b/pkg/log/log_file_test.go
@@ -1,0 +1,195 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/component-base/logs"
+	"k8s.io/klog"
+)
+
+var (
+	testFlags          = initFlags()
+	klogDefaultMaxSize = klog.MaxSize
+)
+
+func initFlags() *pflag.FlagSet {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	AddFlags(flags)
+	flags.AddGoFlagSet(flag.CommandLine)
+	return flags
+}
+
+func restoreFlagDefaultValues() {
+	testFlags.Set(logToStdErrFlag, "true")
+	testFlags.Set(logFileFlag, "")
+	testFlags.Set(logDirFlag, "")
+	testFlags.Set(maxSizeFlag, fmt.Sprintf("%d", klogDefaultMaxSize/1024/1024))
+	testFlags.Set(maxNumFlag, "0")
+
+	klog.MaxSize = klogDefaultMaxSize
+	logFileMaxNum = 0
+	logDir = ""
+}
+
+// Log ~100K bytes.
+func testLogging() {
+	// ~1K bytes per line.
+	line := make([]byte, 1000)
+	for i := 0; i < 1000; i++ {
+		line[i] = byte('0' + i%10)
+	}
+	// Log 100 lines, ~100K bytes.
+	for i := 0; i < 100; i++ {
+		klog.Infof("%d: %s", i, string(line))
+		klog.Warningf("%d: %s", i, string(line))
+	}
+	logs.FlushLogs()
+}
+
+func TestKlogFileLimits(t *testing.T) {
+	testLogDir, err := ioutil.TempDir("", "antrea-log-test")
+	if err != nil {
+		t.Errorf("Failed to create tmp log dir: %v", err)
+		return
+	}
+	defer os.RemoveAll(testLogDir)
+
+	testMaxNum := 2
+	args := []string{"--logtostderr=false", "--log_dir=" + testLogDir, "--log_file_max_size=1",
+		fmt.Sprintf("--log_file_max_num=%d", testMaxNum)}
+	testFlags.Parse(args)
+	InitLogFileLimits(testFlags)
+	logs.InitLogs()
+	defer restoreFlagDefaultValues()
+
+	// Should generate about 5 log files (100K * 40 / 1M), though it is hard
+	// to accurately control log file size and number, because of log file
+	// and line headers, and they can also be affected by the log flush time.
+	for i := 0; i < 40; i++ {
+		testLogging()
+		time.Sleep(time.Millisecond * 100)
+	}
+
+	infoLogFileNum := 0
+	warningLogFileNum := 0
+	validateFn := func() {
+		f, err := os.Open(testLogDir)
+		if err != nil {
+			t.Errorf("Failed to open log directory: %v", err)
+			return
+		}
+		allFiles, err := f.Readdir(-1)
+		if err != nil {
+			t.Errorf("Failed to read log directory: %v", err)
+			return
+		}
+		f.Close()
+
+		infoLogFiles := []os.FileInfo{}
+		warningLogFiles := []os.FileInfo{}
+		for _, file := range allFiles {
+			if !file.Mode().IsRegular() {
+				// Skip dir, symbol link, etc.
+				continue
+			}
+			if !strings.HasPrefix(file.Name(), executableName) {
+				continue
+			}
+			if strings.Contains(file.Name(), ".log.INFO.") {
+				infoLogFiles = append(infoLogFiles, file)
+			} else if strings.Contains(file.Name(), ".log.WARNING.") {
+				warningLogFiles = append(warningLogFiles, file)
+			} else if strings.Contains(file.Name(), ".log.ERROR.") {
+				// The test should not generate many error logs to
+				// avoid too many messages in the test console logs.
+			} else {
+				continue
+			}
+			assert.True(t, file.Size() <= 1*1024*1024, "log file size check: "+file.Name())
+			t.Logf("Log file %s, size %d", file.Name(), file.Size())
+		}
+		infoLogFileNum = len(infoLogFiles)
+		warningLogFileNum = len(warningLogFiles)
+	}
+
+	validateFn()
+	assert.True(t, infoLogFileNum > testMaxNum, "info log file number before checking")
+	assert.True(t, warningLogFileNum > testMaxNum, "warning log file number before checking")
+	t.Logf("INFO log file number: %d, WARNING log file number: %d", infoLogFileNum, warningLogFileNum)
+	// Call checkLogFiles() to delete extra files.
+	checkLogFiles()
+	validateFn()
+	assert.Equal(t, testMaxNum, infoLogFileNum, "info log file number after checking")
+	assert.Equal(t, testMaxNum, warningLogFileNum, "warning log file number after checking")
+}
+
+func TestFlags(t *testing.T) {
+	testcases := []struct {
+		name    string
+		args    []string
+		maxSize uint64
+		maxNum  uint16
+		logDir  string
+	}{
+		{
+			name:    "logtostderr",
+			args:    []string{"--log_file_max_size=1", "--log_file_max_num=1"},
+			maxSize: klogDefaultMaxSize,
+			maxNum:  0,
+			logDir:  "",
+		},
+		{
+			name:    "single file",
+			args:    []string{"--logtostderr=false", "--log_file=test.log", "--log_file_max_size=1", "--log_file_max_num=1"},
+			maxSize: klogDefaultMaxSize,
+			maxNum:  0,
+			logDir:  "",
+		},
+		{
+			name:    "maxnum only",
+			args:    []string{"--logtostderr=false", "--log_dir=/var/log/test", "--log_file_max_num=1"},
+			maxSize: klogDefaultMaxSize,
+			maxNum:  1,
+			logDir:  "/var/log/test",
+		},
+		{
+			name:    "tmp dir",
+			args:    []string{"--logtostderr=false", "--log_file_max_size=1", "--log_file_max_num=2"},
+			maxSize: 1 * 1024 * 1024,
+			maxNum:  2,
+			logDir:  os.TempDir(),
+		},
+	}
+
+	for _, test := range testcases {
+		testFlags.Parse(test.args)
+		InitLogFileLimits(testFlags)
+		assert.Equal(t, test.maxSize, klog.MaxSize, test.name)
+		assert.Equal(t, test.maxNum, logFileMaxNum, test.name)
+		assert.Equal(t, test.logDir, logDir, test.name)
+		restoreFlagDefaultValues()
+	}
+}


### PR DESCRIPTION
klog does not enforce max log file size limit when the log file is not
specifiec by the --log_file argument. This commit sets klog.MaxSize to
the --log_file_max_size argument value when logging to file is enabled
and --log_file is not provided.
The commit also adds a new argument --log_file_max_num to define the
max number of log files to be kept. The file number limit is enforced by
Antrea code that periodically checks the INFO log files and deletes the 
oldest files to keep at most the specified max number of log files.

Fixes: #788