### PR TITLE
[Windows] Update documents for Antrea proxy

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -227,5 +227,3 @@ the HNS Network created by antrea-agent is removed, and the Open vSwitch
 Extension is disabled by default. In this case, the stale OVS bridge and ports
 should be removed. A help script [Clean-AntreaNetwork.ps1](https://raw.githubusercontent.com/tanzu/antrea/master/hack/windows/Clean-AntreaNetwork.ps1)
 can be used to clean the OVS bridge.
-
-2. NetworkPolicy for Service traffic is not supported in current version.


### PR DESCRIPTION
In version 0.8.0, Antrea implements Kubernetes ClusterIP Service
leveraging OVS. This patch updates the related description in
Windows documents:
- Kubernetes ClusterIP Service function is provided by Antrea instead
  of kube-proxy.
- kube-proxy still provide NodePort Service.
- NetworkPolicy for service is full supported.

Signed-off-by: Rui Cao <rcao@vmware.com>