### PR TITLE
[CNP] Agent CNP Tier Support

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -675,8 +675,14 @@ data:
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
     # Service traffic.
       AntreaProxy: true
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: false
+
+    # Enable ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
+    # to define security policies which apply to the entire cluster.
+    #  ClusterNetworkPolicy: false
+
     # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each agent to a configured collector.
     #  FlowExporter: false
 
@@ -794,7 +800,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-62554ht95b
+  name: antrea-config-m7ktkktgdg
   namespace: kube-system
 ---
 apiVersion: v1
@@ -900,7 +906,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-62554ht95b
+          name: antrea-config-m7ktkktgdg
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1115,7 +1121,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-62554ht95b
+          name: antrea-config-m7ktkktgdg
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -675,8 +675,14 @@ data:
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
     # Service traffic.
       AntreaProxy: true
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: false
+
+    # Enable ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
+    # to define security policies which apply to the entire cluster.
+    #  ClusterNetworkPolicy: false
+
     # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each agent to a configured collector.
     #  FlowExporter: false
 
@@ -794,7 +800,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-62554ht95b
+  name: antrea-config-m7ktkktgdg
   namespace: kube-system
 ---
 apiVersion: v1
@@ -900,7 +906,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-62554ht95b
+          name: antrea-config-m7ktkktgdg
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1117,7 +1123,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-62554ht95b
+          name: antrea-config-m7ktkktgdg
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -675,8 +675,14 @@ data:
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
     # Service traffic.
       AntreaProxy: true
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: false
+
+    # Enable ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
+    # to define security policies which apply to the entire cluster.
+    #  ClusterNetworkPolicy: false
+
     # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each agent to a configured collector.
     #  FlowExporter: false
 
@@ -794,7 +800,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-9gt8khtcth
+  name: antrea-config-khb8f44hh6
   namespace: kube-system
 ---
 apiVersion: v1
@@ -900,7 +906,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-9gt8khtcth
+          name: antrea-config-khb8f44hh6
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1115,7 +1121,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-9gt8khtcth
+          name: antrea-config-khb8f44hh6
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -675,8 +675,14 @@ data:
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
     # Service traffic.
     #  AntreaProxy: false
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: false
+
+    # Enable ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
+    # to define security policies which apply to the entire cluster.
+    #  ClusterNetworkPolicy: false
+
     # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each agent to a configured collector.
     #  FlowExporter: false
 
@@ -794,7 +800,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-gf96hhfdg8
+  name: antrea-config-92kk9hc82g
   namespace: kube-system
 ---
 apiVersion: v1
@@ -909,7 +915,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-gf96hhfdg8
+          name: antrea-config-92kk9hc82g
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1159,7 +1165,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-gf96hhfdg8
+          name: antrea-config-92kk9hc82g
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -675,8 +675,14 @@ data:
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
     # Service traffic.
     #  AntreaProxy: false
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: false
+
+    # Enable ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
+    # to define security policies which apply to the entire cluster.
+    #  ClusterNetworkPolicy: false
+
     # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each agent to a configured collector.
     #  FlowExporter: false
 
@@ -794,7 +800,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-mk822kf995
+  name: antrea-config-fg74hdgb78
   namespace: kube-system
 ---
 apiVersion: v1
@@ -900,7 +906,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-mk822kf995
+          name: antrea-config-fg74hdgb78
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1115,7 +1121,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-mk822kf995
+          name: antrea-config-fg74hdgb78
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -4,8 +4,14 @@ featureGates:
 # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
 # Service traffic.
 #  AntreaProxy: false
+
 # Enable traceflow which provides packet tracing feature to diagnose network issue.
 #  Traceflow: false
