### PR TITLE
[Traceflow] Add support for IP and service destination in traceflow graph

### DIFF
--- a/plugins/octant/cmd/antrea-octant-plugin/antrea_info.go
+++ b/plugins/octant/cmd/antrea-octant-plugin/antrea_info.go
@@ -39,27 +39,27 @@ const (
 	heartbeatCol      = "Last Heartbeat Time"
 )
 
-func controllerHandler(request service.Request) (component.ContentResponse, error) {
+func (a *antreaOctantPlugin) controllerHandler(request service.Request) (component.ContentResponse, error) {
 	return component.ContentResponse{
 		Title: component.TitleFromString(controllerTitle),
 		Components: []component.Component{
-			getControllerTable(request),
+			a.getControllerTable(request),
 		},
 	}, nil
 }
 
-func agentHandler(request service.Request) (component.ContentResponse, error) {
+func (a *antreaOctantPlugin) agentHandler(request service.Request) (component.ContentResponse, error) {
 	return component.ContentResponse{
 		Title: component.TitleFromString(agentTitle),
 		Components: []component.Component{
-			getAgentTable(request),
+			a.getAgentTable(request),
 		},
 	}, nil
 }
 
 // getControllerTable gets the table for displaying Controller information
-func getControllerTable(request service.Request) *component.Table {
-	controllers, err := client.ClusterinformationV1beta1().AntreaControllerInfos().List(context.TODO(), v1.ListOptions{})
+func (a *antreaOctantPlugin) getControllerTable(request service.Request) *component.Table {
+	controllers, err := a.client.ClusterinformationV1beta1().AntreaControllerInfos().List(context.TODO(), v1.ListOptions{})
 	if err != nil {
 		log.Fatalf("Failed to get AntreaControllerInfos %v", err)
 	}
@@ -83,8 +83,8 @@ func getControllerTable(request service.Request) *component.Table {
 }
 
 // getAgentTable gets the table for displaying Agent information.
-func getAgentTable(request service.Request) *component.Table {
-	agents, err := client.ClusterinformationV1beta1().AntreaAgentInfos().List(context.TODO(), v1.ListOptions{})
+func (a *antreaOctantPlugin) getAgentTable(request service.Request) *component.Table {
+	agents, err := a.client.ClusterinformationV1beta1().AntreaAgentInfos().List(context.TODO(), v1.ListOptions{})
 	if err != nil {
 		log.Fatalf("Failed to get AntreaAgentInfos %v", err)
 	}

--- a/plugins/octant/cmd/antrea-octant-plugin/main.go
+++ b/plugins/octant/cmd/antrea-octant-plugin/main.go
@@ -30,11 +30,6 @@ import (
 
 var (
 	pluginName = "antrea-octant-plugin"
-	client     *clientset.Clientset
-	graph      = ""
-	lastTf     = opsv1alpha1.Traceflow{
-		ObjectMeta: v1.ObjectMeta{Name: ""},
-	}
 )
 
 const (
@@ -42,19 +37,36 @@ const (
 	title      = "Antrea"
 )
 
-func main() {
-	// Remove the prefix from the go logger since Octant will print logs with timestamps.
-	log.SetPrefix("")
+type antreaOctantPlugin struct {
+	client *clientset.Clientset
+	graph  string
+	lastTf opsv1alpha1.Traceflow
+}
 
+func newAntreaOctantPlugin() *antreaOctantPlugin {
 	// Create a k8s client.
 	config, err := clientcmd.BuildConfigFromFlags("", os.Getenv(kubeConfig))
 	if err != nil {
 		log.Fatalf("Failed to build kubeConfig %v", err)
 	}
-	client, err = clientset.NewForConfig(config)
+	client, err := clientset.NewForConfig(config)
 	if err != nil {
 		log.Fatalf("Failed to create K8s client for %s: %v", pluginName, err)
 	}
+
+	return &antreaOctantPlugin{
+		client: client,
+		graph:  "",
+		lastTf: opsv1alpha1.Traceflow{
+			ObjectMeta: v1.ObjectMeta{Name: ""},
+		},
+	}
+}
+
+func main() {
+	// Remove the prefix from the go logger since Octant will print logs with timestamps.
+	log.SetPrefix("")
+	a := newAntreaOctantPlugin()
 
 	capabilities := &plugin.Capabilities{
 		ActionNames: []string{addTfAction, showGraphAction},
@@ -63,8 +75,8 @@ func main() {
 
 	// Set up navigation services
 	options := []service.PluginOption{
-		service.WithNavigation(handleNavigation, initRoutes),
-		service.WithActionHandler(actionHandler),
+		service.WithNavigation(a.handleNavigation, a.initRoutes),
+		service.WithActionHandler(a.actionHandler),
 	}
 
 	// Register this plugin.
@@ -78,7 +90,7 @@ func main() {
 }
 
 // handleNavigation generates contents displayed on navigation bar and their paths.
-func handleNavigation(request *service.NavigationRequest) (navigation.Navigation, error) {
+func (a *antreaOctantPlugin) handleNavigation(request *service.NavigationRequest) (navigation.Navigation, error) {
 	return navigation.Navigation{
 		Title: title,
 		Path:  request.GeneratePath(),
@@ -109,17 +121,17 @@ func handleNavigation(request *service.NavigationRequest) (navigation.Navigation
 }
 
 // initRoutes routes for Antrea plugin.
-func initRoutes(router *service.Router) {
+func (a *antreaOctantPlugin) initRoutes(router *service.Router) {
 	// Click on the plugin icon or navigation child named Overview to display all Antrea information.
-	router.HandleFunc("", overviewHandler)
-	router.HandleFunc("/components/overview", overviewHandler)
+	router.HandleFunc("", a.overviewHandler)
+	router.HandleFunc("/components/overview", a.overviewHandler)
 
 	// Click on navigation child named Controller Info to display Controller information.
-	router.HandleFunc("/components/controller", controllerHandler)
+	router.HandleFunc("/components/controller", a.controllerHandler)
 
 	// Click on navigation child named Agent Info to display Agent information.
-	router.HandleFunc("/components/agent", agentHandler)
+	router.HandleFunc("/components/agent", a.agentHandler)
 
 	// Click on navigation child named "Antrea Traceflow"/"Tracelist" to display Antrea Traceflow information.
-	router.HandleFunc("/components/traceflow", traceflowHandler)
+	router.HandleFunc("/components/traceflow", a.traceflowHandler)
 }

--- a/plugins/octant/cmd/antrea-octant-plugin/overview.go
+++ b/plugins/octant/cmd/antrea-octant-plugin/overview.go
@@ -30,13 +30,13 @@ const (
 type getTableFunc func(request service.Request) *component.Table
 
 // overviewHandler handlers the layout of Antrea Overview page.
-func overviewHandler(request service.Request) (component.ContentResponse, error) {
+func (a *antreaOctantPlugin) overviewHandler(request service.Request) (component.ContentResponse, error) {
 	layout := flexlayout.New()
 	listSection := layout.AddSection()
 	handlers := []getTableFunc{
-		getControllerTable,
-		getAgentTable,
-		getTfTable,
+		a.getControllerTable,
+		a.getAgentTable,
+		a.getTfTable,
 	}
 	resp := component.NewContentResponse(component.TitleFromString(overviewTitle))
 	err := listSection.Add(component.NewMarkdownText("## "+antreaTitle), component.WidthFull)


### PR DESCRIPTION
1. Enhance the "Start New Trace" page of traceflow plugin.
<img width="500" alt="plugin" src="https://user-images.githubusercontent.com/32829088/88775100-e38ad100-d1b6-11ea-9267-1c4daadf4146.png">


2. Add support for IP and service destinations in traceflow graph.
Also update the "Traceflow Info" form.

<img width="300" alt="plugin" src="https://user-images.githubusercontent.com/32829088/88775573-73307f80-d1b7-11ea-8ee1-270439d15994.png">




