### PR TITLE
Upgrade prometheus image to v2.19.3

### DIFF
--- a/build/yamls/antrea-prometheus.yml
+++ b/build/yamls/antrea-prometheus.yml
@@ -122,7 +122,7 @@ spec:
     spec:
       containers:
         - name: prometheus
-          image: prom/prometheus:v2.2.1
+          image: prom/prometheus:v2.19.3
           args:
             - "--config.file=/etc/prometheus/prometheus.yml"
             - "--storage.tsdb.path=/prometheus/"

--- a/docs/prometheus-integration.md
+++ b/docs/prometheus-integration.md
@@ -21,6 +21,9 @@ Enable Prometheus metrics listener by setting `enablePrometheusMetrics`
 parameter to true in the Controller and the Agent configurations.
  
 ## Prometheus Configuration
+
+### Prometheus version
+Prometheus integration with Antrea is validated as part of CI using Prometheus v2.19.3.
   
 ### Prometheus RBAC
 Prometheus requires access to Kubernetes API resources for the service discovery

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -66,7 +66,9 @@ var prometheusEnabled bool
 // Prometheus server JSON output
 type prometheusServerOutput struct {
 	Status string
-	Data   []map[string]string
+	Data   []struct {
+		Metric string
+	}
 }
 
 func init() {
@@ -254,8 +256,10 @@ func testMetricsFromPrometheusServer(t *testing.T, data *TestData, prometheusJob
 	hostIP, nodePort := getPrometheusEndpoint(t, data)
 
 	// Build the Prometheus query URL
-	path := url.PathEscape("match[]={job=\"" + prometheusJob + "\"}")
-	queryUrl := fmt.Sprintf("http://%s:%d/api/v1/series?%s", hostIP, nodePort, path)
+	// Target metadata API(/api/v1/targets/metadata) has been available since Prometheus v2.4.0.
+	// This API is still experimental in Prometheus v2.19.3.
+	path := url.PathEscape("match_target={job=\"" + prometheusJob + "\"}")
+	queryUrl := fmt.Sprintf("http://%s:%d/api/v1/targets/metadata?%s", hostIP, nodePort, path)
 
 	client := &http.Client{}
 	resp, err := client.Get(queryUrl)
@@ -279,8 +283,7 @@ func testMetricsFromPrometheusServer(t *testing.T, data *TestData, prometheusJob
 	// Create a map of all the metrics which were found on the server
 	testMap := make(map[string]bool)
 	for _, metric := range output.Data {
-		name := strings.TrimSuffix(metric["__name__"], "_bucket")
-		testMap[name] = true
+		testMap[metric.Metric] = true
 	}
 
 	// Validate that all the required metrics exist in the server's output


### PR DESCRIPTION
- Make e2e prometheus test consistent by using querying target metadata API

This PR updates prometheus image to v2.19.3 so that we can get basename without cutting out the metrics name in our e2e test. New codes using querying target metadata API.
https://prometheus.io/docs/prometheus/latest/querying/api/#querying-target-metadata

However, this is still experimental so I won't merge if it's a risk to use the experimental API.