### PR TITLE
Minor fix in networkpolicy_controller_test.go

### DIFF
--- a/pkg/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_test.go
@@ -60,9 +60,10 @@ type networkPolicyController struct {
 	crdInformerFactory         crdinformers.SharedInformerFactory
 }
 
+// objects is an initial set of K8s objects that is exposed through the client.
 func newController(objects ...runtime.Object) (*fake.Clientset, *networkPolicyController) {
 	client := newClientset(objects...)
-	crdClient := fakeversioned.NewSimpleClientset(objects...)
+	crdClient := fakeversioned.NewSimpleClientset()
 	informerFactory := informers.NewSharedInformerFactory(client, informerDefaultResync)
 	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, informerDefaultResync)
 	appliedToGroupStore := store.NewAppliedToGroupStore()


### PR DESCRIPTION
The same runtime.Object list cannot be used with both the standard K8s
client and the Antrea CRD client.