### PR TITLE
Provide pre-built antrea-octant-plugin

### DIFF
--- a/.github/workflows/upload_release_assets.yml
+++ b/.github/workflows/upload_release_assets.yml
@@ -61,6 +61,51 @@ jobs:
         asset_path: ./assets/antctl-windows-x86_64.exe
         asset_name: antctl-windows-x86_64.exe
         asset_content_type: application/octet-stream
+    - name: Upload antrea-octant-plugin-darwin-x86_64
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./assets/antrea-octant-plugin-darwin-x86_64
+        asset_name: antrea-octant-plugin-darwin-x86_64
+        asset_content_type: application/octet-stream
+    - name: Upload antrea-octant-plugin-linux-arm
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./assets/antrea-octant-plugin-linux-arm
+        asset_name: antrea-octant-plugin-linux-arm
+        asset_content_type: application/octet-stream
+    - name: Upload antrea-octant-plugin-linux-arm64
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./assets/antrea-octant-plugin-linux-arm64
+        asset_name: antrea-octant-plugin-linux-arm64
+        asset_content_type: application/octet-stream
+    - name: Upload antrea-octant-plugin-linux-x86_64
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./assets/antrea-octant-plugin-linux-x86_64
+        asset_name: antrea-octant-plugin-linux-x86_64
+        asset_content_type: application/octet-stream
+    - name: Upload antrea-octant-plugin-windows-x86_64.exe
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./assets/antrea-octant-plugin-windows-x86_64.exe
+        asset_name: antrea-octant-plugin-windows-x86_64.exe
+        asset_content_type: application/octet-stream
     - name: Upload antrea.yml
       uses: actions/upload-release-asset@v1
       env:

--- a/plugins/octant/Makefile
+++ b/plugins/octant/Makefile
@@ -1,13 +1,20 @@
-SHELL  := /bin/bash
-GO     ?= go
-BINDIR ?= $(CURDIR)/bin
+SHELL                            := /bin/bash
+GO                               ?= go
+LDFLAGS                          :=
+GOFLAGS                          :=
+BINDIR                           ?= $(CURDIR)/bin
+ANTREA_OCTANT_PLUGIN_BINARY_NAME ?= antrea-octant-plugin
 
 .PHONY: antrea-octant-plugin
 antrea-octant-plugin:
 	@mkdir -p $(BINDIR)
-	GOOS=linux $(GO) build -o $(BINDIR) github.com/vmware-tanzu/antrea/plugins/octant/cmd/antrea-octant-plugin
+	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' github.com/vmware-tanzu/antrea/plugins/octant/cmd/antrea-octant-plugin
 
 .PHONY: octant-plugins
 octant-plugins:
 	@mkdir -p $(BINDIR)
-	GOOS=linux $(GO) build -o $(BINDIR) github.com/vmware-tanzu/antrea/plugins/octant/cmd/...
+	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' github.com/vmware-tanzu/antrea/plugins/octant/cmd/...
+
+.PHONY: antrea-octant-plugin-release
+antrea-octant-plugin-release:
+	@$(GO) build -o $(BINDIR)/$(ANTREA_OCTANT_PLUGIN_BINARY_NAME) $(GOFLAGS) -ldflags '$(LDFLAGS)'  github.com/vmware-tanzu/antrea/plugins/octant/cmd/antrea-octant-plugin

--- a/plugins/octant/cmd/antrea-octant-plugin/main.go
+++ b/plugins/octant/cmd/antrea-octant-plugin/main.go
@@ -39,6 +39,7 @@ var (
 const (
 	kubeConfig      = "KUBECONFIG"
 	title           = "Antrea Information"
+	overviewTitle   = "Overview"
 	controllerTitle = "Antrea Controller Info"
 	agentTitle      = "Antrea Agent Info"
 	versionCol      = "Version"
@@ -93,8 +94,13 @@ func main() {
 func handleNavigation(request *service.NavigationRequest) (navigation.Navigation, error) {
 	return navigation.Navigation{
 		Title: title,
-		Path:  request.GeneratePath("components"),
+		Path:  request.GeneratePath(),
 		Children: []navigation.Navigation{
+			{
+				Title:    overviewTitle,
+				Path:     request.GeneratePath("components/overview"),
+				IconName: "folder",
+			},
 			{
 				Title:    controllerTitle,
 				Path:     request.GeneratePath("components/controller"),
@@ -115,8 +121,8 @@ func initRoutes(router *service.Router) {
 	controllerCols := component.NewTableCols(versionCol, podCol, nodeCol, serviceCol, crdCol, heartbeatCol)
 	agentCols := component.NewTableCols(versionCol, podCol, nodeCol, subnetCol, bridgeCol, podNumCol, crdCol, heartbeatCol)
 
-	// Click on navigation bar named Antrea Information to display Antrea components (both Controller and Agent) information.
-	router.HandleFunc("/components", func(request service.Request) (component.ContentResponse, error) {
+	// Click on navigation child named Overview to display Antrea components (both Controller and Agent) information.
+	router.HandleFunc("/components/overview", func(request service.Request) (component.ContentResponse, error) {
 		controllerRows := getControllerRows()
 		agentRows := getAgentRows()
 		return component.ContentResponse{


### PR DESCRIPTION
1. Modify prepare-assets to provide pre-built antrea-octant-plugin
for different platforms in release assets.

2. Change antrea-octant-plugin to adapt to 0.13.1 octant changes.
It seems that clicking on parent navigation bar will not show content
changes but only all the child navigation bars in octant release 0.13.1,
so this patch adds child navigation bar named overview to show
both Antrea controller and agent information tables.

Fixes:#853