### PR TITLE
Fix golangci targets on macOS

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,10 @@ jobs:
 
   golangci-lint:
     name: Golangci-lint
-    runs-on: [ubuntu-18.04]
+    strategy:
+      matrix:
+        platform: [ubuntu-18.04, macos-latest]
+    runs-on: ${{ matrix.platform }}
     steps:
     - name: Set up Go 1.13
       uses: actions/setup-go@v1

--- a/Makefile
+++ b/Makefile
@@ -178,17 +178,23 @@ fmt:
 	@echo "===> Installing Golangci-lint <==="
 	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $@ v1.21.0
 
+# Setting CGO_ENABLED=1 to run golangci-lint is required on macOS to avoid the following error:
+#   build github.com/goccy/go-graphviz/internal/ccall: cannot load github.com/goccy/go-graphviz/internal/ccall: no Go source files
+# By default go never enables cgo when cross-compiling, but it is required by
+# go-graphviz. golangci-lint invokes "go list" to list source directories, which in turn tries to
+# build.
+
 .PHONY: golangci
 golangci: .golangci-bin
-	@GOOS=linux .golangci-bin/golangci-lint run -c .golangci.yml
+	@GOOS=linux CGO_ENABLED=1 .golangci-bin/golangci-lint run -c .golangci.yml
 
 .PHONY: golangci-fix
 golangci-fix: .golangci-bin
-	@GOOS=linux .golangci-bin/golangci-lint run -c .golangci.yml --fix
+	@GOOS=linux CGO_ENABLED=1 .golangci-bin/golangci-lint run -c .golangci.yml --fix
 
 .PHONY: lint
 lint: .golangci-bin
-	@GOOS=linux .golangci-bin/golangci-lint run -c .golangci-golint.yml
+	@GOOS=linux CGO_ENABLED=1 .golangci-bin/golangci-lint run -c .golangci-golint.yml
 
 .PHONY: clean
 clean:

--- a/pkg/agent/util/doc.go
+++ b/pkg/agent/util/doc.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 // Copyright 2020 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,13 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ovsctl
-
-import "os/exec"
-
-// File path of the ovs-vswitchd control UNIX domain socket.
-const ovsVSwitchdUDS = "/var/run/openvswitch/ovs-vswitchd.*.ctl"
-
-func getOVSCommand(cmdStr string) *exec.Cmd {
-	return exec.Command("/bin/sh", "-c", cmdStr)
-}
+// Package util contains utility functions which are used in the agent implementation.
+package util

--- a/pkg/agent/util/sysctl/doc.go
+++ b/pkg/agent/util/sysctl/doc.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 // Copyright 2020 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,13 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ovsctl
-
-import "os/exec"
-
-// File path of the ovs-vswitchd control UNIX domain socket.
-const ovsVSwitchdUDS = "/var/run/openvswitch/ovs-vswitchd.*.ctl"
-
-func getOVSCommand(cmdStr string) *exec.Cmd {
-	return exec.Command("/bin/sh", "-c", cmdStr)
-}
+// Package systcl contains utility functions to read and write sysctl configuration on Linux.
+package sysctl

--- a/pkg/agent/util/winfirewall/doc.go
+++ b/pkg/agent/util/winfirewall/doc.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 // Copyright 2020 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,13 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ovsctl
-
-import "os/exec"
-
-// File path of the ovs-vswitchd control UNIX domain socket.
-const ovsVSwitchdUDS = "/var/run/openvswitch/ovs-vswitchd.*.ctl"
-
-func getOVSCommand(cmdStr string) *exec.Cmd {
-	return exec.Command("/bin/sh", "-c", cmdStr)
-}
+// Package winfirewall contains utility functions to configure the Windows firewall.
+package winfirewall


### PR DESCRIPTION
Ever since goccy/go-graphviz was added as a dependency, running "make
golangci" (and related targets) has been broken on macOS. This is
because goccy/go-graphviz requires cgo to be enabled and go disables it
when cross-compiling (we set GOOS to linux in "make golangci" to ensure
that files with a linux build tag are verified by the linters).

We now run "make golangci" from a macOS worker in CI to avoid breaking
this again in the future.

In the future, we should also ensure that the linters are run on
Windows-specific files.

This commit also adds a few "missing" doc.go files.