### PR TITLE
Enforce Traceflow validation at CRD schema

### DIFF
--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -176,6 +176,8 @@ spec:
     singular: traceflow
   preserveUnknownFields: false
   scope: Cluster
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -189,7 +191,7 @@ spec:
               - required:
                 - ip
               properties:
-                ip:
+                IP:
                   format: ipv4
                   type: string
                 namespace:
@@ -251,6 +253,49 @@ spec:
           required:
           - source
           - destination
+          type: object
+        status:
+          properties:
+            dataplaneTag:
+              type: integer
+            phase:
+              type: string
+            reason:
+              type: string
+            results:
+              items:
+                properties:
+                  node:
+                    type: string
+                  observations:
+                    properties:
+                      action:
+                        type: string
+                      component:
+                        type: string
+                      componentInfo:
+                        type: string
+                      dstMAC:
+                        type: string
+                      networkPolicy:
+                        type: string
+                      pod:
+                        type: string
+                      translatedDstIP:
+                        type: string
+                      translatedSrcIP:
+                        type: string
+                      ttl:
+                        type: integer
+                      tunnelDstIP:
+                        type: string
+                    type: object
+                  role:
+                    type: string
+                  timestamp:
+                    type: integer
+                type: object
+              type: array
           type: object
       required:
       - spec

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -174,12 +174,70 @@ spec:
     shortNames:
     - tf
     singular: traceflow
+  preserveUnknownFields: false
   scope: Cluster
   validation:
     openAPIV3Schema:
       properties:
         spec:
           properties:
+            destination:
+              oneOf:
+              - required:
+                - pod
+                - namespace
+              - required:
+                - ip
+              properties:
+                ip:
+                  format: ipv4
+                  type: string
+                namespace:
+                  type: string
+                pod:
+                  type: string
+              type: object
+            packet:
+              properties:
+                ipHeader:
+                  properties:
+                    flags:
+                      type: integer
+                    protocol:
+                      type: integer
+                    srcIp:
+                      format: ipv4
+                      type: string
+                    ttl:
+                      type: integer
+                  type: object
+                transportHeader:
+                  properties:
+                    icmp:
+                      properties:
+                        id:
+                          type: integer
+                        sequence:
+                          type: integer
+                      type: object
+                    tcp:
+                      properties:
+                        dstPort:
+                          type: integer
+                        flags:
+                          type: integer
+                        srcPort:
+                          type: integer
+                      type: object
+                    udp:
+                      properties:
+                        dstPort:
+                          type: integer
+                        srcPort:
+                          type: integer
+                      type: object
+                  type: object
+              type: object
             source:
               properties:
                 namespace:
@@ -192,6 +250,7 @@ spec:
               type: object
           required:
           - source
+          - destination
           type: object
       required:
       - spec

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -456,6 +456,7 @@ rules:
   - ops.antrea.tanzu.vmware.com
   resources:
   - traceflows
+  - traceflows/status
   verbs:
   - get
   - watch
@@ -557,6 +558,7 @@ rules:
   - ops.antrea.tanzu.vmware.com
   resources:
   - traceflows
+  - traceflows/status
   verbs:
   - get
   - watch

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -268,28 +268,30 @@ spec:
                   node:
                     type: string
                   observations:
-                    properties:
-                      action:
-                        type: string
-                      component:
-                        type: string
-                      componentInfo:
-                        type: string
-                      dstMAC:
-                        type: string
-                      networkPolicy:
-                        type: string
-                      pod:
-                        type: string
-                      translatedDstIP:
-                        type: string
-                      translatedSrcIP:
-                        type: string
-                      ttl:
-                        type: integer
-                      tunnelDstIP:
-                        type: string
-                    type: object
+                    items:
+                      properties:
+                        action:
+                          type: string
+                        component:
+                          type: string
+                        componentInfo:
+                          type: string
+                        dstMAC:
+                          type: string
+                        networkPolicy:
+                          type: string
+                        pod:
+                          type: string
+                        translatedDstIP:
+                          type: string
+                        translatedSrcIP:
+                          type: string
+                        ttl:
+                          type: integer
+                        tunnelDstIP:
+                          type: string
+                      type: object
+                    type: array
                   role:
                     type: string
                   timestamp:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -191,7 +191,7 @@ spec:
               - required:
                 - ip
               properties:
