### PR TITLE
Some miscellaneous minor fixes

### DIFF
--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -1,8 +1,8 @@
 # Antrea Feature Gates
 
-This page contains an overview of the various feature gates an administrator can
-specify for Antrea components. We follow the same convention as the [Kubernetes
-feature
+This page contains an overview of the various features an administrator can turn
+on or off for Antrea components. We follow the same convention as the
+[Kubernetes feature
 gates](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/).
 
 In particular:
@@ -12,9 +12,9 @@ In particular:
  by editing the appropriate `.conf` entry in the Antrea manifest.
  * a feature in the GA stage will be enabled by default and cannot be disabled.
 
-Some feature gates are specific to the Agent, others are specific to the
-Controller, and some apply to both and should be enabled / disabled consistently
-in both `.conf` entries.
+Some features are specific to the Agent, others are specific to the Controller,
+and some apply to both and should be enabled / disabled consistently in both
+`.conf` entries.
 
 To enable / disable a feature, edit the Antrea manifest appropriately. For
 example, to enable `AntreaProxy` on Linux, edit the Agent configuration in the
@@ -29,7 +29,7 @@ example, to enable `AntreaProxy` on Linux, edit the Agent configuration in the
       AntreaProxy: true
 ```
 
-## Stages for all Feature Gates
+## List of Available Features
 
 | Feature Name            | Component          | Default | Stage | Alpha Release | Beta Release | GA Release | Extra Requirements | Notes |
 | ----------------------- | ------------------ | ------- | ----- | ------------- | ------------ | ---------- | ------------------ | ----- |
@@ -37,7 +37,7 @@ example, to enable `AntreaProxy` on Linux, edit the Agent configuration in the
 | `ClusterNetworkPolicy`  | Controller         | `false` | Alpha | v0.8.0        | N/A          | N/A        | No                 |       |
 | `Traceflow`             | Agent + Controller | `false` | Alpha | v0.8.0        | N/A          | N/A        | Yes                |       |
 
-## Description and Requirements of Feature Gates
+## Description and Requirements of Features
 
 ### AntreaProxy
 

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -780,9 +780,9 @@ func (data *TestData) restartAntreaControllerPod(timeout time.Duration) (*v1.Pod
 	return newPod, nil
 }
 
-// restartAntreaAgentPod deletes the antrea-agent Pod to force it to be re-scheduled. It then waits
-// for the new Pod to become available, and returns it.
-func (data *TestData) restartAntreaAgentPod(timeout time.Duration) ([]*v1.Pod, error) {
+// restartAntreaAgentPods deletes all the antrea-agent Pods to force them to be re-scheduled. It
+// then waits for the new Pods to become available.
+func (data *TestData) restartAntreaAgentPods(timeout time.Duration) error {
 	var gracePeriodSeconds int64 = 1
 	deleteOptions := metav1.DeleteOptions{
 		GracePeriodSeconds: &gracePeriodSeconds,
@@ -791,31 +791,10 @@ func (data *TestData) restartAntreaAgentPod(timeout time.Duration) ([]*v1.Pod, e
 		LabelSelector: "app=antrea,component=antrea-agent",
 	}
 	if err := data.clientset.CoreV1().Pods(antreaNamespace).DeleteCollection(context.TODO(), deleteOptions, listOptions); err != nil {
-		return nil, fmt.Errorf("error when deleting antrea-agent Pod: %v", err)
+		return fmt.Errorf("error when deleting antrea-agent Pods: %v", err)
 	}
 
-	var newPods []*v1.Pod
-	// wait for new antrea-agent Pod
-	if err := wait.Poll(1*time.Second, timeout, func() (bool, error) {
-		pods, err := data.clientset.CoreV1().Pods("kube-system").List(context.TODO(), listOptions)
-		if err != nil {
-			return false, fmt.Errorf("failed to list antrea-agent Pods: %v", err)
-		}
-		if len(pods.Items) != clusterInfo.numNodes {
-			return false, nil
-		}
-		for i := 0; i < clusterInfo.numNodes; i++ {
-			pod := pods.Items[i]
-			if pod.Status.Phase != v1.PodRunning || pod.DeletionTimestamp != nil {
-				return false, nil
-			}
-			newPods = append(newPods, &pod)
-		}
-		return true, nil
-	}); err != nil {
-		return nil, err
-	}
-	return newPods, nil
+	return data.waitForAntreaDaemonSetPods(timeout)
 }
 
 // validatePodIP checks that the provided IP address is in the Pod Network CIDR for the cluster.

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -240,7 +240,7 @@ func (data *TestData) enableTraceflow(t *testing.T) error {
 	if err != nil {
 		return fmt.Errorf("error when restarting antrea-controller Pod: %v", err)
 	}
-	_, err = data.restartAntreaAgentPod(defaultTimeout)
+	err = data.restartAntreaAgentPods(defaultTimeout)
 	if err != nil {
 		return fmt.Errorf("error when restarting antrea-agent Pod: %v", err)
 	}


### PR DESCRIPTION
 * Use more specialized asserts (which give better error messages) in
 log unit tests.
 * Rename restartAntreaAgentPod to restartAntreaAgentPods in e2e test
 framework and simplify implementation.
 * Try not to conflate "Feature Gates" with "Features" in the
 documentation.