+
+# Enable ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
+# to define security policies which apply to the entire cluster.
+#  ClusterNetworkPolicy: false
+
 # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each agent to a configured collector.
 #  FlowExporter: false
 

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -91,7 +91,9 @@ func run(o *Options) error {
 
 	ovsBridgeClient := ovsconfig.NewOVSBridge(o.config.OVSBridge, o.config.OVSDatapathType, ovsdbConnection)
 	ovsBridgeMgmtAddr := ofconfig.GetMgmtAddress(o.config.OVSRunDir, o.config.OVSBridge)
-	ofClient := openflow.NewClient(o.config.OVSBridge, ovsBridgeMgmtAddr, features.DefaultFeatureGate.Enabled(features.AntreaProxy))
+	ofClient := openflow.NewClient(o.config.OVSBridge, ovsBridgeMgmtAddr,
+		features.DefaultFeatureGate.Enabled(features.AntreaProxy),
+		features.DefaultFeatureGate.Enabled(features.ClusterNetworkPolicy))
 
 	_, serviceCIDRNet, _ := net.ParseCIDR(o.config.ServiceCIDR)
 	_, encapMode := config.GetTrafficEncapModeFromStr(o.config.TrafficEncapMode)

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -181,6 +181,7 @@ fi
 
 if $NP; then
     sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*ClusterNetworkPolicy[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/  ClusterNetworkPolicy: true/" antrea-controller.conf
+    sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*ClusterNetworkPolicy[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/  ClusterNetworkPolicy: true/" antrea-agent.conf
 fi
 
 if [[ $ENCAP_MODE != "" ]]; then

--- a/pkg/agent/controller/networkpolicy/cache.go
+++ b/pkg/agent/controller/networkpolicy/cache.go
@@ -62,11 +62,11 @@ type rule struct {
 	Services []v1beta1.Service
 	// Action of this rule. nil for k8s NetworkPolicy.
 	Action *secv1alpha1.RuleAction
-	// Priority of this rule within the NetworkPolicy. Defaults to -1 for k8s NetworkPolicy.
+	// Priority of this rule within the NetworkPolicy. Defaults to -1 for K8s NetworkPolicy.
 	Priority int32
-	// Priority of the NetworkPolicy to which this rule belong. nil for k8s NetworkPolicy.
+	// Priority of the NetworkPolicy to which this rule belong. nil for K8s NetworkPolicy.
 	PolicyPriority *float64
-	// Priority of the tier that the NetworkPolicy belong. nil for k8s NetworkPolicy.
+	// Priority of the tier that the NetworkPolicy belongs to. nil for K8s NetworkPolicy.
 	TierPriority *v1beta1.TierPriority
 	// Targets of this rule.
 	AppliedToGroups []string

--- a/pkg/agent/controller/networkpolicy/cache.go
+++ b/pkg/agent/controller/networkpolicy/cache.go
@@ -115,7 +115,7 @@ func (r *CompletedRule) String() string {
 
 // isAntreaNetworkPolicyRule returns true if the rule is part of a ClusterNetworkPolicy.
 func (r *CompletedRule) isAntreaNetworkPolicyRule() bool {
-	return r.PolicyPriority != nil && r.TierPriority != nil
+	return r.PolicyPriority != nil
 }
 
 // ruleCache caches Antrea AddressGroups, AppliedToGroups and NetworkPolicies,

--- a/pkg/agent/controller/networkpolicy/priority.go
+++ b/pkg/agent/controller/networkpolicy/priority.go
@@ -26,125 +26,236 @@ import (
 
 const (
 	PriorityBottomCNP     = uint16(100)
-	InitialPriorityOffset = uint16(130)
+	PriorityTopCNP        = uint16(65000)
+	InitialPriorityOffset = uint16(640)
 	InitialPriorityZones  = 100
-	DefaultTierStart      = uint16(13100)
 )
 
-// priorityAssigner is a struct that maintains the current boundaries of
-// all ClusterNetworkPolicy categories/priorities and rule priorities, and knows
-// how to re-assign priorities if certain section overflows.
-type priorityAssigner struct {
-	// priorityMap maintains the current mapping between a known CNP priority to OF priority.
-	priorityMap map[types.Priority]uint16
-	// priorityOffset stores the current size of a priority zone.
-	// When tiering is introduced, each tier will keep its own priorityOffset.
-	priorityOffset uint16
-	// numPriorityZones stores the current number of numPriorityZones (within the default tier).
-	// When tiering is introduced, each tier will keep its own numPriorityZones.
-	numPriorityZones int32
+// InitialOFPriorityGetter is a function that will map types.Priority to a specific initial OpenFlow
+// priority on a table. It is used to space out the priorities in the OVS table and provide a initial
+// "guess" on the OpenFlow priority that can be assigned to the input Priority. If that OpenFlow
+// priority is not available, getInsertionPoint of priorityAssigner will then search for the appropriate
+// OpenFlow priority to insert the input Priority.
+type InitialOFPriorityGetter func(p types.Priority) uint16
+
+// InitialOFPrioritySingleTierPerTable is a InitialOFPriorityGetter that can be used by OVS tables
+// handling only one ANP/CNP Tier. It roughly divides the table into 100 zones and computes the initial
+// OpenFlow priority based on rule priority.
+func InitialOFPrioritySingleTierPerTable(p types.Priority) uint16 {
+	priorityIndex := int32(math.Floor(p.PolicyPriority))
+	if priorityIndex > InitialPriorityZones-1 {
+		priorityIndex = InitialPriorityZones - 1
+	}
+	offset := InitialPriorityOffset*uint16(priorityIndex) + uint16(p.RulePriority)
+	return PriorityTopCNP - offset + uint16(1)
 }
 
-func newPriorityAssigner() *priorityAssigner {
+// priorityAssigner is a struct that maintains the current mapping between types.Priority and
+// OpenFlow priorities in a single OVS table. It also knows how to re-assign priorities if certain section overflows.
+type priorityAssigner struct {
+	// priorityMap maintains the current mapping of known Prioriteis to OpenFlow priorities.
+	priorityMap map[types.Priority]uint16
+	// priorityMap maintains the current mapping of a OpenFlow priorities in the table to Priorities.
+	ofPriorityMap map[uint16]types.Priority
+	// sortedPriorities maintains a slice of sorted OpenFlow priorities in the table that are occupied.
+	sortedOFPriorities []uint16
+	// initialOFPriorityFunc determines the initial OpenFlow priority to be checked for input Priorities.
+	initialOFPriorityFunc InitialOFPriorityGetter
+}
+
+func newPriorityAssigner(initialOFPriorityFunc InitialOFPriorityGetter) *priorityAssigner {
 	pa := &priorityAssigner{
-		priorityMap:      map[types.Priority]uint16{},
-		priorityOffset:   InitialPriorityOffset,
-		numPriorityZones: InitialPriorityZones,
+		priorityMap:           map[types.Priority]uint16{},
+		ofPriorityMap:         map[uint16]types.Priority{},
+		sortedOFPriorities:    []uint16{},
+		initialOFPriorityFunc: initialOFPriorityFunc,
 	}
 	return pa
 }
 
-// getPriorityZoneIndex returns the priorityZone index for the given priority.
-// It maps policyPriority [0.0-1.0) to 0, [1.0-2.0) to 1 and so on so forth.
-// policyPriorities over 99.0 will be mapped to zone 99, without zone expansion for now.
-func (pa *priorityAssigner) getPriorityZoneIndex(p types.Priority) int32 {
-	floorPriority := int32(math.Floor(p.PolicyPriority))
-	if floorPriority > pa.numPriorityZones-1 {
-		floorPriority = pa.numPriorityZones - 1
+// clearOFPriority makes the input ofPriority available for the table.
+func (pa *priorityAssigner) clearOFPriority(ofPriority uint16) {
+	delete(pa.ofPriorityMap, ofPriority)
+	idxToDel := sort.Search(len(pa.sortedOFPriorities), func(i int) bool { return ofPriority <= pa.sortedOFPriorities[i] })
+	pa.sortedOFPriorities = append(pa.sortedOFPriorities[:idxToDel], pa.sortedOFPriorities[idxToDel+1:]...)
+}
+
+// updatePriorityAssignment updates the all local maps to correlate input ofPriority and Priority.
+func (pa *priorityAssigner) updatePriorityAssignment(ofPriority uint16, p types.Priority) {
+	if _, exists := pa.ofPriorityMap[ofPriority]; exists {
+		pa.clearOFPriority(ofPriority)
 	}
-	return floorPriority
+	pa.ofPriorityMap[ofPriority] = p
+	pa.priorityMap[p] = ofPriority
+	keys := append(pa.sortedOFPriorities, ofPriority)
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	pa.sortedOFPriorities = keys
 }
 
-// getPriorityZoneStart returns the starting OF priority for the priorityZone for the input.
-func (pa *priorityAssigner) getPriorityZoneStart(p types.Priority) uint16 {
-	priorityIndex := pa.getPriorityZoneIndex(p)
-	return DefaultTierStart - pa.priorityOffset*uint16(priorityIndex)
-}
-
-// getPriorityZoneSize returns the size of the priorityZone for the input.
-func (pa *priorityAssigner) getPriorityZoneSize(p types.Priority) uint16 {
-	zoneStart := pa.getPriorityZoneStart(p)
-	if zoneStart-pa.priorityOffset < PriorityBottomCNP {
-		return zoneStart - PriorityBottomCNP
+// getNextOccupiedOFPriority returns the next ofPriority that is currently occupied on the table,
+// as well as the corresponded Priority, starting from the input ofPriority.
+// Note that if the input ofPriority itself is occupied, this function will return that ofPriority
+// and the Priority that maps to it currently. The search is based on sortedOFPriorities as it assumes
+// the table is sparse in most cases.
+func (pa *priorityAssigner) getNextOccupiedOFPriority(ofPriority uint16) (*uint16, *types.Priority) {
+	idx := sort.Search(len(pa.sortedOFPriorities), func(i int) bool { return ofPriority <= pa.sortedOFPriorities[i] })
+	if idx < len(pa.sortedOFPriorities) {
+		nextOccupied := pa.sortedOFPriorities[idx]
+		priority := pa.ofPriorityMap[nextOccupied]
+		return &nextOccupied, &priority
 	}
-	return pa.priorityOffset
+	return nil, nil
 }
 
-// sortPriorities sorts a list of priorities.
-func (pa *priorityAssigner) sortPriorities(priorities []types.Priority) {
-	sort.Slice(priorities, func(i, j int) bool {
-		if priorities[i].PolicyPriority == priorities[j].PolicyPriority {
-			return priorities[i].RulePriority < priorities[j].RulePriority
+// getNextVacantOFPriority returns the next ofPriority that is currently vacant on the table,
+// starting from the input ofPriority.
+// Note that if the input ofPriority itself is vacant, it will simply return that ofPriority.
+// The search is incrementally against all ofPriorities available as it assumes the table is sparse in most cases.
+func (pa *priorityAssigner) getNextVacantOFPriority(ofPriority uint16) *uint16 {
+	for i := ofPriority; i <= PriorityTopCNP; i++ {
+		if _, exists := pa.ofPriorityMap[i]; !exists {
+			return &i
 		}
-		return priorities[i].PolicyPriority < priorities[j].PolicyPriority
-	})
+	}
+	return nil
 }
 
-// getIndexSamePriorityZone returns a list of sorted priorities that needs to be present in the same
-// priority zone of the input priority.
-func (pa *priorityAssigner) getIndexSamePriorityZone(p types.Priority) []types.Priority {
-	affected := []types.Priority{p}
-	for k := range pa.priorityMap {
-		if pa.getPriorityZoneStart(k) == pa.getPriorityZoneStart(p) {
-			affected = append(affected, k)
-		}
+// getLastOccupiedOFPriority returns the first smaller ofPriority that is currently occupied on the table,
+// as well as the corresponded Priority, starting from the input ofPriority.
+// Note that the function must return a ofPriority that is smaller than the input ofPriority.
+// The search is based on sortedOFPriorities as it assumes the table is sparse in most cases.
+func (pa *priorityAssigner) getLastOccupiedOFPriority(ofPriority uint16) (*uint16, *types.Priority) {
+	idx := sort.Search(len(pa.sortedOFPriorities), func(i int) bool { return ofPriority <= pa.sortedOFPriorities[i] })
+	if idx > 0 {
+		lastOccupied := pa.sortedOFPriorities[idx-1]
+		priority := pa.ofPriorityMap[lastOccupied]
+		return &lastOccupied, &priority
 	}
-	pa.sortPriorities(affected)
-	return affected
+	return nil, nil
 }
 
-// syncPriorityZone computes the new expected OF priorties for each priority in the same priority zone
-// of the input priority, and returns installed priorities that need to be re-assigned if necessary.
-func (pa *priorityAssigner) syncPriorityZone(p types.Priority) (*uint16, map[uint16]uint16, error) {
-
-	// newPriority is the OF priority to be assigned for a new priority.
-	// For priority Release, newPriority returned should be nil.
-	var newPriority uint16
-	// priorityUpdates stores all the OF priority re-assignments to be performed by client
-	priorityUpdates := map[uint16]uint16{}
-
-	affected := pa.getIndexSamePriorityZone(p)
-	if uint16(len(affected)) > pa.getPriorityZoneSize(p) {
-		// TODO: Dynamically adjust priorityZone size to handle overflow
-		return nil, priorityUpdates, fmt.Errorf("priorityZone for [%v %v) has overflowed",
-			pa.getPriorityZoneIndex(p), pa.getPriorityZoneIndex(p)+1)
-	}
-	for offset, priority := range affected {
-		computedPriority := pa.getPriorityZoneStart(p) - uint16(offset)
-		oldOFPriority, updateExisting := pa.priorityMap[priority]
-		if updateExisting && computedPriority != oldOFPriority {
-			klog.V(2).Infof("Original priority %d needs to be reassigned %d now", oldOFPriority, computedPriority)
-			priorityUpdates[oldOFPriority] = computedPriority
-		} else if !updateExisting {
-			// A new Priority has been added to priorityMap
-			newPriority = computedPriority
+// getLastVacantOFPriority returns the first smaller ofPriority that is currently vacant on the table,
+// starting from the ofPriority one below the input.
+// The search is incrementally against all ofPriorities available as it assumes the table is sparse in most cases.
+func (pa *priorityAssigner) getLastVacantOFPriority(ofPriority uint16) *uint16 {
+	for i := ofPriority - 1; i >= PriorityBottomCNP; i-- {
+		if _, exists := pa.ofPriorityMap[i]; !exists {
+			return &i
 		}
-		pa.priorityMap[priority] = computedPriority
 	}
-	return &newPriority, priorityUpdates, nil
+	return nil
+}
+
+// upperBoundOk returns if the Priorities *on* and after the input ofPriority are higher than the input Priority.
+func (pa *priorityAssigner) upperBoundOk(ofPriority uint16, p types.Priority) bool {
+	of, priority := pa.getNextOccupiedOFPriority(ofPriority)
+	return of == nil || p.Less(*priority)
+}
+
+// lowerBoundOk returns if the Priorities before the input ofPriority are lower than the input Priority.
+func (pa *priorityAssigner) lowerBoundOk(ofPriority uint16, p types.Priority) bool {
+	of, priority := pa.getLastOccupiedOFPriority(ofPriority)
+	return of == nil || priority.Less(p)
+}
+
+// getInsertionPoint searches for the ofPriority to insert the input Priority in the table.
+// It is guaranteed that the Priorities before the insertionPoint index is lower than the input Priority,
+// and Priorities *on* and after the insertionPoint index is higher than the input Priority.
+func (pa *priorityAssigner) getInsertionPoint(p types.Priority) (uint16, bool) {
+	insertionPoint := pa.initialOFPriorityFunc(p)
+	occupied, upwardSearching := false, false
+Loop:
+	for insertionPoint > PriorityBottomCNP && insertionPoint <= PriorityTopCNP {
+		switch {
+		case pa.upperBoundOk(insertionPoint, p) && pa.lowerBoundOk(insertionPoint, p):
+			if _, occupied = pa.ofPriorityMap[insertionPoint]; occupied && !upwardSearching {
+				insertionPoint--
+				continue Loop
+			}
+			break Loop
+		case pa.upperBoundOk(insertionPoint, p):
+			insertionPoint--
+		case pa.lowerBoundOk(insertionPoint, p):
+			insertionPoint++
+			upwardSearching = true
+		}
+	}
+	return insertionPoint, occupied
+}
+
+// reassignPriorities re-arranges current Priority mappings to make place for the inserting Prioirty. It sifts
+// existing priorites up or down based on cost (how many priorities it needs to move). siftPrioritiesDown is used
+// as a tie-breaker. An error should only be returned if all the available ofPriorities on the table are occupied.
+func (pa *priorityAssigner) reassignPriorities(insertionPoint uint16, p types.Priority) (*uint16, map[uint16]uint16, error) {
+	nextVacant, lastVacant := pa.getNextVacantOFPriority(insertionPoint), pa.getLastVacantOFPriority(insertionPoint)
+	switch {
+	case (insertionPoint == PriorityBottomCNP || lastVacant == nil) && nextVacant != nil:
+		return pa.siftPrioritiesUp(insertionPoint, *nextVacant, p)
+	case (insertionPoint > PriorityTopCNP || nextVacant == nil) && lastVacant != nil:
+		return pa.siftPrioritiesDown(insertionPoint-uint16(1), *lastVacant, p)
+	case nextVacant != nil && lastVacant != nil:
+		costSiftUp := *nextVacant - insertionPoint
+		costSiftDown := insertionPoint - *lastVacant - uint16(1)
+		if costSiftUp < costSiftDown {
+			return pa.siftPrioritiesUp(insertionPoint, *nextVacant, p)
+		} else {
+			return pa.siftPrioritiesDown(insertionPoint-uint16(1), *lastVacant, p)
+		}
+	default:
+		return nil, map[uint16]uint16{}, fmt.Errorf("no available Openflow priority left to insert priority %v", p)
+	}
+}
+
+// siftPrioritiesUp moves all consecutive occupied ofPriorities and corresponding Priorities up by one ofPriority,
+// starting from the insertionPoint. It also assigns the freed ofPriority to the input Priority.
+func (pa *priorityAssigner) siftPrioritiesUp(insertionPoint, nextVacant uint16, p types.Priority) (*uint16, map[uint16]uint16, error) {
+	priorityReassignments := map[uint16]uint16{}
+	if insertionPoint >= nextVacant {
+		return nil, priorityReassignments, fmt.Errorf("failed to determine the range for sifting priorities")
+	}
+	for i := nextVacant; i > insertionPoint; i-- {
+		p, _ := pa.ofPriorityMap[i-uint16(1)]
+		pa.updatePriorityAssignment(i, p)
+		priorityReassignments[i-uint16(1)] = i
+		klog.V(2).Infof("Original priority %v now needs to be re-assigned %v", i-uint16(1), i)
+	}
+	pa.updatePriorityAssignment(insertionPoint, p)
+	return &insertionPoint, priorityReassignments, nil
+}
+
+// siftPrioritiesDown moves all consecutive occupied ofPriorities and corresponding Priorities down by one ofPriority,
+// starting from the insertionPoint. It also assigns the freed ofPriority to the input Priority.
+func (pa *priorityAssigner) siftPrioritiesDown(insertionPoint, lastVacant uint16, p types.Priority) (*uint16, map[uint16]uint16, error) {
+	priorityReassignments := map[uint16]uint16{}
+	if insertionPoint <= lastVacant {
+		return nil, priorityReassignments, fmt.Errorf("failed to determine the range for sifting priorities")
+	}
+	for i := lastVacant; i < insertionPoint; i++ {
+		p, _ := pa.ofPriorityMap[i+uint16(1)]
+		pa.updatePriorityAssignment(i, p)
+		priorityReassignments[i+uint16(1)] = i
+		klog.V(2).Infof("Original priority %v now needs to be re-assigned %v", i+uint16(1), i)
+	}
+	pa.updatePriorityAssignment(insertionPoint, p)
+	return &insertionPoint, priorityReassignments, nil
 }
 
 // GetOFPriority retrieves the OFPriority for the input Priority to be installed,
 // and returns installed priorities that need to be re-assigned if necessary.
 func (pa *priorityAssigner) GetOFPriority(p types.Priority) (*uint16, map[uint16]uint16, error) {
-	ofPriority, exists := pa.priorityMap[p]
-	if !exists {
-		return pa.syncPriorityZone(p)
+	noPriorityReassignments := map[uint16]uint16{}
+	if ofPriority, exists := pa.priorityMap[p]; exists {
+		return &ofPriority, noPriorityReassignments, nil
 	}
-	return &ofPriority, map[uint16]uint16{}, nil
+	insertionPoint, occupied := pa.getInsertionPoint(p)
+	if insertionPoint == PriorityBottomCNP || insertionPoint > PriorityTopCNP || occupied {
+		return pa.reassignPriorities(insertionPoint, p)
+	}
+	pa.updatePriorityAssignment(insertionPoint, p)
+	return &insertionPoint, noPriorityReassignments, nil
 }
 
-// RegisterPriorities registers a list of Priorities to be created with priorityMap.
+// RegisterPriorities registers a list of Priorities to be created with the priorityAssigner.
 // It is used to populate the priorityMap in case of batch rule adds.
 func (pa *priorityAssigner) RegisterPriorities(priorities []types.Priority) error {
 	for _, p := range priorities {
@@ -155,14 +266,13 @@ func (pa *priorityAssigner) RegisterPriorities(priorities []types.Priority) erro
 	return nil
 }
 
-// Release removes the priority that currently corresponds to the input OFPriority from the priorityMap.
-func (pa *priorityAssigner) Release(priorityNum uint16) error {
-	for priorityKey, p := range pa.priorityMap {
-		if priorityNum == p {
-			delete(pa.priorityMap, priorityKey)
-			return nil
-		}
+// Release removes the priority that currently corresponds to the input OFPriority from the known priorities.
+func (pa *priorityAssigner) Release(ofPriority uint16) {
+	priority, exists := pa.ofPriorityMap[ofPriority]
+	if !exists {
+		klog.V(2).Infof("OpenFlow priority %v not known to this table, skip releasing priority", ofPriority)
+		return
 	}
-	klog.V(2).Infof("OF priority %v not stored in priorityMap, skip releasing priority", priorityNum)
-	return nil
+	delete(pa.priorityMap, priority)
+	pa.clearOFPriority(ofPriority)
 }

--- a/pkg/agent/controller/networkpolicy/priority.go
+++ b/pkg/agent/controller/networkpolicy/priority.go
@@ -46,8 +46,7 @@ func InitialOFPrioritySingleTierPerTable(p types.Priority) uint16 {
 	if priorityIndex > InitialPriorityZones-1 {
 		priorityIndex = InitialPriorityZones - 1
 	}
-	offset := InitialPriorityOffset*uint16(priorityIndex) + uint16(p.RulePriority)
-	return PriorityTopCNP - offset + uint16(1)
+	return PriorityTopCNP - InitialPriorityOffset*uint16(priorityIndex) - uint16(p.RulePriority)
 }
 
 // priorityAssigner is a struct that maintains the current mapping between types.Priority and

--- a/pkg/agent/controller/networkpolicy/priority_test.go
+++ b/pkg/agent/controller/networkpolicy/priority_test.go
@@ -1,0 +1,263 @@
+package networkpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/types"
+)
+
+var (
+	p111  = types.Priority{TierPriority: 1, PolicyPriority: 1, RulePriority: 1}
+	p1121 = types.Priority{TierPriority: 1, PolicyPriority: 1.2, RulePriority: 1}
+	p1122 = types.Priority{TierPriority: 1, PolicyPriority: 1.2, RulePriority: 2}
+	p1131 = types.Priority{TierPriority: 1, PolicyPriority: 1.3, RulePriority: 1}
+	p1132 = types.Priority{TierPriority: 1, PolicyPriority: 1.3, RulePriority: 2}
+	p1141 = types.Priority{TierPriority: 1, PolicyPriority: 1.4, RulePriority: 1}
+	p1142 = types.Priority{TierPriority: 1, PolicyPriority: 1.4, RulePriority: 2}
+	p1161 = types.Priority{TierPriority: 1, PolicyPriority: 1.6, RulePriority: 1}
+	p191  = types.Priority{TierPriority: 1, PolicyPriority: 9, RulePriority: 1}
+	p192  = types.Priority{TierPriority: 1, PolicyPriority: 9, RulePriority: 2}
+	p193  = types.Priority{TierPriority: 1, PolicyPriority: 9, RulePriority: 3}
+	p194  = types.Priority{TierPriority: 1, PolicyPriority: 9, RulePriority: 4}
+)
+
+func TestUpdatePriorityAssignment(t *testing.T) {
+	tests := []struct {
+		name                string
+		argsPriorities      []types.Priority
+		argsOFPriorities    []uint16
+		expectedPriorityMap map[types.Priority]uint16
+		expectedOFMap       map[uint16]types.Priority
+		expectedSorted      []uint16
+	}{
+		{
+			"in-order",
+			[]types.Priority{p111, p1121, p1122},
+			[]uint16{10000, 9999, 9998},
+			map[types.Priority]uint16{p111: 10000, p1121: 9999, p1122: 9998},
+			map[uint16]types.Priority{10000: p111, 9999: p1121, 9998: p1122},
+			[]uint16{9998, 9999, 10000},
+		},
+		{
+			"reverse-order",
+			[]types.Priority{p1122, p1121, p111},
+			[]uint16{9998, 9999, 10000},
+			map[types.Priority]uint16{p111: 10000, p1121: 9999, p1122: 9998},
+			map[uint16]types.Priority{10000: p111, 9999: p1121, 9998: p1122},
+			[]uint16{9998, 9999, 10000},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pa := newPriorityAssigner(InitialOFPrioritySingleTierPerTable)
+			for i := 0; i < len(tt.argsPriorities); i++ {
+				pa.updatePriorityAssignment(tt.argsOFPriorities[i], tt.argsPriorities[i])
+			}
+			assert.Equalf(t, tt.expectedPriorityMap, pa.priorityMap, "Got priorityMap %v, expected %v", pa.priorityMap, tt.expectedPriorityMap)
+			assert.Equalf(t, tt.expectedOFMap, pa.ofPriorityMap, "Got ofPriorityMap %v, expected %v", pa.ofPriorityMap, tt.expectedOFMap)
+			assert.Equalf(t, tt.expectedSorted, pa.sortedOFPriorities, "Got sortedOFPriorities %v, expected %v", pa.sortedOFPriorities, tt.expectedSorted)
+		})
+	}
+}
+
+func TestGetInsertionPoint(t *testing.T) {
+	tests := []struct {
+		name                 string
+		argsPriorities       []types.Priority
+		argsOFPriorities     []uint16
+		insertingPriority    types.Priority
+		initialOFPriority    uint16
+		expectInsertionPoint uint16
+		expectOccupied       bool
+	}{
+		{
+			"spot-on",
+			[]types.Priority{},
+			[]uint16{},
+			p111,
+			10000,
+			10000,
+			false,
+		},
+		{
+			"stepped-on-toes-lower",
+			[]types.Priority{p111},
+			[]uint16{10000},
+			p1121,
+			10000,
+			9999,
+			false,
+		},
+		{
+			"stepped-on-toes-higher",
+			[]types.Priority{p1121},
+			[]uint16{10000},
+			p111,
+			10000,
+			10001,
+			false,
+		},
+		{
+			"search-up",
+			[]types.Priority{p1121, p1122, p1131, p1132},
+			[]uint16{10000, 9999, 9998, 9997},
+			p111,
+			9998,
+			10001,
+			false,
+		},
+		{
+			"search-down",
+			[]types.Priority{p1121, p1122, p1131},
+			[]uint16{10000, 9999, 9998},
+			p1132,
+			10000,
+			9997,
+			false,
+		},
+		{
+			"find-insertion-up",
+			[]types.Priority{p111, p1121, p1131, p1132},
+			[]uint16{10000, 9999, 9998, 9997},
+			p1122,
+			9997,
+			9999,
+			true,
+		},
+		{
+			"find-insertion-down",
+			[]types.Priority{p111, p1121, p1131, p1132},
+			[]uint16{10000, 9999, 9998, 9997},
+			p1122,
+			10000,
+			9999,
+			true,
+		},
+		{
+			"upper-bound",
+			[]types.Priority{p1121, p1122, p1131},
+			[]uint16{PriorityTopCNP, PriorityTopCNP - 1, PriorityTopCNP - 2},
+			p111,
+			PriorityTopCNP - 2,
+			PriorityTopCNP + 1,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pa := newPriorityAssigner(func(p types.Priority) uint16 {
+				return tt.initialOFPriority
+			})
+			for i := 0; i < len(tt.argsPriorities); i++ {
+				pa.updatePriorityAssignment(tt.argsOFPriorities[i], tt.argsPriorities[i])
+			}
+			got, occupied := pa.getInsertionPoint(tt.insertingPriority)
+			assert.Equalf(t, tt.expectInsertionPoint, got, "Got insertion point %v, expected %v", got, tt.expectInsertionPoint)
+			assert.Equalf(t, tt.expectOccupied, occupied, "Got insertion point occupied %v, expected %v", got, tt.expectOccupied)
+		})
+	}
+}
+
+func TestReassignPriorities(t *testing.T) {
+
+	tests := []struct {
+		name                string
+		argsPriorities      []types.Priority
+		argsOFPriorities    []uint16
+		insertingPriorities []types.Priority
+		insertionPoints     []uint16
+		expectedAssigned    []uint16
+		expectedUpdates     []map[uint16]uint16
+	}{
+		{
+			"sift-down-at-upper-bound",
+			[]types.Priority{p192, p194},
+			[]uint16{PriorityTopCNP, PriorityTopCNP - 1},
+			[]types.Priority{p191, p193},
+			[]uint16{PriorityTopCNP + 1, PriorityTopCNP - 1},
+			[]uint16{PriorityTopCNP, PriorityTopCNP - 2},
+			[]map[uint16]uint16{
+				{
+					PriorityTopCNP:     PriorityTopCNP - 1,
+					PriorityTopCNP - 1: PriorityTopCNP - 2,
+				},
+				{
+					PriorityTopCNP - 2: PriorityTopCNP - 3,
+				},
+			},
+		},
+		{
+			"sift-up-at-lower-bound",
+			[]types.Priority{p1131, p1121},
+			[]uint16{PriorityBottomCNP, PriorityBottomCNP + 1},
+			[]types.Priority{p1122, p1132},
+			[]uint16{PriorityBottomCNP + 1, PriorityBottomCNP},
+			[]uint16{PriorityBottomCNP + 1, PriorityBottomCNP},
+			[]map[uint16]uint16{
+				{
+					PriorityBottomCNP + 1: PriorityBottomCNP + 2,
+				},
+				{
+					PriorityBottomCNP:     PriorityBottomCNP + 1,
+					PriorityBottomCNP + 1: PriorityBottomCNP + 2,
+					PriorityBottomCNP + 2: PriorityBottomCNP + 3,
+				},
+			},
+		},
+		{
+			"sift-based-on-cost",
+			[]types.Priority{p111, p1122, p1132},
+			[]uint16{10000, 9999, 9998},
+			[]types.Priority{p1131, p1121},
+			[]uint16{9999, 10000},
+			[]uint16{9998, 10000},
+			[]map[uint16]uint16{
+				{9998: 9997}, {10000: 10001},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pa := newPriorityAssigner(InitialOFPrioritySingleTierPerTable)
+			for i := 0; i < len(tt.argsPriorities); i++ {
+				pa.updatePriorityAssignment(tt.argsOFPriorities[i], tt.argsPriorities[i])
+			}
+			for i := 0; i < len(tt.insertingPriorities); i++ {
+				got, updates, err := pa.reassignPriorities(tt.insertionPoints[i], tt.insertingPriorities[i])
+				assert.Equalf(t, err, nil, "Error occurred in reassigning priorities")
+				assert.Equalf(t, tt.expectedAssigned[i], *got, "Got %v for priority %v, expected %v",
+					got, tt.insertingPriorities[i], tt.expectedAssigned[i])
+				assert.Equalf(t, tt.expectedUpdates[i], updates, "Got updates %v for priority %v, expected %v",
+					updates, tt.insertingPriorities[i], tt.expectedUpdates[i])
+			}
+		})
+	}
+}
+
+func TestRegisterPrioritiesAndRelease(t *testing.T) {
+	pa := newPriorityAssigner(InitialOFPrioritySingleTierPerTable)
+	err := pa.RegisterPriorities([]types.Priority{
+		p111, p1121, p1122, p1141, p1142, p1131, p1161,
+	})
+	assert.Equalf(t, err, nil, "Error occurred in registering priorities")
+	expectedOFMap := map[uint16]types.Priority{
+		64360: p111, 64359: p1121, 64358: p1122, 64357: p1131, 64356: p1141, 64355: p1142, 64354: p1161,
+	}
+	assert.Equalf(t, expectedOFMap, pa.ofPriorityMap, "Got ofPriorityMap %v, expected %v", pa.ofPriorityMap, expectedOFMap)
+
+	pa.Release(64359)
+	pa.Release(64356)
+	pa.Release(64354)
+	expectedOFMap = map[uint16]types.Priority{
+		64360: p111, 64358: p1122, 64357: p1131, 64355: p1142,
+	}
+	expectedPriorityMap := map[types.Priority]uint16{
+		p111: 64360, p1122: 64358, p1131: 64357, p1142: 64355,
+	}
+	expectedSorted := []uint16{64355, 64357, 64358, 64360}
+	assert.Equalf(t, expectedOFMap, pa.ofPriorityMap, "Got ofPriorityMap %v, expected %v", pa.ofPriorityMap, expectedOFMap)
+	assert.Equalf(t, expectedPriorityMap, pa.priorityMap, "Got priorityMap %v, expected %v", pa.priorityMap, expectedPriorityMap)
+	assert.Equalf(t, expectedSorted, pa.sortedOFPriorities, "Got sortedOFPriorities %v, expected %v", pa.sortedOFPriorities, expectedSorted)
+}

--- a/pkg/agent/controller/networkpolicy/priority_test.go
+++ b/pkg/agent/controller/networkpolicy/priority_test.go
@@ -9,18 +9,18 @@ import (
 )
 
 var (
-	p111  = types.Priority{TierPriority: 1, PolicyPriority: 1, RulePriority: 1}
-	p1121 = types.Priority{TierPriority: 1, PolicyPriority: 1.2, RulePriority: 1}
-	p1122 = types.Priority{TierPriority: 1, PolicyPriority: 1.2, RulePriority: 2}
-	p1131 = types.Priority{TierPriority: 1, PolicyPriority: 1.3, RulePriority: 1}
-	p1132 = types.Priority{TierPriority: 1, PolicyPriority: 1.3, RulePriority: 2}
-	p1141 = types.Priority{TierPriority: 1, PolicyPriority: 1.4, RulePriority: 1}
-	p1142 = types.Priority{TierPriority: 1, PolicyPriority: 1.4, RulePriority: 2}
-	p1161 = types.Priority{TierPriority: 1, PolicyPriority: 1.6, RulePriority: 1}
-	p191  = types.Priority{TierPriority: 1, PolicyPriority: 9, RulePriority: 1}
-	p192  = types.Priority{TierPriority: 1, PolicyPriority: 9, RulePriority: 2}
-	p193  = types.Priority{TierPriority: 1, PolicyPriority: 9, RulePriority: 3}
-	p194  = types.Priority{TierPriority: 1, PolicyPriority: 9, RulePriority: 4}
+	p111  = types.Priority{TierPriority: 1, PolicyPriority: 1, RulePriority: 0}
+	p1121 = types.Priority{TierPriority: 1, PolicyPriority: 1.2, RulePriority: 0}
+	p1122 = types.Priority{TierPriority: 1, PolicyPriority: 1.2, RulePriority: 1}
+	p1131 = types.Priority{TierPriority: 1, PolicyPriority: 1.3, RulePriority: 0}
+	p1132 = types.Priority{TierPriority: 1, PolicyPriority: 1.3, RulePriority: 1}
+	p1141 = types.Priority{TierPriority: 1, PolicyPriority: 1.4, RulePriority: 0}
+	p1142 = types.Priority{TierPriority: 1, PolicyPriority: 1.4, RulePriority: 1}
+	p1161 = types.Priority{TierPriority: 1, PolicyPriority: 1.6, RulePriority: 0}
+	p191  = types.Priority{TierPriority: 1, PolicyPriority: 9, RulePriority: 0}
+	p192  = types.Priority{TierPriority: 1, PolicyPriority: 9, RulePriority: 1}
+	p193  = types.Priority{TierPriority: 1, PolicyPriority: 9, RulePriority: 2}
+	p194  = types.Priority{TierPriority: 1, PolicyPriority: 9, RulePriority: 3}
 )
 
 func TestUpdatePriorityAssignment(t *testing.T) {

--- a/pkg/agent/controller/networkpolicy/priority_test.go
+++ b/pkg/agent/controller/networkpolicy/priority_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package networkpolicy
 
 import (

--- a/pkg/agent/controller/networkpolicy/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/reconciler.go
@@ -177,7 +177,7 @@ func newReconciler(ofClient openflow.Client, ifaceStore interfacestore.Interface
 	priorityAssigners := map[binding.TableIDType]*priorityAssigner{}
 	priorityMutex := map[binding.TableIDType]*sync.RWMutex{}
 	for _, table := range cnpTables {
-		priorityAssigners[table] = newPriorityAssigner()
+		priorityAssigners[table] = newPriorityAssigner(InitialOFPrioritySingleTierPerTable)
 		priorityMutex[table] = &sync.RWMutex{}
 	}
 	reconciler := &reconciler{

--- a/pkg/agent/controller/networkpolicy/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/reconciler.go
@@ -261,7 +261,7 @@ func (r *reconciler) getOFPriority(rule *CompletedRule, table binding.TableIDTyp
 	}
 	// Re-assign installed priorities on OVS
 	if len(priorityUpdates) > 0 {
-		err := r.ofClient.ReassignFlowPriorities(priorityUpdates)
+		err := r.ofClient.ReassignFlowPriorities(priorityUpdates, table)
 		if err != nil {
 			// TODO: revert the priorityUpdates in priorityMap if err occurred here.
 			r.priorityAssigners[table].Release(*ofPriority)

--- a/pkg/agent/controller/networkpolicy/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/reconciler_test.go
@@ -84,21 +84,42 @@ func TestReconcilerForget(t *testing.T) {
 	}{
 		{
 			"unknown-rule",
-			map[string]*lastRealized{"foo": {ofIDs: map[servicesKey]uint32{servicesKey1: 8}}},
+			map[string]*lastRealized{
+				"foo": {
+					ofIDs: map[servicesKey]uint32{servicesKey1: 8},
+					CompletedRule: &CompletedRule{
+						rule: &rule{Direction: v1beta1.DirectionIn, PolicyPriority: nil},
+					},
+				},
+			},
 			"unknown-rule-id",
 			nil,
 			false,
 		},
 		{
 			"known-single-ofrule",
-			map[string]*lastRealized{"foo": {ofIDs: map[servicesKey]uint32{servicesKey1: 8}}},
+			map[string]*lastRealized{
+				"foo": {
+					ofIDs: map[servicesKey]uint32{servicesKey1: 8},
+					CompletedRule: &CompletedRule{
+						rule: &rule{Direction: v1beta1.DirectionIn, PolicyPriority: nil},
+					},
+				},
+			},
 			"foo",
 			[]uint32{8},
 			false,
 		},
 		{
 			"known-multiple-ofrule",
-			map[string]*lastRealized{"foo": {ofIDs: map[servicesKey]uint32{servicesKey1: 8, servicesKey2: 9}}},
+			map[string]*lastRealized{
+				"foo": {
+					ofIDs: map[servicesKey]uint32{servicesKey1: 8, servicesKey2: 9},
+					CompletedRule: &CompletedRule{
+						rule: &rule{Direction: v1beta1.DirectionIn, PolicyPriority: nil},
+					},
+				},
+			},
 			"foo",
 			[]uint32{8, 9},
 			false,

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -181,8 +181,8 @@ type Client interface {
 	GetNetworkPolicyFlowKeys(npName, npNamespace string) []string
 
 	// ReassignFlowPriorities takes a list of priority updates, and update the actionFlows to replace
-	// the old priority with the desired one, for each priority update.
-	ReassignFlowPriorities(updates map[uint16]uint16) error
+	// the old priority with the desired one, for each priority update on that table.
+	ReassignFlowPriorities(updates map[uint16]uint16, table binding.TableIDType) error
 
 	// SubscribePacketIn subscribes packet-in channel in bridge. This method requires a receiver to
 	// pop data from "ch" timely, otherwise it will block all inbound messages from OVS.

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -88,7 +88,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}
@@ -116,7 +116,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}
@@ -157,7 +157,7 @@ func TestFlowInstallationFailed(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}
@@ -191,7 +191,7 @@ func TestConcurrentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}

--- a/pkg/agent/openflow/network_policy.go
+++ b/pkg/agent/openflow/network_policy.go
@@ -1048,7 +1048,7 @@ func (c *client) getStalePriorities(conj *policyRuleConjunction) (staleOFPriorit
 		priorityStale := true
 		for i := 0; i < len(conjs); i++ {
 			conjFiltered := conjs[i].(*policyRuleConjunction)
-			if conj.id != conjFiltered.id || conj.ruleTableID == conjFiltered.ruleTableID {
+			if conj.id != conjFiltered.id && conj.ruleTableID == conjFiltered.ruleTableID {
 				// There are other policyRuleConjuctions in the same table created with this
 				// ofPriority. The ofPriority is thus not stale and cannot be released.
 				priorityStale = false

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -36,28 +36,36 @@ import (
 
 const (
 	// Flow table id index
-	ClassifierTable       binding.TableIDType = 0
-	uplinkTable           binding.TableIDType = 5
-	spoofGuardTable       binding.TableIDType = 10
-	arpResponderTable     binding.TableIDType = 20
-	serviceHairpinTable   binding.TableIDType = 29
-	conntrackTable        binding.TableIDType = 30
-	conntrackStateTable   binding.TableIDType = 31
-	sessionAffinityTable  binding.TableIDType = 40
-	dnatTable             binding.TableIDType = 40
-	serviceLBTable        binding.TableIDType = 41
-	endpointDNATTable     binding.TableIDType = 42
-	cnpEgressRuleTable    binding.TableIDType = 45
-	EgressRuleTable       binding.TableIDType = 50
-	EgressDefaultTable    binding.TableIDType = 60
-	l3ForwardingTable     binding.TableIDType = 70
-	l2ForwardingCalcTable binding.TableIDType = 80
-	cnpIngressRuleTable   binding.TableIDType = 85
-	IngressRuleTable      binding.TableIDType = 90
-	IngressDefaultTable   binding.TableIDType = 100
-	conntrackCommitTable  binding.TableIDType = 105
-	hairpinSNATTable      binding.TableIDType = 106
-	L2ForwardingOutTable  binding.TableIDType = 110
+	ClassifierTable             binding.TableIDType = 0
+	uplinkTable                 binding.TableIDType = 5
+	spoofGuardTable             binding.TableIDType = 10
+	arpResponderTable           binding.TableIDType = 20
+	serviceHairpinTable         binding.TableIDType = 29
+	conntrackTable              binding.TableIDType = 30
+	conntrackStateTable         binding.TableIDType = 31
+	sessionAffinityTable        binding.TableIDType = 40
+	dnatTable                   binding.TableIDType = 40
+	serviceLBTable              binding.TableIDType = 41
+	endpointDNATTable           binding.TableIDType = 42
+	EmergencyEgressRuleTable    binding.TableIDType = 45
+	SecurityOpsEgressRuleTable  binding.TableIDType = 46
+	NetworkOpsEgressRuleTable   binding.TableIDType = 47
+	PlatformEgressRuleTable     binding.TableIDType = 48
+	ApplicationEgressRuleTable  binding.TableIDType = 49
+	EgressRuleTable             binding.TableIDType = 50
+	EgressDefaultTable          binding.TableIDType = 60
+	l3ForwardingTable           binding.TableIDType = 70
+	l2ForwardingCalcTable       binding.TableIDType = 80
+	EmergencyIngressRuleTable   binding.TableIDType = 85
+	SecurityOpsIngressRuleTable binding.TableIDType = 86
+	NetworkOpsIngressRuleTable  binding.TableIDType = 87
+	PlatformIngressRuleTable    binding.TableIDType = 88
+	ApplicationIngressRuleTable binding.TableIDType = 89
+	IngressRuleTable            binding.TableIDType = 90
+	IngressDefaultTable         binding.TableIDType = 100
+	conntrackCommitTable        binding.TableIDType = 105
+	hairpinSNATTable            binding.TableIDType = 106
+	L2ForwardingOutTable        binding.TableIDType = 110
 
 	// Flow priority level
 	priorityHigh   = uint16(210)
@@ -93,12 +101,20 @@ var (
 		{sessionAffinityTable, "SessionAffinity"},
 		{serviceLBTable, "ServiceLB"},
 		{endpointDNATTable, "EndpointDNAT"},
-		{cnpEgressRuleTable, "CNPEgressRule"},
+		{EmergencyEgressRuleTable, "CNPEmergencyEgressRule"},
+		{SecurityOpsEgressRuleTable, "CNPSecurityOpsEgressRule"},
+		{NetworkOpsEgressRuleTable, "CNPNetworkOpsEgressRule"},
+		{PlatformEgressRuleTable, "CNPPlatformEgressRule"},
+		{ApplicationEgressRuleTable, "CNPApplicationEgressRule"},
 		{EgressRuleTable, "EgressRule"},
 		{EgressDefaultTable, "EgressDefaultRule"},
 		{l3ForwardingTable, "l3Forwarding"},
 		{l2ForwardingCalcTable, "L2Forwarding"},
-		{cnpIngressRuleTable, "CNPIngressRule"},
+		{EmergencyIngressRuleTable, "CNPEmergencyIngressRule"},
+		{SecurityOpsIngressRuleTable, "CNPSecurityOpsIngressRule"},
+		{NetworkOpsIngressRuleTable, "CNPNetworkOpsIngressRule"},
+		{PlatformIngressRuleTable, "CNPPlatformIngressRule"},
+		{ApplicationIngressRuleTable, "CNPApplicationIngressRule"},
 		{IngressRuleTable, "IngressRule"},
 		{IngressDefaultTable, "IngressDefaultRule"},
 		{conntrackCommitTable, "ConntrackCommit"},
@@ -128,6 +144,26 @@ func GetFlowTableNumber(tableName string) binding.TableIDType {
 		}
 	}
 	return binding.TableIDAll
+}
+
+func GetCNPEgressTables() []binding.TableIDType {
+	return []binding.TableIDType{
+		EmergencyEgressRuleTable,
+		SecurityOpsEgressRuleTable,
+		NetworkOpsEgressRuleTable,
+		PlatformEgressRuleTable,
+		ApplicationEgressRuleTable,
+	}
+}
+
+func GetCNPIngressTables() []binding.TableIDType {
+	return []binding.TableIDType{
+		EmergencyIngressRuleTable,
+		SecurityOpsIngressRuleTable,
+		NetworkOpsIngressRuleTable,
+		PlatformIngressRuleTable,
+		ApplicationIngressRuleTable,
+	}
 }
 
 type regType uint
@@ -888,11 +924,15 @@ func (c *client) establishedConnectionFlows(category cookie.Category) (flows []b
 		Action().GotoTable(egressDropTable.GetNext()).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
-	cnpEgressEstFlow := c.pipeline[cnpEgressRuleTable].BuildFlow(priorityTopCNP).MatchProtocol(binding.ProtocolIP).
-		MatchCTStateNew(false).MatchCTStateEst(true).
-		Action().GotoTable(egressDropTable.GetNext()).
-		Cookie(c.cookieAllocator.Request(category).Raw()).
-		Done()
+	var cnpEgressFlows []binding.Flow
+	for _, tableID := range GetCNPEgressTables() {
+		cnpEgressEstFlow := c.pipeline[tableID].BuildFlow(priorityTopCNP).MatchProtocol(binding.ProtocolIP).
+			MatchCTStateNew(false).MatchCTStateEst(true).
+			Action().GotoTable(egressDropTable.GetNext()).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done()
+		cnpEgressFlows = append(cnpEgressFlows, cnpEgressEstFlow)
+	}
 	// ingressDropTable checks the destination address of packets, and drops packets sent to the AppliedToGroup but not
 	// matching the NetworkPolicy rules. Packets in the established connections need not to be checked with the
 	// ingressRuleTable or ingressDropTable.
@@ -902,12 +942,19 @@ func (c *client) establishedConnectionFlows(category cookie.Category) (flows []b
 		Action().GotoTable(ingressDropTable.GetNext()).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
-	cnpIngressEstFlow := c.pipeline[cnpIngressRuleTable].BuildFlow(priorityTopCNP).MatchProtocol(binding.ProtocolIP).
-		MatchCTStateNew(false).MatchCTStateEst(true).
-		Action().GotoTable(ingressDropTable.GetNext()).
-		Cookie(c.cookieAllocator.Request(category).Raw()).
-		Done()
-	return []binding.Flow{egressEstFlow, ingressEstFlow, cnpEgressEstFlow, cnpIngressEstFlow}
+	var cnpIngressFlows []binding.Flow
+	for _, tableID := range GetCNPIngressTables() {
+		cnpIngressEstFlow := c.pipeline[tableID].BuildFlow(priorityTopCNP).MatchProtocol(binding.ProtocolIP).
+			MatchCTStateNew(false).MatchCTStateEst(true).
+			Action().GotoTable(ingressDropTable.GetNext()).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done()
+		cnpIngressFlows = append(cnpIngressFlows, cnpIngressEstFlow)
+	}
+	allEstFlows := []binding.Flow{egressEstFlow, ingressEstFlow}
+	allEstFlows = append(allEstFlows, cnpEgressFlows...)
+	allEstFlows = append(allEstFlows, cnpIngressFlows...)
+	return allEstFlows
 }
 
 func (c *client) addFlowMatch(fb binding.FlowBuilder, matchType int, matchValue interface{}) binding.FlowBuilder {
@@ -1278,46 +1325,62 @@ func priorityIndexFunc(obj interface{}) ([]string, error) {
 func generatePipeline(bridge binding.Bridge, enableProxy bool) map[binding.TableIDType]binding.Table {
 	if enableProxy {
 		return map[binding.TableIDType]binding.Table{
-			ClassifierTable:       bridge.CreateTable(ClassifierTable, spoofGuardTable, binding.TableMissActionDrop),
-			uplinkTable:           bridge.CreateTable(uplinkTable, spoofGuardTable, binding.TableMissActionNone),
-			spoofGuardTable:       bridge.CreateTable(spoofGuardTable, serviceHairpinTable, binding.TableMissActionDrop),
-			arpResponderTable:     bridge.CreateTable(arpResponderTable, binding.LastTableID, binding.TableMissActionDrop),
-			serviceHairpinTable:   bridge.CreateTable(serviceHairpinTable, conntrackTable, binding.TableMissActionNext),
-			conntrackTable:        bridge.CreateTable(conntrackTable, conntrackStateTable, binding.TableMissActionNone),
-			conntrackStateTable:   bridge.CreateTable(conntrackStateTable, endpointDNATTable, binding.TableMissActionNext),
-			sessionAffinityTable:  bridge.CreateTable(sessionAffinityTable, binding.LastTableID, binding.TableMissActionNone),
-			serviceLBTable:        bridge.CreateTable(serviceLBTable, endpointDNATTable, binding.TableMissActionNext),
-			endpointDNATTable:     bridge.CreateTable(endpointDNATTable, cnpEgressRuleTable, binding.TableMissActionNext),
-			cnpEgressRuleTable:    bridge.CreateTable(cnpEgressRuleTable, EgressRuleTable, binding.TableMissActionNext),
-			EgressRuleTable:       bridge.CreateTable(EgressRuleTable, EgressDefaultTable, binding.TableMissActionNext),
-			EgressDefaultTable:    bridge.CreateTable(EgressDefaultTable, l3ForwardingTable, binding.TableMissActionNext),
-			l3ForwardingTable:     bridge.CreateTable(l3ForwardingTable, l2ForwardingCalcTable, binding.TableMissActionNext),
-			l2ForwardingCalcTable: bridge.CreateTable(l2ForwardingCalcTable, cnpIngressRuleTable, binding.TableMissActionNext),
-			cnpIngressRuleTable:   bridge.CreateTable(cnpIngressRuleTable, IngressRuleTable, binding.TableMissActionNext),
-			IngressRuleTable:      bridge.CreateTable(IngressRuleTable, IngressDefaultTable, binding.TableMissActionNext),
-			IngressDefaultTable:   bridge.CreateTable(IngressDefaultTable, conntrackCommitTable, binding.TableMissActionNext),
-			conntrackCommitTable:  bridge.CreateTable(conntrackCommitTable, hairpinSNATTable, binding.TableMissActionNext),
-			hairpinSNATTable:      bridge.CreateTable(hairpinSNATTable, L2ForwardingOutTable, binding.TableMissActionNext),
-			L2ForwardingOutTable:  bridge.CreateTable(L2ForwardingOutTable, binding.LastTableID, binding.TableMissActionDrop),
+			ClassifierTable:             bridge.CreateTable(ClassifierTable, spoofGuardTable, binding.TableMissActionDrop),
+			uplinkTable:                 bridge.CreateTable(uplinkTable, spoofGuardTable, binding.TableMissActionNone),
+			spoofGuardTable:             bridge.CreateTable(spoofGuardTable, serviceHairpinTable, binding.TableMissActionDrop),
+			arpResponderTable:           bridge.CreateTable(arpResponderTable, binding.LastTableID, binding.TableMissActionDrop),
+			serviceHairpinTable:         bridge.CreateTable(serviceHairpinTable, conntrackTable, binding.TableMissActionNext),
+			conntrackTable:              bridge.CreateTable(conntrackTable, conntrackStateTable, binding.TableMissActionNone),
+			conntrackStateTable:         bridge.CreateTable(conntrackStateTable, endpointDNATTable, binding.TableMissActionNext),
+			sessionAffinityTable:        bridge.CreateTable(sessionAffinityTable, binding.LastTableID, binding.TableMissActionNone),
+			serviceLBTable:              bridge.CreateTable(serviceLBTable, endpointDNATTable, binding.TableMissActionNext),
+			endpointDNATTable:           bridge.CreateTable(endpointDNATTable, EmergencyEgressRuleTable, binding.TableMissActionNext),
+			EmergencyEgressRuleTable:    bridge.CreateTable(EmergencyEgressRuleTable, SecurityOpsEgressRuleTable, binding.TableMissActionNext),
+			SecurityOpsEgressRuleTable:  bridge.CreateTable(SecurityOpsEgressRuleTable, NetworkOpsEgressRuleTable, binding.TableMissActionNext),
+			NetworkOpsEgressRuleTable:   bridge.CreateTable(NetworkOpsEgressRuleTable, PlatformEgressRuleTable, binding.TableMissActionNext),
+			PlatformEgressRuleTable:     bridge.CreateTable(PlatformEgressRuleTable, ApplicationEgressRuleTable, binding.TableMissActionNext),
+			ApplicationEgressRuleTable:  bridge.CreateTable(ApplicationEgressRuleTable, EgressRuleTable, binding.TableMissActionNext),
+			EgressRuleTable:             bridge.CreateTable(EgressRuleTable, EgressDefaultTable, binding.TableMissActionNext),
+			EgressDefaultTable:          bridge.CreateTable(EgressDefaultTable, l3ForwardingTable, binding.TableMissActionNext),
+			l3ForwardingTable:           bridge.CreateTable(l3ForwardingTable, l2ForwardingCalcTable, binding.TableMissActionNext),
+			l2ForwardingCalcTable:       bridge.CreateTable(l2ForwardingCalcTable, EmergencyIngressRuleTable, binding.TableMissActionNext),
+			EmergencyIngressRuleTable:   bridge.CreateTable(EmergencyIngressRuleTable, SecurityOpsIngressRuleTable, binding.TableMissActionNext),
+			SecurityOpsIngressRuleTable: bridge.CreateTable(SecurityOpsIngressRuleTable, NetworkOpsIngressRuleTable, binding.TableMissActionNext),
+			NetworkOpsIngressRuleTable:  bridge.CreateTable(NetworkOpsIngressRuleTable, PlatformIngressRuleTable, binding.TableMissActionNext),
+			PlatformIngressRuleTable:    bridge.CreateTable(PlatformIngressRuleTable, ApplicationIngressRuleTable, binding.TableMissActionNext),
+			ApplicationIngressRuleTable: bridge.CreateTable(ApplicationIngressRuleTable, IngressRuleTable, binding.TableMissActionNext),
+			IngressRuleTable:            bridge.CreateTable(IngressRuleTable, IngressDefaultTable, binding.TableMissActionNext),
+			IngressDefaultTable:         bridge.CreateTable(IngressDefaultTable, conntrackCommitTable, binding.TableMissActionNext),
+			conntrackCommitTable:        bridge.CreateTable(conntrackCommitTable, hairpinSNATTable, binding.TableMissActionNext),
+			hairpinSNATTable:            bridge.CreateTable(hairpinSNATTable, L2ForwardingOutTable, binding.TableMissActionNext),
+			L2ForwardingOutTable:        bridge.CreateTable(L2ForwardingOutTable, binding.LastTableID, binding.TableMissActionDrop),
 		}
 	}
 	return map[binding.TableIDType]binding.Table{
-		ClassifierTable:       bridge.CreateTable(ClassifierTable, spoofGuardTable, binding.TableMissActionDrop),
-		spoofGuardTable:       bridge.CreateTable(spoofGuardTable, conntrackTable, binding.TableMissActionDrop),
-		arpResponderTable:     bridge.CreateTable(arpResponderTable, binding.LastTableID, binding.TableMissActionDrop),
-		conntrackTable:        bridge.CreateTable(conntrackTable, conntrackStateTable, binding.TableMissActionNone),
-		conntrackStateTable:   bridge.CreateTable(conntrackStateTable, dnatTable, binding.TableMissActionNext),
-		dnatTable:             bridge.CreateTable(dnatTable, cnpEgressRuleTable, binding.TableMissActionNext),
-		cnpEgressRuleTable:    bridge.CreateTable(cnpEgressRuleTable, EgressRuleTable, binding.TableMissActionNext),
-		EgressRuleTable:       bridge.CreateTable(EgressRuleTable, EgressDefaultTable, binding.TableMissActionNext),
-		EgressDefaultTable:    bridge.CreateTable(EgressDefaultTable, l3ForwardingTable, binding.TableMissActionNext),
-		l3ForwardingTable:     bridge.CreateTable(l3ForwardingTable, l2ForwardingCalcTable, binding.TableMissActionNext),
-		l2ForwardingCalcTable: bridge.CreateTable(l2ForwardingCalcTable, cnpIngressRuleTable, binding.TableMissActionNext),
-		cnpIngressRuleTable:   bridge.CreateTable(cnpIngressRuleTable, IngressRuleTable, binding.TableMissActionNext),
-		IngressRuleTable:      bridge.CreateTable(IngressRuleTable, IngressDefaultTable, binding.TableMissActionNext),
-		IngressDefaultTable:   bridge.CreateTable(IngressDefaultTable, conntrackCommitTable, binding.TableMissActionNext),
-		conntrackCommitTable:  bridge.CreateTable(conntrackCommitTable, L2ForwardingOutTable, binding.TableMissActionNext),
-		L2ForwardingOutTable:  bridge.CreateTable(L2ForwardingOutTable, binding.LastTableID, binding.TableMissActionDrop),
+		ClassifierTable:             bridge.CreateTable(ClassifierTable, spoofGuardTable, binding.TableMissActionDrop),
+		spoofGuardTable:             bridge.CreateTable(spoofGuardTable, conntrackTable, binding.TableMissActionDrop),
+		arpResponderTable:           bridge.CreateTable(arpResponderTable, binding.LastTableID, binding.TableMissActionDrop),
+		conntrackTable:              bridge.CreateTable(conntrackTable, conntrackStateTable, binding.TableMissActionNone),
+		conntrackStateTable:         bridge.CreateTable(conntrackStateTable, dnatTable, binding.TableMissActionNext),
+		dnatTable:                   bridge.CreateTable(dnatTable, EmergencyEgressRuleTable, binding.TableMissActionNext),
+		EmergencyEgressRuleTable:    bridge.CreateTable(EmergencyEgressRuleTable, SecurityOpsEgressRuleTable, binding.TableMissActionNext),
+		SecurityOpsEgressRuleTable:  bridge.CreateTable(SecurityOpsEgressRuleTable, NetworkOpsEgressRuleTable, binding.TableMissActionNext),
+		NetworkOpsEgressRuleTable:   bridge.CreateTable(NetworkOpsEgressRuleTable, PlatformEgressRuleTable, binding.TableMissActionNext),
+		PlatformEgressRuleTable:     bridge.CreateTable(PlatformEgressRuleTable, ApplicationEgressRuleTable, binding.TableMissActionNext),
+		ApplicationEgressRuleTable:  bridge.CreateTable(ApplicationEgressRuleTable, EgressRuleTable, binding.TableMissActionNext),
+		EgressRuleTable:             bridge.CreateTable(EgressRuleTable, EgressDefaultTable, binding.TableMissActionNext),
+		EgressDefaultTable:          bridge.CreateTable(EgressDefaultTable, l3ForwardingTable, binding.TableMissActionNext),
+		l3ForwardingTable:           bridge.CreateTable(l3ForwardingTable, l2ForwardingCalcTable, binding.TableMissActionNext),
+		l2ForwardingCalcTable:       bridge.CreateTable(l2ForwardingCalcTable, EmergencyIngressRuleTable, binding.TableMissActionNext),
+		EmergencyIngressRuleTable:   bridge.CreateTable(EmergencyIngressRuleTable, SecurityOpsIngressRuleTable, binding.TableMissActionNext),
+		SecurityOpsIngressRuleTable: bridge.CreateTable(SecurityOpsIngressRuleTable, NetworkOpsIngressRuleTable, binding.TableMissActionNext),
+		NetworkOpsIngressRuleTable:  bridge.CreateTable(NetworkOpsIngressRuleTable, PlatformIngressRuleTable, binding.TableMissActionNext),
+		PlatformIngressRuleTable:    bridge.CreateTable(PlatformIngressRuleTable, ApplicationIngressRuleTable, binding.TableMissActionNext),
+		ApplicationIngressRuleTable: bridge.CreateTable(ApplicationIngressRuleTable, IngressRuleTable, binding.TableMissActionNext),
+		IngressRuleTable:            bridge.CreateTable(IngressRuleTable, IngressDefaultTable, binding.TableMissActionNext),
+		IngressDefaultTable:         bridge.CreateTable(IngressDefaultTable, conntrackCommitTable, binding.TableMissActionNext),
+		conntrackCommitTable:        bridge.CreateTable(conntrackCommitTable, L2ForwardingOutTable, binding.TableMissActionNext),
+		L2ForwardingOutTable:        bridge.CreateTable(L2ForwardingOutTable, binding.LastTableID, binding.TableMissActionDrop),
 	}
 }
 

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -434,17 +434,17 @@ func (mr *MockClientMockRecorder) IsConnected() *gomock.Call {
 }
 
 // ReassignFlowPriorities mocks base method
-func (m *MockClient) ReassignFlowPriorities(arg0 map[uint16]uint16) error {
+func (m *MockClient) ReassignFlowPriorities(arg0 map[uint16]uint16, arg1 openflow.TableIDType) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReassignFlowPriorities", arg0)
+	ret := m.ctrl.Call(m, "ReassignFlowPriorities", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReassignFlowPriorities indicates an expected call of ReassignFlowPriorities
-func (mr *MockClientMockRecorder) ReassignFlowPriorities(arg0 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) ReassignFlowPriorities(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReassignFlowPriorities", reflect.TypeOf((*MockClient)(nil).ReassignFlowPriorities), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReassignFlowPriorities", reflect.TypeOf((*MockClient)(nil).ReassignFlowPriorities), arg0, arg1)
 }
 
 // RegisterPacketInHandler mocks base method

--- a/pkg/agent/types/networkpolicy.go
+++ b/pkg/agent/types/networkpolicy.go
@@ -60,7 +60,7 @@ func (r *PolicyRule) IsAntreaNetworkPolicyRule() bool {
 	return r.Priority != nil
 }
 
-// Priority is a struct that is composed of CNP priority, rule priority and tier priority.
+// Priority is a struct that is composed of Antrea NetworkPolicy priority, rule priority and Tier priority.
 // It is used as the basic unit for priority sorting.
 type Priority struct {
 	TierPriority   v1beta1.TierPriority

--- a/pkg/agent/types/networkpolicy.go
+++ b/pkg/agent/types/networkpolicy.go
@@ -17,6 +17,7 @@ package types
 import (
 	"github.com/vmware-tanzu/antrea/pkg/apis/networking/v1beta1"
 	secv1alpha1 "github.com/vmware-tanzu/antrea/pkg/apis/security/v1alpha1"
+	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
 )
 
 type AddressCategory uint8
@@ -49,6 +50,7 @@ type PolicyRule struct {
 	Action          *secv1alpha1.RuleAction
 	Priority        *uint16
 	FlowID          uint32
+	TableID         binding.TableIDType
 	PolicyName      string
 	PolicyNamespace string
 }
@@ -58,10 +60,20 @@ func (r *PolicyRule) IsAntreaNetworkPolicyRule() bool {
 	return r.Priority != nil
 }
 
-// Priority is a struct that is composed of CNP priority, rule priority and
-// tier/category priority in the future. It is used as the basic unit for
-// priority sorting.
+// Priority is a struct that is composed of CNP priority, rule priority and tier priority.
+// It is used as the basic unit for priority sorting.
 type Priority struct {
+	TierPriority   v1beta1.TierPriority
 	PolicyPriority float64
 	RulePriority   int32
+}
+
+func (p *Priority) Less(p2 Priority) bool {
+	if p.TierPriority == p2.TierPriority {
+		if p.PolicyPriority == p2.PolicyPriority {
+			return p.RulePriority > p2.RulePriority
+		}
+		return p.PolicyPriority > p2.PolicyPriority
+	}
+	return p.TierPriority > p2.TierPriority
 }

--- a/test/e2e/utils/cnpspecbuilder.go
+++ b/test/e2e/utils/cnpspecbuilder.go
@@ -52,6 +52,11 @@ func (b *ClusterNetworkPolicySpecBuilder) SetPriority(p float64) *ClusterNetwork
 	return b
 }
 
+func (b *ClusterNetworkPolicySpecBuilder) SetTier(tier string) *ClusterNetworkPolicySpecBuilder {
+	b.Spec.Tier = tier
+	return b
+}
+
 func (b *ClusterNetworkPolicySpecBuilder) SetAppliedToGroup(podSelector map[string]string,
 	nsSelector map[string]string,
 	podSelectorMatchExp *[]metav1.LabelSelectorRequirement,

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -90,7 +90,7 @@ func TestConnectivityFlows(t *testing.T) {
 	// Initialize ovs metrics (Prometheus) to test them
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, true)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 	defer func() {
@@ -117,7 +117,7 @@ func TestConnectivityFlows(t *testing.T) {
 }
 
 func TestReplayFlowsConnectivityFlows(t *testing.T) {
-	c = ofClient.NewClient(br, bridgeMgmtAddr, true)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -144,7 +144,7 @@ func TestReplayFlowsConnectivityFlows(t *testing.T) {
 }
 
 func TestReplayFlowsNetworkPolicyFlows(t *testing.T) {
-	c = ofClient.NewClient(br, bridgeMgmtAddr, true)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -309,7 +309,7 @@ func TestNetworkPolicyFlows(t *testing.T) {
 	// Initialize ovs metrics (Prometheus) to test them
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, true)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 
@@ -640,7 +640,7 @@ func preparePodFlows(podIP net.IP, podMAC net.HardwareAddr, podOFPort uint32, gw
 			[]*ofTestUtils.ExpectFlow{
 				{
 					MatchStr: fmt.Sprintf("priority=200,dl_dst=%s", podMAC.String()),
-					ActStr:   fmt.Sprintf("load:0x%x->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],goto_table:85", podOFPort),
+					ActStr:   fmt.Sprintf("load:0x%x->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],goto_table:90", podOFPort),
 				},
 			},
 		},
@@ -694,7 +694,7 @@ func prepareGatewayFlows(gwIP net.IP, gwMAC net.HardwareAddr, gwOFPort uint32, v
 			[]*ofTestUtils.ExpectFlow{
 				{
 					MatchStr: fmt.Sprintf("priority=200,dl_dst=%s", gwMAC.String()),
-					ActStr:   fmt.Sprintf("load:0x%x->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],goto_table:85", gwOFPort),
+					ActStr:   fmt.Sprintf("load:0x%x->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],goto_table:90", gwOFPort),
 				},
 			},
 		},
@@ -794,11 +794,7 @@ func prepareDefaultFlows() []expectTableFlows {
 		},
 		{
 			uint8(42),
-			[]*ofTestUtils.ExpectFlow{{MatchStr: "priority=0", ActStr: "goto_table:45"}},
-		},
-		{
-			uint8(45),
-			[]*ofTestUtils.ExpectFlow{{MatchStr: "priority=0", ActStr: "goto_table:46"}},
+			[]*ofTestUtils.ExpectFlow{{MatchStr: "priority=0", ActStr: "goto_table:50"}},
 		},
 		{
 			uint8(50),
@@ -814,11 +810,7 @@ func prepareDefaultFlows() []expectTableFlows {
 		},
 		{
 			uint8(80),
-			[]*ofTestUtils.ExpectFlow{{MatchStr: "priority=0", ActStr: "goto_table:85"}},
-		},
-		{
-			uint8(85),
-			[]*ofTestUtils.ExpectFlow{{MatchStr: "priority=0", ActStr: "goto_table:86"}},
+			[]*ofTestUtils.ExpectFlow{{MatchStr: "priority=0", ActStr: "goto_table:90"}},
 		},
 		{
 			uint8(90),

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -174,6 +174,7 @@ func TestReplayFlowsNetworkPolicyFlows(t *testing.T) {
 		Service:         []v1beta1.Service{npPort1},
 		Action:          &defaultAction,
 		FlowID:          ruleID,
+		TableID:         ofClient.IngressRuleTable,
 		PolicyName:      "np1",
 		PolicyNamespace: "ns1",
 	}
@@ -338,6 +339,7 @@ func TestNetworkPolicyFlows(t *testing.T) {
 		Service:         []v1beta1.Service{npPort1},
 		Action:          &defaultAction,
 		FlowID:          ruleID,
+		TableID:         ofClient.IngressRuleTable,
 		PolicyName:      "np1",
 		PolicyNamespace: "ns1",
 	}
@@ -376,6 +378,7 @@ func TestNetworkPolicyFlows(t *testing.T) {
 		Service:         []v1beta1.Service{npPort2},
 		Action:          &defaultAction,
 		FlowID:          ruleID2,
+		TableID:         ofClient.IngressRuleTable,
 		PolicyName:      "np1",
 		PolicyNamespace: "ns1",
 	}
@@ -795,7 +798,7 @@ func prepareDefaultFlows() []expectTableFlows {
 		},
 		{
 			uint8(45),
-			[]*ofTestUtils.ExpectFlow{{MatchStr: "priority=0", ActStr: "goto_table:50"}},
+			[]*ofTestUtils.ExpectFlow{{MatchStr: "priority=0", ActStr: "goto_table:46"}},
 		},
 		{
 			uint8(50),
@@ -815,7 +818,7 @@ func prepareDefaultFlows() []expectTableFlows {
 		},
 		{
 			uint8(85),
-			[]*ofTestUtils.ExpectFlow{{MatchStr: "priority=0", ActStr: "goto_table:90"}},
+			[]*ofTestUtils.ExpectFlow{{MatchStr: "priority=0", ActStr: "goto_table:86"}},
 		},
 		{
 			uint8(90),


### PR DESCRIPTION
Add support for Tiered ClusterNetworkPolicies in Antrea agent. This PR adds the following:

- Updated internal NP types in agent to support tiers
- Moved OVS table determination logic into the networkpolicy pkg
- Updated OVS pipeline to reserve separate tables for each CNP Tier
- Refactored priorityAssigner logic to minimize reassignments and support any priority distribution within a Tier