### PR TITLE
Register ClusterNetworkPolicy Informer only if the feature is enabled

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -189,10 +189,7 @@ func run(o *Options) error {
 	go cniServer.Run(stopCh)
 
 	informerFactory.Start(stopCh)
-	// Only start watching CRDs when Traceflow is enabled.
-	if features.DefaultFeatureGate.Enabled(features.Traceflow) {
-		crdInformerFactory.Start(stopCh)
-	}
+	crdInformerFactory.Start(stopCh)
 
 	go antreaClientProvider.Run(stopCh)
 

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -119,11 +119,7 @@ func run(o *Options) error {
 	stopCh := signals.RegisterSignalHandlers()
 
 	informerFactory.Start(stopCh)
-
-	// Only start watching CRDs when ClusterNetworkPolicy or Traceflow is enabled.
-	if features.DefaultFeatureGate.Enabled(features.ClusterNetworkPolicy) || features.DefaultFeatureGate.Enabled(features.Traceflow) {
-		crdInformerFactory.Start(stopCh)
-	}
+	crdInformerFactory.Start(stopCh)
 
 	go controllerMonitor.Run(stopCh)
 


### PR DESCRIPTION
crdInformerFactory is a shared Informer factory, which should not rely
on specific features. Informers specific to a feature should be
registered conditionally, so that the crdInformerFactory won't start
watching corresponding resources when the feature is disabled.

Fixes #898