### PR TITLE
Set default tunnel type to Geneve

### DIFF
--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -34,7 +34,7 @@ const (
 	defaultHostGateway        = "antrea-gw0"
 	defaultHostProcPathPrefix = "/host"
 	defaultServiceCIDR        = "10.96.0.0/12"
-	defaultTunnelType         = ovsconfig.VXLANTunnel
+	defaultTunnelType         = ovsconfig.GeneveTunnel
 	defaultMTUGeneve          = 1450
 	defaultMTUVXLAN           = 1450
 	defaultMTUGRE             = 1462

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -22,15 +22,16 @@ function echoerr {
 
 _usage="Usage: $0 [--mode (dev|release)] [--kind] [--ipsec] [--keep] [--help|-h]
 Generate a YAML manifest for Antrea using Kustomize and print it to stdout.
-        --mode (dev|release)  Choose the configuration variant that you need (default is 'dev')
-        --encap-mode          Traffic encapsulation mode. (default is 'encap')
-        --kind                Generate a manifest appropriate for running Antrea in a Kind cluster
-        --cloud               Generate a manifest appropriate for running Antrea in Public Cloud
-        --ipsec               Generate a manifest with IPSec encryption of tunnel traffic enabled
-        --proxy               Generate a manifest with Antrea proxy enabled
-        --np                  Generate a manifest with Namespaced Antrea NetworkPolicy CRDs and ClusterNetworkPolicy related CRDs enabled
-        --keep                Debug flag which will preserve the generated kustomization.yml
-        --help, -h            Print this message and exit
+        --mode (dev|release)          Choose the configuration variant that you need (default is 'dev')
+        --encap-mode                  Traffic encapsulation mode. (default is 'encap')
+        --kind                        Generate a manifest appropriate for running Antrea in a Kind cluster
+        --cloud                       Generate a manifest appropriate for running Antrea in Public Cloud
+        --ipsec                       Generate a manifest with IPSec encryption of tunnel traffic enabled
+        --proxy                       Generate a manifest with Antrea proxy enabled
+        --np                          Generate a manifest with Namespaced Antrea NetworkPolicy CRDs and ClusterNetworkPolicy related CRDs enabled
+        --keep                        Debug flag which will preserve the generated kustomization.yml
+	--tun (geneve|vxlan|gre|stt)  Choose encap tunnel type from geneve, gre, stt and vxlan (default is geneve)
+        --help, -h                    Print this message and exit
 
 In 'release' mode, environment variables IMG_NAME and IMG_TAG must be set.
 
@@ -55,6 +56,7 @@ NP=false
 KEEP=false
 ENCAP_MODE=""
 CLOUD=""
+TUN_TYPE="geneve"
 
 while [[ $# -gt 0 ]]
 do
@@ -93,6 +95,10 @@ case $key in
     KEEP=true
     shift
     ;;
+    --tun)
+    TUN_TYPE="$2"
+    shift 2
+    ;;
     -h|--help)
     print_usage
     exit 0
@@ -106,6 +112,12 @@ done
 
 if [ "$MODE" != "dev" ] && [ "$MODE" != "release" ]; then
     echoerr "--mode must be one of 'dev' or 'release'"
+    print_help
+    exit 1
+fi
+
+if [ "$TUN_TYPE" != "geneve" ] && [ "$TUN_TYPE" != "vxlan" ] && [ "$TUN_TYPE" != "gre" ] && [ "$TUN_TYPE" != "stt" ]; then
+    echoerr "--tun must be one of 'geneve', 'gre', 'stt' or 'vxlan'"
     print_help
     exit 1
 fi
@@ -168,6 +180,10 @@ fi
 
 if [[ $ENCAP_MODE != "" ]]; then
     sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*trafficEncapMode[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/trafficEncapMode: $ENCAP_MODE/" antrea-agent.conf
+fi
+
+if [[ $TUN_TYPE != "geneve" ]]; then
+    sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*tunnelType[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/tunnelType: $TUN_TYPE/" antrea-agent.conf
 fi
 
 # unfortunately 'kustomize edit add configmap' does not support specifying 'merge' as the behavior,

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -30,7 +30,7 @@ Generate a YAML manifest for Antrea using Kustomize and print it to stdout.
         --proxy                       Generate a manifest with Antrea proxy enabled
         --np                          Generate a manifest with Namespaced Antrea NetworkPolicy CRDs and ClusterNetworkPolicy related CRDs enabled
         --keep                        Debug flag which will preserve the generated kustomization.yml
-	--tun (geneve|vxlan|gre|stt)  Choose encap tunnel type from geneve, gre, stt and vxlan (default is geneve)
+        --tun (geneve|vxlan|gre|stt)  Choose encap tunnel type from geneve, gre, stt and vxlan (default is geneve)
         --help, -h                    Print this message and exit
 
 In 'release' mode, environment variables IMG_NAME and IMG_TAG must be set.

--- a/hack/netpol/test-kind.sh
+++ b/hack/netpol/test-kind.sh
@@ -19,7 +19,7 @@ kind load docker-image antrea/netpol:latest
 # pre-load the test container image on all the Nodes
 docker pull antrea/netpol-test
 kind load docker-image antrea/netpol-test
-$ROOT_DIR/hack/generate-manifest.sh --kind | kubectl apply -f -
+$ROOT_DIR/hack/generate-manifest.sh --kind --tun "vxlan" | kubectl apply -f -
 
 echo "===> Creating netpol ClusterRoleBinding, ServiceAccount and Job <==="
 


### PR DESCRIPTION
Set default tunnel type to Geneve for Antrea and run netpol tests with VXLAN tunnel type. Netpol tests will be switched back to
default tunnel type once failure in running netpol test suite in Kind clusters is root caused.