### PR TITLE
Set default tunnel type to geneve

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -52,7 +52,7 @@ jobs:
         sudo mv kind /usr/local/bin
     - name: Run e2e tests
       run: |
-        ./ci/kind/test-e2e-kind.sh encap
+        ./ci/kind/test-e2e-kind.sh --encap-mode encap
 
   test-e2e-encap-proxy:
     name: E2e tests on a Kind cluster on Linux with proxy enabled
@@ -83,7 +83,7 @@ jobs:
         sudo mv kind /usr/local/bin
     - name: Run e2e tests
       run: |
-        ./ci/kind/test-e2e-kind.sh encap --proxy
+        ./ci/kind/test-e2e-kind.sh --encap-mode encap --proxy
 
   test-e2e-noencap:
     name: E2e tests on a Kind cluster on Linux (noEncap)
@@ -114,7 +114,7 @@ jobs:
         sudo mv kind /usr/local/bin
     - name: Run e2e tests
       run: |
-        ./ci/kind/test-e2e-kind.sh noEncap
+        ./ci/kind/test-e2e-kind.sh --encap-mode noEncap
 
   test-e2e-noencap-proxy:
     name: E2e tests on a Kind cluster on Linux (noEncap) with proxy enabled
@@ -145,7 +145,7 @@ jobs:
         sudo mv kind /usr/local/bin
     - name: Run e2e tests
       run: |
-        ./ci/kind/test-e2e-kind.sh noEncap --proxy
+        ./ci/kind/test-e2e-kind.sh --encap-mode noEncap --proxy
 
   test-e2e-hybrid:
     name: E2e tests on a Kind cluster on Linux (hybrid)
@@ -176,7 +176,7 @@ jobs:
         sudo mv kind /usr/local/bin
     - name: Run e2e tests
       run: |
-        ./ci/kind/test-e2e-kind.sh hybrid
+        ./ci/kind/test-e2e-kind.sh --encap-mode hybrid
 
   test-e2e-hybrid-proxy:
     name: E2e tests on a Kind cluster on Linux (hybrid) with proxy enabled
@@ -207,7 +207,38 @@ jobs:
         sudo mv kind /usr/local/bin
     - name: Run e2e tests
       run: |
-        ./ci/kind/test-e2e-kind.sh hybrid --proxy
+        ./ci/kind/test-e2e-kind.sh --encap-mode hybrid --proxy
+
+  test-e2e-encap-np:
+    name: E2e tests on a Kind cluster on Linux with Antrea NetworkPolicies enabled
+    needs: build-antrea-image
+    runs-on: [ubuntu-18.04]
+    steps:
+    - name: Free disk space
+      # https://github.com/actions/virtual-environments/issues/709
+      run: |
+        sudo apt-get clean
+        df -h
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - name: Download Antrea image from previous job
+      uses: actions/download-artifact@v1
+      with:
+        name: antrea-ubuntu
+    - name: Load Antrea image
+      run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
+    - name: Install Kind
+      env:
+        KIND_VERSION: v0.7.0
+      run: |
+        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
+        chmod +x ./kind
+        sudo mv kind /usr/local/bin
+    - name: Run e2e tests
+      run: |
+        ./ci/kind/test-e2e-kind.sh --encap-mode encap --np
 
   test-netpol-tmp:
     name: Run experimental network policy tests (netpol) on Kind cluster

--- a/build/yamls/patches/np/npRbac.yml
+++ b/build/yamls/patches/np/npRbac.yml
@@ -5,13 +5,105 @@ metadata:
   name: antrea-controller
 rules:
   - apiGroups:
-      - security.antrea.tanzu.vmware.com
+      - ""
+    resources:
+      - nodes
+      - pods
+      - namespaces
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - networking.k8s.io
     resources:
       - networkpolicies
     verbs:
       - get
       - watch
       - list
+  - apiGroups:
+      - clusterinformation.antrea.tanzu.vmware.com
+    resources:
+      - antreacontrollerinfos
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - clusterinformation.antrea.tanzu.vmware.com
+    resources:
+      - antreaagentinfos
+    verbs:
+      - list
+      - delete
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  # This is the content of built-in role kube-system/extension-apiserver-authentication-reader.
+  # But it doesn't have list/watch permission before K8s v1.17.0 so the extension apiserver (antrea-controller) will
+  # have permission issue after bumping up apiserver library to a version that supports dynamic authentication.
+  # See https://github.com/kubernetes/kubernetes/pull/85375
+  # To support K8s clusters older than v1.17.0, we grant the required permissions directly instead of relying on
+  # the extension-apiserver-authentication role.
+  - apiGroups:
+      - ""
+    resourceNames:
+      - extension-apiserver-authentication
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - antrea-ca
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    resourceNames:
+      - v1beta1.system.antrea.tanzu.vmware.com
+      - v1beta1.networking.antrea.tanzu.vmware.com
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - security.antrea.tanzu.vmware.com
+    resources:
+      - clusternetworkpolicies
+      - networkpolicies
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - ops.antrea.tanzu.vmware.com
+    resources:
+      - traceflows
+    verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
   - apiGroups:
       - core.antrea.tanzu.vmware.com
     resources:

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -18,31 +18,82 @@
 
 set -eo pipefail
 