-                IP:
+                ip:
                   format: ipv4
                   type: string
                 namespace:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -205,7 +205,7 @@ spec:
                       type: integer
                     protocol:
                       type: integer
-                    srcIp:
+                    srcIP:
                       format: ipv4
                       type: string
                     ttl:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -176,6 +176,8 @@ spec:
     singular: traceflow
   preserveUnknownFields: false
   scope: Cluster
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -189,7 +191,7 @@ spec:
               - required:
                 - ip
               properties:
-                ip:
+                IP:
                   format: ipv4
                   type: string
                 namespace:
@@ -251,6 +253,49 @@ spec:
           required:
           - source
           - destination
+          type: object
+        status:
+          properties:
+            dataplaneTag:
+              type: integer
+            phase:
+              type: string
+            reason:
+              type: string
+            results:
+              items:
+                properties:
+                  node:
+                    type: string
+                  observations:
+                    properties:
+                      action:
+                        type: string
+                      component:
+                        type: string
+                      componentInfo:
+                        type: string
+                      dstMAC:
+                        type: string
+                      networkPolicy:
+                        type: string
+                      pod:
+                        type: string
+                      translatedDstIP:
+                        type: string
+                      translatedSrcIP:
+                        type: string
+                      ttl:
+                        type: integer
+                      tunnelDstIP:
+                        type: string
+                    type: object
+                  role:
+                    type: string
+                  timestamp:
+                    type: integer
+                type: object
+              type: array
           type: object
       required:
       - spec

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -174,12 +174,70 @@ spec:
     shortNames:
     - tf
     singular: traceflow
+  preserveUnknownFields: false
   scope: Cluster
   validation:
     openAPIV3Schema:
       properties:
         spec:
           properties:
+            destination:
+              oneOf:
+              - required:
+                - pod
+                - namespace
+              - required:
+                - ip
+              properties:
+                ip:
+                  format: ipv4
+                  type: string
+                namespace:
+                  type: string
+                pod:
+                  type: string
+              type: object
+            packet:
+              properties:
+                ipHeader:
+                  properties:
+                    flags:
+                      type: integer
+                    protocol:
+                      type: integer
+                    srcIp:
+                      format: ipv4
+                      type: string
+                    ttl:
+                      type: integer
+                  type: object
+                transportHeader:
+                  properties:
+                    icmp:
+                      properties:
+                        id:
+                          type: integer
+                        sequence:
+                          type: integer
+                      type: object
+                    tcp:
+                      properties:
+                        dstPort:
+                          type: integer
+                        flags:
+                          type: integer
+                        srcPort:
+                          type: integer
+                      type: object
+                    udp:
+                      properties:
+                        dstPort:
+                          type: integer
+                        srcPort:
+                          type: integer
+                      type: object
+                  type: object
+              type: object
             source:
               properties:
                 namespace:
@@ -192,6 +250,7 @@ spec:
               type: object
           required:
           - source
+          - destination
           type: object
       required:
       - spec

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -456,6 +456,7 @@ rules:
   - ops.antrea.tanzu.vmware.com
   resources:
   - traceflows
+  - traceflows/status
   verbs:
   - get
   - watch
@@ -557,6 +558,7 @@ rules:
   - ops.antrea.tanzu.vmware.com
   resources:
   - traceflows
+  - traceflows/status
   verbs:
   - get
   - watch

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -268,28 +268,30 @@ spec:
                   node:
                     type: string
                   observations:
-                    properties:
-                      action:
-                        type: string
-                      component:
-                        type: string
-                      componentInfo:
-                        type: string
-                      dstMAC:
-                        type: string
-                      networkPolicy:
-                        type: string
-                      pod:
-                        type: string
-                      translatedDstIP:
-                        type: string
-                      translatedSrcIP:
-                        type: string
-                      ttl:
-                        type: integer
-                      tunnelDstIP:
-                        type: string
-                    type: object
+                    items:
+                      properties:
+                        action:
+                          type: string
+                        component:
+                          type: string
+                        componentInfo:
+                          type: string
+                        dstMAC:
+                          type: string
+                        networkPolicy:
+                          type: string
+                        pod:
+                          type: string
+                        translatedDstIP:
+                          type: string
+                        translatedSrcIP:
+                          type: string
+                        ttl:
+                          type: integer
+                        tunnelDstIP:
+                          type: string
+                      type: object
+                    type: array
                   role:
                     type: string
                   timestamp:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -191,7 +191,7 @@ spec:
               - required:
                 - ip
               properties:
