### PR TITLE
Add additional fields to kubectl get traceflow

### DIFF
--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -167,6 +167,29 @@ metadata:
     app: antrea
   name: traceflows.ops.antrea.tanzu.vmware.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: The phase of the Traceflow.
+    name: Phase
+    type: string
+  - JSONPath: .spec.source.pod
+    description: The name of the source Pod.
+    name: Source-Pod
+    priority: 10
+    type: string
+  - JSONPath: .spec.destination.pod
+    description: The name of the destination Pod.
+    name: Destination-Pod
+    priority: 10
+    type: string
+  - JSONPath: .spec.destination.ip
+    description: The IP address of the destination.
+    name: Destination-IP
+    priority: 10
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: ops.antrea.tanzu.vmware.com
   names:
     kind: Traceflow

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -167,6 +167,29 @@ metadata:
     app: antrea
   name: traceflows.ops.antrea.tanzu.vmware.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: The phase of the Traceflow.
+    name: Phase
+    type: string
+  - JSONPath: .spec.source.pod
+    description: The name of the source Pod.
+    name: Source-Pod
+    priority: 10
+    type: string
+  - JSONPath: .spec.destination.pod
+    description: The name of the destination Pod.
+    name: Destination-Pod
+    priority: 10
+    type: string
+  - JSONPath: .spec.destination.ip
+    description: The IP address of the destination.
+    name: Destination-IP
+    priority: 10
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: ops.antrea.tanzu.vmware.com
   names:
     kind: Traceflow

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -167,6 +167,29 @@ metadata:
     app: antrea
   name: traceflows.ops.antrea.tanzu.vmware.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: The phase of the Traceflow.
+    name: Phase
+    type: string
+  - JSONPath: .spec.source.pod
+    description: The name of the source Pod.
+    name: Source-Pod
+    priority: 10
+    type: string
+  - JSONPath: .spec.destination.pod
+    description: The name of the destination Pod.
+    name: Destination-Pod
+    priority: 10
+    type: string
+  - JSONPath: .spec.destination.ip
+    description: The IP address of the destination.
+    name: Destination-IP
+    priority: 10
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: ops.antrea.tanzu.vmware.com
   names:
     kind: Traceflow

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -167,6 +167,29 @@ metadata:
     app: antrea
   name: traceflows.ops.antrea.tanzu.vmware.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: The phase of the Traceflow.
+    name: Phase
+    type: string
+  - JSONPath: .spec.source.pod
+    description: The name of the source Pod.
+    name: Source-Pod
+    priority: 10
+    type: string
+  - JSONPath: .spec.destination.pod
+    description: The name of the destination Pod.
+    name: Destination-Pod
+    priority: 10
+    type: string
+  - JSONPath: .spec.destination.ip
+    description: The IP address of the destination.
+    name: Destination-IP
+    priority: 10
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: ops.antrea.tanzu.vmware.com
   names:
     kind: Traceflow

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -52,6 +52,29 @@ spec:
     kind: Traceflow
     shortNames:
       - tf
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: The phase of the Traceflow.
+    name: Phase
+    type: string
+  - JSONPath: .spec.source.pod
+    description: The name of the source Pod.
+    name: Source-Pod
+    type: string
+    priority: 10
+  - JSONPath: .spec.destination.pod
+    description: The name of the destination Pod.
+    name: Destination-Pod
+    type: string
+    priority: 10
+  - JSONPath: .spec.destination.ip
+    description: The IP address of the destination.
+    name: Destination-IP
+    type: string
+    priority: 10
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   # Prune any unknown fields
   preserveUnknownFields: false
   validation:


### PR DESCRIPTION
Add Phase as part of `kubectl get` output. In addition to that, add source-pod, destination-pod and destination-ip as wide
option output for `kubectl get -o`.
```
kubectl get tf tf1
NAME   PHASE    AGE
tf1    Failed   44s
```

```
kubectl get tf tf1 -o wide
NAME   PHASE     SOURCE-POD   DESTINATION-POD   DESTINATION-IP   AGE
tf1    Running   appdns       appserver                          4s
```
