### PR TITLE
Update kustomize version to v3.8.1

### DIFF
--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -937,8 +937,6 @@ spec:
         command:
         - antrea-agent
         env:
-        - name: ANTREA_CLOUD_EKS
-          value: "true"
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -951,6 +949,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: ANTREA_CLOUD_EKS
+          value: "true"
         image: antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -935,36 +935,6 @@ spec:
         component: antrea-agent
     spec:
       containers:
-      - command:
-        - start_ovs_ipsec
-        image: antrea/antrea-ubuntu:latest
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - timeout 5 container_liveness_probe ovs-ipsec
-          initialDelaySeconds: 5
-          periodSeconds: 5
-        name: antrea-ipsec
-        resources:
-          requests:
-            cpu: 50m
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-        volumeMounts:
-        - mountPath: /var/run/openvswitch
-          name: host-var-run-antrea
-          subPath: openvswitch
-        - mountPath: /var/log/openvswitch
-          name: host-var-log-antrea
-          subPath: openvswitch
-        - mountPath: /var/log/strongswan
-          name: host-var-log-antrea
-          subPath: strongswan
       - args:
         - --config
         - /etc/antrea/antrea-agent.conf
@@ -976,11 +946,6 @@ spec:
         command:
         - antrea-agent
         env:
-        - name: ANTREA_IPSEC_PSK
-          valueFrom:
-            secretKeyRef:
-              key: psk
-              name: antrea-ipsec
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -993,6 +958,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: ANTREA_IPSEC_PSK
+          valueFrom:
+            secretKeyRef:
+              key: psk
+              name: antrea-ipsec
         image: antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1081,6 +1051,36 @@ spec:
         - mountPath: /var/log/openvswitch
           name: host-var-log-antrea
           subPath: openvswitch
+      - command:
+        - start_ovs_ipsec
+        image: antrea/antrea-ubuntu:latest
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - timeout 5 container_liveness_probe ovs-ipsec
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        name: antrea-ipsec
+        resources:
+          requests:
+            cpu: 50m
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+        volumeMounts:
+        - mountPath: /var/run/openvswitch
+          name: host-var-run-antrea
+          subPath: openvswitch
+        - mountPath: /var/log/openvswitch
+          name: host-var-log-antrea
+          subPath: openvswitch
+        - mountPath: /var/log/strongswan
+          name: host-var-log-antrea
+          subPath: strongswan
       hostNetwork: true
       initContainers:
       - command:

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -180,7 +180,6 @@ spec:
         name: host
       - hostPath:
           path: \\.\pipe\rancher_wins
-          type: null
         name: wins
   updateStrategy:
     type: RollingUpdate

--- a/build/yamls/windows/base/agent.yml
+++ b/build/yamls/windows/base/agent.yml
@@ -101,6 +101,5 @@ spec:
         - name: wins
           hostPath:
             path: \\.\pipe\rancher_wins
-            type: null
   updateStrategy:
     type: RollingUpdate

--- a/hack/verify-kustomize.sh
+++ b/hack/verify-kustomize.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 _GOPATH_BIN="$(go env GOPATH)/bin"
-_MIN_KUSTOMIZE_VERSION="v3.3.0"
+_MIN_KUSTOMIZE_VERSION="v3.8.1"
 
 # Ensure the kustomize tool exists and is a viable version, or installs it
 verify_kustomize() {


### PR DESCRIPTION
In v3.8.0, kustomize stopped using apimachinery by default and switched
to its own library (kyaml) for K8s resource YAML manipulation. Because
of this change, the generated YAMLs are different: fields within objects
may be ordered differently, and the latest kustomize generally does a
better job dropping empty fields. We are switching the min required
version of kustomize to 3.8.1 so that Antrea developers can keep working
with a recent version of kustomize without CI checks failing. Note that
we are using 3.8.1 and not 3.8.0 which has some known issues.

For new developers which do not have kustomize, the new version will be
installed automatically when running generate-manifest.sh. Others will
see an error message about their version of kustomize being too old, and
they can update with:

```
GO111MODULE=on go get sigs.k8s.io/kustomize/kustomize/v3
```

Fixes #975