### PR TITLE
Use pgrep instead of pidof in E2E test

### DIFF
--- a/test/e2e/batch_test.go
+++ b/test/e2e/batch_test.go
@@ -38,7 +38,7 @@ func TestBatchCreatePods(t *testing.T) {
 
 	getFDs := func() string {
 		// In case that antrea-agent is not running as Pid 1 in future.
-		cmds := []string{"pidof", "antrea-agent"}
+		cmds := []string{"pgrep", "-o", "antrea-agent"}
 		pid, _, err := data.runCommandFromPod(antreaNamespace, podName, "antrea-agent", cmds)
 		assert.NoError(t, err)
 


### PR DESCRIPTION
pgrep is provided in Ubuntu and Debian by default. pidof is provided by
the sysvinit-utils package, which is not available in Debian. Use of
pgrep will allow downstream to repackage Antrea agent into various
distributions and still re-using the E2E test.