-                IP:
+                ip:
                   format: ipv4
                   type: string
                 namespace:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -205,7 +205,7 @@ spec:
                       type: integer
                     protocol:
                       type: integer
-                    srcIp:
+                    srcIP:
                       format: ipv4
                       type: string
                     ttl:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -176,6 +176,8 @@ spec:
     singular: traceflow
   preserveUnknownFields: false
   scope: Cluster
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -189,7 +191,7 @@ spec:
               - required:
                 - ip
               properties:
-                ip:
+                IP:
                   format: ipv4
                   type: string
                 namespace:
@@ -251,6 +253,49 @@ spec:
           required:
           - source
           - destination
+          type: object
+        status:
+          properties:
+            dataplaneTag:
+              type: integer
+            phase:
+              type: string
+            reason:
+              type: string
+            results:
+              items:
+                properties:
+                  node:
+                    type: string
+                  observations:
+                    properties:
+                      action:
+                        type: string
+                      component:
+                        type: string
+                      componentInfo:
+                        type: string
+                      dstMAC:
+                        type: string
+                      networkPolicy:
+                        type: string
+                      pod:
+                        type: string
+                      translatedDstIP:
+                        type: string
+                      translatedSrcIP:
+                        type: string
+                      ttl:
+                        type: integer
+                      tunnelDstIP:
+                        type: string
+                    type: object
+                  role:
+                    type: string
+                  timestamp:
+                    type: integer
+                type: object
+              type: array
           type: object
       required:
       - spec

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -174,12 +174,70 @@ spec:
     shortNames:
     - tf
     singular: traceflow
+  preserveUnknownFields: false
   scope: Cluster
   validation:
     openAPIV3Schema:
       properties:
         spec:
           properties:
+            destination:
+              oneOf:
+              - required:
+                - pod
+                - namespace
+              - required:
+                - ip
+              properties:
+                ip:
+                  format: ipv4
+                  type: string
+                namespace:
+                  type: string
+                pod:
+                  type: string
+              type: object
+            packet:
+              properties:
+                ipHeader:
+                  properties:
+                    flags:
+                      type: integer
+                    protocol:
+                      type: integer
+                    srcIp:
+                      format: ipv4
+                      type: string
+                    ttl:
+                      type: integer
+                  type: object
+                transportHeader:
+                  properties:
+                    icmp:
+                      properties:
+                        id:
+                          type: integer
+                        sequence:
+                          type: integer
+                      type: object
+                    tcp:
+                      properties:
+                        dstPort:
+                          type: integer
+                        flags:
+                          type: integer
+                        srcPort:
+                          type: integer
+                      type: object
+                    udp:
+                      properties:
+                        dstPort:
+                          type: integer
+                        srcPort:
+                          type: integer
+                      type: object
+                  type: object
+              type: object
             source:
               properties:
                 namespace:
@@ -192,6 +250,7 @@ spec:
               type: object
           required:
           - source
+          - destination
           type: object
       required:
       - spec

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -456,6 +456,7 @@ rules:
   - ops.antrea.tanzu.vmware.com
   resources:
   - traceflows
+  - traceflows/status
   verbs:
   - get
   - watch
@@ -557,6 +558,7 @@ rules:
   - ops.antrea.tanzu.vmware.com
   resources:
   - traceflows
+  - traceflows/status
   verbs:
   - get
   - watch

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -268,28 +268,30 @@ spec:
                   node:
                     type: string
                   observations:
