### PR TITLE
Support service destination in traceflow

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -224,6 +224,9 @@ spec:
                 - pod
                 - namespace
               - required:
+                - service
+                - namespace
+              - required:
                 - ip
               properties:
                 ip:
@@ -232,6 +235,8 @@ spec:
                 namespace:
                   type: string
                 pod:
+                  type: string
+                service:
                   type: string
               type: object
             packet:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -224,6 +224,9 @@ spec:
                 - pod
                 - namespace
               - required:
+                - service
+                - namespace
+              - required:
                 - ip
               properties:
                 ip:
@@ -232,6 +235,8 @@ spec:
                 namespace:
                   type: string
                 pod:
+                  type: string
+                service:
                   type: string
               type: object
             packet:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -224,6 +224,9 @@ spec:
                 - pod
                 - namespace
               - required:
+                - service
+                - namespace
+              - required:
                 - ip
               properties:
                 ip:
@@ -232,6 +235,8 @@ spec:
                 namespace:
                   type: string
                 pod:
+                  type: string
+                service:
                   type: string
               type: object
             packet:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -224,6 +224,9 @@ spec:
                 - pod
                 - namespace
               - required:
+                - service
+                - namespace
+              - required:
                 - ip
               properties:
                 ip:
@@ -232,6 +235,8 @@ spec:
                 namespace:
                   type: string
                 pod:
+                  type: string
+                service:
                   type: string
               type: object
             packet:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -224,6 +224,9 @@ spec:
                 - pod
                 - namespace
               - required:
+                - service
+                - namespace
+              - required:
                 - ip
               properties:
                 ip:
@@ -232,6 +235,8 @@ spec:
                 namespace:
                   type: string
                 pod:
+                  type: string
+                service:
                   type: string
               type: object
             packet:

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -104,6 +104,8 @@ spec:
               properties:
                 pod:
                   type: string
+                service:
+                  type: string
                 namespace:
                   type: string
                 ip:
@@ -111,6 +113,7 @@ spec:
                   format: ipv4
               oneOf:
                 - required: ["pod", "namespace"]
+                - required: ["service", "namespace"]
                 - required: ["ip"]
             packet:
               type: object

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -138,6 +138,7 @@ func run(o *Options) error {
 	if features.DefaultFeatureGate.Enabled(features.Traceflow) {
 		traceflowController = traceflow.NewTraceflowController(
 			k8sClient,
+			informerFactory,
 			crdClient,
 			traceflowInformer,
 			ofClient,

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -93,7 +93,7 @@ func run(o *Options) error {
 
 	var traceflowController *traceflow.Controller
 	if features.DefaultFeatureGate.Enabled(features.Traceflow) {
-		traceflowController = traceflow.NewTraceflowController(crdClient, traceflowInformer)
+		traceflowController = traceflow.NewTraceflowController(crdClient, podInformer, traceflowInformer)
 	}
 
 	apiServerConfig, err := createAPIServerConfig(o.config.ClientConnection.Kubeconfig,


### PR DESCRIPTION
Result example:
```
    results:
    - node: gran-k8s0-1
      observations:
      - action: Forwarded
        component: SpoofGuard
      - action: Forwarded
        component: LB
        pod: kube-system/antrea-octant-7cb57d66bc-vtvmz
        translatedDstIP: 192.168.0.69
      - action: Forwarded
        component: NetworkPolicy
        componentInfo: EgressRule
        networkPolicy: default/allow-all
      - action: Forwarded
        component: Forwarding
        componentInfo: Output
        tunnelDstIP: 10.176.26.135
      timestamp: 1595490479
```
