### PR TITLE
Fix intraNodeUDPDstIPTraceflow Traceflow e2e test

### DIFF
--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -254,9 +254,9 @@ func TestTraceflow(t *testing.T) {
 							Action:        v1alpha1.Forwarded,
 						},
 						{
-							Component:     v1alpha1.Forwarding,
-							ComponentInfo: "Output",
-							Action:        v1alpha1.Delivered,
+							Component:     v1alpha1.NetworkPolicy,
+							ComponentInfo: "IngressDefaultRule",
+							Action:        v1alpha1.Dropped,
 						},
 					},
 				},


### PR DESCRIPTION
The test was incorrect (traffic is dropped by an ingress policy
rule). However, this only became apparent after #981 was merged and the
DMAC of the Traceflow packet started being set correctly.