-                    properties:
-                      action:
-                        type: string
-                      component:
-                        type: string
-                      componentInfo:
-                        type: string
-                      dstMAC:
-                        type: string
-                      networkPolicy:
-                        type: string
-                      pod:
-                        type: string
-                      translatedDstIP:
-                        type: string
-                      translatedSrcIP:
-                        type: string
-                      ttl:
-                        type: integer
-                      tunnelDstIP:
-                        type: string
-                    type: object
+                    items:
+                      properties:
+                        action:
+                          type: string
+                        component:
+                          type: string
+                        componentInfo:
+                          type: string
+                        dstMAC:
+                          type: string
+                        networkPolicy:
+                          type: string
+                        pod:
+                          type: string
+                        translatedDstIP:
+                          type: string
+                        translatedSrcIP:
+                          type: string
+                        ttl:
+                          type: integer
+                        tunnelDstIP:
+                          type: string
+                      type: object
+                    type: array
                   role:
                     type: string
                   timestamp:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -191,7 +191,7 @@ spec:
               - required:
                 - ip
               properties:
-                IP:
+                ip:
                   format: ipv4
                   type: string
                 namespace:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -205,7 +205,7 @@ spec:
                       type: integer
                     protocol:
                       type: integer
-                    srcIp:
+                    srcIP:
                       format: ipv4
                       type: string
                     ttl:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -176,6 +176,8 @@ spec:
     singular: traceflow
   preserveUnknownFields: false
   scope: Cluster
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -189,7 +191,7 @@ spec:
               - required:
                 - ip
               properties:
-                ip:
+                IP:
                   format: ipv4
                   type: string
                 namespace:
@@ -251,6 +253,49 @@ spec:
           required:
           - source
           - destination
+          type: object
+        status:
+          properties:
+            dataplaneTag:
+              type: integer
+            phase:
+              type: string
+            reason:
+              type: string
+            results:
+              items:
+                properties:
+                  node:
+                    type: string
+                  observations:
+                    properties:
+                      action:
+                        type: string
+                      component:
+                        type: string
+                      componentInfo:
+                        type: string
+                      dstMAC:
+                        type: string
+                      networkPolicy:
+                        type: string
+                      pod:
+                        type: string
+                      translatedDstIP:
+                        type: string
+                      translatedSrcIP:
+                        type: string
+                      ttl:
+                        type: integer
+                      tunnelDstIP:
+                        type: string
+                    type: object
+                  role:
+                    type: string
+                  timestamp:
+                    type: integer
+                type: object
+              type: array
           type: object
       required:
       - spec

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -174,12 +174,70 @@ spec:
     shortNames:
     - tf
     singular: traceflow
+  preserveUnknownFields: false
   scope: Cluster
   validation:
     openAPIV3Schema:
       properties:
         spec:
           properties:
+            destination:
+              oneOf:
+              - required:
+                - pod
+                - namespace
+              - required:
+                - ip
+              properties:
+                ip:
+                  format: ipv4
+                  type: string
+                namespace:
+                  type: string
+                pod:
+                  type: string
+              type: object
+            packet:
+              properties:
+                ipHeader:
+                  properties:
+                    flags:
+                      type: integer
+                    protocol:
+                      type: integer
+                    srcIp:
+                      format: ipv4
+                      type: string
+                    ttl:
+                      type: integer
+                  type: object
+                transportHeader:
+                  properties:
+                    icmp:
+                      properties:
+                        id:
+                          type: integer
+                        sequence:
+                          type: integer
+                      type: object
+                    tcp:
+                      properties:
+                        dstPort:
+                          type: integer
+                        flags:
+                          type: integer
+                        srcPort:
+                          type: integer
+                      type: object
+                    udp:
+                      properties:
+                        dstPort:
+                          type: integer
+                        srcPort:
+                          type: integer
+                      type: object
+                  type: object
+              type: object
             source:
               properties:
                 namespace:
@@ -192,6 +250,7 @@ spec:
               type: object
           required:
           - source
+          - destination
           type: object
       required:
       - spec

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -456,6 +456,7 @@ rules:
   - ops.antrea.tanzu.vmware.com
   resources:
   - traceflows
+  - traceflows/status
   verbs:
   - get
   - watch
@@ -557,6 +558,7 @@ rules:
   - ops.antrea.tanzu.vmware.com
   resources:
   - traceflows
+  - traceflows/status
   verbs:
   - get
   - watch

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -268,28 +268,30 @@ spec:
                   node:
                     type: string
                   observations:
