### PR TITLE
Add finding destination MAC by IP in traceflow

### DIFF
--- a/pkg/agent/controller/traceflow/traceflow_controller.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller.go
@@ -274,8 +274,12 @@ func (c *Controller) injectPacket(tf *opsv1alpha1.Traceflow) error {
 	dstMAC := ""
 	dstIP := tf.Spec.Destination.IP
 	dstNodeIP := ""
-	// TODO: Find MAC by dstIP
-	if dstIP == "" {
+	if dstIP != "" {
+		dstPodInterface, hasInterface := c.interfaceStore.GetInterfaceByIP(dstIP)
+		if hasInterface {
+			dstMAC = dstPodInterface.MAC.String()
+		}
+	} else {
 		dstPodInterfaces := c.interfaceStore.GetContainerInterfacesByPod(tf.Spec.Destination.Pod, tf.Spec.Destination.Namespace)
 		if len(dstPodInterfaces) > 0 {
 			dstMAC = dstPodInterfaces[0].MAC.String()


### PR DESCRIPTION
Find the destination MAC in traceflow controller by destination IP via local cache.

Solved a TODO in traceflow. Testing accepted on local machine.