### PR TITLE
Remove unnecessary testing.TB in runAntctl()

### DIFF
--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -38,7 +38,7 @@ func antctlOutput(stdout, stderr string, tb testing.TB) {
 }
 
 // runAntctl runs antctl commands on antrea Pods, the controller, or agents.
-func runAntctl(podName string, cmds []string, data *TestData, tb testing.TB) (string, string, error) {
+func runAntctl(podName string, cmds []string, data *TestData) (string, string, error) {
 	var containerName string
 	if strings.Contains(podName, "agent") {
 		containerName = "antrea-agent"
@@ -64,7 +64,7 @@ func TestAntctlAgentLocalAccess(t *testing.T) {
 		args := append([]string{"antctl", "-v"}, c...)
 		cmd := strings.Join(args, " ")
 		t.Run(cmd, func(t *testing.T) {
-			stdout, stderr, err := runAntctl(podName, args, data, t)
+			stdout, stderr, err := runAntctl(podName, args, data)
 			antctlOutput(stdout, stderr, t)
 			if err != nil {
 				t.Fatalf("Error when running `antctl %s` from %s: %v", c, podName, err)
@@ -147,7 +147,7 @@ func TestAntctlVerboseMode(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("Running commnad `%s` on pod %s", tc.commands, podName)
-			stdout, stderr, err := runAntctl(podName, tc.commands, data, t)
+			stdout, stderr, err := runAntctl(podName, tc.commands, data)
 			antctlOutput(stdout, stderr, t)
 			assert.Nil(t, err)
 			if !tc.hasStderr {

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -83,7 +83,7 @@ func (data *TestData) testDeletePod(t *testing.T, podName string, nodeName strin
 	t.Logf("The Antrea Pod for Node '%s' is '%s'", nodeName, antreaPodName)
 
 	cmds := []string{"antctl", "get", "podinterface", podName, "-n", testNamespace, "-o", "json"}
-	stdout, _, err := runAntctl(antreaPodName, cmds, data, t)
+	stdout, _, err := runAntctl(antreaPodName, cmds, data)
 	var podInterfaces []podinterface.Response
 	if err := json.Unmarshal([]byte(stdout), &podInterfaces); err != nil {
 		t.Fatalf("Error when querying the pod interface: %v", err)

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -332,7 +332,7 @@ func createAndWaitForPod(t *testing.T, data *TestData, createFunc func(name stri
 func waitForAgentCondition(t *testing.T, data *TestData, podName string, conditionType v1beta1.AgentConditionType, expectedStatus corev1.ConditionStatus) {
 	if err := wait.Poll(1*time.Second, defaultTimeout, func() (bool, error) {
 		cmds := []string{"antctl", "get", "agentinfo", "-o", "json"}
-		stdout, _, err := runAntctl(podName, cmds, data, t)
+		stdout, _, err := runAntctl(podName, cmds, data)
 		var agentInfo agentinfo.AntreaAgentInfoResponse
 		err = json.Unmarshal([]byte(stdout), &agentInfo)
 		if err != nil {

--- a/test/e2e/security_test.go
+++ b/test/e2e/security_test.go
@@ -213,7 +213,7 @@ func testCert(t *testing.T, data *TestData, expectedCABundle string, restartPod 
 	// antrea-agents reconnect every 5 seconds, we expect their connections are restored in a few seconds.
 	if err := wait.Poll(2*time.Second, 30*time.Second, func() (bool, error) {
 		cmds := []string{"antctl", "get", "controllerinfo", "-o", "json"}
-		stdout, _, err := runAntctl(antreaController.Name, cmds, data, t)
+		stdout, _, err := runAntctl(antreaController.Name, cmds, data)
 		var controllerInfo v1beta1.AntreaControllerInfo
 		err = json.Unmarshal([]byte(stdout), &controllerInfo)
 		if err != nil {


### PR DESCRIPTION
It seems tb is used by no one in runAntctl()