+function echoerr {
+    >&2 echo "$@"
+}
+
+_usage="Usage: $0 [--encap-mode <mode>] [--proxy] [--np] [--help|-h]
+        --encap-mode                  Traffic encapsulation mode. (default is 'encap')
+        --proxy                       Enables Antrea proxy.
+        --np                          Enables Namespaced Antrea NetworkPolicy CRDs and ClusterNetworkPolicy related CRDs.
+        --help, -h                    Print this message and exit
+"
+
+function print_usage {
+    echoerr "$_usage"
+}
+
+
 TESTBED_CMD=$(dirname $0)"/kind-setup.sh"
 YML_CMD=$(dirname $0)"/../../hack/generate-manifest.sh"
 COMMON_IMAGES="busybox nginx antrea/antrea-ubuntu:latest"
 
 function quit {
   if [[ $? != 0 ]]; then
-    echo " Test failed cleaning testbed"
+    echoerr " Test failed cleaning testbed"
     $TESTBED_CMD destroy kind
   fi
 }
 trap "quit" INT EXIT
 
-function run_test {
-  mode=$1
-  proxy=$2
-  args=$3
-  if [[ $proxy != "--proxy" ]]; then
-    proxy=""
-    args=$2
-  fi
+mode=""
+proxy=false
+np=false
+while [[ $# -gt 0 ]]
+do
+key="$1"
 
-  echo "create test bed with args $args"
+case $key in
+    --proxy)
+    proxy=true
+    shift
+    ;;
+    --np)
+    np=true
+    shift
+    ;;
+    --encap-mode)
+    mode="$2"
+    shift 2
+    ;;
+    -h|--help)
+    print_usage
+    exit 0
+    ;;
+    *)    # unknown option
+    echoerr "Unknown option $1"
+    exit 1
+    ;;
+esac
+done
+
+manifest_args=""
+if $proxy; then
+    manifest_args="$manifest_args --proxy"
+fi
+if $np; then
+    # See https://github.com/vmware-tanzu/antrea/issues/897
+    manifest_args="$manifest_args --np --tun vxlan"
+fi
+
+function run_test {
+  current_mode=$1
+  args=$2
+
+  echo "creating test bed with args $args"
   eval "timeout 600 $TESTBED_CMD create kind --antrea-cni false $args"
 
-  $YML_CMD --kind --encap-mode $mode $proxy | docker exec -i kind-control-plane dd of=/root/antrea.yml
+  $YML_CMD --kind --encap-mode $current_mode $manifest_args | docker exec -i kind-control-plane dd of=/root/antrea.yml
   sleep 1
   go test -v -timeout=30m github.com/vmware-tanzu/antrea/test/e2e -provider=kind
   $TESTBED_CMD destroy kind
@@ -51,17 +102,17 @@ function run_test {
 docker pull busybox
 docker pull nginx
 
-if [[ $# == 0 ]] || [[ $1 == "encap" ]]; then
+if [[ "$mode" == "" ]] || [[ "$mode" == "encap" ]]; then
   echo "======== Test encap mode =========="
-  run_test encap $2 "--images \"$COMMON_IMAGES\""
+  run_test encap "--images \"$COMMON_IMAGES\""
 fi
-if [[ $# == 0 ]] || [[ $1 == "noEncap" ]]; then
+if [[ "$mode" == "" ]] || [[ "$mode" == "noEncap" ]]; then
   echo "======== Test noencap mode =========="
-  run_test noEncap $2 "--images \"$COMMON_IMAGES\""
+  run_test noEncap "--images \"$COMMON_IMAGES\""
 fi
-if [[ $# == 0 ]] || [[ $1 == "hybrid" ]]; then
+if [[ "$mode" == "" ]] || [[ "$mode" == "hybrid" ]]; then
   echo "======== Test hybrid mode =========="
-  run_test hybrid $2 "--subnets \"20.20.20.0/24\" --images \"$COMMON_IMAGES\""
+  run_test hybrid "--subnets \"20.20.20.0/24\" --images \"$COMMON_IMAGES\""
 fi
 exit 0
 

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -34,7 +34,7 @@ const (
 	defaultHostGateway        = "antrea-gw0"
 	defaultHostProcPathPrefix = "/host"
 	defaultServiceCIDR        = "10.96.0.0/12"
-	defaultTunnelType         = ovsconfig.VXLANTunnel
+	defaultTunnelType         = ovsconfig.GeneveTunnel
 	defaultMTUGeneve          = 1450
 	defaultMTUVXLAN           = 1450
 	defaultMTUGRE             = 1462

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -22,15 +22,16 @@ function echoerr {
 
 _usage="Usage: $0 [--mode (dev|release)] [--kind] [--ipsec] [--keep] [--help|-h]
 Generate a YAML manifest for Antrea using Kustomize and print it to stdout.
-        --mode (dev|release)  Choose the configuration variant that you need (default is 'dev')
-        --encap-mode          Traffic encapsulation mode. (default is 'encap')
-        --kind                Generate a manifest appropriate for running Antrea in a Kind cluster
-        --cloud               Generate a manifest appropriate for running Antrea in Public Cloud
-        --ipsec               Generate a manifest with IPSec encryption of tunnel traffic enabled
-        --proxy               Generate a manifest with Antrea proxy enabled
-        --np                  Generate a manifest with Namespaced Antrea NetworkPolicy CRDs and ClusterNetworkPolicy related CRDs enabled
-        --keep                Debug flag which will preserve the generated kustomization.yml
-        --help, -h            Print this message and exit
+        --mode (dev|release)          Choose the configuration variant that you need (default is 'dev')
+        --encap-mode                  Traffic encapsulation mode. (default is 'encap')
+        --kind                        Generate a manifest appropriate for running Antrea in a Kind cluster
+        --cloud                       Generate a manifest appropriate for running Antrea in Public Cloud
+        --ipsec                       Generate a manifest with IPSec encryption of tunnel traffic enabled
+        --proxy                       Generate a manifest with Antrea proxy enabled
+        --np                          Generate a manifest with Namespaced Antrea NetworkPolicy CRDs and ClusterNetworkPolicy related CRDs enabled
+        --keep                        Debug flag which will preserve the generated kustomization.yml
+        --tun (geneve|vxlan|gre|stt)  Choose encap tunnel type from geneve, gre, stt and vxlan (default is geneve)
+        --help, -h                    Print this message and exit
 
 In 'release' mode, environment variables IMG_NAME and IMG_TAG must be set.
 
@@ -55,6 +56,7 @@ NP=false
 KEEP=false
 ENCAP_MODE=""
 CLOUD=""
+TUN_TYPE="geneve"
 
 while [[ $# -gt 0 ]]
 do
@@ -93,6 +95,10 @@ case $key in
     KEEP=true
     shift
     ;;
+    --tun)
+    TUN_TYPE="$2"
+    shift 2
+    ;;
     -h|--help)
     print_usage
     exit 0
@@ -106,6 +112,12 @@ done
 
 if [ "$MODE" != "dev" ] && [ "$MODE" != "release" ]; then
     echoerr "--mode must be one of 'dev' or 'release'"
+    print_help
+    exit 1
+fi
+
+if [ "$TUN_TYPE" != "geneve" ] && [ "$TUN_TYPE" != "vxlan" ] && [ "$TUN_TYPE" != "gre" ] && [ "$TUN_TYPE" != "stt" ]; then
+    echoerr "--tun must be one of 'geneve', 'gre', 'stt' or 'vxlan'"
     print_help
     exit 1
 fi
@@ -168,6 +180,10 @@ fi
 
 if [[ $ENCAP_MODE != "" ]]; then
     sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*trafficEncapMode[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/trafficEncapMode: $ENCAP_MODE/" antrea-agent.conf
+fi
+
+if [[ $TUN_TYPE != "geneve" ]]; then
+    sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*tunnelType[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/tunnelType: $TUN_TYPE/" antrea-agent.conf
 fi
 
 # unfortunately 'kustomize edit add configmap' does not support specifying 'merge' as the behavior,

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -175,7 +175,7 @@ if $PROXY; then
 fi
 
 if $NP; then
-    sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*enableSecurityCRDs[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/enableSecurityCRDs: true/" antrea-controller.conf
+    sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*ClusterNetworkPolicy[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/  ClusterNetworkPolicy: true/" antrea-controller.conf
 fi
 
 if [[ $ENCAP_MODE != "" ]]; then

--- a/hack/netpol/test-kind.sh
+++ b/hack/netpol/test-kind.sh
@@ -19,7 +19,7 @@ kind load docker-image antrea/netpol:latest
 # pre-load the test container image on all the Nodes
 docker pull antrea/netpol-test
 kind load docker-image antrea/netpol-test
-$ROOT_DIR/hack/generate-manifest.sh --kind | kubectl apply -f -
+$ROOT_DIR/hack/generate-manifest.sh --kind --tun "vxlan" | kubectl apply -f -
 
 echo "===> Creating netpol ClusterRoleBinding, ServiceAccount and Job <==="
 


### PR DESCRIPTION
Set default tunnel type to Geneve

Set default tunnel type to Geneve for Antrea instead of VXLAN.
When running NetworkPolicy tests in Kind, we "force" the tunnel type to
VXLAN as we observe some failures with Geneve (see #897).

We also change the Github CI jobs so that CNP tests are run in their own
job. This is to address the issue above, and is also a partial
implementation of #893.