### PR TITLE
Enhance Antrea-Octant-Plugin

### DIFF
--- a/pkg/graphviz/traceflow.go
+++ b/pkg/graphviz/traceflow.go
@@ -26,89 +26,53 @@ import (
 	opsv1alpha1 "github.com/vmware-tanzu/antrea/pkg/apis/ops/v1alpha1"
 )
 
-var (
-	clusterSrcName = "cluster_source"
-	clusterDstName = "cluster_dest"
+const (
+	darkRed    = "#B20000"
+	mistyRose  = "#EDD5D5"
+	fireBrick  = "#B22222"
+	ghostWhite = "#F8F8FF"
+	gainsboro  = "#DCDCDC"
+	lightGrey  = "#C8C8C8"
+	silver     = "#C0C0C0"
+	grey       = "#808080"
+	dimGrey    = "#696969"
 )
 
-func genSubGraph(graph *cgraph.Graph, result *opsv1alpha1.NodeResult, firstNodeName string, dir cgraph.DirType, addNodeNum int) []*cgraph.Node {
-	var nodes []*cgraph.Node
-	obs := result.Observations
+var (
+	clusterSrcName = "cluster_source"
+	clusterDstName = "cluster_destination"
+)
 
-	// Show the name of cluster.
-	if len(result.Node) > 0 {
-		graph.SetLabel(result.Node)
-		if dir == cgraph.ForwardDir {
-			graph.SetLabelJust(cgraph.LeftJust)
-		} else {
-			graph.SetLabelJust(cgraph.RightJust)
-		}
-	}
+func createNodeWithDefaultStyle(graph *cgraph.Graph, name string) *cgraph.Node {
+	node, _ := graph.CreateNode(name)
+	node.SetShape(cgraph.BoxShape)
+	node.SetStyle(cgraph.RoundedNodeStyle + "," + cgraph.FilledNodeStyle + "," + cgraph.SolidNodeStyle)
+	node.SetColor(dimGrey)
+	return node
+}
 
-	// Construct the first node. Show it only if we know the name of it.
-	node, _ := graph.CreateNode(firstNodeName)
-	nodes = append(nodes, node)
-	if len(firstNodeName) > 0 {
-		node.SetFontColor("white")
-		node.SetColor("royalblue1")
-		node.SetStyle(cgraph.FilledNodeStyle)
-	} else {
-		node.SetStyle("invis")
-	}
+// EndpointNode is the the type of node for endpoints in networks like the sender and the receiver.
+func createEndpointNodeWithDefaultStyle(graph *cgraph.Graph, name string) *cgraph.Node {
+	node, _ := graph.CreateNode(name)
+	node.SetColor(grey)
+	node.SetFillColor(lightGrey)
+	node.SetStyle(cgraph.FilledNodeStyle + "," + cgraph.BoldNodeStyle)
+	return node
+}
 
-	// Reorder the observations according to the direction of edges.
-	if dir == cgraph.BackDir {
-		for i := len(obs)/2 - 1; i >= 0; i-- {
-			opp := len(obs) - 1 - i
-			obs[i], obs[opp] = obs[opp], obs[i]
-		}
-	}
+func createEdgeWithDefaultStyle(graph *cgraph.Graph, name string, start *cgraph.Node, end *cgraph.Node) *cgraph.Edge {
+	edge, _ := graph.CreateEdge(name, start, end)
+	edge.SetPenWidth(2.0)
+	edge.SetColor(silver)
+	return edge
+}
 
-	// Draw the actual observations of traceflow.
-	for _, o := range obs {
-		// Construct node and edge.
-		nodeName := fmt.Sprintf("%s_%d", graph.Name(), len(nodes))
-		node, _ := graph.CreateNode(nodeName)
-		node.SetLabel(string(o.Component))
-		node.SetShape(cgraph.BoxShape)
-		node.SetStyle(cgraph.RoundedNodeStyle + "," + cgraph.FilledNodeStyle)
-		node.SetFontColor("white")
-		nodes = append(nodes, node)
-		if len(nodes) > 1 {
-			edgeName := fmt.Sprintf("%s_%d", graph.Name(), len(nodes))
-			edge, _ := graph.CreateEdge(edgeName, nodes[len(nodes)-2], nodes[len(nodes)-1])
-			edge.SetDir(dir)
-			edge.SetPenWidth(3.0)
-			edge.SetColor("limegreen")
-			if len(nodes) == 2 {
-				edge.SetMinLen(1 + addNodeNum)
-			} else {
-				edge.SetMinLen(1)
-			}
-			if o.Action == opsv1alpha1.Dropped && dir == cgraph.BackDir {
-				edge.SetStyle("invis")
-			}
-		}
-		// Set the pattern of node.
-		labelStr := string(o.Component)
-		if len(o.ComponentInfo) > 0 {
-			labelStr += "\n" + o.ComponentInfo
-		}
-		labelStr += "\n" + string(o.Action)
-		if o.Component == opsv1alpha1.NetworkPolicy && len(o.NetworkPolicy) > 0 {
-			labelStr += "\nNetpol: " + o.NetworkPolicy
-		}
-		if o.Action == opsv1alpha1.Dropped {
-			node.SetColor("violet")
-		} else {
-			node.SetColor("turquoise3")
-			if len(o.TunnelDstIP) > 0 {
-				labelStr += "\nTo: " + o.TunnelDstIP
-			}
-		}
-		node.SetLabel(labelStr)
-	}
-	return nodes
+// In Graphviz, cluster is a subgraph which is surrounded by a rectangle and the nodes belonging to the cluster are drawn together.
+func createClusterWithDefaultStyle(graph *cgraph.Graph, name string) *cgraph.Graph {
+	cluster := graph.SubGraph(name, 1)
+	cluster.SetBackgroundColor(ghostWhite)
+	cluster.SetStyle(cgraph.FilledGraphStyle + "," + cgraph.BoldGraphStyle)
+	return cluster
 }
 
 func isSender(result opsv1alpha1.NodeResult) bool {
@@ -188,13 +152,14 @@ func genOutput(g *graphviz.Graphviz, graph *cgraph.Graph, isSingleCluster bool) 
 	if err := graph.Close(); err != nil {
 		log.Fatal(err)
 	}
-	g.Close()
+	if err := g.Close(); err != nil {
+		log.Fatal(err)
+	}
 
 	str := buf.String()
 	if isSingleCluster {
 		return str
 	}
-	// In Graphviz, cluster is a subgraph which is surrounded by a rectangle and the nodes belonging to the cluster are drawn together.
 	// Swap source and destination cluster if destination cluster appears before source cluster.
 	srcStartIdx, srcEndIdx := findClusterString(str, clusterSrcName)
 	dstStartIdx, dstEndIdx := findClusterString(str, clusterDstName)
@@ -204,8 +169,86 @@ func genOutput(g *graphviz.Graphviz, graph *cgraph.Graph, isSingleCluster bool) 
 	return str
 }
 
+func genSubGraph(graph *cgraph.Graph, result opsv1alpha1.NodeResult, firstNodeName string, dir cgraph.DirType, addNodeNum int) []*cgraph.Node {
+	var nodes []*cgraph.Node
+
+	// Show the name of cluster.
+	if len(result.Node) > 0 {
+		graph.SetLabel(result.Node)
+		if dir == cgraph.ForwardDir {
+			graph.SetLabelJust(cgraph.LeftJust)
+		} else {
+			graph.SetLabelJust(cgraph.RightJust)
+		}
+	}
+
+	// Construct the first node. Show it only if we know the name of it.
+	node := createEndpointNodeWithDefaultStyle(graph, firstNodeName)
+	nodes = append(nodes, node)
+	if len(firstNodeName) > 0 {
+		node.SetColor(grey)
+		node.SetFillColor(lightGrey)
+		node.SetStyle(cgraph.BoldNodeStyle + "," + cgraph.FilledNodeStyle)
+	} else {
+		node.SetStyle("invis")
+	}
+
+	// Reorder the observations according to the direction of edges.
+	// Before that, deep copy observations to prevent possible risks of the original traceflow being modified.
+	obs := make([]opsv1alpha1.Observation, len(result.Observations))
+	copy(obs, result.Observations)
+	if dir == cgraph.BackDir {
+		for i := len(obs)/2 - 1; i >= 0; i-- {
+			opp := len(obs) - 1 - i
+			obs[i], obs[opp] = obs[opp], obs[i]
+		}
+	}
+
+	// Draw the actual observations of traceflow.
+	for _, o := range obs {
+		// Construct node and edge.
+		nodeName := fmt.Sprintf("%s_%d", graph.Name(), len(nodes))
+		node := createNodeWithDefaultStyle(graph, nodeName)
+		node.SetLabel(string(o.Component))
+		nodes = append(nodes, node)
+		if len(nodes) > 1 {
+			edgeName := fmt.Sprintf("%s_%d", graph.Name(), len(nodes))
+			edge := createEdgeWithDefaultStyle(graph, edgeName, nodes[len(nodes)-2], nodes[len(nodes)-1])
+			edge.SetDir(dir)
+			// Make the graph centered by adjusting the length of edge between the first two nodes.
+			if len(nodes) == 2 {
+				edge.SetMinLen(1 + addNodeNum)
+			} else {
+				edge.SetMinLen(1)
+			}
+			if o.Action == opsv1alpha1.Dropped && dir == cgraph.BackDir {
+				edge.SetStyle("invis")
+			}
+		}
+		// Set the pattern of node.
+		labelStr := string(o.Component)
+		if len(o.ComponentInfo) > 0 {
+			labelStr += "\n" + o.ComponentInfo
+		}
+		labelStr += "\n" + string(o.Action)
+		if o.Component == opsv1alpha1.NetworkPolicy && len(o.NetworkPolicy) > 0 {
+			labelStr += "\nNetpol: " + o.NetworkPolicy
+		}
+		if o.Action == opsv1alpha1.Dropped {
+			node.SetColor(fireBrick)
+			node.SetFillColor(mistyRose)
+		} else {
+			node.SetFillColor(gainsboro)
+			if len(o.TunnelDstIP) > 0 {
+				labelStr += "\nTo: " + o.TunnelDstIP
+			}
+		}
+		node.SetLabel(labelStr)
+	}
+	return nodes
+}
+
 func GenGraph(tf *opsv1alpha1.Traceflow) string {
-	var err error
 	g := graphviz.New()
 	graph, err := g.Graph()
 	if err != nil {
@@ -217,15 +260,14 @@ func GenGraph(tf *opsv1alpha1.Traceflow) string {
 
 	senderRst := getNodeResult(tf, isSender)
 	receiverRst := getNodeResult(tf, isReceiver)
-	if tf == nil || senderRst == nil || tf.Status.Phase != opsv1alpha1.Succeeded || len(senderRst.Observations) == 0 {
+	if senderRst == nil || tf.Status.Phase != opsv1alpha1.Succeeded || len(senderRst.Observations) == 0 {
 		return genOutput(g, graph, true)
 	}
 
-	cluster1 := graph.SubGraph(clusterSrcName, 1)
-	cluster1.SetStyle(cgraph.FilledGraphStyle)
+	cluster1 := createClusterWithDefaultStyle(graph, clusterSrcName)
 	// Handle single node traceflow.
 	if receiverRst == nil {
-		nodes := genSubGraph(cluster1, senderRst, getSrcNodeName(tf), cgraph.ForwardDir, 0)
+		nodes := genSubGraph(cluster1, *senderRst, getSrcNodeName(tf), cgraph.ForwardDir, 0)
 		// Draw the destination pod and involved edge.
 		edgeName := fmt.Sprintf("%s_%d", cluster1.Name(), len(senderRst.Observations))
 		if len(nodes) == 0 {
@@ -235,23 +277,19 @@ func GenGraph(tf *opsv1alpha1.Traceflow) string {
 		// If the last action of the sender is FORWARDED,
 		// then the packet has been sent out by sender, implying that there is a disconnection.
 		case opsv1alpha1.Forwarded:
-			lastNode, _ := graph.CreateNode(getDstNodeName(tf))
+			lastNode := createEndpointNodeWithDefaultStyle(graph, getDstNodeName(tf))
 			edge, _ := graph.CreateEdge(edgeName, nodes[len(nodes)-1], lastNode)
-			edge.SetColor("red")
+			edge.SetColor(darkRed)
+			edge.SetPenWidth(2.0)
 			edge.SetStyle(cgraph.DashedEdgeStyle)
 		case opsv1alpha1.Delivered:
-			lastNode, _ := cluster1.CreateNode(getDstNodeName(tf))
-			edge, _ := cluster1.CreateEdge(edgeName, nodes[len(nodes)-1], lastNode)
-			edge.SetPenWidth(3.0)
-			lastNode.SetFontColor("white")
-			lastNode.SetColor("royalblue1")
-			lastNode.SetStyle(cgraph.FilledNodeStyle)
-			edge.SetColor("limegreen")
+			lastNode := createEndpointNodeWithDefaultStyle(cluster1, getDstNodeName(tf))
+			createEdgeWithDefaultStyle(cluster1, edgeName, nodes[len(nodes)-1], lastNode)
 		}
 		return genOutput(g, graph, true)
 	}
 
-	// Make the graph centered by equalizing the number of nodes on both sides.
+	// Make the graph centered by balancing the difference of node numbers on two sides with the length of first edge.
 	var nodeNum int
 	if len(senderRst.Observations) > len(receiverRst.Observations) {
 		nodeNum = len(senderRst.Observations)
@@ -260,19 +298,16 @@ func GenGraph(tf *opsv1alpha1.Traceflow) string {
 	}
 
 	// Draw the nodes for the sender.
-	nodes1 := genSubGraph(cluster1, senderRst, getSrcNodeName(tf), cgraph.ForwardDir, nodeNum-len(senderRst.Observations))
+	nodes1 := genSubGraph(cluster1, *senderRst, getSrcNodeName(tf), cgraph.ForwardDir, nodeNum-len(senderRst.Observations))
 
 	// Draw the nodes for the receiver.
-	cluster2 := graph.SubGraph(clusterDstName, 1)
-	cluster2.SetStyle(cgraph.FilledGraphStyle)
-	nodes2 := genSubGraph(cluster2, receiverRst, getDstNodeName(tf), cgraph.BackDir, nodeNum-len(receiverRst.Observations))
+	cluster2 := createClusterWithDefaultStyle(graph, clusterDstName)
+	nodes2 := genSubGraph(cluster2, *receiverRst, getDstNodeName(tf), cgraph.BackDir, nodeNum-len(receiverRst.Observations))
 
 	// Draw the cross-cluster edge.
 	if len(nodes1) > 0 && len(nodes2) > 0 {
-		edge, _ := graph.CreateEdge("cross_node", nodes1[len(nodes1)-1], nodes2[len(nodes2)-1])
+		edge := createEdgeWithDefaultStyle(graph, "cross_node", nodes1[len(nodes1)-1], nodes2[len(nodes2)-1])
 		edge.SetConstraint(false)
-		edge.SetPenWidth(3.0)
-		edge.SetColor("limegreen")
 	}
 
 	return genOutput(g, graph, false)

--- a/plugins/octant/Makefile
+++ b/plugins/octant/Makefile
@@ -10,11 +10,6 @@ antrea-octant-plugin:
 	@mkdir -p $(BINDIR)
 	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' github.com/vmware-tanzu/antrea/plugins/octant/cmd/antrea-octant-plugin
 
-.PHONY: antrea-traceflow-plugin
-antrea-traceflow-plugin:
-	@mkdir -p $(BINDIR)
-	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' github.com/vmware-tanzu/antrea/plugins/octant/cmd/antrea-traceflow-plugin
-
 .PHONY: octant-plugins
 octant-plugins:
 	@mkdir -p $(BINDIR)

--- a/plugins/octant/cmd/antrea-octant-plugin/antrea_info.go
+++ b/plugins/octant/cmd/antrea-octant-plugin/antrea_info.go
@@ -1,0 +1,109 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"log"
+	"strconv"
+
+	"github.com/vmware-tanzu/octant/pkg/plugin/service"
+	"github.com/vmware-tanzu/octant/pkg/view/component"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	controllerTitle = "Controller Info"
+	agentTitle      = "Agent Info"
+
+	versionCol        = "Version"
+	podCol            = "Pod"
+	nodeCol           = "Node"
+	serviceCol        = "Service"
+	clusterInfoCrdCol = "Monitoring CRD"
+	subnetCol         = "NodeSubnet"
+	bridgeCol         = "OVS Bridge"
+	podNumCol         = "Local Pod Num"
+	heartbeatCol      = "Last Heartbeat Time"
+)
+
+func controllerHandler(request service.Request) (component.ContentResponse, error) {
+	return component.ContentResponse{
+		Title: component.TitleFromString(controllerTitle),
+		Components: []component.Component{
+			getControllerTable(request),
+		},
+	}, nil
+}
+
+func agentHandler(request service.Request) (component.ContentResponse, error) {
+	return component.ContentResponse{
+		Title: component.TitleFromString(agentTitle),
+		Components: []component.Component{
+			getAgentTable(request),
+		},
+	}, nil
+}
+
+// getControllerTable gets the table for displaying Controller information
+func getControllerTable(request service.Request) *component.Table {
+	controllers, err := client.ClusterinformationV1beta1().AntreaControllerInfos().List(context.TODO(), v1.ListOptions{})
+	if err != nil {
+		log.Fatalf("Failed to get AntreaControllerInfos %v", err)
+	}
+	controllerRows := make([]component.TableRow, 0)
+	for _, controller := range controllers.Items {
+		controllerRows = append(controllerRows, component.TableRow{
+			versionCol: component.NewText(controller.Version),
+			podCol: component.NewLink(controller.PodRef.Name, controller.PodRef.Name,
+				"/overview/namespace/"+controller.PodRef.Namespace+"/workloads/pods/"+controller.PodRef.Name),
+			nodeCol: component.NewLink(controller.NodeRef.Name, controller.NodeRef.Name,
+				"/cluster-overview/nodes/"+controller.NodeRef.Name),
+			serviceCol: component.NewLink(controller.ServiceRef.Name, controller.ServiceRef.Name,
+				"/overview/namespace/"+controller.PodRef.Namespace+"/discovery-and-load-balancing/services/"+controller.ServiceRef.Name),
+			clusterInfoCrdCol: component.NewLink(controller.Name, controller.Name,
+				"/cluster-overview/custom-resources/antreacontrollerinfos.clusterinformation.antrea.tanzu.vmware.com/v1beta1/"+controller.Name),
+			heartbeatCol: component.NewText(controller.ControllerConditions[0].LastHeartbeatTime.String()),
+		})
+	}
+	controllerCols := component.NewTableCols(versionCol, podCol, nodeCol, serviceCol, clusterInfoCrdCol, heartbeatCol)
+	return component.NewTableWithRows(controllerTitle, "We couldn't find any Antrea controllers!", controllerCols, controllerRows)
+}
+
+// getAgentTable gets the table for displaying Agent information.
+func getAgentTable(request service.Request) *component.Table {
+	agents, err := client.ClusterinformationV1beta1().AntreaAgentInfos().List(context.TODO(), v1.ListOptions{})
+	if err != nil {
+		log.Fatalf("Failed to get AntreaAgentInfos %v", err)
+	}
+	agentRows := make([]component.TableRow, 0)
+	for _, agent := range agents.Items {
+		agentRows = append(agentRows, component.TableRow{
+			versionCol: component.NewText(agent.Version),
+			podCol: component.NewLink(agent.PodRef.Name, agent.PodRef.Name,
+				"/overview/namespace/"+agent.PodRef.Namespace+"/workloads/pods/"+agent.PodRef.Name),
+			nodeCol: component.NewLink(agent.NodeRef.Name, agent.NodeRef.Name,
+				"/cluster-overview/nodes/"+agent.NodeRef.Name),
+			subnetCol: component.NewText(agent.NodeSubnet[0]),
+			bridgeCol: component.NewText(agent.OVSInfo.BridgeName),
+			podNumCol: component.NewText(strconv.Itoa(int(agent.LocalPodNum))),
+			clusterInfoCrdCol: component.NewLink(agent.Name, agent.Name,
+				"/cluster-overview/custom-resources/antreaagentinfos.clusterinformation.antrea.tanzu.vmware.com/v1beta1/"+agent.Name),
+			heartbeatCol: component.NewText(agent.AgentConditions[0].LastHeartbeatTime.String()),
+		})
+	}
+	agentCols := component.NewTableCols(versionCol, podCol, nodeCol, subnetCol, bridgeCol, podNumCol, clusterInfoCrdCol, heartbeatCol)
+	return component.NewTableWithRows(agentTitle, "We couldn't find any Antrea agents!", agentCols, agentRows)
+}

--- a/plugins/octant/cmd/antrea-octant-plugin/overview.go
+++ b/plugins/octant/cmd/antrea-octant-plugin/overview.go
@@ -1,0 +1,57 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+
+	"github.com/vmware-tanzu/octant/pkg/plugin/service"
+	"github.com/vmware-tanzu/octant/pkg/view/component"
+	"github.com/vmware-tanzu/octant/pkg/view/flexlayout"
+)
+
+const (
+	overviewTitle = "Overview"
+	antreaTitle   = "Antrea"
+)
+
+type getTableFunc func(request service.Request) *component.Table
+
+// overviewHandler handlers the layout of Antrea Overview page.
+func overviewHandler(request service.Request) (component.ContentResponse, error) {
+	layout := flexlayout.New()
+	listSection := layout.AddSection()
+	handlers := []getTableFunc{
+		getControllerTable,
+		getAgentTable,
+		getTfTable,
+	}
+	resp := component.NewContentResponse(component.TitleFromString(overviewTitle))
+	err := listSection.Add(component.NewMarkdownText("## "+antreaTitle), component.WidthFull)
+	if err != nil {
+		log.Printf("Failed to load a tab in overview page, err: %v", err)
+		return component.EmptyContentResponse, err
+	}
+	for _, handler := range handlers {
+		table := handler(request)
+		err := listSection.Add(table, component.WidthFull)
+		if err != nil {
+			log.Printf("Failed to load a tab in overview page, err: %v", err)
+			return component.EmptyContentResponse, err
+		}
+	}
+	resp.Components = append(resp.Components, layout.ToComponent(overviewTitle))
+	return *resp, nil
+}

--- a/plugins/octant/cmd/antrea-octant-plugin/traceflow.go
+++ b/plugins/octant/cmd/antrea-octant-plugin/traceflow.go
@@ -17,35 +17,31 @@ package main
 import (
 	"context"
 	"log"
-	"os"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/vmware-tanzu/octant/pkg/navigation"
-	"github.com/vmware-tanzu/octant/pkg/plugin"
 	"github.com/vmware-tanzu/octant/pkg/plugin/service"
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 	"github.com/vmware-tanzu/octant/pkg/view/flexlayout"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	opsv1alpha1 "github.com/vmware-tanzu/antrea/pkg/apis/ops/v1alpha1"
-	clientset "github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned"
 	"github.com/vmware-tanzu/antrea/pkg/graphviz"
 )
 
 var (
-	pluginName                           = "antreaTraceflowPlugin"
-	addTfAction                          = pluginName + "/addTf"
-	showGraphAction                      = pluginName + "/showGraphAction"
-	client          *clientset.Clientset = nil
-	kubeConfig                           = "KUBECONFIG"
+	addTfAction     = "traceflow/addTf"
+	showGraphAction = "traceflow/showGraphAction"
 )
 
 const (
+	traceflowTitle         = "Traceflow Info"
+	antreaTraceflowTitle   = "Antrea Traceflow"
+	octantTraceflowCRDPath = "/cluster-overview/custom-resources/traceflows.ops.antrea.tanzu.vmware.com/v1alpha1/"
+
 	tfNameCol       = "Trace"
 	srcNamespaceCol = "Source Namespace"
 	srcPodCol       = "Source Pod"
@@ -54,11 +50,8 @@ const (
 	dstPodCol       = "Destination Pod"
 	dstPortCol      = "Destination Port"
 	protocolCol     = "Protocol"
-	crdCol          = "Detailed Information"
 	phaseCol        = "Phase"
 	ageCol          = "Age"
-
-	octantTraceflowCRDPath = "/cluster-overview/custom-resources/traceflows.ops.antrea.tanzu.vmware.com/v1alpha1/"
 
 	namespaceStrPattern = `[a-z0-9]([-a-z0-9]*[a-z0-9])?`
 	podStrPattern       = `[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*`
@@ -79,65 +72,7 @@ var supportedProtocols = map[string]int32{
 	"UDP":  UDPProtocol,
 }
 
-// This is antrea-traceflow-plugin.
-func main() {
-	localPlugin := newTraceflowPlugin()
-
-	// Remove the prefix from the go logger since Octant will print logs with timestamps.
-	log.SetPrefix("")
-
-	capabilities := &plugin.Capabilities{
-		ActionNames: []string{addTfAction, showGraphAction},
-		IsModule:    true,
-	}
-
-	// Set up what should happen when Octant calls this plugin.
-	options := []service.PluginOption{
-		service.WithActionHandler(localPlugin.actionHandler),
-		service.WithNavigation(localPlugin.navHandler, localPlugin.initRoutes),
-	}
-
-	p, err := service.Register(pluginName, "A plugin that starts Antrea Traceflow sessions to trace packets "+
-		"in the Antrea network and draws graphs for the result packet flows.", capabilities, options...)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	log.Printf(pluginName + " is starting")
-	p.Serve()
-}
-
-type traceflowPlugin struct {
-	client     *clientset.Clientset
-	graph      string
-	lastTfName string
-}
-
-func newTraceflowPlugin() *traceflowPlugin {
-	config, err := clientcmd.BuildConfigFromFlags("", os.Getenv(kubeConfig))
-	if err != nil {
-		log.Fatalf("Failed to build kubeConfig %v", err)
-	}
-	client, err = clientset.NewForConfig(config)
-	if err != nil {
-		log.Fatalf("Failed to create K8s client for %s: %v", pluginName, err)
-	}
-	return &traceflowPlugin{
-		client:     client,
-		graph:      "",
-		lastTfName: "",
-	}
-}
-
-func (a *traceflowPlugin) navHandler(request *service.NavigationRequest) (navigation.Navigation, error) {
-	return navigation.Navigation{
-		Title:    "Trace Flow",
-		Path:     request.GeneratePath("components"),
-		IconName: "cloud",
-	}, nil
-}
-
-func (a *traceflowPlugin) regExpMatch(pattern, str string) bool {
+func regExpMatch(pattern, str string) bool {
 	match, err := regexp.MatchString(pattern, str)
 	if err != nil {
 		log.Printf("Failed to judge srcPod string pattern: %s", err)
@@ -150,7 +85,8 @@ func (a *traceflowPlugin) regExpMatch(pattern, str string) bool {
 	return true
 }
 
-func (a *traceflowPlugin) actionHandler(request *service.ActionRequest) error {
+// actionHandler handlers clicks and actions from "Start New Trace" and "Generate Trace Graph" buttons.
+func actionHandler(request *service.ActionRequest) error {
 	actionName, err := request.Payload.String("action")
 	if err != nil {
 		log.Printf("Failed to get input at string: %s", err)
@@ -163,7 +99,7 @@ func (a *traceflowPlugin) actionHandler(request *service.ActionRequest) error {
 		if err != nil {
 			log.Printf("Failed to get srcNamespace at string : %s", err)
 		}
-		if match := a.regExpMatch(namespaceStrPattern, srcNamespace); !match {
+		if match := regExpMatch(namespaceStrPattern, srcNamespace); !match {
 			return nil
 		}
 
@@ -171,7 +107,7 @@ func (a *traceflowPlugin) actionHandler(request *service.ActionRequest) error {
 		if err != nil {
 			log.Printf("Failed to get srcPod at string : %s", err)
 		}
-		if match := a.regExpMatch(podStrPattern, srcPod); !match {
+		if match := regExpMatch(podStrPattern, srcPod); !match {
 			return nil
 		}
 
@@ -184,7 +120,7 @@ func (a *traceflowPlugin) actionHandler(request *service.ActionRequest) error {
 		if err != nil {
 			log.Printf("Failed to get dstNamespace at string : %s", err)
 		}
-		if match := a.regExpMatch(namespaceStrPattern, dstNamespace); !match {
+		if match := regExpMatch(namespaceStrPattern, dstNamespace); !match {
 			return nil
 		}
 
@@ -192,7 +128,7 @@ func (a *traceflowPlugin) actionHandler(request *service.ActionRequest) error {
 		if err != nil {
 			log.Printf("Failed to get dstPod at string : %s", err)
 		}
-		if match := a.regExpMatch(podStrPattern, dstPod); !match {
+		if match := regExpMatch(podStrPattern, dstPod); !match {
 			return nil
 		}
 
@@ -211,7 +147,7 @@ func (a *traceflowPlugin) actionHandler(request *service.ActionRequest) error {
 		// If it is, then the user creates more than one traceflows in one second, which is not allowed.
 		tfName := srcPod + "-" + dstPod + "-" + time.Now().Format(TIME_FORMAT_YYYYMMDD_HHMMSS)
 		ctx := context.Background()
-		tfOld, err := a.client.OpsV1alpha1().Traceflows().Get(ctx, tfName, metav1.GetOptions{})
+		tfOld, err := client.OpsV1alpha1().Traceflows().Get(ctx, tfName, v1.GetOptions{})
 		if err != nil {
 			log.Printf("Failed to get traceflow \"%s\", detailed error: %s", tfName, err)
 		}
@@ -222,7 +158,7 @@ func (a *traceflowPlugin) actionHandler(request *service.ActionRequest) error {
 		}
 
 		tf := &opsv1alpha1.Traceflow{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: v1.ObjectMeta{
 				Name: tfName,
 			},
 			Spec: opsv1alpha1.TraceflowSpec{
@@ -279,14 +215,14 @@ func (a *traceflowPlugin) actionHandler(request *service.ActionRequest) error {
 				}
 			}
 		}
-		tf, err = a.client.OpsV1alpha1().Traceflows().Create(ctx, tf, metav1.CreateOptions{})
+		tf, err = client.OpsV1alpha1().Traceflows().Create(ctx, tf, v1.CreateOptions{})
 		if err != nil {
 			log.Printf("Failed to create traceflow CRD \"%s\", err: %s", tfName, err)
 			return nil
 		}
 		log.Printf("Create traceflow CRD \"%s\" successfully, Traceflow Results: %+v", tfName, tf)
-		a.lastTfName = tf.Name
-		a.graph = graphviz.GenGraph(tf)
+		lastTf = *tf
+		graph = graphviz.GenGraph(&lastTf)
 		return nil
 	case showGraphAction:
 		name, err := request.Payload.String("name")
@@ -296,14 +232,14 @@ func (a *traceflowPlugin) actionHandler(request *service.ActionRequest) error {
 		}
 		// Invoke GenGraph to show
 		ctx := context.Background()
-		tf, err := a.client.OpsV1alpha1().Traceflows().Get(ctx, name, metav1.GetOptions{})
+		tf, err := client.OpsV1alpha1().Traceflows().Get(ctx, name, v1.GetOptions{})
 		if err != nil {
 			log.Printf("Failed to get traceflow CRD \"%s\", err: %s ", name, err)
 			return nil
 		}
 		log.Printf("Get traceflow CRD \"%s\" successfully, Traceflow Results: %+v", name, tf)
-		a.lastTfName = tf.Name
-		a.graph = graphviz.GenGraph(tf)
+		lastTf = *tf
+		graph = graphviz.GenGraph(&lastTf)
 		return nil
 	default:
 		log.Fatalf("Failed to find defined handler after receiving action request for %s", pluginName)
@@ -311,13 +247,10 @@ func (a *traceflowPlugin) actionHandler(request *service.ActionRequest) error {
 	}
 }
 
-func (a *traceflowPlugin) initRoutes(router *service.Router) {
-	router.HandleFunc("/components", a.traceflowHandler)
-}
-
-func (a *traceflowPlugin) traceflowHandler(request service.Request) (component.ContentResponse, error) {
+// traceflowHandler handlers the layout of Traceflow page.
+func traceflowHandler(request service.Request) (component.ContentResponse, error) {
 	layout := flexlayout.New()
-	card := component.NewCard(component.TitleFromString("Antrea Traceflow"))
+	card := component.NewCard(component.TitleFromString(antreaTraceflowTitle))
 	form := component.Form{Fields: []component.FormField{
 		component.NewFormFieldText(srcNamespaceCol, srcNamespaceCol, ""),
 		component.NewFormFieldText(srcPodCol, srcPodCol, ""),
@@ -347,21 +280,24 @@ func (a *traceflowPlugin) traceflowHandler(request service.Request) (component.C
 	card.AddAction(genGraph)
 
 	graphCard := component.NewCard(component.TitleFromString("Antrea Traceflow Graph"))
-	if a.lastTfName != "" {
+	if lastTf.Name != "" {
 		// Invoke GenGraph to show
 		log.Printf("Generating content from CRD...")
 		ctx := context.Background()
-		tf, err := a.client.OpsV1alpha1().Traceflows().Get(ctx, a.lastTfName, metav1.GetOptions{})
+		tf, err := client.OpsV1alpha1().Traceflows().Get(ctx, lastTf.Name, v1.GetOptions{})
 		if err != nil {
-			log.Printf("Failed to generate content from CRD, lastTfName %v, err: %s", a.lastTfName, err)
-			return component.ContentResponse{}, nil
+			log.Printf("Failed to get latest CRD, using traceflow results cache, last traceflow name: %s, err: %s", lastTf.Name, err)
+			graph = graphviz.GenGraph(&lastTf)
+			log.Printf("Generated content from CRD cache successfully, last traceflow name: %s", lastTf.Name)
+		} else {
+			lastTf = *tf
+			graph = graphviz.GenGraph(&lastTf)
+			log.Printf("Generated content from latest CRD successfully, last traceflow name %s", lastTf.Name)
 		}
-		log.Printf("Traceflow Results: %+v", tf)
-		a.graph = graphviz.GenGraph(tf)
-		log.Printf("Generated content from CRD successfully, lastTfName %v", a.lastTfName)
+		log.Printf("Traceflow Results: %+v", lastTf)
 	}
-	if a.graph != "" {
-		graphCard.SetBody(component.NewGraphviz(a.graph))
+	if graph != "" {
+		graphCard.SetBody(component.NewGraphviz(graph))
 	} else {
 		graphCard.SetBody(component.NewText(""))
 	}
@@ -369,31 +305,34 @@ func (a *traceflowPlugin) traceflowHandler(request service.Request) (component.C
 	err := listSection.Add(card, component.WidthFull)
 	if err != nil {
 		log.Printf("Failed to add card to section: %s", err)
-		return component.ContentResponse{}, nil
+		return component.EmptyContentResponse, nil
 	}
-	if a.graph != "" {
+	if graph != "" {
 		err = listSection.Add(graphCard, component.WidthFull)
 		if err != nil {
 			log.Printf("Failed to add graphCard to section: %s", err)
-			return component.ContentResponse{}, nil
+			return component.EmptyContentResponse, nil
 		}
 	}
 
-	tfCols := component.NewTableCols(tfNameCol, srcNamespaceCol, srcPodCol, dstNamespaceCol, dstPodCol, crdCol, phaseCol, ageCol)
-	tfTable := component.NewTableWithRows("Trace List", "", tfCols, a.getTfRows())
-	return component.ContentResponse{
-		Title: component.TitleFromString("Antrea Traceflow"),
+	resp := component.ContentResponse{
+		Title: component.TitleFromString(antreaTraceflowTitle),
 		Components: []component.Component{
-			layout.ToComponent("Antrea Traceflow"),
-			tfTable,
+			layout.ToComponent(antreaTraceflowTitle),
+			getTfTable(request),
 		},
-	}, nil
+	}
+	// Setting the accessor ensures that the page shows the first tab when clicked.
+	for i, c := range resp.Components {
+		c.SetAccessor(resp.Title[0].String() + strconv.Itoa(i))
+	}
+	return resp, nil
 }
 
-// getTfRows gets rows for displaying Controller information
-func (a *traceflowPlugin) getTfRows() []component.TableRow {
+// getTfTable gets the table for displaying Traceflow information
+func getTfTable(request service.Request) *component.Table {
 	ctx := context.Background()
-	tfs, err := client.OpsV1alpha1().Traceflows().List(ctx, metav1.ListOptions{})
+	tfs, err := client.OpsV1alpha1().Traceflows().List(ctx, v1.ListOptions{})
 	if err != nil {
 		log.Fatalf("Failed to get Traceflows %v", err)
 		return nil
@@ -404,15 +343,15 @@ func (a *traceflowPlugin) getTfRows() []component.TableRow {
 	tfRows := make([]component.TableRow, 0)
 	for _, tf := range tfs.Items {
 		tfRows = append(tfRows, component.TableRow{
-			tfNameCol:       component.NewText(tf.Name),
+			tfNameCol:       component.NewLink(tf.Name, tf.Name, octantTraceflowCRDPath+tf.Name),
 			srcNamespaceCol: component.NewText(tf.Spec.Source.Namespace),
 			srcPodCol:       component.NewText(tf.Spec.Source.Pod),
 			dstNamespaceCol: component.NewText(tf.Spec.Destination.Namespace),
 			dstPodCol:       component.NewText(tf.Spec.Destination.Pod),
-			crdCol:          component.NewLink(tf.Name, tf.Name, octantTraceflowCRDPath+tf.Name),
 			phaseCol:        component.NewText(string(tf.Status.Phase)),
 			ageCol:          component.NewTimestamp(tf.CreationTimestamp.Time),
 		})
 	}
-	return tfRows
+	tfCols := component.NewTableCols(tfNameCol, srcNamespaceCol, srcPodCol, dstNamespaceCol, dstPodCol, phaseCol, ageCol)
+	return component.NewTableWithRows(traceflowTitle, "We couldn't find any traceflows!", tfCols, tfRows)
 }


### PR DESCRIPTION
1. Enhance Traceflow graph color theme.
Before:
![netpol](https://user-images.githubusercontent.com/32829088/86082432-4f9beb80-baca-11ea-8181-69f0f47848e2.png)
![discon](https://user-images.githubusercontent.com/32829088/86082425-4d399180-baca-11ea-8296-f6871228778d.png)

After:
![netpol](https://user-images.githubusercontent.com/32829088/87269256-3732c480-c4ff-11ea-8dd4-89509c8ac039.png)
![discon](https://user-images.githubusercontent.com/32829088/86564107-33032600-bf98-11ea-895b-bc363c5488da.png)

2. Merge Antrea plugins into one plugin: Antrea Octant Plugin
- Add two tabs in the Overview page of the plugin;
- Move the original traceflow plugin page into the folder "Antrea".

![image](https://user-images.githubusercontent.com/32829088/88159575-0c9fe480-cc40-11ea-89b7-07bf2d5c393e.png)



3. Change the layout of Antrea Overview page
Before: Put all tabs together and show them in Overview page
![image](https://user-images.githubusercontent.com/32829088/87408398-fb2e5b00-c5f5-11ea-9f9c-c8ab31d05c47.png)

After: Put all CRD forms in one page (this format fits with the default Octant Homepage)
![image](https://user-images.githubusercontent.com/32829088/88159736-4bce3580-cc40-11ea-9bef-13a0a23a85a2.png)