-                    properties:
-                      action:
-                        type: string
-                      component:
-                        type: string
-                      componentInfo:
-                        type: string
-                      dstMAC:
-                        type: string
-                      networkPolicy:
-                        type: string
-                      pod:
-                        type: string
-                      translatedDstIP:
-                        type: string
-                      translatedSrcIP:
-                        type: string
-                      ttl:
-                        type: integer
-                      tunnelDstIP:
-                        type: string
-                    type: object
+                    items:
+                      properties:
+                        action:
+                          type: string
+                        component:
+                          type: string
+                        componentInfo:
+                          type: string
+                        dstMAC:
+                          type: string
+                        networkPolicy:
+                          type: string
+                        pod:
+                          type: string
+                        translatedDstIP:
+                          type: string
+                        translatedSrcIP:
+                          type: string
+                        ttl:
+                          type: integer
+                        tunnelDstIP:
+                          type: string
+                      type: object
+                    type: array
                   role:
                     type: string
                   timestamp:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -191,7 +191,7 @@ spec:
               - required:
                 - ip
               properties:
-                IP:
+                ip:
                   format: ipv4
                   type: string
                 namespace:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -205,7 +205,7 @@ spec:
                       type: integer
                     protocol:
                       type: integer
-                    srcIp:
+                    srcIP:
                       format: ipv4
                       type: string
                     ttl:

--- a/build/yamls/base/agent-rbac.yml
+++ b/build/yamls/base/agent-rbac.yml
@@ -89,6 +89,7 @@ rules:
       - ops.antrea.tanzu.vmware.com
     resources:
       - traceflows
+      - traceflows/status
     verbs:
       - get
       - watch

--- a/build/yamls/base/controller-rbac.yml
+++ b/build/yamls/base/controller-rbac.yml
@@ -103,6 +103,7 @@ rules:
       - ops.antrea.tanzu.vmware.com
     resources:
       - traceflows
+      - traceflows/status
     verbs:
       - get
       - watch

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -151,28 +151,30 @@ spec:
                   timestamp:
                     type: integer
                   observations:
-                    type: object
-                    properties:
-                      component:
-                        type: string
-                      componentInfo:
-                        type: string
-                      action:
-                        type: string
-                      pod:
-                        type: string
-                      dstMAC:
-                        type: string
-                      networkPolicy:
-                        type: string
-                      ttl:
-                        type: integer
-                      translatedSrcIP:
-                        type: string
-                      translatedDstIP:
-                        type: string
-                      tunnelDstIP:
-                        type: string
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        component:
+                          type: string
+                        componentInfo:
+                          type: string
+                        action:
+                          type: string
+                        pod:
+                          type: string
+                        dstMAC:
+                          type: string
+                        networkPolicy:
+                          type: string
+                        ttl:
+                          type: integer
+                        translatedSrcIP:
+                          type: string
+                        translatedDstIP:
+                          type: string
+                        tunnelDstIP:
+                          type: string
   subresources:
     status: {} 
 ---

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -95,7 +95,7 @@ spec:
                 ipHeader:
                   type: object
                   properties:
-                    srcIp:
+                    srcIP:
                       type: string
                       format: ipv4
                     protocol:

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -52,6 +52,8 @@ spec:
     kind: Traceflow
     shortNames:
       - tf
+  # Prune any unknown fields
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       type: object
@@ -62,6 +64,7 @@ spec:
           type: object
           required:
             - source
+            - destination
           properties:
             source:
               type: object
@@ -73,6 +76,61 @@ spec:
                   type: string
                 namespace:
                   type: string
+            destination:
+              type: object
+              properties:
+                pod:
+                  type: string
+                namespace:
+                  type: string
+                ip:
+                  type: string
+                  format: ipv4
+              oneOf:
+                - required: ["pod", "namespace"]
+                - required: ["ip"]
+            packet:
+              type: object
+              properties:
+                ipHeader:
+                  type: object
+                  properties:
+                    srcIp:
+                      type: string
+                      format: ipv4
+                    protocol:
+                      type: integer
+                    ttl:
+                      type: integer
+                    flags:
+                      type: integer
+                transportHeader:
+                  type: object
+                  properties:
+                    icmp:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                        sequence:
+                          type: integer
+                    udp:
+                      type: object
+                      properties:
+                        srcPort:
+                          type: integer
+                        dstPort:
+                          type: integer
+                    tcp:
+                      type: object
+                      properties:
+                        srcPort:
+                          type: integer
+                        dstPort:
+                          type: integer
+                        flags:
+                          type: integer
+
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -83,7 +83,7 @@ spec:
                   type: string
                 namespace:
                   type: string
