### PR TITLE
Add support for matching DSCP field in the IP header

### DIFF
--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -209,6 +209,7 @@ type FlowBuilder interface {
 	MatchARPSpa(ip net.IP) FlowBuilder
 	MatchARPTpa(ip net.IP) FlowBuilder
 	MatchARPOp(op uint16) FlowBuilder
+	MatchIPDscp(dscp uint8) FlowBuilder
 	MatchCTStateNew(isSet bool) FlowBuilder
 	MatchCTStateRel(isSet bool) FlowBuilder
 	MatchCTStateRpl(isSet bool) FlowBuilder

--- a/pkg/ovs/openflow/ofctrl_builder.go
+++ b/pkg/ovs/openflow/ofctrl_builder.go
@@ -275,6 +275,15 @@ func (b *ofFlowBuilder) MatchARPOp(op uint16) FlowBuilder {
 	return b
 }
 
+// MatchIPDscp adds match condition for matching DSCP field in the IP header. Note, OVS use TOS to present DSCP, and
+// the field name is shown as "nw_tos" with OVS command line, and the value is calculated by shifting the given value
+// left 2 bits.
+func (b *ofFlowBuilder) MatchIPDscp(dscp uint8) FlowBuilder {
+	b.matchers = append(b.matchers, fmt.Sprintf("nw_tos=%d", dscp<<2))
+	b.Match.IpDscp = dscp
+	return b
+}
+
 // MatchConjID adds match condition for matching conj_id.
 func (b *ofFlowBuilder) MatchConjID(value uint32) FlowBuilder {
 	b.matchers = append(b.matchers, fmt.Sprintf("conj_id=%d", value))

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -1374,6 +1374,20 @@ func (mr *MockFlowBuilderMockRecorder) MatchDstMAC(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchDstMAC", reflect.TypeOf((*MockFlowBuilder)(nil).MatchDstMAC), arg0)
 }
 
+// MatchIPDscp mocks base method
+func (m *MockFlowBuilder) MatchIPDscp(arg0 byte) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MatchIPDscp", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// MatchIPDscp indicates an expected call of MatchIPDscp
+func (mr *MockFlowBuilderMockRecorder) MatchIPDscp(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchIPDscp", reflect.TypeOf((*MockFlowBuilder)(nil).MatchIPDscp), arg0)
+}
+
 // MatchInPort mocks base method
 func (m *MockFlowBuilder) MatchInPort(arg0 uint32) openflow.FlowBuilder {
 	m.ctrl.T.Helper()

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -66,6 +66,8 @@ var (
 	tunnelPeer       = net.ParseIP("10.1.1.2")
 	peerGW           = net.ParseIP("192.168.2.1")
 	vMAC, _          = net.ParseMAC("aa:bb:cc:dd:ee:ff")
+
+	ipDscp = uint8(10)
 )
 
 func newOFBridge(brName string) binding.Bridge {
@@ -956,6 +958,13 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 			MatchDstIPNet(*serviceCIDR).
 			Action().Output(int(gwOFPort)).
 			Done(),
+		table.BuildFlow(priorityNormal).
+			Cookie(getCookieID()).
+			MatchProtocol(binding.ProtocolIP).
+			MatchSrcIP(podIP).
+			MatchIPDscp(ipDscp).
+			Action().GotoTable(table.GetNext()).
+			Done(),
 		table.BuildFlow(priorityNormal+20).MatchProtocol(binding.ProtocolIP).Cookie(getCookieID()).MatchTCPDstPort(uint16(8080)).
 			Action().Conjunction(uint32(1001), uint8(3), uint8(3)).Done(),
 		table.BuildFlow(priorityNormal+20).MatchProtocol(binding.ProtocolIP).Cookie(getCookieID()).MatchSrcIP(podIP).
@@ -993,6 +1002,7 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 		&ExpectFlow{"priority=200,dl_dst=aa:aa:aa:aa:aa:13", fmt.Sprintf("load:0x3->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],%s", gotoTableAction)},
 		&ExpectFlow{"priority=200,ip,reg0=0x10000/0x10000", "output:NXM_NX_REG1[]"},
 		&ExpectFlow{"priority=200,ip,nw_dst=172.16.0.0/16", "output:1"},
+		&ExpectFlow{fmt.Sprintf("priority=200,ip,nw_src=192.168.1.3,nw_tos=%d", ipDscp<<2), gotoTableAction},
 		&ExpectFlow{"priority=220,tcp,tp_dst=8080", "conjunction(1001,3/3)"},
 		&ExpectFlow{"priority=220,ip,nw_src=192.168.1.3", "conjunction(1001,1/3)"},
 		&ExpectFlow{"priority=220,ip,nw_dst=192.168.3.0/24", "conjunction(1001,2/3)"},


### PR DESCRIPTION
OVS supports to match DSCP field in OpenFlow, and the field is shown
as "nw_tos" in OVS command line. Besides, the TOS value is shifting
the DSCP value left 2 bits.

Fixes #1003 