### PR TITLE
[Windows] Support LoadBalancer Service

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -114,6 +114,11 @@ type Client interface {
 	InstallServiceFlows(groupID binding.GroupIDType, svcIP net.IP, svcPort uint16, protocol binding.Protocol, affinityTimeout uint16) error
 	// UninstallServiceFlows removes flows installed by InstallServiceFlows.
 	UninstallServiceFlows(svcIP net.IP, svcPort uint16, protocol binding.Protocol) error
+	// InstallLoadBalancerServiceFromOutsideFlows installs flows for LoadBalancer Service traffic from outside node.
+	// The traffic is received from uplink port and will be forwarded to gateway by the installed flows. And then
+	// kube-proxy will handle the traffic.
+	// This function is only used for Windows platform.
+	InstallLoadBalancerServiceFromOutsideFlows(svcIP net.IP, svcPort uint16, protocol binding.Protocol) error
 
 	// GetFlowTableStatus should return an array of flow table status, all existing flow tables should be included in the list.
 	GetFlowTableStatus() []binding.TableStatus
@@ -419,6 +424,15 @@ func (c *client) UninstallServiceFlows(svcIP net.IP, svcPort uint16, protocol bi
 	defer c.replayMutex.RUnlock()
 	cacheKey := fmt.Sprintf("Service:%s:%d:%s", svcIP, svcPort, protocol)
 	return c.deleteFlows(c.serviceFlowCache, cacheKey)
+}
+
+func (c *client) InstallLoadBalancerServiceFromOutsideFlows(svcIP net.IP, svcPort uint16, protocol binding.Protocol) error {
+	c.replayMutex.RLock()
+	defer c.replayMutex.RUnlock()
+	var flows []binding.Flow
+	flows = append(flows, c.loadBalancerServiceFromOutsideFlow(config.UplinkOFPort, config.HostGatewayOFPort, svcIP, svcPort, protocol))
+	cacheKey := fmt.Sprintf("LoadBalancerService:%s:%d:%s", svcIP, svcPort, protocol)
+	return c.addFlows(c.serviceFlowCache, cacheKey, flows)
 }
 
 func (c *client) InstallClusterServiceFlows() error {

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -35,6 +35,7 @@ import (
 const (
 	// Flow table id index
 	ClassifierTable       binding.TableIDType = 0
+	uplinkTable           binding.TableIDType = 5
 	spoofGuardTable       binding.TableIDType = 10
 	arpResponderTable     binding.TableIDType = 20
 	serviceHairpinTable   binding.TableIDType = 29
@@ -80,6 +81,7 @@ var (
 		Name   string
 	}{
 		{ClassifierTable, "Classification"},
+		{uplinkTable, "Uplink"},
 		{spoofGuardTable, "SpoofGuard"},
 		{arpResponderTable, "ARPResponder"},
 		{serviceHairpinTable, "ServiceHairpin"},
@@ -346,13 +348,17 @@ func (c *client) podClassifierFlow(podOFPort uint32, category cookie.Category) b
 // hostBridgeUplinkFlows generates the flows that forward traffic between bridge local port and uplink port to support
 // host communicate with outside. These flows are only needed on windows platform.
 func (c *client) hostBridgeUplinkFlows(uplinkPort uint32, bridgeLocalPort uint32, category cookie.Category) (flows []binding.Flow) {
-	classifierTable := c.pipeline[ClassifierTable]
 	flows = []binding.Flow{
-		classifierTable.BuildFlow(priorityLow).MatchInPort(uplinkPort).
+		c.pipeline[ClassifierTable].BuildFlow(priorityNormal).
+			MatchInPort(uplinkPort).
+			Action().GotoTable(uplinkTable).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+		c.pipeline[uplinkTable].BuildFlow(priorityMiss).
 			Action().Output(int(bridgeLocalPort)).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done(),
-		classifierTable.BuildFlow(priorityNormal).MatchInPort(bridgeLocalPort).
+		c.pipeline[ClassifierTable].BuildFlow(priorityNormal).MatchInPort(bridgeLocalPort).
 			Action().Output(int(uplinkPort)).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done(),
@@ -960,9 +966,8 @@ func (c *client) bridgeAndUplinkFlows(uplinkOfport uint32, bridgeLocalPort uint3
 	}
 	flows := []binding.Flow{
 		// Forward the packet to conntrackTable if it enters the OVS pipeline from the uplink interface.
-		c.pipeline[ClassifierTable].BuildFlow(priorityNormal).
+		c.pipeline[uplinkTable].BuildFlow(priorityNormal).
 			MatchProtocol(binding.ProtocolIP).
-			MatchInPort(uplinkOfport).
 			Action().LoadRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
 			Action().GotoTable(conntrackTable).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
@@ -1072,6 +1077,25 @@ func (c *client) l3ToExternalFlows(nodeIP net.IP, localSubnet net.IPNet, outputP
 			Done(),
 	}
 	return flows
+}
+
+// loadBalancerServiceFromOutsideFlow generates the flow to forward LoadBalancer service traffic from outside node
+// to gateway. kube-proxy will then handle the traffic.
+func (c *client) loadBalancerServiceFromOutsideFlow(uplinkPort uint32, gwPort uint32, svcIP net.IP, svcPort uint16, protocol binding.Protocol) binding.Flow {
+	flowBuilder := c.pipeline[uplinkTable].BuildFlow(priorityHigh)
+	if protocol == binding.ProtocolTCP {
+		flowBuilder = flowBuilder.MatchTCPDstPort(svcPort)
+	} else if protocol == binding.ProtocolUDP {
+		flowBuilder = flowBuilder.MatchUDPDstPort(svcPort)
+	} else if protocol == binding.ProtocolSCTP {
+		flowBuilder = flowBuilder.MatchSCTPDstPort(svcPort)
+	}
+	return flowBuilder.
+		MatchInPort(uplinkPort).
+		MatchDstIP(svcIP).
+		Action().Output(int(gwPort)).
+		Cookie(c.cookieAllocator.Request(cookie.Service).Raw()).
+		Done()
 }
 
 // serviceLearnFlow generates the flow with learn action which adds new flows in
@@ -1214,6 +1238,7 @@ func generatePipeline(bridge binding.Bridge, enableProxy bool) map[binding.Table
 	if enableProxy {
 		return map[binding.TableIDType]binding.Table{
 			ClassifierTable:       bridge.CreateTable(ClassifierTable, spoofGuardTable, binding.TableMissActionDrop),
+			uplinkTable:           bridge.CreateTable(uplinkTable, spoofGuardTable, binding.TableMissActionNone),
 			spoofGuardTable:       bridge.CreateTable(spoofGuardTable, serviceHairpinTable, binding.TableMissActionDrop),
 			arpResponderTable:     bridge.CreateTable(arpResponderTable, binding.LastTableID, binding.TableMissActionDrop),
 			serviceHairpinTable:   bridge.CreateTable(serviceHairpinTable, conntrackTable, binding.TableMissActionNext),

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -307,6 +307,20 @@ func (mr *MockClientMockRecorder) InstallGatewayFlows(arg0, arg1, arg2 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallGatewayFlows", reflect.TypeOf((*MockClient)(nil).InstallGatewayFlows), arg0, arg1, arg2)
 }
 
+// InstallLoadBalancerServiceFromOutsideFlows mocks base method
+func (m *MockClient) InstallLoadBalancerServiceFromOutsideFlows(arg0 net.IP, arg1 uint16, arg2 openflow.Protocol) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallLoadBalancerServiceFromOutsideFlows", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallLoadBalancerServiceFromOutsideFlows indicates an expected call of InstallLoadBalancerServiceFromOutsideFlows
+func (mr *MockClientMockRecorder) InstallLoadBalancerServiceFromOutsideFlows(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallLoadBalancerServiceFromOutsideFlows", reflect.TypeOf((*MockClient)(nil).InstallLoadBalancerServiceFromOutsideFlows), arg0, arg1, arg2)
+}
+
 // InstallNodeFlows mocks base method
 func (m *MockClient) InstallNodeFlows(arg0 string, arg1 net.HardwareAddr, arg2 net.IPNet, arg3, arg4 net.IP, arg5, arg6 uint32) error {
 	m.ctrl.T.Helper()

--- a/pkg/agent/proxy/proxier_linux.go
+++ b/pkg/agent/proxy/proxier_linux.go
@@ -1,0 +1,35 @@
+// +build !windows
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"net"
+
+	"k8s.io/klog"
+
+	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
+)
+
+// installLoadBalancerServiceFlows install OpenFlow entries for LoadBalancer Service.
+// The rules for traffic from local Pod to LoadBalancer Service are same with rules for Cluster Service.
+// For the LoadBalancer Service traffic from outside, kube-proxy will handle it.
+func (p *Proxier) installLoadBalancerServiceFlows(groupID binding.GroupIDType, svcIP net.IP, svcPort uint16, protocol binding.Protocol, affinityTimeout uint16) error {
+	if err := p.ofClient.InstallServiceFlows(groupID, svcIP, svcPort, protocol, affinityTimeout); err != nil {
+		klog.Errorf("Error when installing LoadBalancer Service flows: %v", err)
+		return err
+	}
+	return nil
+}

--- a/pkg/agent/proxy/proxier_windows.go
+++ b/pkg/agent/proxy/proxier_windows.go
@@ -1,0 +1,40 @@
+// +build windows
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"net"
+
+	"k8s.io/klog"
+
+	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
+)
+
+// installLoadBalancerServiceFlows installs OpenFlow entries for LoadBalancer Service.
+// The rules for traffic from local Pod to LoadBalancer Service are the same with rules for Cluster Service.
+// For the LoadBalancer Service traffic from outside, specific rules are install to forward the packets
+// to the host network to let kube-proxy handle the traffic.
+func (p *Proxier) installLoadBalancerServiceFlows(groupID binding.GroupIDType, svcIP net.IP, svcPort uint16, protocol binding.Protocol, affinityTimeout uint16) error {
+	if err := p.ofClient.InstallServiceFlows(groupID, svcIP, svcPort, protocol, affinityTimeout); err != nil {
+		klog.Errorf("Error when installing LoadBalancer Service flows: %v", err)
+		return err
+	}
+	if err := p.ofClient.InstallLoadBalancerServiceFromOutsideFlows(svcIP, svcPort, protocol); err != nil {
+		klog.Errorf("Error when installing LoadBalancer Service flows: %v", err)
+		return err
+	}
+	return nil
+}

--- a/pkg/agent/proxy/types/types.go
+++ b/pkg/agent/proxy/types/types.go
@@ -32,7 +32,8 @@ func (si *ServiceInfo) Equal(bSvcInfo *ServiceInfo) bool {
 	return si.SessionAffinityType() == bSvcInfo.SessionAffinityType() &&
 		si.StickyMaxAgeSeconds() == bSvcInfo.StickyMaxAgeSeconds() &&
 		si.OFProtocol == bSvcInfo.OFProtocol &&
-		si.Port() == bSvcInfo.Port()
+		si.Port() == bSvcInfo.Port() &&
+		len(si.LoadBalancerIPStrings()) == len(bSvcInfo.LoadBalancerIPStrings())
 }
 
 // NewServiceInfo returns a new k8sproxy.ServicePort which abstracts a serviceInfo.

--- a/test/e2e/bandwidth_test.go
+++ b/test/e2e/bandwidth_test.go
@@ -60,7 +60,7 @@ func benchmarkBandwidthService(t *testing.T, endpointNode, clientNode string) {
 	}
 	defer teardownTest(t, data)
 
-	svc, err := data.createService("perftest-b", iperfPort, iperfPort, map[string]string{"antrea-e2e": "perftest-b"}, false)
+	svc, err := data.createService("perftest-b", iperfPort, iperfPort, map[string]string{"antrea-e2e": "perftest-b"}, false, v1.ServiceTypeClusterIP)
 	if err != nil {
 		t.Fatalf("Error when creating perftest service: %v", err)
 	}

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -27,6 +27,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type expectTableFlows struct {
+	tableID int
+	flows   []string
+}
+
 func skipIfProxyDisabled(t *testing.T, data *TestData) {
 	if enabled, err := proxyEnabled(data); err != nil {
 		t.Fatalf("Error when detecting proxy: %v", err)
@@ -60,18 +65,29 @@ func TestProxyServiceSessionAffinity(t *testing.T) {
 	nginxIP, err := data.podWaitForIP(defaultTimeout, "nginx", testNamespace)
 	require.NoError(t, err)
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, "nginx", testNamespace))
-	svc, err := data.createNginxService(true)
+	svc, err := data.createNginxClusterIPService(true)
+	require.NoError(t, err)
+	ingressIPs := []string{"169.254.169.253", "169.254.169.254"}
+	_, err = data.createNginxLoadBalancerService(false, ingressIPs)
 	require.NoError(t, err)
 	require.NoError(t, data.createBusyboxPodOnNode("busybox", nodeName))
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, "busybox", testNamespace))
 	stdout, stderr, err := data.runCommandFromPod(testNamespace, "busybox", busyboxContainerName, []string{"wget", "-O", "-", svc.Spec.ClusterIP, "-T", "1"})
 	require.NoError(t, err, fmt.Sprintf("stdout: %s\n, stderr: %s", stdout, stderr))
+	for _, ingressIP := range ingressIPs {
+		stdout, stderr, err := data.runCommandFromPod(testNamespace, "busybox", busyboxContainerName, []string{"wget", "-O", "-", ingressIP, "-T", "1"})
+		require.NoError(t, err, fmt.Sprintf("stdout: %s\n, stderr: %s", stdout, stderr))
+	}
+
 	agentName, err := data.getAntreaPodOnNode(nodeName)
 	require.NoError(t, err)
 	table40Output, _, err := data.runCommandFromPod(metav1.NamespaceSystem, agentName, "antrea-agent", []string{"ovs-ofctl", "dump-flows", defaultBridgeName, "table=40"})
 	require.NoError(t, err)
 	require.Contains(t, table40Output, fmt.Sprintf("nw_dst=%s,tp_dst=80", svc.Spec.ClusterIP))
 	require.Contains(t, table40Output, fmt.Sprintf("load:0x%s->NXM_NX_REG3[]", strings.TrimLeft(hex.EncodeToString(net.ParseIP(nginxIP).To4()), "0")))
+	for _, ingressIP := range ingressIPs {
+		require.Contains(t, table40Output, fmt.Sprintf("nw_dst=%s,tp_dst=80", ingressIP))
+	}
 }
 
 func TestProxyHairpin(t *testing.T) {
@@ -87,7 +103,7 @@ func TestProxyHairpin(t *testing.T) {
 	err = data.createPodOnNode("busybox", nodeName, "busybox", []string{"nc", "-lk", "-p", "80"}, nil, nil, []v1.ContainerPort{{ContainerPort: 80, Protocol: v1.ProtocolTCP}})
 	require.NoError(t, err)
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, "busybox", testNamespace))
-	svc, err := data.createService("busybox", 80, 80, map[string]string{"antrea-e2e": "busybox"}, false)
+	svc, err := data.createService("busybox", 80, 80, map[string]string{"antrea-e2e": "busybox"}, false, v1.ServiceTypeClusterIP)
 	require.NoError(t, err)
 	stdout, stderr, err := data.runCommandFromPod(testNamespace, "busybox", busyboxContainerName, []string{"nc", svc.Spec.ClusterIP, "80", "-w", "1", "-e", "ls", "/"})
 	require.NoError(t, err, fmt.Sprintf("stdout: %s\n, stderr: %s", stdout, stderr))
@@ -106,7 +122,7 @@ func TestProxyEndpointLifeCycle(t *testing.T) {
 	require.NoError(t, data.createNginxPod("nginx", nodeName))
 	nginxIP, err := data.podWaitForIP(defaultTimeout, "nginx", testNamespace)
 	require.NoError(t, err)
-	_, err = data.createNginxService(false)
+	_, err = data.createNginxClusterIPService(false)
 	require.NoError(t, err)
 	agentName, err := data.getAntreaPodOnNode(nodeName)
 	require.NoError(t, err)
@@ -143,34 +159,54 @@ func TestProxyServiceLifeCycle(t *testing.T) {
 	require.NoError(t, data.createNginxPod("nginx", nodeName))
 	nginxIP, err := data.podWaitForIP(defaultTimeout, "nginx", testNamespace)
 	require.NoError(t, err)
-	svc, err := data.createNginxService(false)
+	svc, err := data.createNginxClusterIPService(false)
+	require.NoError(t, err)
+	ingressIPs := []string{"169.254.169.253", "169.254.169.254"}
+	_, err = data.createNginxLoadBalancerService(false, ingressIPs)
 	require.NoError(t, err)
 	agentName, err := data.getAntreaPodOnNode(nodeName)
 	require.NoError(t, err)
 
-	keywords := map[int]string{
-		41: fmt.Sprintf("nw_dst=%s,tp_dst=80", svc.Spec.ClusterIP), // serviceLBTable
-		42: fmt.Sprintf("nat(dst=%s:80)", nginxIP),                 // endpointNATTable
+	svcLBflows := make([]string, len(ingressIPs)+1)
+	svcLBflows[0] = fmt.Sprintf("nw_dst=%s,tp_dst=80", svc.Spec.ClusterIP)
+	for idx, ingressIP := range ingressIPs {
+		svcLBflows[idx+1] = fmt.Sprintf("nw_dst=%s,tp_dst=80", ingressIP)
 	}
+	expectedFlows := []expectTableFlows{
+		{
+			41, // serviceLBTable
+			svcLBflows,
+		},
+		{
+			42,
+			[]string{fmt.Sprintf("nat(dst=%s:80)", nginxIP)}, // endpointNATTable
+		},
+	}
+
 	groupKeyword := fmt.Sprintf("load:0x%s->NXM_NX_REG3[],load:0x%x->NXM_NX_REG4[0..15],load:0x2->NXM_NX_REG4[16..18]", strings.TrimLeft(string(hex.EncodeToString(net.ParseIP(nginxIP).To4())), "0"), 80)
 	groupOutput, _, err := data.runCommandFromPod(metav1.NamespaceSystem, agentName, "antrea-agent", []string{"ovs-ofctl", "dump-groups", defaultBridgeName})
 	require.NoError(t, err)
 	require.Contains(t, groupOutput, groupKeyword)
-	for tableID, keyword := range keywords {
-		tableOutput, _, err := data.runCommandFromPod(metav1.NamespaceSystem, agentName, "antrea-agent", []string{"ovs-ofctl", "dump-flows", defaultBridgeName, fmt.Sprintf("table=%d", tableID)})
+	for _, expectedTable := range expectedFlows {
+		tableOutput, _, err := data.runCommandFromPod(metav1.NamespaceSystem, agentName, "antrea-agent", []string{"ovs-ofctl", "dump-flows", defaultBridgeName, fmt.Sprintf("table=%d", expectedTable.tableID)})
 		require.NoError(t, err)
-		require.Contains(t, tableOutput, keyword)
+		for _, expectedFlow := range expectedTable.flows {
+			require.Contains(t, tableOutput, expectedFlow)
+		}
 	}
 
 	require.NoError(t, data.deleteService("nginx"))
+	require.NoError(t, data.deleteService("nginx-loadbalancer"))
 	time.Sleep(time.Second)
 
 	groupOutput, _, err = data.runCommandFromPod(metav1.NamespaceSystem, agentName, "antrea-agent", []string{"ovs-ofctl", "dump-groups", defaultBridgeName})
 	require.NoError(t, err)
 	require.NotContains(t, groupOutput, groupKeyword)
-	for tableID, keyword := range keywords {
-		tableOutput, _, err := data.runCommandFromPod(metav1.NamespaceSystem, agentName, "antrea-agent", []string{"ovs-ofctl", "dump-flows", defaultBridgeName, fmt.Sprintf("table=%d", tableID)})
+	for _, expectedTable := range expectedFlows {
+		tableOutput, _, err := data.runCommandFromPod(metav1.NamespaceSystem, agentName, "antrea-agent", []string{"ovs-ofctl", "dump-flows", defaultBridgeName, fmt.Sprintf("table=%d", expectedTable.tableID)})
 		require.NoError(t, err)
-		require.NotContains(t, tableOutput, keyword)
+		for _, expectedFlow := range expectedTable.flows {
+			require.NotContains(t, tableOutput, expectedFlow)
+		}
 	}
 }

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -794,12 +794,17 @@ func prepareExternalFlows(nodeIP net.IP, localSubnet *net.IPNet) []expectTableFl
 			uint8(0),
 			[]*ofTestUtils.ExpectFlow{
 				{
-					fmt.Sprintf("priority=200,ip,in_port=%d", config1.UplinkOFPort),
-					"load:0x4->NXM_NX_REG0[0..15],goto_table:30",
-				},
-				{
 					fmt.Sprintf("priority=210,ip,in_port=LOCAL,nw_dst=%s", localSubnet.String()),
 					"set_field:aa:bb:cc:dd:ee:ff->eth_dst,goto_table:30",
+				},
+			},
+		},
+		{
+			uint8(5),
+			[]*ofTestUtils.ExpectFlow{
+				{
+					fmt.Sprintf("priority=200,ip"),
+					"load:0x4->NXM_NX_REG0[0..15],goto_table:30",
 				},
 			},
 		},


### PR DESCRIPTION
Support handle LoadBalancer Service traffic:
- Install loadbalancing OpenFlow entires for Pod to LoadBalancer
  Service traffic. The traffic handling logic is same with the
  existing logic for ClusterService.
- Install OpenFlow entires for LoadBalancer Service traffic from
  outside. The traffic is forwarded antrea gateway, and then
  kube-proxy will handle the traffic.
- Add new OpenFlow table "UplinkTable" to place OpenFlow entries
  which are used to handle packtes received from uplink port.