-                IP:
+                ip:
                   type: string
                   format: ipv4
               oneOf:

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -83,7 +83,7 @@ spec:
                   type: string
                 namespace:
                   type: string
-                ip:
+                IP:
                   type: string
                   format: ipv4
               oneOf:
@@ -130,7 +130,51 @@ spec:
                           type: integer
                         flags:
                           type: integer
-
+        status:
+          type: object
+          properties:
+            reason:
+              type: string
+            dataplaneTag:
+              type: integer
+            phase:
+              type: string
+            results:
+              type: array
+              items:
+                type: object
+                properties:
+                  node:
+                    type: string
+                  role:
+                    type: string
+                  timestamp:
+                    type: integer
+                  observations:
+                    type: object
+                    properties:
+                      component:
+                        type: string
+                      componentInfo:
+                        type: string
+                      action:
+                        type: string
+                      pod:
+                        type: string
+                      dstMAC:
+                        type: string
+                      networkPolicy:
+                        type: string
+                      ttl:
+                        type: integer
+                      translatedSrcIP:
+                        type: string
+                      translatedDstIP:
+                        type: string
+                      tunnelDstIP:
+                        type: string
+  subresources:
+    status: {} 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/pkg/agent/controller/traceflow/packetin.go
+++ b/pkg/agent/controller/traceflow/packetin.go
@@ -49,7 +49,7 @@ func (c *Controller) HandlePacketIn(pktIn *ofctrl.PacketIn) error {
 			return err
 		}
 		tf.Status.Results = append(tf.Status.Results, *nodeResult)
-		tf, err = c.traceflowClient.OpsV1alpha1().Traceflows().Update(context.TODO(), tf, v1.UpdateOptions{})
+		tf, err = c.traceflowClient.OpsV1alpha1().Traceflows().UpdateStatus(context.TODO(), tf, v1.UpdateOptions{})
 		if err != nil {
 			klog.Warningf("Update traceflow failed: %+v", err)
 			return err

--- a/pkg/agent/controller/traceflow/traceflow_controller.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller.go
@@ -354,7 +354,7 @@ func (c *Controller) errorTraceflowCRD(tf *opsv1alpha1.Traceflow, reason string)
 	}
 	patchData := Traceflow{Status: opsv1alpha1.TraceflowStatus{Phase: tf.Status.Phase, Reason: reason}}
 	payloads, _ := json.Marshal(patchData)
-	return c.traceflowClient.OpsV1alpha1().Traceflows().Patch(context.TODO(), tf.Name, types.MergePatchType, payloads, v1.PatchOptions{})
+	return c.traceflowClient.OpsV1alpha1().Traceflows().Patch(context.TODO(), tf.Name, types.MergePatchType, payloads, v1.PatchOptions{}, "status")
 }
 
 // Deallocate tag from cache. Ignore DataplaneTag == 0 which is invalid case.

--- a/pkg/apis/ops/v1alpha1/types.go
+++ b/pkg/apis/ops/v1alpha1/types.go
@@ -81,7 +81,7 @@ type Destination struct {
 	// Service is the destination service, exclusive with destination pod.
 	Service string `json:"service,omitempty"`
 	// IP is the destination IP.
-	IP string `json:"IP,omitempty"`
+	IP string `json:"ip,omitempty"`
 }
 
 // IPHeader describes spec of an IPv4 header. IPv6 not supported yet.

