### PR TITLE
[Windows] Set the uplink port with "no-flood"

### DIFF
--- a/pkg/ovs/ovsctl/interface.go
+++ b/pkg/ovs/ovsctl/interface.go
@@ -43,6 +43,8 @@ type OVSCtlClient interface {
 	DumpGroups(args ...string) ([][]string, error)
 	// RunOfctlCmd executes "ovs-ofctl" command and returns the outputs.
 	RunOfctlCmd(cmd string, args ...string) ([]byte, error)
+	// SetPortNoFlood sets the given port with config "no-flood". This configuration must work with OpenFlow10.
+	SetPortNoFlood(ofport int) error
 	// Trace executes "ovs-appctl ofproto/trace" to perform OVS packet tracing.
 	Trace(req *TracingRequest) (string, error)
 }

--- a/pkg/ovs/ovsctl/ofctl.go
+++ b/pkg/ovs/ovsctl/ofctl.go
@@ -87,6 +87,11 @@ func (c *ovsCtlClient) DumpGroups(args ...string) ([][]string, error) {
 	return groupList, nil
 }
 
+func (c *ovsCtlClient) SetPortNoFlood(ofport int) error {
+	cmdStr := fmt.Sprintf("ovs-ofctl mod-port %s %d no-flood", c.bridge, ofport)
+	return getOVSCommand(cmdStr).Run()
+}
+
 func (c *ovsCtlClient) RunOfctlCmd(cmd string, args ...string) ([]byte, error) {
 	cmdStr := fmt.Sprintf("ovs-ofctl -O Openflow13 %s %s", cmd, c.bridge)
 	cmdStr = cmdStr + " " + strings.Join(args, " ")

--- a/pkg/ovs/ovsctl/testing/mock_ovsctl.go
+++ b/pkg/ovs/ovsctl/testing/mock_ovsctl.go
@@ -136,6 +136,20 @@ func (mr *MockOVSCtlClientMockRecorder) RunOfctlCmd(arg0 interface{}, arg1 ...in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunOfctlCmd", reflect.TypeOf((*MockOVSCtlClient)(nil).RunOfctlCmd), varargs...)
 }
 
+// SetPortNoFlood mocks base method
+func (m *MockOVSCtlClient) SetPortNoFlood(arg0 int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetPortNoFlood", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetPortNoFlood indicates an expected call of SetPortNoFlood
+func (mr *MockOVSCtlClientMockRecorder) SetPortNoFlood(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPortNoFlood", reflect.TypeOf((*MockOVSCtlClient)(nil).SetPortNoFlood), arg0)
+}
+
 // Trace mocks base method
 func (m *MockOVSCtlClient) Trace(arg0 *ovsctl.TracingRequest) (string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Set the uplink port with configuration "no-flood", so that the ARP "normal"
flow will not forward the packets to the uplink interface.
"no-flood" config is supported only in OpenFlow10, so using the ovs command
to set it.

Fixes #865 