### PR TITLE
[Windows] Set rewrite-MAC mark for NodePort Service packet

### DIFF
--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -968,12 +968,13 @@ func (c *client) bridgeAndUplinkFlows(uplinkOfport uint32, bridgeLocalPort uint3
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done(),
 		// Forward the packet to conntrackTable if it enters the OVS pipeline from the bridge interface and is sent to
-		// local Pods.
+		// local Pods. Set the packet with MAC rewrite mark, so that the dstMAC will be re-written with real MAC in
+		// the L3Routing table, and it could be forwarded to the valid OVS interface.
 		c.pipeline[ClassifierTable].BuildFlow(priorityHigh).
 			MatchProtocol(binding.ProtocolIP).
 			MatchInPort(bridgeLocalPort).
 			MatchDstIPNet(localSubnet).
-			Action().SetDstMAC(globalVirtualMAC).
+			Action().LoadRegRange(int(marksReg), macRewriteMark, macRewriteMarkRange).
 			Action().GotoTable(conntrackTable).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done(),

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -799,7 +799,7 @@ func prepareExternalFlows(nodeIP net.IP, localSubnet *net.IPNet) []expectTableFl
 				},
 				{
 					fmt.Sprintf("priority=210,ip,in_port=LOCAL,nw_dst=%s", localSubnet.String()),
-					"set_field:aa:bb:cc:dd:ee:ff->eth_dst,goto_table:30",
+					"load:0x1->NXM_NX_REG0[19],goto_table:30",
 				},
 			},
 		},


### PR DESCRIPTION
Set the packet with rewrite-MAC mark if it enters OVS from bridge interface,
and targets at local Pods, so that the packet's dst MAC could be re-written
in L3Routing table with the correct value.

Fixes #947 