--- a/pkg/controller/traceflow/controller.go
+++ b/pkg/controller/traceflow/controller.go
@@ -212,12 +212,6 @@ func (c *Controller) syncTraceflow(traceflowName string) (retry bool, err error)
 }
 
 func (c *Controller) startTraceflow(tf *opsv1alpha1.Traceflow) (*opsv1alpha1.Traceflow, error) {
-	// Validate if the traceflow request meets requirement.
-	if err := validate(tf); err != nil {
-		c.errorTraceflowCRD(tf, err.Error())
-		return nil, err
-	}
-
 	// Allocate data plane tag.
 	tag, err := c.allocateTag(tf)
 	if err != nil {
@@ -274,20 +268,6 @@ func (c *Controller) errorTraceflowCRD(tf *opsv1alpha1.Traceflow, reason string)
 	patchData := Traceflow{Status: opsv1alpha1.TraceflowStatus{Phase: tf.Status.Phase, Reason: reason}}
 	payloads, _ := json.Marshal(patchData)
 	return c.client.OpsV1alpha1().Traceflows().Patch(context.TODO(), tf.Name, types.MergePatchType, payloads, v1.PatchOptions{})
-}
-
-// TODO: more restrictive validation in this function and CRD definition
-func validate(tf *opsv1alpha1.Traceflow) error {
-	if len(tf.Spec.Destination.Service) != 0 {
-		return errors.New("destination service is not supported")
-	}
-	if len(tf.Spec.Destination.Pod) != 0 && len(tf.Spec.Destination.IP) != 0 {
-		return errors.New("destination pod and IP cannot be both set")
-	}
-	if len(tf.Spec.Destination.Pod) == 0 && len(tf.Spec.Destination.IP) == 0 {
-		return errors.New("destination pod and IP cannot be both not set")
-	}
-	return nil
 }
 
 func (c *Controller) occupyTag(tf *opsv1alpha1.Traceflow) error {

--- a/pkg/controller/traceflow/controller.go
+++ b/pkg/controller/traceflow/controller.go
@@ -236,7 +236,7 @@ func (c *Controller) checkTraceflowStatus(tf *opsv1alpha1.Traceflow) (retry bool
 	}
 	if sender && receiver {
 		tf.Status.Phase = opsv1alpha1.Succeeded
-		_, err = c.client.OpsV1alpha1().Traceflows().Update(context.TODO(), tf, v1.UpdateOptions{})
+		_, err = c.client.OpsV1alpha1().Traceflows().UpdateStatus(context.TODO(), tf, v1.UpdateOptions{})
 		return
 	}
 	if time.Now().UTC().Sub(tf.CreationTimestamp.UTC()).Seconds() > timeout {

--- a/pkg/controller/traceflow/controller.go
+++ b/pkg/controller/traceflow/controller.go
@@ -256,7 +256,7 @@ func (c *Controller) runningTraceflowCRD(tf *opsv1alpha1.Traceflow, dataPlaneTag
 	}
 	patchData := Traceflow{Status: opsv1alpha1.TraceflowStatus{Phase: tf.Status.Phase, DataplaneTag: dataPlaneTag}}
 	payloads, _ := json.Marshal(patchData)
-	return c.client.OpsV1alpha1().Traceflows().Patch(context.TODO(), tf.Name, types.MergePatchType, payloads, v1.PatchOptions{})
+	return c.client.OpsV1alpha1().Traceflows().Patch(context.TODO(), tf.Name, types.MergePatchType, payloads, v1.PatchOptions{}, "status")
 }
 
 func (c *Controller) errorTraceflowCRD(tf *opsv1alpha1.Traceflow, reason string) (*opsv1alpha1.Traceflow, error) {
@@ -267,7 +267,7 @@ func (c *Controller) errorTraceflowCRD(tf *opsv1alpha1.Traceflow, reason string)
 	}
 	patchData := Traceflow{Status: opsv1alpha1.TraceflowStatus{Phase: tf.Status.Phase, Reason: reason}}
 	payloads, _ := json.Marshal(patchData)
-	return c.client.OpsV1alpha1().Traceflows().Patch(context.TODO(), tf.Name, types.MergePatchType, payloads, v1.PatchOptions{})
+	return c.client.OpsV1alpha1().Traceflows().Patch(context.TODO(), tf.Name, types.MergePatchType, payloads, v1.PatchOptions{}, "status")
 }
 
 func (c *Controller) occupyTag(tf *opsv1alpha1.Traceflow) error {


### PR DESCRIPTION
Complete the Traceflow CRD schema and ensure that unknown fields are not set in CRD. This PR also ensures that
Namespace/Pod and IP fields are mutually exclusive in Destination and removes validation from controller.
