### PR TITLE
Switch CRD apiVersion to v1 from v1beta1

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -15,10 +15,14 @@ spec:
   scope: Cluster
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -35,29 +39,20 @@ spec:
   scope: Cluster
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
     app: antrea
   name: clusternetworkpolicies.security.antrea.tanzu.vmware.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.tier
-    description: The Tier to which this ClusterNetworkPolicy belongs to.
-    name: Tier
-    type: string
-  - JSONPath: .spec.priority
-    description: The Priority of this ClusterNetworkPolicy relative to other policies.
-    format: float
-    name: Priority
-    type: number
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: security.antrea.tanzu.vmware.com
   names:
     kind: ClusterNetworkPolicy
@@ -66,8 +61,8 @@ spec:
     - cnp
     - acnp
     singular: clusternetworkpolicy
-  preserveUnknownFields: false
   scope: Cluster
+<<<<<<< HEAD
   validation:
     openAPIV3Schema:
       properties:
@@ -166,12 +161,131 @@ spec:
           - priority
           type: object
       type: object
+=======
+>>>>>>> 3c3b508... Resolve conflicts
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The Tier to which this ClusterNetworkPolicy belongs to.
+      jsonPath: .spec.tier
+      name: Tier
+      type: string
+    - description: The Priority of this ClusterNetworkPolicy relative to other policies.
+      format: float
+      jsonPath: .spec.priority
+      name: Priority
+      type: number
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              appliedTo:
+                items:
+                  properties:
+                    namespaceSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                    podSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                type: array
+              egress:
+                items:
+                  properties:
+                    action:
+                      enum:
+                      - Allow
+                      - Drop
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      items:
+                        properties:
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                items:
+                  properties:
+                    action:
+                      enum:
+                      - Allow
+                      - Drop
+                      type: string
+                    from:
+                      items:
+                        properties:
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              priority:
+                format: float
+                maximum: 10000
+                minimum: 1
+                type: number
+              tier:
+                enum:
+                - Emergency
+                - SecurityOps
+                - NetworkOps
+                - Platform
+                - Application
+                type: string
+            required:
+            - appliedTo
+            - priority
+            type: object
+        type: object
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -185,63 +299,49 @@ spec:
     shortNames:
     - ee
     singular: externalentity
-  preserveUnknownFields: false
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            endpoints:
-              items:
-                properties:
-                  ip:
-                    format: ipv4
-                    type: string
-                  name:
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        name:
-                          type: string
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                type: object
-              type: array
-            externalNode:
-              type: string
-          type: object
-      type: object
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              endpoints:
+                items:
+                  properties:
+                    ip:
+                      format: ipv4
+                      type: string
+                    name:
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              externalNode:
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
     app: antrea
   name: networkpolicies.security.antrea.tanzu.vmware.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.tier
-    description: The Tier to which this Antrea NetworkPolicy belongs to.
-    name: Tier
-    type: string
-  - JSONPath: .spec.priority
-    description: The Priority of this Antrea NetworkPolicy relative to other policies.
-    format: float
-    name: Priority
-    type: number
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: security.antrea.tanzu.vmware.com
   names:
     kind: NetworkPolicy
@@ -250,121 +350,133 @@ spec:
     - netpol
     - anp
     singular: networkpolicy
-  preserveUnknownFields: false
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            appliedTo:
-              items:
-                properties:
-                  podSelector:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                type: object
-              type: array
-            egress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                  to:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            ingress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  from:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            priority:
-              format: float
-              maximum: 10000
-              minimum: 1
-              type: number
-            tier:
-              enum:
-              - Emergency
-              - SecurityOps
-              - NetworkOps
-              - Platform
-              - Application
-              type: string
-          required:
-          - appliedTo
-          - priority
-          type: object
-      type: object
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The Tier to which this Antrea NetworkPolicy belongs to.
+      jsonPath: .spec.tier
+      name: Tier
+      type: string
+    - description: The Priority of this Antrea NetworkPolicy relative to other policies.
+      format: float
+      jsonPath: .spec.priority
+      name: Priority
+      type: number
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              appliedTo:
+                items:
+                  properties:
+                    podSelector:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                type: array
+              egress:
+                items:
+                  properties:
+                    action:
+                      enum:
+                      - Allow
+                      - Drop
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      items:
+                        properties:
+                          externalEntitySelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                items:
+                  properties:
+                    action:
+                      enum:
+                      - Allow
+                      - Drop
+                      type: string
+                    from:
+                      items:
+                        properties:
+                          externalEntitySelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              priority:
+                format: float
+                maximum: 10000
+                minimum: 1
+                type: number
+              tier:
+                enum:
+                - Emergency
+                - SecurityOps
+                - NetworkOps
+                - Platform
+                - Application
+                type: string
+            required:
+            - appliedTo
+            - priority
+            type: object
+        type: object
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -415,29 +527,6 @@ metadata:
     app: antrea
   name: traceflows.ops.antrea.tanzu.vmware.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: The phase of the Traceflow.
-    name: Phase
-    type: string
-  - JSONPath: .spec.source.pod
-    description: The name of the source Pod.
-    name: Source-Pod
-    priority: 10
-    type: string
-  - JSONPath: .spec.destination.pod
-    description: The name of the destination Pod.
-    name: Destination-Pod
-    priority: 10
-    type: string
-  - JSONPath: .spec.destination.ip
-    description: The IP address of the destination.
-    name: Destination-IP
-    priority: 10
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: ops.antrea.tanzu.vmware.com
   names:
     kind: Traceflow
@@ -445,143 +534,165 @@ spec:
     shortNames:
     - tf
     singular: traceflow
-  preserveUnknownFields: false
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            destination:
-              oneOf:
-              - required:
+  versions:
+  - additionalPrinterColumns:
+    - description: The phase of the Traceflow.
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: The name of the source Pod.
+      jsonPath: .spec.source.pod
+      name: Source-Pod
+      priority: 10
+      type: string
+    - description: The name of the destination Pod.
+      jsonPath: .spec.destination.pod
+      name: Destination-Pod
+      priority: 10
+      type: string
+    - description: The IP address of the destination.
+      jsonPath: .spec.destination.ip
+      name: Destination-IP
+      priority: 10
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              destination:
+                oneOf:
+                - required:
+                  - pod
+                  - namespace
+                - required:
+                  - service
+                  - namespace
+                - required:
+                  - ip
+                properties:
+                  ip:
+                    format: ipv4
+                    type: string
+                  namespace:
+                    type: string
+                  pod:
+                    type: string
+                  service:
+                    type: string
+                type: object
+              packet:
+                properties:
+                  ipHeader:
+                    properties:
+                      flags:
+                        type: integer
+                      protocol:
+                        type: integer
+                      srcIP:
+                        format: ipv4
+                        type: string
+                      ttl:
+                        type: integer
+                    type: object
+                  transportHeader:
+                    properties:
+                      icmp:
+                        properties:
+                          id:
+                            type: integer
+                          sequence:
+                            type: integer
+                        type: object
+                      tcp:
+                        properties:
+                          dstPort:
+                            type: integer
+                          flags:
+                            type: integer
+                          srcPort:
+                            type: integer
+                        type: object
+                      udp:
+                        properties:
+                          dstPort:
+                            type: integer
+                          srcPort:
+                            type: integer
+                        type: object
+                    type: object
+                type: object
+              source:
+                properties:
+                  namespace:
+                    type: string
+                  pod:
+                    type: string
+                required:
                 - pod
                 - namespace
-              - required:
-                - service
-                - namespace
-              - required:
-                - ip
-              properties:
-                ip:
-                  format: ipv4
-                  type: string
-                namespace:
-                  type: string
-                pod:
-                  type: string
-                service:
-                  type: string
-              type: object
-            packet:
-              properties:
-                ipHeader:
-                  properties:
-                    flags:
-                      type: integer
-                    protocol:
-                      type: integer
-                    srcIP:
-                      format: ipv4
-                      type: string
-                    ttl:
-                      type: integer
-                  type: object
-                transportHeader:
-                  properties:
-                    icmp:
-                      properties:
-                        id:
-                          type: integer
-                        sequence:
-                          type: integer
-                      type: object
-                    tcp:
-                      properties:
-                        dstPort:
-                          type: integer
-                        flags:
-                          type: integer
-                        srcPort:
-                          type: integer
-                      type: object
-                    udp:
-                      properties:
-                        dstPort:
-                          type: integer
-                        srcPort:
-                          type: integer
-                      type: object
-                  type: object
-              type: object
-            source:
-              properties:
-                namespace:
-                  type: string
-                pod:
-                  type: string
-              required:
-              - pod
-              - namespace
-              type: object
-          required:
-          - source
-          - destination
-          type: object
-        status:
-          properties:
-            dataplaneTag:
-              type: integer
-            phase:
-              type: string
-            reason:
-              type: string
-            results:
-              items:
-                properties:
-                  node:
-                    type: string
-                  observations:
-                    items:
-                      properties:
-                        action:
-                          type: string
-                        component:
-                          type: string
-                        componentInfo:
-                          type: string
-                        dstMAC:
-                          type: string
-                        networkPolicy:
-                          type: string
-                        pod:
-                          type: string
-                        translatedDstIP:
-                          type: string
-                        translatedSrcIP:
-                          type: string
-                        ttl:
-                          type: integer
-                        tunnelDstIP:
-                          type: string
-                      type: object
-                    type: array
-                  role:
-                    type: string
-                  timestamp:
-                    type: integer
                 type: object
-              type: array
-          type: object
-      required:
-      - spec
-      type: object
-  versions:
-  - name: v1alpha1
+            required:
+            - source
+            - destination
+            type: object
+          status:
+            properties:
+              dataplaneTag:
+                type: integer
+              phase:
+                type: string
+              reason:
+                type: string
+              results:
+                items:
+                  properties:
+                    node:
+                      type: string
+                    observations:
+                      items:
+                        properties:
+                          action:
+                            type: string
+                          component:
+                            type: string
+                          componentInfo:
+                            type: string
+                          dstMAC:
+                            type: string
+                          networkPolicy:
+                            type: string
+                          pod:
+                            type: string
+                          translatedDstIP:
+                            type: string
+                          translatedSrcIP:
+                            type: string
+                          ttl:
+                            type: integer
+                          tunnelDstIP:
+                            type: string
+                        type: object
+                      type: array
+                    role:
+                      type: string
+                    timestamp:
+                      type: integer
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -62,107 +62,6 @@ spec:
     - acnp
     singular: clusternetworkpolicy
   scope: Cluster
-<<<<<<< HEAD
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            appliedTo:
-              items:
-                properties:
-                  namespaceSelector:
-                    x-kubernetes-preserve-unknown-fields: true
-                  podSelector:
-                    x-kubernetes-preserve-unknown-fields: true
-                type: object
-              type: array
-            egress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                  to:
-                    items:
-                      properties:
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            ingress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  from:
-                    items:
-                      properties:
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            priority:
-              format: float
-              maximum: 10000
-              minimum: 1
-              type: number
-            tier:
-              type: string
-          required:
-          - appliedTo
-          - priority
-          type: object
-      type: object
-=======
->>>>>>> 3c3b508... Resolve conflicts
   versions:
   - additionalPrinterColumns:
     - description: The Tier to which this ClusterNetworkPolicy belongs to.
@@ -181,17 +80,17 @@ spec:
     schema:
       openAPIV3Schema:
         properties:
-          spec:
-            properties:
-              appliedTo:
-                items:
-                  properties:
-                    namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
-                    podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
-                  type: object
-                type: array
+          appliedTo:
+            items:
+              properties:
+                namespaceSelector:
+                  x-kubernetes-preserve-unknown-fields: true
+                podSelector:
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+            type: array
+          ingress:
+            items:
               egress:
                 items:
                   properties:
@@ -228,14 +127,14 @@ spec:
                   - action
                   type: object
                 type: array
-              ingress:
-                items:
-                  properties:
-                    action:
-                      enum:
-                      - Allow
-                      - Drop
-                      type: string
+              properties:
+                action:
+                  enum:
+                  - Allow
+                  - Drop
+                  type: string
+                from:
+                  items:
                     from:
                       items:
                         properties:
@@ -251,36 +150,40 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
-                    ports:
-                      items:
+                    properties:
+                      ipBlock:
                         properties:
                           port:
                             x-kubernetes-int-or-string: true
                           protocol:
                             type: string
                         type: object
-                      type: array
-                  required:
-                  - action
-                  type: object
-                type: array
-              priority:
-                format: float
-                maximum: 10000
-                minimum: 1
-                type: number
-              tier:
-                enum:
-                - Emergency
-                - SecurityOps
-                - NetworkOps
-                - Platform
-                - Application
-                type: string
-            required:
-            - appliedTo
-            - priority
-            type: object
+                      namespaceSelector:
+                        x-kubernetes-preserve-unknown-fields: true
+                      podSelector:
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  type: array
+                ports:
+                  items:
+                    properties:
+                      port:
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        type: string
+                    type: object
+                  type: array
+              required:
+              - action
+              type: object
+            type: array
+          priority:
+            format: float
+            maximum: 10000
+            minimum: 1
+            type: number
+          tier:
+            type: string
         type: object
     served: true
     storage: true
@@ -483,14 +386,6 @@ metadata:
     app: antrea
   name: tiers.security.antrea.tanzu.vmware.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.priority
-    description: The Priority of this Tier relative to other Tiers.
-    name: Priority
-    type: integer
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: security.antrea.tanzu.vmware.com
   names:
     kind: Tier
@@ -498,29 +393,36 @@ spec:
     shortNames:
     - tr
     singular: tier
-  preserveUnknownFields: false
   scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            description:
-              type: string
-            priority:
-              maximum: 255
-              minimum: 0
-              type: integer
-          required:
-          - priority
-          type: object
-      type: object
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The Priority of this Tier relative to other Tiers.
+      jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              description:
+                type: string
+              priority:
+                maximum: 255
+                minimum: 0
+                type: integer
+            required:
+            - priority
+            type: object
+        type: object
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -80,25 +80,92 @@ spec:
     schema:
       openAPIV3Schema:
         properties:
-          appliedTo:
-            items:
-              properties:
-                namespaceSelector:
-                  x-kubernetes-preserve-unknown-fields: true
-                podSelector:
-                  x-kubernetes-preserve-unknown-fields: true
-              type: object
-            type: array
-          ingress:
-            items:
-              egress:
+          spec:
+            properties:
+              appliedTo:
                 items:
+                  properties:
+                    namespaceSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                    podSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                type: array
+              ingress:
+                items:
+                  egress:
+                    items:
+                      properties:
+                        action:
+                          enum:
+                          - Allow
+                          - Drop
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          type: array
+                        to:
+                          items:
+                            properties:
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                              podSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
                   properties:
                     action:
                       enum:
                       - Allow
                       - Drop
                       type: string
+                    from:
+                      items:
+                        from:
+                          items:
+                            properties:
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                              podSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        properties:
+                          ipBlock:
+                            properties:
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
                     ports:
                       items:
                         properties:
@@ -108,82 +175,18 @@ spec:
                             type: string
                         type: object
                       type: array
-                    to:
-                      items:
-                        properties:
-                          ipBlock:
-                            properties:
-                              cidr:
-                                format: cidr
-                                type: string
-                            type: object
-                          namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                          podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                      type: array
                   required:
                   - action
                   type: object
                 type: array
-              properties:
-                action:
-                  enum:
-                  - Allow
-                  - Drop
-                  type: string
-                from:
-                  items:
-                    from:
-                      items:
-                        properties:
-                          ipBlock:
-                            properties:
-                              cidr:
-                                format: cidr
-                                type: string
-                            type: object
-                          namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                          podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                      type: array
-                    properties:
-                      ipBlock:
-                        properties:
-                          port:
-                            x-kubernetes-int-or-string: true
-                          protocol:
-                            type: string
-                        type: object
-                      namespaceSelector:
-                        x-kubernetes-preserve-unknown-fields: true
-                      podSelector:
-                        x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                  type: array
-                ports:
-                  items:
-                    properties:
-                      port:
-                        x-kubernetes-int-or-string: true
-                      protocol:
-                        type: string
-                    type: object
-                  type: array
-              required:
-              - action
-              type: object
-            type: array
-          priority:
-            format: float
-            maximum: 10000
-            minimum: 1
-            type: number
-          tier:
-            type: string
+              priority:
+                format: float
+                maximum: 10000
+                minimum: 1
+                type: number
+              tier:
+                type: string
+            type: object
         type: object
     served: true
     storage: true

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -18,7 +18,7 @@ spec:
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -38,7 +38,7 @@ spec:
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -364,7 +364,7 @@ spec:
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -62,108 +62,6 @@ spec:
     - acnp
     singular: clusternetworkpolicy
   scope: Cluster
-<<<<<<< HEAD
-<<<<<<< HEAD
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            appliedTo:
-              items:
-                properties:
-                  namespaceSelector:
-                    x-kubernetes-preserve-unknown-fields: true
-                  podSelector:
-                    x-kubernetes-preserve-unknown-fields: true
-                type: object
-              type: array
-            egress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                  to:
-                    items:
-                      properties:
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            ingress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  from:
-                    items:
-                      properties:
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            priority:
-              format: float
-              maximum: 10000
-              minimum: 1
-              type: number
-            tier:
-              type: string
-          required:
-          - appliedTo
-          - priority
-          type: object
-      type: object
-=======
->>>>>>> 3c3b508... Resolve conflicts
   versions:
   - additionalPrinterColumns:
     - description: The Tier to which this ClusterNetworkPolicy belongs to.
@@ -182,17 +80,17 @@ spec:
     schema:
       openAPIV3Schema:
         properties:
-          spec:
-            properties:
-              appliedTo:
-                items:
-                  properties:
-                    namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
-                    podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
-                  type: object
-                type: array
+          appliedTo:
+            items:
+              properties:
+                namespaceSelector:
+                  x-kubernetes-preserve-unknown-fields: true
+                podSelector:
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+            type: array
+          ingress:
+            items:
               egress:
                 items:
                   properties:
@@ -229,14 +127,14 @@ spec:
                   - action
                   type: object
                 type: array
-              ingress:
-                items:
-                  properties:
-                    action:
-                      enum:
-                      - Allow
-                      - Drop
-                      type: string
+              properties:
+                action:
+                  enum:
+                  - Allow
+                  - Drop
+                  type: string
+                from:
+                  items:
                     from:
                       items:
                         properties:
@@ -252,36 +150,40 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
-                    ports:
-                      items:
+                    properties:
+                      ipBlock:
                         properties:
                           port:
                             x-kubernetes-int-or-string: true
                           protocol:
                             type: string
                         type: object
-                      type: array
-                  required:
-                  - action
-                  type: object
-                type: array
-              priority:
-                format: float
-                maximum: 10000
-                minimum: 1
-                type: number
-              tier:
-                enum:
-                - Emergency
-                - SecurityOps
-                - NetworkOps
-                - Platform
-                - Application
-                type: string
-            required:
-            - appliedTo
-            - priority
-            type: object
+                      namespaceSelector:
+                        x-kubernetes-preserve-unknown-fields: true
+                      podSelector:
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  type: array
+                ports:
+                  items:
+                    properties:
+                      port:
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        type: string
+                    type: object
+                  type: array
+              required:
+              - action
+              type: object
+            type: array
+          priority:
+            format: float
+            maximum: 10000
+            minimum: 1
+            type: number
+          tier:
+            type: string
         type: object
     served: true
     storage: true
@@ -484,14 +386,6 @@ metadata:
     app: antrea
   name: tiers.security.antrea.tanzu.vmware.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.priority
-    description: The Priority of this Tier relative to other Tiers.
-    name: Priority
-    type: integer
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: security.antrea.tanzu.vmware.com
   names:
     kind: Tier
@@ -499,29 +393,36 @@ spec:
     shortNames:
     - tr
     singular: tier
-  preserveUnknownFields: false
   scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            description:
-              type: string
-            priority:
-              maximum: 255
-              minimum: 0
-              type: integer
-          required:
-          - priority
-          type: object
-      type: object
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The Priority of this Tier relative to other Tiers.
+      jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              description:
+                type: string
+              priority:
+                maximum: 255
+                minimum: 0
+                type: integer
+            required:
+            - priority
+            type: object
+        type: object
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -15,6 +15,10 @@ spec:
   scope: Cluster
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
 ---
@@ -35,6 +39,10 @@ spec:
   scope: Cluster
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
 ---
@@ -45,6 +53,7 @@ metadata:
     app: antrea
   name: clusternetworkpolicies.security.antrea.tanzu.vmware.com
 spec:
+<<<<<<< HEAD
   additionalPrinterColumns:
   - JSONPath: .spec.tier
     description: The Tier to which this ClusterNetworkPolicy belongs to.
@@ -58,6 +67,8 @@ spec:
   - JSONPath: .metadata.creationTimestamp
     name: Age
     type: date
+=======
+>>>>>>> 960197f... Run make manifest
   group: security.antrea.tanzu.vmware.com
   names:
     kind: ClusterNetworkPolicy
@@ -66,8 +77,8 @@ spec:
     - cnp
     - acnp
     singular: clusternetworkpolicy
-  preserveUnknownFields: false
   scope: Cluster
+<<<<<<< HEAD
   validation:
     openAPIV3Schema:
       properties:
@@ -359,8 +370,111 @@ spec:
           - priority
           type: object
       type: object
+=======
+>>>>>>> 960197f... Run make manifest
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - JSONPath: .spec.priority
+      description: The Priority of this ClusterNetworkPolicy relative to other policies.
+      format: float
+      name: Priority
+      type: number
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              appliedTo:
+                items:
+                  properties:
+                    namespaceSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                    podSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                type: array
+              egress:
+                items:
+                  properties:
+                    action:
+                      pattern: \bAllow|\bDrop
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      items:
+                        properties:
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                items:
+                  properties:
+                    action:
+                      pattern: \bAllow|\bDrop
+                      type: string
+                    from:
+                      items:
+                        properties:
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              priority:
+                format: float
+                maximum: 10000
+                minimum: 1
+                type: number
+            required:
+            - appliedTo
+            - priority
+            type: object
+        type: object
     served: true
     storage: true
 ---
@@ -415,29 +529,6 @@ metadata:
     app: antrea
   name: traceflows.ops.antrea.tanzu.vmware.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: The phase of the Traceflow.
-    name: Phase
-    type: string
-  - JSONPath: .spec.source.pod
-    description: The name of the source Pod.
-    name: Source-Pod
-    priority: 10
-    type: string
-  - JSONPath: .spec.destination.pod
-    description: The name of the destination Pod.
-    name: Destination-Pod
-    priority: 10
-    type: string
-  - JSONPath: .spec.destination.ip
-    description: The IP address of the destination.
-    name: Destination-IP
-    priority: 10
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: ops.antrea.tanzu.vmware.com
   names:
     kind: Traceflow
@@ -445,20 +536,104 @@ spec:
     shortNames:
     - tf
     singular: traceflow
-  preserveUnknownFields: false
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            destination:
-              oneOf:
-              - required:
+  versions:
+  - additionalPrinterColumns:
+    - JSONPath: .status.phase
+      description: The phase of the Traceflow.
+      name: Phase
+      type: string
+    - JSONPath: .spec.source.pod
+      description: The name of the source Pod.
+      name: Source-Pod
+      priority: 10
+      type: string
+    - JSONPath: .spec.destination.pod
+      description: The name of the destination Pod.
+      name: Destination-Pod
+      priority: 10
+      type: string
+    - JSONPath: .spec.destination.ip
+      description: The IP address of the destination.
+      name: Destination-IP
+      priority: 10
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              destination:
+                oneOf:
+                - required:
+                  - pod
+                  - namespace
+                - required:
+                  - ip
+                properties:
+                  ip:
+                    format: ipv4
+                    type: string
+                  namespace:
+                    type: string
+                  pod:
+                    type: string
+                type: object
+              packet:
+                properties:
+                  ipHeader:
+                    properties:
+                      flags:
+                        type: integer
+                      protocol:
+                        type: integer
+                      srcIP:
+                        format: ipv4
+                        type: string
+                      ttl:
+                        type: integer
+                    type: object
+                  transportHeader:
+                    properties:
+                      icmp:
+                        properties:
+                          id:
+                            type: integer
+                          sequence:
+                            type: integer
+                        type: object
+                      tcp:
+                        properties:
+                          dstPort:
+                            type: integer
+                          flags:
+                            type: integer
+                          srcPort:
+                            type: integer
+                        type: object
+                      udp:
+                        properties:
+                          dstPort:
+                            type: integer
+                          srcPort:
+                            type: integer
+                        type: object
+                    type: object
+                type: object
+              source:
+                properties:
+                  namespace:
+                    type: string
+                  pod:
+                    type: string
+                required:
                 - pod
                 - namespace
+<<<<<<< HEAD
               - required:
                 - service
                 - namespace
@@ -478,110 +653,65 @@ spec:
             packet:
               properties:
                 ipHeader:
-                  properties:
-                    flags:
-                      type: integer
-                    protocol:
-                      type: integer
-                    srcIP:
-                      format: ipv4
-                      type: string
-                    ttl:
-                      type: integer
-                  type: object
-                transportHeader:
-                  properties:
-                    icmp:
-                      properties:
-                        id:
-                          type: integer
-                        sequence:
-                          type: integer
-                      type: object
-                    tcp:
-                      properties:
-                        dstPort:
-                          type: integer
-                        flags:
-                          type: integer
-                        srcPort:
-                          type: integer
-                      type: object
-                    udp:
-                      properties:
-                        dstPort:
-                          type: integer
-                        srcPort:
-                          type: integer
-                      type: object
-                  type: object
-              type: object
-            source:
-              properties:
-                namespace:
-                  type: string
-                pod:
-                  type: string
-              required:
-              - pod
-              - namespace
-              type: object
-          required:
-          - source
-          - destination
-          type: object
-        status:
-          properties:
-            dataplaneTag:
-              type: integer
-            phase:
-              type: string
-            reason:
-              type: string
-            results:
-              items:
-                properties:
-                  node:
-                    type: string
-                  observations:
-                    items:
-                      properties:
-                        action:
-                          type: string
-                        component:
-                          type: string
-                        componentInfo:
-                          type: string
-                        dstMAC:
-                          type: string
-                        networkPolicy:
-                          type: string
-                        pod:
-                          type: string
-                        translatedDstIP:
-                          type: string
-                        translatedSrcIP:
-                          type: string
-                        ttl:
-                          type: integer
-                        tunnelDstIP:
-                          type: string
-                      type: object
-                    type: array
-                  role:
-                    type: string
-                  timestamp:
-                    type: integer
+=======
                 type: object
-              type: array
-          type: object
-      required:
-      - spec
-      type: object
-  versions:
-  - name: v1alpha1
+            required:
+            - source
+            - destination
+            type: object
+          status:
+            properties:
+              dataplaneTag:
+                type: integer
+              phase:
+                type: string
+              reason:
+                type: string
+              results:
+                items:
+>>>>>>> 960197f... Run make manifest
+                  properties:
+                    node:
+                      type: string
+                    observations:
+                      items:
+                        properties:
+                          action:
+                            type: string
+                          component:
+                            type: string
+                          componentInfo:
+                            type: string
+                          dstMAC:
+                            type: string
+                          networkPolicy:
+                            type: string
+                          pod:
+                            type: string
+                          translatedDstIP:
+                            type: string
+                          translatedSrcIP:
+                            type: string
+                          ttl:
+                            type: integer
+                          tunnelDstIP:
+                            type: string
+                        type: object
+                      type: array
+                    role:
+                      type: string
+                    timestamp:
+                      type: integer
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -80,25 +80,92 @@ spec:
     schema:
       openAPIV3Schema:
         properties:
-          appliedTo:
-            items:
-              properties:
-                namespaceSelector:
-                  x-kubernetes-preserve-unknown-fields: true
-                podSelector:
-                  x-kubernetes-preserve-unknown-fields: true
-              type: object
-            type: array
-          ingress:
-            items:
-              egress:
+          spec:
+            properties:
+              appliedTo:
                 items:
+                  properties:
+                    namespaceSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                    podSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                type: array
+              ingress:
+                items:
+                  egress:
+                    items:
+                      properties:
+                        action:
+                          enum:
+                          - Allow
+                          - Drop
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          type: array
+                        to:
+                          items:
+                            properties:
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                              podSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
                   properties:
                     action:
                       enum:
                       - Allow
                       - Drop
                       type: string
+                    from:
+                      items:
+                        from:
+                          items:
+                            properties:
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                              podSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        properties:
+                          ipBlock:
+                            properties:
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
                     ports:
                       items:
                         properties:
@@ -108,82 +175,18 @@ spec:
                             type: string
                         type: object
                       type: array
-                    to:
-                      items:
-                        properties:
-                          ipBlock:
-                            properties:
-                              cidr:
-                                format: cidr
-                                type: string
-                            type: object
-                          namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                          podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                      type: array
                   required:
                   - action
                   type: object
                 type: array
-              properties:
-                action:
-                  enum:
-                  - Allow
-                  - Drop
-                  type: string
-                from:
-                  items:
-                    from:
-                      items:
-                        properties:
-                          ipBlock:
-                            properties:
-                              cidr:
-                                format: cidr
-                                type: string
-                            type: object
-                          namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                          podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                      type: array
-                    properties:
-                      ipBlock:
-                        properties:
-                          port:
-                            x-kubernetes-int-or-string: true
-                          protocol:
-                            type: string
-                        type: object
-                      namespaceSelector:
-                        x-kubernetes-preserve-unknown-fields: true
-                      podSelector:
-                        x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                  type: array
-                ports:
-                  items:
-                    properties:
-                      port:
-                        x-kubernetes-int-or-string: true
-                      protocol:
-                        type: string
-                    type: object
-                  type: array
-              required:
-              - action
-              type: object
-            type: array
-          priority:
-            format: float
-            maximum: 10000
-            minimum: 1
-            type: number
-          tier:
-            type: string
+              priority:
+                format: float
+                maximum: 10000
+                minimum: 1
+                type: number
+              tier:
+                type: string
+            type: object
         type: object
     served: true
     storage: true

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -53,22 +53,6 @@ metadata:
     app: antrea
   name: clusternetworkpolicies.security.antrea.tanzu.vmware.com
 spec:
-<<<<<<< HEAD
-  additionalPrinterColumns:
-  - JSONPath: .spec.tier
-    description: The Tier to which this ClusterNetworkPolicy belongs to.
-    name: Tier
-    type: string
-  - JSONPath: .spec.priority
-    description: The Priority of this ClusterNetworkPolicy relative to other policies.
-    format: float
-    name: Priority
-    type: number
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
-=======
->>>>>>> 960197f... Run make manifest
   group: security.antrea.tanzu.vmware.com
   names:
     kind: ClusterNetworkPolicy
@@ -78,6 +62,7 @@ spec:
     - acnp
     singular: clusternetworkpolicy
   scope: Cluster
+<<<<<<< HEAD
 <<<<<<< HEAD
   validation:
     openAPIV3Schema:
@@ -177,203 +162,14 @@ spec:
           - priority
           type: object
       type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  labels:
-    app: antrea
-  name: externalentities.core.antrea.tanzu.vmware.com
-spec:
-  group: core.antrea.tanzu.vmware.com
-  names:
-    kind: ExternalEntity
-    plural: externalentities
-    shortNames:
-    - ee
-    singular: externalentity
-  preserveUnknownFields: false
-  scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            endpoints:
-              items:
-                properties:
-                  ip:
-                    format: ipv4
-                    type: string
-                  name:
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        name:
-                          type: string
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                type: object
-              type: array
-            externalNode:
-              type: string
-          type: object
-      type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  labels:
-    app: antrea
-  name: networkpolicies.security.antrea.tanzu.vmware.com
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.tier
-    description: The Tier to which this Antrea NetworkPolicy belongs to.
-    name: Tier
-    type: string
-  - JSONPath: .spec.priority
-    description: The Priority of this Antrea NetworkPolicy relative to other policies.
-    format: float
-    name: Priority
-    type: number
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
-  group: security.antrea.tanzu.vmware.com
-  names:
-    kind: NetworkPolicy
-    plural: networkpolicies
-    shortNames:
-    - netpol
-    - anp
-    singular: networkpolicy
-  preserveUnknownFields: false
-  scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            appliedTo:
-              items:
-                properties:
-                  podSelector:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                type: object
-              type: array
-            egress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                  to:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            ingress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  from:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            priority:
-              format: float
-              maximum: 10000
-              minimum: 1
-              type: number
-            tier:
-              enum:
-              - Emergency
-              - SecurityOps
-              - NetworkOps
-              - Platform
-              - Application
-              type: string
-          required:
-          - appliedTo
-          - priority
-          type: object
-      type: object
 =======
->>>>>>> 960197f... Run make manifest
+>>>>>>> 3c3b508... Resolve conflicts
   versions:
   - additionalPrinterColumns:
+    - description: The Tier to which this ClusterNetworkPolicy belongs to.
+      jsonPath: .spec.tier
+      name: Tier
+      type: string
     - description: The Priority of this ClusterNetworkPolicy relative to other policies.
       format: float
       jsonPath: .spec.priority
@@ -401,7 +197,9 @@ spec:
                 items:
                   properties:
                     action:
-                      pattern: \bAllow|\bDrop
+                      enum:
+                      - Allow
+                      - Drop
                       type: string
                     ports:
                       items:
@@ -435,7 +233,9 @@ spec:
                 items:
                   properties:
                     action:
-                      pattern: \bAllow|\bDrop
+                      enum:
+                      - Allow
+                      - Drop
                       type: string
                     from:
                       items:
@@ -470,6 +270,205 @@ spec:
                 maximum: 10000
                 minimum: 1
                 type: number
+              tier:
+                enum:
+                - Emergency
+                - SecurityOps
+                - NetworkOps
+                - Platform
+                - Application
+                type: string
+            required:
+            - appliedTo
+            - priority
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app: antrea
+  name: externalentities.core.antrea.tanzu.vmware.com
+spec:
+  group: core.antrea.tanzu.vmware.com
+  names:
+    kind: ExternalEntity
+    plural: externalentities
+    shortNames:
+    - ee
+    singular: externalentity
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              endpoints:
+                items:
+                  properties:
+                    ip:
+                      format: ipv4
+                      type: string
+                    name:
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              externalNode:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app: antrea
+  name: networkpolicies.security.antrea.tanzu.vmware.com
+spec:
+  group: security.antrea.tanzu.vmware.com
+  names:
+    kind: NetworkPolicy
+    plural: networkpolicies
+    shortNames:
+    - netpol
+    - anp
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Tier to which this Antrea NetworkPolicy belongs to.
+      jsonPath: .spec.tier
+      name: Tier
+      type: string
+    - description: The Priority of this Antrea NetworkPolicy relative to other policies.
+      format: float
+      jsonPath: .spec.priority
+      name: Priority
+      type: number
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              appliedTo:
+                items:
+                  properties:
+                    podSelector:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                type: array
+              egress:
+                items:
+                  properties:
+                    action:
+                      enum:
+                      - Allow
+                      - Drop
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      items:
+                        properties:
+                          externalEntitySelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                items:
+                  properties:
+                    action:
+                      enum:
+                      - Allow
+                      - Drop
+                      type: string
+                    from:
+                      items:
+                        properties:
+                          externalEntitySelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              priority:
+                format: float
+                maximum: 10000
+                minimum: 1
+                type: number
+              tier:
+                enum:
+                - Emergency
+                - SecurityOps
+                - NetworkOps
+                - Platform
+                - Application
+                type: string
             required:
             - appliedTo
             - priority
@@ -573,6 +572,9 @@ spec:
                   - pod
                   - namespace
                 - required:
+                  - service
+                  - namespace
+                - required:
                   - ip
                 properties:
                   ip:
@@ -581,6 +583,8 @@ spec:
                   namespace:
                     type: string
                   pod:
+                    type: string
+                  service:
                     type: string
                 type: object
               packet:
@@ -633,27 +637,6 @@ spec:
                 required:
                 - pod
                 - namespace
-<<<<<<< HEAD
-              - required:
-                - service
-                - namespace
-              - required:
-                - ip
-              properties:
-                ip:
-                  format: ipv4
-                  type: string
-                namespace:
-                  type: string
-                pod:
-                  type: string
-                service:
-                  type: string
-              type: object
-            packet:
-              properties:
-                ipHeader:
-=======
                 type: object
             required:
             - source
@@ -669,7 +652,6 @@ spec:
                 type: string
               results:
                 items:
->>>>>>> 960197f... Run make manifest
                   properties:
                     node:
                       type: string

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -374,12 +374,12 @@ spec:
 >>>>>>> 960197f... Run make manifest
   versions:
   - additionalPrinterColumns:
-    - JSONPath: .spec.priority
-      description: The Priority of this ClusterNetworkPolicy relative to other policies.
+    - description: The Priority of this ClusterNetworkPolicy relative to other policies.
       format: float
+      jsonPath: .spec.priority
       name: Priority
       type: number
-    - JSONPath: .metadata.creationTimestamp
+    - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
     name: v1alpha1
@@ -539,26 +539,26 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - JSONPath: .status.phase
-      description: The phase of the Traceflow.
+    - description: The phase of the Traceflow.
+      jsonPath: .status.phase
       name: Phase
       type: string
-    - JSONPath: .spec.source.pod
-      description: The name of the source Pod.
+    - description: The name of the source Pod.
+      jsonPath: .spec.source.pod
       name: Source-Pod
       priority: 10
       type: string
-    - JSONPath: .spec.destination.pod
-      description: The name of the destination Pod.
+    - description: The name of the destination Pod.
+      jsonPath: .spec.destination.pod
       name: Destination-Pod
       priority: 10
       type: string
-    - JSONPath: .spec.destination.ip
-      description: The IP address of the destination.
+    - description: The IP address of the destination.
+      jsonPath: .spec.destination.ip
       name: Destination-IP
       priority: 10
       type: string
-    - JSONPath: .metadata.creationTimestamp
+    - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
     name: v1alpha1

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -18,7 +18,7 @@ spec:
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -38,7 +38,7 @@ spec:
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -364,7 +364,7 @@ spec:
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -62,108 +62,6 @@ spec:
     - acnp
     singular: clusternetworkpolicy
   scope: Cluster
-<<<<<<< HEAD
-<<<<<<< HEAD
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            appliedTo:
-              items:
-                properties:
-                  namespaceSelector:
-                    x-kubernetes-preserve-unknown-fields: true
-                  podSelector:
-                    x-kubernetes-preserve-unknown-fields: true
-                type: object
-              type: array
-            egress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                  to:
-                    items:
-                      properties:
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            ingress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  from:
-                    items:
-                      properties:
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            priority:
-              format: float
-              maximum: 10000
-              minimum: 1
-              type: number
-            tier:
-              type: string
-          required:
-          - appliedTo
-          - priority
-          type: object
-      type: object
-=======
->>>>>>> 3c3b508... Resolve conflicts
   versions:
   - additionalPrinterColumns:
     - description: The Tier to which this ClusterNetworkPolicy belongs to.
@@ -182,17 +80,17 @@ spec:
     schema:
       openAPIV3Schema:
         properties:
-          spec:
-            properties:
-              appliedTo:
-                items:
-                  properties:
-                    namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
-                    podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
-                  type: object
-                type: array
+          appliedTo:
+            items:
+              properties:
+                namespaceSelector:
+                  x-kubernetes-preserve-unknown-fields: true
+                podSelector:
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+            type: array
+          ingress:
+            items:
               egress:
                 items:
                   properties:
@@ -229,14 +127,14 @@ spec:
                   - action
                   type: object
                 type: array
-              ingress:
-                items:
-                  properties:
-                    action:
-                      enum:
-                      - Allow
-                      - Drop
-                      type: string
+              properties:
+                action:
+                  enum:
+                  - Allow
+                  - Drop
+                  type: string
+                from:
+                  items:
                     from:
                       items:
                         properties:
@@ -252,36 +150,40 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
-                    ports:
-                      items:
+                    properties:
+                      ipBlock:
                         properties:
                           port:
                             x-kubernetes-int-or-string: true
                           protocol:
                             type: string
                         type: object
-                      type: array
-                  required:
-                  - action
-                  type: object
-                type: array
-              priority:
-                format: float
-                maximum: 10000
-                minimum: 1
-                type: number
-              tier:
-                enum:
-                - Emergency
-                - SecurityOps
-                - NetworkOps
-                - Platform
-                - Application
-                type: string
-            required:
-            - appliedTo
-            - priority
-            type: object
+                      namespaceSelector:
+                        x-kubernetes-preserve-unknown-fields: true
+                      podSelector:
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  type: array
+                ports:
+                  items:
+                    properties:
+                      port:
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        type: string
+                    type: object
+                  type: array
+              required:
+              - action
+              type: object
+            type: array
+          priority:
+            format: float
+            maximum: 10000
+            minimum: 1
+            type: number
+          tier:
+            type: string
         type: object
     served: true
     storage: true
@@ -484,14 +386,6 @@ metadata:
     app: antrea
   name: tiers.security.antrea.tanzu.vmware.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.priority
-    description: The Priority of this Tier relative to other Tiers.
-    name: Priority
-    type: integer
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: security.antrea.tanzu.vmware.com
   names:
     kind: Tier
@@ -499,29 +393,36 @@ spec:
     shortNames:
     - tr
     singular: tier
-  preserveUnknownFields: false
   scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            description:
-              type: string
-            priority:
-              maximum: 255
-              minimum: 0
-              type: integer
-          required:
-          - priority
-          type: object
-      type: object
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The Priority of this Tier relative to other Tiers.
+      jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              description:
+                type: string
+              priority:
+                maximum: 255
+                minimum: 0
+                type: integer
+            required:
+            - priority
+            type: object
+        type: object
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -15,6 +15,10 @@ spec:
   scope: Cluster
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
 ---
@@ -35,6 +39,10 @@ spec:
   scope: Cluster
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
 ---
@@ -45,6 +53,7 @@ metadata:
     app: antrea
   name: clusternetworkpolicies.security.antrea.tanzu.vmware.com
 spec:
+<<<<<<< HEAD
   additionalPrinterColumns:
   - JSONPath: .spec.tier
     description: The Tier to which this ClusterNetworkPolicy belongs to.
@@ -58,6 +67,8 @@ spec:
   - JSONPath: .metadata.creationTimestamp
     name: Age
     type: date
+=======
+>>>>>>> 960197f... Run make manifest
   group: security.antrea.tanzu.vmware.com
   names:
     kind: ClusterNetworkPolicy
@@ -66,8 +77,8 @@ spec:
     - cnp
     - acnp
     singular: clusternetworkpolicy
-  preserveUnknownFields: false
   scope: Cluster
+<<<<<<< HEAD
   validation:
     openAPIV3Schema:
       properties:
@@ -359,8 +370,111 @@ spec:
           - priority
           type: object
       type: object
+=======
+>>>>>>> 960197f... Run make manifest
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - JSONPath: .spec.priority
+      description: The Priority of this ClusterNetworkPolicy relative to other policies.
+      format: float
+      name: Priority
+      type: number
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              appliedTo:
+                items:
+                  properties:
+                    namespaceSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                    podSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                type: array
+              egress:
+                items:
+                  properties:
+                    action:
+                      pattern: \bAllow|\bDrop
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      items:
+                        properties:
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                items:
+                  properties:
+                    action:
+                      pattern: \bAllow|\bDrop
+                      type: string
+                    from:
+                      items:
+                        properties:
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              priority:
+                format: float
+                maximum: 10000
+                minimum: 1
+                type: number
+            required:
+            - appliedTo
+            - priority
+            type: object
+        type: object
     served: true
     storage: true
 ---
@@ -415,29 +529,6 @@ metadata:
     app: antrea
   name: traceflows.ops.antrea.tanzu.vmware.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: The phase of the Traceflow.
-    name: Phase
-    type: string
-  - JSONPath: .spec.source.pod
-    description: The name of the source Pod.
-    name: Source-Pod
-    priority: 10
-    type: string
-  - JSONPath: .spec.destination.pod
-    description: The name of the destination Pod.
-    name: Destination-Pod
-    priority: 10
-    type: string
-  - JSONPath: .spec.destination.ip
-    description: The IP address of the destination.
-    name: Destination-IP
-    priority: 10
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: ops.antrea.tanzu.vmware.com
   names:
     kind: Traceflow
@@ -445,20 +536,104 @@ spec:
     shortNames:
     - tf
     singular: traceflow
-  preserveUnknownFields: false
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            destination:
-              oneOf:
-              - required:
+  versions:
+  - additionalPrinterColumns:
+    - JSONPath: .status.phase
+      description: The phase of the Traceflow.
+      name: Phase
+      type: string
+    - JSONPath: .spec.source.pod
+      description: The name of the source Pod.
+      name: Source-Pod
+      priority: 10
+      type: string
+    - JSONPath: .spec.destination.pod
+      description: The name of the destination Pod.
+      name: Destination-Pod
+      priority: 10
+      type: string
+    - JSONPath: .spec.destination.ip
+      description: The IP address of the destination.
+      name: Destination-IP
+      priority: 10
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              destination:
+                oneOf:
+                - required:
+                  - pod
+                  - namespace
+                - required:
+                  - ip
+                properties:
+                  ip:
+                    format: ipv4
+                    type: string
+                  namespace:
+                    type: string
+                  pod:
+                    type: string
+                type: object
+              packet:
+                properties:
+                  ipHeader:
+                    properties:
+                      flags:
+                        type: integer
+                      protocol:
+                        type: integer
+                      srcIP:
+                        format: ipv4
+                        type: string
+                      ttl:
+                        type: integer
+                    type: object
+                  transportHeader:
+                    properties:
+                      icmp:
+                        properties:
+                          id:
+                            type: integer
+                          sequence:
+                            type: integer
+                        type: object
+                      tcp:
+                        properties:
+                          dstPort:
+                            type: integer
+                          flags:
+                            type: integer
+                          srcPort:
+                            type: integer
+                        type: object
+                      udp:
+                        properties:
+                          dstPort:
+                            type: integer
+                          srcPort:
+                            type: integer
+                        type: object
+                    type: object
+                type: object
+              source:
+                properties:
+                  namespace:
+                    type: string
+                  pod:
+                    type: string
+                required:
                 - pod
                 - namespace
+<<<<<<< HEAD
               - required:
                 - service
                 - namespace
@@ -478,110 +653,65 @@ spec:
             packet:
               properties:
                 ipHeader:
-                  properties:
-                    flags:
-                      type: integer
-                    protocol:
-                      type: integer
-                    srcIP:
-                      format: ipv4
-                      type: string
-                    ttl:
-                      type: integer
-                  type: object
-                transportHeader:
-                  properties:
-                    icmp:
-                      properties:
-                        id:
-                          type: integer
-                        sequence:
-                          type: integer
-                      type: object
-                    tcp:
-                      properties:
-                        dstPort:
-                          type: integer
-                        flags:
-                          type: integer
-                        srcPort:
-                          type: integer
-                      type: object
-                    udp:
-                      properties:
-                        dstPort:
-                          type: integer
-                        srcPort:
-                          type: integer
-                      type: object
-                  type: object
-              type: object
-            source:
-              properties:
-                namespace:
-                  type: string
-                pod:
-                  type: string
-              required:
-              - pod
-              - namespace
-              type: object
-          required:
-          - source
-          - destination
-          type: object
-        status:
-          properties:
-            dataplaneTag:
-              type: integer
-            phase:
-              type: string
-            reason:
-              type: string
-            results:
-              items:
-                properties:
-                  node:
-                    type: string
-                  observations:
-                    items:
-                      properties:
-                        action:
-                          type: string
-                        component:
-                          type: string
-                        componentInfo:
-                          type: string
-                        dstMAC:
-                          type: string
-                        networkPolicy:
-                          type: string
-                        pod:
-                          type: string
-                        translatedDstIP:
-                          type: string
-                        translatedSrcIP:
-                          type: string
-                        ttl:
-                          type: integer
-                        tunnelDstIP:
-                          type: string
-                      type: object
-                    type: array
-                  role:
-                    type: string
-                  timestamp:
-                    type: integer
+=======
                 type: object
-              type: array
-          type: object
-      required:
-      - spec
-      type: object
-  versions:
-  - name: v1alpha1
+            required:
+            - source
+            - destination
+            type: object
+          status:
+            properties:
+              dataplaneTag:
+                type: integer
+              phase:
+                type: string
+              reason:
+                type: string
+              results:
+                items:
+>>>>>>> 960197f... Run make manifest
+                  properties:
+                    node:
+                      type: string
+                    observations:
+                      items:
+                        properties:
+                          action:
+                            type: string
+                          component:
+                            type: string
+                          componentInfo:
+                            type: string
+                          dstMAC:
+                            type: string
+                          networkPolicy:
+                            type: string
+                          pod:
+                            type: string
+                          translatedDstIP:
+                            type: string
+                          translatedSrcIP:
+                            type: string
+                          ttl:
+                            type: integer
+                          tunnelDstIP:
+                            type: string
+                        type: object
+                      type: array
+                    role:
+                      type: string
+                    timestamp:
+                      type: integer
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -80,25 +80,92 @@ spec:
     schema:
       openAPIV3Schema:
         properties:
-          appliedTo:
-            items:
-              properties:
-                namespaceSelector:
-                  x-kubernetes-preserve-unknown-fields: true
-                podSelector:
-                  x-kubernetes-preserve-unknown-fields: true
-              type: object
-            type: array
-          ingress:
-            items:
-              egress:
+          spec:
+            properties:
+              appliedTo:
                 items:
+                  properties:
+                    namespaceSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                    podSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                type: array
+              ingress:
+                items:
+                  egress:
+                    items:
+                      properties:
+                        action:
+                          enum:
+                          - Allow
+                          - Drop
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          type: array
+                        to:
+                          items:
+                            properties:
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                              podSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
                   properties:
                     action:
                       enum:
                       - Allow
                       - Drop
                       type: string
+                    from:
+                      items:
+                        from:
+                          items:
+                            properties:
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                              podSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        properties:
+                          ipBlock:
+                            properties:
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
                     ports:
                       items:
                         properties:
@@ -108,82 +175,18 @@ spec:
                             type: string
                         type: object
                       type: array
-                    to:
-                      items:
-                        properties:
-                          ipBlock:
-                            properties:
-                              cidr:
-                                format: cidr
-                                type: string
-                            type: object
-                          namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                          podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                      type: array
                   required:
                   - action
                   type: object
                 type: array
-              properties:
-                action:
-                  enum:
-                  - Allow
-                  - Drop
-                  type: string
-                from:
-                  items:
-                    from:
-                      items:
-                        properties:
-                          ipBlock:
-                            properties:
-                              cidr:
-                                format: cidr
-                                type: string
-                            type: object
-                          namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                          podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                      type: array
-                    properties:
-                      ipBlock:
-                        properties:
-                          port:
-                            x-kubernetes-int-or-string: true
-                          protocol:
-                            type: string
-                        type: object
-                      namespaceSelector:
-                        x-kubernetes-preserve-unknown-fields: true
-                      podSelector:
-                        x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                  type: array
-                ports:
-                  items:
-                    properties:
-                      port:
-                        x-kubernetes-int-or-string: true
-                      protocol:
-                        type: string
-                    type: object
-                  type: array
-              required:
-              - action
-              type: object
-            type: array
-          priority:
-            format: float
-            maximum: 10000
-            minimum: 1
-            type: number
-          tier:
-            type: string
+              priority:
+                format: float
+                maximum: 10000
+                minimum: 1
+                type: number
+              tier:
+                type: string
+            type: object
         type: object
     served: true
     storage: true

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -53,22 +53,6 @@ metadata:
     app: antrea
   name: clusternetworkpolicies.security.antrea.tanzu.vmware.com
 spec:
-<<<<<<< HEAD
-  additionalPrinterColumns:
-  - JSONPath: .spec.tier
-    description: The Tier to which this ClusterNetworkPolicy belongs to.
-    name: Tier
-    type: string
-  - JSONPath: .spec.priority
-    description: The Priority of this ClusterNetworkPolicy relative to other policies.
-    format: float
-    name: Priority
-    type: number
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
-=======
->>>>>>> 960197f... Run make manifest
   group: security.antrea.tanzu.vmware.com
   names:
     kind: ClusterNetworkPolicy
@@ -78,6 +62,7 @@ spec:
     - acnp
     singular: clusternetworkpolicy
   scope: Cluster
+<<<<<<< HEAD
 <<<<<<< HEAD
   validation:
     openAPIV3Schema:
@@ -177,203 +162,14 @@ spec:
           - priority
           type: object
       type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  labels:
-    app: antrea
-  name: externalentities.core.antrea.tanzu.vmware.com
-spec:
-  group: core.antrea.tanzu.vmware.com
-  names:
-    kind: ExternalEntity
-    plural: externalentities
-    shortNames:
-    - ee
-    singular: externalentity
-  preserveUnknownFields: false
-  scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            endpoints:
-              items:
-                properties:
-                  ip:
-                    format: ipv4
-                    type: string
-                  name:
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        name:
-                          type: string
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                type: object
-              type: array
-            externalNode:
-              type: string
-          type: object
-      type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  labels:
-    app: antrea
-  name: networkpolicies.security.antrea.tanzu.vmware.com
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.tier
-    description: The Tier to which this Antrea NetworkPolicy belongs to.
-    name: Tier
-    type: string
-  - JSONPath: .spec.priority
-    description: The Priority of this Antrea NetworkPolicy relative to other policies.
-    format: float
-    name: Priority
-    type: number
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
-  group: security.antrea.tanzu.vmware.com
-  names:
-    kind: NetworkPolicy
-    plural: networkpolicies
-    shortNames:
-    - netpol
-    - anp
-    singular: networkpolicy
-  preserveUnknownFields: false
-  scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            appliedTo:
-              items:
-                properties:
-                  podSelector:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                type: object
-              type: array
-            egress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                  to:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            ingress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  from:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            priority:
-              format: float
-              maximum: 10000
-              minimum: 1
-              type: number
-            tier:
-              enum:
-              - Emergency
-              - SecurityOps
-              - NetworkOps
-              - Platform
-              - Application
-              type: string
-          required:
-          - appliedTo
-          - priority
-          type: object
-      type: object
 =======
->>>>>>> 960197f... Run make manifest
+>>>>>>> 3c3b508... Resolve conflicts
   versions:
   - additionalPrinterColumns:
+    - description: The Tier to which this ClusterNetworkPolicy belongs to.
+      jsonPath: .spec.tier
+      name: Tier
+      type: string
     - description: The Priority of this ClusterNetworkPolicy relative to other policies.
       format: float
       jsonPath: .spec.priority
@@ -401,7 +197,9 @@ spec:
                 items:
                   properties:
                     action:
-                      pattern: \bAllow|\bDrop
+                      enum:
+                      - Allow
+                      - Drop
                       type: string
                     ports:
                       items:
@@ -435,7 +233,9 @@ spec:
                 items:
                   properties:
                     action:
-                      pattern: \bAllow|\bDrop
+                      enum:
+                      - Allow
+                      - Drop
                       type: string
                     from:
                       items:
@@ -470,6 +270,205 @@ spec:
                 maximum: 10000
                 minimum: 1
                 type: number
+              tier:
+                enum:
+                - Emergency
+                - SecurityOps
+                - NetworkOps
+                - Platform
+                - Application
+                type: string
+            required:
+            - appliedTo
+            - priority
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app: antrea
+  name: externalentities.core.antrea.tanzu.vmware.com
+spec:
+  group: core.antrea.tanzu.vmware.com
+  names:
+    kind: ExternalEntity
+    plural: externalentities
+    shortNames:
+    - ee
+    singular: externalentity
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              endpoints:
+                items:
+                  properties:
+                    ip:
+                      format: ipv4
+                      type: string
+                    name:
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              externalNode:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app: antrea
+  name: networkpolicies.security.antrea.tanzu.vmware.com
+spec:
+  group: security.antrea.tanzu.vmware.com
+  names:
+    kind: NetworkPolicy
+    plural: networkpolicies
+    shortNames:
+    - netpol
+    - anp
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Tier to which this Antrea NetworkPolicy belongs to.
+      jsonPath: .spec.tier
+      name: Tier
+      type: string
+    - description: The Priority of this Antrea NetworkPolicy relative to other policies.
+      format: float
+      jsonPath: .spec.priority
+      name: Priority
+      type: number
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              appliedTo:
+                items:
+                  properties:
+                    podSelector:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                type: array
+              egress:
+                items:
+                  properties:
+                    action:
+                      enum:
+                      - Allow
+                      - Drop
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      items:
+                        properties:
+                          externalEntitySelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                items:
+                  properties:
+                    action:
+                      enum:
+                      - Allow
+                      - Drop
+                      type: string
+                    from:
+                      items:
+                        properties:
+                          externalEntitySelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              priority:
+                format: float
+                maximum: 10000
+                minimum: 1
+                type: number
+              tier:
+                enum:
+                - Emergency
+                - SecurityOps
+                - NetworkOps
+                - Platform
+                - Application
+                type: string
             required:
             - appliedTo
             - priority
@@ -573,6 +572,9 @@ spec:
                   - pod
                   - namespace
                 - required:
+                  - service
+                  - namespace
+                - required:
                   - ip
                 properties:
                   ip:
@@ -581,6 +583,8 @@ spec:
                   namespace:
                     type: string
                   pod:
+                    type: string
+                  service:
                     type: string
                 type: object
               packet:
@@ -633,27 +637,6 @@ spec:
                 required:
                 - pod
                 - namespace
-<<<<<<< HEAD
-              - required:
-                - service
-                - namespace
-              - required:
-                - ip
-              properties:
-                ip:
-                  format: ipv4
-                  type: string
-                namespace:
-                  type: string
-                pod:
-                  type: string
-                service:
-                  type: string
-              type: object
-            packet:
-              properties:
-                ipHeader:
-=======
                 type: object
             required:
             - source
@@ -669,7 +652,6 @@ spec:
                 type: string
               results:
                 items:
->>>>>>> 960197f... Run make manifest
                   properties:
                     node:
                       type: string

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -374,12 +374,12 @@ spec:
 >>>>>>> 960197f... Run make manifest
   versions:
   - additionalPrinterColumns:
-    - JSONPath: .spec.priority
-      description: The Priority of this ClusterNetworkPolicy relative to other policies.
+    - description: The Priority of this ClusterNetworkPolicy relative to other policies.
       format: float
+      jsonPath: .spec.priority
       name: Priority
       type: number
-    - JSONPath: .metadata.creationTimestamp
+    - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
     name: v1alpha1
@@ -539,26 +539,26 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - JSONPath: .status.phase
-      description: The phase of the Traceflow.
+    - description: The phase of the Traceflow.
+      jsonPath: .status.phase
       name: Phase
       type: string
-    - JSONPath: .spec.source.pod
-      description: The name of the source Pod.
+    - description: The name of the source Pod.
+      jsonPath: .spec.source.pod
       name: Source-Pod
       priority: 10
       type: string
-    - JSONPath: .spec.destination.pod
-      description: The name of the destination Pod.
+    - description: The name of the destination Pod.
+      jsonPath: .spec.destination.pod
       name: Destination-Pod
       priority: 10
       type: string
-    - JSONPath: .spec.destination.ip
-      description: The IP address of the destination.
+    - description: The IP address of the destination.
+      jsonPath: .spec.destination.ip
       name: Destination-IP
       priority: 10
       type: string
-    - JSONPath: .metadata.creationTimestamp
+    - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
     name: v1alpha1

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -62,108 +62,6 @@ spec:
     - acnp
     singular: clusternetworkpolicy
   scope: Cluster
-<<<<<<< HEAD
-<<<<<<< HEAD
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            appliedTo:
-              items:
-                properties:
-                  namespaceSelector:
-                    x-kubernetes-preserve-unknown-fields: true
-                  podSelector:
-                    x-kubernetes-preserve-unknown-fields: true
-                type: object
-              type: array
-            egress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                  to:
-                    items:
-                      properties:
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            ingress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  from:
-                    items:
-                      properties:
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            priority:
-              format: float
-              maximum: 10000
-              minimum: 1
-              type: number
-            tier:
-              type: string
-          required:
-          - appliedTo
-          - priority
-          type: object
-      type: object
-=======
->>>>>>> 3c3b508... Resolve conflicts
   versions:
   - additionalPrinterColumns:
     - description: The Tier to which this ClusterNetworkPolicy belongs to.
@@ -182,17 +80,17 @@ spec:
     schema:
       openAPIV3Schema:
         properties:
-          spec:
-            properties:
-              appliedTo:
-                items:
-                  properties:
-                    namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
-                    podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
-                  type: object
-                type: array
+          appliedTo:
+            items:
+              properties:
+                namespaceSelector:
+                  x-kubernetes-preserve-unknown-fields: true
+                podSelector:
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+            type: array
+          ingress:
+            items:
               egress:
                 items:
                   properties:
@@ -229,14 +127,14 @@ spec:
                   - action
                   type: object
                 type: array
-              ingress:
-                items:
-                  properties:
-                    action:
-                      enum:
-                      - Allow
-                      - Drop
-                      type: string
+              properties:
+                action:
+                  enum:
+                  - Allow
+                  - Drop
+                  type: string
+                from:
+                  items:
                     from:
                       items:
                         properties:
@@ -252,36 +150,40 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
-                    ports:
-                      items:
+                    properties:
+                      ipBlock:
                         properties:
                           port:
                             x-kubernetes-int-or-string: true
                           protocol:
                             type: string
                         type: object
-                      type: array
-                  required:
-                  - action
-                  type: object
-                type: array
-              priority:
-                format: float
-                maximum: 10000
-                minimum: 1
-                type: number
-              tier:
-                enum:
-                - Emergency
-                - SecurityOps
-                - NetworkOps
-                - Platform
-                - Application
-                type: string
-            required:
-            - appliedTo
-            - priority
-            type: object
+                      namespaceSelector:
+                        x-kubernetes-preserve-unknown-fields: true
+                      podSelector:
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  type: array
+                ports:
+                  items:
+                    properties:
+                      port:
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        type: string
+                    type: object
+                  type: array
+              required:
+              - action
+              type: object
+            type: array
+          priority:
+            format: float
+            maximum: 10000
+            minimum: 1
+            type: number
+          tier:
+            type: string
         type: object
     served: true
     storage: true
@@ -484,14 +386,6 @@ metadata:
     app: antrea
   name: tiers.security.antrea.tanzu.vmware.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.priority
-    description: The Priority of this Tier relative to other Tiers.
-    name: Priority
-    type: integer
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: security.antrea.tanzu.vmware.com
   names:
     kind: Tier
@@ -499,29 +393,36 @@ spec:
     shortNames:
     - tr
     singular: tier
-  preserveUnknownFields: false
   scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            description:
-              type: string
-            priority:
-              maximum: 255
-              minimum: 0
-              type: integer
-          required:
-          - priority
-          type: object
-      type: object
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The Priority of this Tier relative to other Tiers.
+      jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              description:
+                type: string
+              priority:
+                maximum: 255
+                minimum: 0
+                type: integer
+            required:
+            - priority
+            type: object
+        type: object
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -38,7 +38,7 @@ spec:
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -364,7 +364,7 @@ spec:
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -18,7 +18,7 @@ spec:
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -15,6 +15,10 @@ spec:
   scope: Cluster
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
 ---
@@ -35,6 +39,10 @@ spec:
   scope: Cluster
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
 ---
@@ -45,6 +53,7 @@ metadata:
     app: antrea
   name: clusternetworkpolicies.security.antrea.tanzu.vmware.com
 spec:
+<<<<<<< HEAD
   additionalPrinterColumns:
   - JSONPath: .spec.tier
     description: The Tier to which this ClusterNetworkPolicy belongs to.
@@ -58,6 +67,8 @@ spec:
   - JSONPath: .metadata.creationTimestamp
     name: Age
     type: date
+=======
+>>>>>>> 960197f... Run make manifest
   group: security.antrea.tanzu.vmware.com
   names:
     kind: ClusterNetworkPolicy
@@ -66,8 +77,8 @@ spec:
     - cnp
     - acnp
     singular: clusternetworkpolicy
-  preserveUnknownFields: false
   scope: Cluster
+<<<<<<< HEAD
   validation:
     openAPIV3Schema:
       properties:
@@ -359,8 +370,111 @@ spec:
           - priority
           type: object
       type: object
+=======
+>>>>>>> 960197f... Run make manifest
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - JSONPath: .spec.priority
+      description: The Priority of this ClusterNetworkPolicy relative to other policies.
+      format: float
+      name: Priority
+      type: number
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              appliedTo:
+                items:
+                  properties:
+                    namespaceSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                    podSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                type: array
+              egress:
+                items:
+                  properties:
+                    action:
+                      pattern: \bAllow|\bDrop
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      items:
+                        properties:
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                items:
+                  properties:
+                    action:
+                      pattern: \bAllow|\bDrop
+                      type: string
+                    from:
+                      items:
+                        properties:
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              priority:
+                format: float
+                maximum: 10000
+                minimum: 1
+                type: number
+            required:
+            - appliedTo
+            - priority
+            type: object
+        type: object
     served: true
     storage: true
 ---
@@ -415,29 +529,6 @@ metadata:
     app: antrea
   name: traceflows.ops.antrea.tanzu.vmware.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: The phase of the Traceflow.
-    name: Phase
-    type: string
-  - JSONPath: .spec.source.pod
-    description: The name of the source Pod.
-    name: Source-Pod
-    priority: 10
-    type: string
-  - JSONPath: .spec.destination.pod
-    description: The name of the destination Pod.
-    name: Destination-Pod
-    priority: 10
-    type: string
-  - JSONPath: .spec.destination.ip
-    description: The IP address of the destination.
-    name: Destination-IP
-    priority: 10
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: ops.antrea.tanzu.vmware.com
   names:
     kind: Traceflow
@@ -445,20 +536,104 @@ spec:
     shortNames:
     - tf
     singular: traceflow
-  preserveUnknownFields: false
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            destination:
-              oneOf:
-              - required:
+  versions:
+  - additionalPrinterColumns:
+    - JSONPath: .status.phase
+      description: The phase of the Traceflow.
+      name: Phase
+      type: string
+    - JSONPath: .spec.source.pod
+      description: The name of the source Pod.
+      name: Source-Pod
+      priority: 10
+      type: string
+    - JSONPath: .spec.destination.pod
+      description: The name of the destination Pod.
+      name: Destination-Pod
+      priority: 10
+      type: string
+    - JSONPath: .spec.destination.ip
+      description: The IP address of the destination.
+      name: Destination-IP
+      priority: 10
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              destination:
+                oneOf:
+                - required:
+                  - pod
+                  - namespace
+                - required:
+                  - ip
+                properties:
+                  ip:
+                    format: ipv4
+                    type: string
+                  namespace:
+                    type: string
+                  pod:
+                    type: string
+                type: object
+              packet:
+                properties:
+                  ipHeader:
+                    properties:
+                      flags:
+                        type: integer
+                      protocol:
+                        type: integer
+                      srcIP:
+                        format: ipv4
+                        type: string
+                      ttl:
+                        type: integer
+                    type: object
+                  transportHeader:
+                    properties:
+                      icmp:
+                        properties:
+                          id:
+                            type: integer
+                          sequence:
+                            type: integer
+                        type: object
+                      tcp:
+                        properties:
+                          dstPort:
+                            type: integer
+                          flags:
+                            type: integer
+                          srcPort:
+                            type: integer
+                        type: object
+                      udp:
+                        properties:
+                          dstPort:
+                            type: integer
+                          srcPort:
+                            type: integer
+                        type: object
+                    type: object
+                type: object
+              source:
+                properties:
+                  namespace:
+                    type: string
+                  pod:
+                    type: string
+                required:
                 - pod
                 - namespace
+<<<<<<< HEAD
               - required:
                 - service
                 - namespace
@@ -478,110 +653,65 @@ spec:
             packet:
               properties:
                 ipHeader:
-                  properties:
-                    flags:
-                      type: integer
-                    protocol:
-                      type: integer
-                    srcIP:
-                      format: ipv4
-                      type: string
-                    ttl:
-                      type: integer
-                  type: object
-                transportHeader:
-                  properties:
-                    icmp:
-                      properties:
-                        id:
-                          type: integer
-                        sequence:
-                          type: integer
-                      type: object
-                    tcp:
-                      properties:
-                        dstPort:
-                          type: integer
-                        flags:
-                          type: integer
-                        srcPort:
-                          type: integer
-                      type: object
-                    udp:
-                      properties:
-                        dstPort:
-                          type: integer
-                        srcPort:
-                          type: integer
-                      type: object
-                  type: object
-              type: object
-            source:
-              properties:
-                namespace:
-                  type: string
-                pod:
-                  type: string
-              required:
-              - pod
-              - namespace
-              type: object
-          required:
-          - source
-          - destination
-          type: object
-        status:
-          properties:
-            dataplaneTag:
-              type: integer
-            phase:
-              type: string
-            reason:
-              type: string
-            results:
-              items:
-                properties:
-                  node:
-                    type: string
-                  observations:
-                    items:
-                      properties:
-                        action:
-                          type: string
-                        component:
-                          type: string
-                        componentInfo:
-                          type: string
-                        dstMAC:
-                          type: string
-                        networkPolicy:
-                          type: string
-                        pod:
-                          type: string
-                        translatedDstIP:
-                          type: string
-                        translatedSrcIP:
-                          type: string
-                        ttl:
-                          type: integer
-                        tunnelDstIP:
-                          type: string
-                      type: object
-                    type: array
-                  role:
-                    type: string
-                  timestamp:
-                    type: integer
+=======
                 type: object
-              type: array
-          type: object
-      required:
-      - spec
-      type: object
-  versions:
-  - name: v1alpha1
+            required:
+            - source
+            - destination
+            type: object
+          status:
+            properties:
+              dataplaneTag:
+                type: integer
+              phase:
+                type: string
+              reason:
+                type: string
+              results:
+                items:
+>>>>>>> 960197f... Run make manifest
+                  properties:
+                    node:
+                      type: string
+                    observations:
+                      items:
+                        properties:
+                          action:
+                            type: string
+                          component:
+                            type: string
+                          componentInfo:
+                            type: string
+                          dstMAC:
+                            type: string
+                          networkPolicy:
+                            type: string
+                          pod:
+                            type: string
+                          translatedDstIP:
+                            type: string
+                          translatedSrcIP:
+                            type: string
+                          ttl:
+                            type: integer
+                          tunnelDstIP:
+                            type: string
+                        type: object
+                      type: array
+                    role:
+                      type: string
+                    timestamp:
+                      type: integer
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -80,25 +80,92 @@ spec:
     schema:
       openAPIV3Schema:
         properties:
-          appliedTo:
-            items:
-              properties:
-                namespaceSelector:
-                  x-kubernetes-preserve-unknown-fields: true
-                podSelector:
-                  x-kubernetes-preserve-unknown-fields: true
-              type: object
-            type: array
-          ingress:
-            items:
-              egress:
+          spec:
+            properties:
+              appliedTo:
                 items:
+                  properties:
+                    namespaceSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                    podSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                type: array
+              ingress:
+                items:
+                  egress:
+                    items:
+                      properties:
+                        action:
+                          enum:
+                          - Allow
+                          - Drop
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          type: array
+                        to:
+                          items:
+                            properties:
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                              podSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
                   properties:
                     action:
                       enum:
                       - Allow
                       - Drop
                       type: string
+                    from:
+                      items:
+                        from:
+                          items:
+                            properties:
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                              podSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        properties:
+                          ipBlock:
+                            properties:
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
                     ports:
                       items:
                         properties:
@@ -108,82 +175,18 @@ spec:
                             type: string
                         type: object
                       type: array
-                    to:
-                      items:
-                        properties:
-                          ipBlock:
-                            properties:
-                              cidr:
-                                format: cidr
-                                type: string
-                            type: object
-                          namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                          podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                      type: array
                   required:
                   - action
                   type: object
                 type: array
-              properties:
-                action:
-                  enum:
-                  - Allow
-                  - Drop
-                  type: string
-                from:
-                  items:
-                    from:
-                      items:
-                        properties:
-                          ipBlock:
-                            properties:
-                              cidr:
-                                format: cidr
-                                type: string
-                            type: object
-                          namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                          podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                      type: array
-                    properties:
-                      ipBlock:
-                        properties:
-                          port:
-                            x-kubernetes-int-or-string: true
-                          protocol:
-                            type: string
-                        type: object
-                      namespaceSelector:
-                        x-kubernetes-preserve-unknown-fields: true
-                      podSelector:
-                        x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                  type: array
-                ports:
-                  items:
-                    properties:
-                      port:
-                        x-kubernetes-int-or-string: true
-                      protocol:
-                        type: string
-                    type: object
-                  type: array
-              required:
-              - action
-              type: object
-            type: array
-          priority:
-            format: float
-            maximum: 10000
-            minimum: 1
-            type: number
-          tier:
-            type: string
+              priority:
+                format: float
+                maximum: 10000
+                minimum: 1
+                type: number
+              tier:
+                type: string
+            type: object
         type: object
     served: true
     storage: true

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -53,22 +53,6 @@ metadata:
     app: antrea
   name: clusternetworkpolicies.security.antrea.tanzu.vmware.com
 spec:
-<<<<<<< HEAD
-  additionalPrinterColumns:
-  - JSONPath: .spec.tier
-    description: The Tier to which this ClusterNetworkPolicy belongs to.
-    name: Tier
-    type: string
-  - JSONPath: .spec.priority
-    description: The Priority of this ClusterNetworkPolicy relative to other policies.
-    format: float
-    name: Priority
-    type: number
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
-=======
->>>>>>> 960197f... Run make manifest
   group: security.antrea.tanzu.vmware.com
   names:
     kind: ClusterNetworkPolicy
@@ -78,6 +62,7 @@ spec:
     - acnp
     singular: clusternetworkpolicy
   scope: Cluster
+<<<<<<< HEAD
 <<<<<<< HEAD
   validation:
     openAPIV3Schema:
@@ -177,203 +162,14 @@ spec:
           - priority
           type: object
       type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  labels:
-    app: antrea
-  name: externalentities.core.antrea.tanzu.vmware.com
-spec:
-  group: core.antrea.tanzu.vmware.com
-  names:
-    kind: ExternalEntity
-    plural: externalentities
-    shortNames:
-    - ee
-    singular: externalentity
-  preserveUnknownFields: false
-  scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            endpoints:
-              items:
-                properties:
-                  ip:
-                    format: ipv4
-                    type: string
-                  name:
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        name:
-                          type: string
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                type: object
-              type: array
-            externalNode:
-              type: string
-          type: object
-      type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  labels:
-    app: antrea
-  name: networkpolicies.security.antrea.tanzu.vmware.com
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.tier
-    description: The Tier to which this Antrea NetworkPolicy belongs to.
-    name: Tier
-    type: string
-  - JSONPath: .spec.priority
-    description: The Priority of this Antrea NetworkPolicy relative to other policies.
-    format: float
-    name: Priority
-    type: number
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
-  group: security.antrea.tanzu.vmware.com
-  names:
-    kind: NetworkPolicy
-    plural: networkpolicies
-    shortNames:
-    - netpol
-    - anp
-    singular: networkpolicy
-  preserveUnknownFields: false
-  scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            appliedTo:
-              items:
-                properties:
-                  podSelector:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                type: object
-              type: array
-            egress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                  to:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            ingress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  from:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            priority:
-              format: float
-              maximum: 10000
-              minimum: 1
-              type: number
-            tier:
-              enum:
-              - Emergency
-              - SecurityOps
-              - NetworkOps
-              - Platform
-              - Application
-              type: string
-          required:
-          - appliedTo
-          - priority
-          type: object
-      type: object
 =======
->>>>>>> 960197f... Run make manifest
+>>>>>>> 3c3b508... Resolve conflicts
   versions:
   - additionalPrinterColumns:
+    - description: The Tier to which this ClusterNetworkPolicy belongs to.
+      jsonPath: .spec.tier
+      name: Tier
+      type: string
     - description: The Priority of this ClusterNetworkPolicy relative to other policies.
       format: float
       jsonPath: .spec.priority
@@ -401,7 +197,9 @@ spec:
                 items:
                   properties:
                     action:
-                      pattern: \bAllow|\bDrop
+                      enum:
+                      - Allow
+                      - Drop
                       type: string
                     ports:
                       items:
@@ -435,7 +233,9 @@ spec:
                 items:
                   properties:
                     action:
-                      pattern: \bAllow|\bDrop
+                      enum:
+                      - Allow
+                      - Drop
                       type: string
                     from:
                       items:
@@ -470,6 +270,205 @@ spec:
                 maximum: 10000
                 minimum: 1
                 type: number
+              tier:
+                enum:
+                - Emergency
+                - SecurityOps
+                - NetworkOps
+                - Platform
+                - Application
+                type: string
+            required:
+            - appliedTo
+            - priority
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app: antrea
+  name: externalentities.core.antrea.tanzu.vmware.com
+spec:
+  group: core.antrea.tanzu.vmware.com
+  names:
+    kind: ExternalEntity
+    plural: externalentities
+    shortNames:
+    - ee
+    singular: externalentity
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              endpoints:
+                items:
+                  properties:
+                    ip:
+                      format: ipv4
+                      type: string
+                    name:
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              externalNode:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app: antrea
+  name: networkpolicies.security.antrea.tanzu.vmware.com
+spec:
+  group: security.antrea.tanzu.vmware.com
+  names:
+    kind: NetworkPolicy
+    plural: networkpolicies
+    shortNames:
+    - netpol
+    - anp
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Tier to which this Antrea NetworkPolicy belongs to.
+      jsonPath: .spec.tier
+      name: Tier
+      type: string
+    - description: The Priority of this Antrea NetworkPolicy relative to other policies.
+      format: float
+      jsonPath: .spec.priority
+      name: Priority
+      type: number
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              appliedTo:
+                items:
+                  properties:
+                    podSelector:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                type: array
+              egress:
+                items:
+                  properties:
+                    action:
+                      enum:
+                      - Allow
+                      - Drop
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      items:
+                        properties:
+                          externalEntitySelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                items:
+                  properties:
+                    action:
+                      enum:
+                      - Allow
+                      - Drop
+                      type: string
+                    from:
+                      items:
+                        properties:
+                          externalEntitySelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              priority:
+                format: float
+                maximum: 10000
+                minimum: 1
+                type: number
+              tier:
+                enum:
+                - Emergency
+                - SecurityOps
+                - NetworkOps
+                - Platform
+                - Application
+                type: string
             required:
             - appliedTo
             - priority
@@ -573,6 +572,9 @@ spec:
                   - pod
                   - namespace
                 - required:
+                  - service
+                  - namespace
+                - required:
                   - ip
                 properties:
                   ip:
@@ -581,6 +583,8 @@ spec:
                   namespace:
                     type: string
                   pod:
+                    type: string
+                  service:
                     type: string
                 type: object
               packet:
@@ -633,27 +637,6 @@ spec:
                 required:
                 - pod
                 - namespace
-<<<<<<< HEAD
-              - required:
-                - service
-                - namespace
-              - required:
-                - ip
-              properties:
-                ip:
-                  format: ipv4
-                  type: string
-                namespace:
-                  type: string
-                pod:
-                  type: string
-                service:
-                  type: string
-              type: object
-            packet:
-              properties:
-                ipHeader:
-=======
                 type: object
             required:
             - source
@@ -669,7 +652,6 @@ spec:
                 type: string
               results:
                 items:
->>>>>>> 960197f... Run make manifest
                   properties:
                     node:
                       type: string

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -374,12 +374,12 @@ spec:
 >>>>>>> 960197f... Run make manifest
   versions:
   - additionalPrinterColumns:
-    - JSONPath: .spec.priority
-      description: The Priority of this ClusterNetworkPolicy relative to other policies.
+    - description: The Priority of this ClusterNetworkPolicy relative to other policies.
       format: float
+      jsonPath: .spec.priority
       name: Priority
       type: number
-    - JSONPath: .metadata.creationTimestamp
+    - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
     name: v1alpha1
@@ -539,26 +539,26 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - JSONPath: .status.phase
-      description: The phase of the Traceflow.
+    - description: The phase of the Traceflow.
+      jsonPath: .status.phase
       name: Phase
       type: string
-    - JSONPath: .spec.source.pod
-      description: The name of the source Pod.
+    - description: The name of the source Pod.
+      jsonPath: .spec.source.pod
       name: Source-Pod
       priority: 10
       type: string
-    - JSONPath: .spec.destination.pod
-      description: The name of the destination Pod.
+    - description: The name of the destination Pod.
+      jsonPath: .spec.destination.pod
       name: Destination-Pod
       priority: 10
       type: string
-    - JSONPath: .spec.destination.ip
-      description: The IP address of the destination.
+    - description: The IP address of the destination.
+      jsonPath: .spec.destination.ip
       name: Destination-IP
       priority: 10
       type: string
-    - JSONPath: .metadata.creationTimestamp
+    - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
     name: v1alpha1

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -62,108 +62,6 @@ spec:
     - acnp
     singular: clusternetworkpolicy
   scope: Cluster
-<<<<<<< HEAD
-<<<<<<< HEAD
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            appliedTo:
-              items:
-                properties:
-                  namespaceSelector:
-                    x-kubernetes-preserve-unknown-fields: true
-                  podSelector:
-                    x-kubernetes-preserve-unknown-fields: true
-                type: object
-              type: array
-            egress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                  to:
-                    items:
-                      properties:
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            ingress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  from:
-                    items:
-                      properties:
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            priority:
-              format: float
-              maximum: 10000
-              minimum: 1
-              type: number
-            tier:
-              type: string
-          required:
-          - appliedTo
-          - priority
-          type: object
-      type: object
-=======
->>>>>>> 3c3b508... Resolve conflicts
   versions:
   - additionalPrinterColumns:
     - description: The Tier to which this ClusterNetworkPolicy belongs to.
@@ -182,17 +80,17 @@ spec:
     schema:
       openAPIV3Schema:
         properties:
-          spec:
-            properties:
-              appliedTo:
-                items:
-                  properties:
-                    namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
-                    podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
-                  type: object
-                type: array
+          appliedTo:
+            items:
+              properties:
+                namespaceSelector:
+                  x-kubernetes-preserve-unknown-fields: true
+                podSelector:
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+            type: array
+          ingress:
+            items:
               egress:
                 items:
                   properties:
@@ -229,14 +127,14 @@ spec:
                   - action
                   type: object
                 type: array
-              ingress:
-                items:
-                  properties:
-                    action:
-                      enum:
-                      - Allow
-                      - Drop
-                      type: string
+              properties:
+                action:
+                  enum:
+                  - Allow
+                  - Drop
+                  type: string
+                from:
+                  items:
                     from:
                       items:
                         properties:
@@ -252,36 +150,40 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
-                    ports:
-                      items:
+                    properties:
+                      ipBlock:
                         properties:
                           port:
                             x-kubernetes-int-or-string: true
                           protocol:
                             type: string
                         type: object
-                      type: array
-                  required:
-                  - action
-                  type: object
-                type: array
-              priority:
-                format: float
-                maximum: 10000
-                minimum: 1
-                type: number
-              tier:
-                enum:
-                - Emergency
-                - SecurityOps
-                - NetworkOps
-                - Platform
-                - Application
-                type: string
-            required:
-            - appliedTo
-            - priority
-            type: object
+                      namespaceSelector:
+                        x-kubernetes-preserve-unknown-fields: true
+                      podSelector:
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  type: array
+                ports:
+                  items:
+                    properties:
+                      port:
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        type: string
+                    type: object
+                  type: array
+              required:
+              - action
+              type: object
+            type: array
+          priority:
+            format: float
+            maximum: 10000
+            minimum: 1
+            type: number
+          tier:
+            type: string
         type: object
     served: true
     storage: true
@@ -484,14 +386,6 @@ metadata:
     app: antrea
   name: tiers.security.antrea.tanzu.vmware.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.priority
-    description: The Priority of this Tier relative to other Tiers.
-    name: Priority
-    type: integer
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: security.antrea.tanzu.vmware.com
   names:
     kind: Tier
@@ -499,29 +393,36 @@ spec:
     shortNames:
     - tr
     singular: tier
-  preserveUnknownFields: false
   scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            description:
-              type: string
-            priority:
-              maximum: 255
-              minimum: 0
-              type: integer
-          required:
-          - priority
-          type: object
-      type: object
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The Priority of this Tier relative to other Tiers.
+      jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              description:
+                type: string
+              priority:
+                maximum: 255
+                minimum: 0
+                type: integer
+            required:
+            - priority
+            type: object
+        type: object
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -38,7 +38,7 @@ spec:
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -364,7 +364,7 @@ spec:
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -18,7 +18,7 @@ spec:
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -15,6 +15,10 @@ spec:
   scope: Cluster
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
 ---
@@ -35,6 +39,10 @@ spec:
   scope: Cluster
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
 ---
@@ -45,6 +53,7 @@ metadata:
     app: antrea
   name: clusternetworkpolicies.security.antrea.tanzu.vmware.com
 spec:
+<<<<<<< HEAD
   additionalPrinterColumns:
   - JSONPath: .spec.tier
     description: The Tier to which this ClusterNetworkPolicy belongs to.
@@ -58,6 +67,8 @@ spec:
   - JSONPath: .metadata.creationTimestamp
     name: Age
     type: date
+=======
+>>>>>>> 960197f... Run make manifest
   group: security.antrea.tanzu.vmware.com
   names:
     kind: ClusterNetworkPolicy
@@ -66,8 +77,8 @@ spec:
     - cnp
     - acnp
     singular: clusternetworkpolicy
-  preserveUnknownFields: false
   scope: Cluster
+<<<<<<< HEAD
   validation:
     openAPIV3Schema:
       properties:
@@ -359,8 +370,111 @@ spec:
           - priority
           type: object
       type: object
+=======
+>>>>>>> 960197f... Run make manifest
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - JSONPath: .spec.priority
+      description: The Priority of this ClusterNetworkPolicy relative to other policies.
+      format: float
+      name: Priority
+      type: number
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              appliedTo:
+                items:
+                  properties:
+                    namespaceSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                    podSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                type: array
+              egress:
+                items:
+                  properties:
+                    action:
+                      pattern: \bAllow|\bDrop
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      items:
+                        properties:
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                items:
+                  properties:
+                    action:
+                      pattern: \bAllow|\bDrop
+                      type: string
+                    from:
+                      items:
+                        properties:
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              priority:
+                format: float
+                maximum: 10000
+                minimum: 1
+                type: number
+            required:
+            - appliedTo
+            - priority
+            type: object
+        type: object
     served: true
     storage: true
 ---
@@ -415,29 +529,6 @@ metadata:
     app: antrea
   name: traceflows.ops.antrea.tanzu.vmware.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: The phase of the Traceflow.
-    name: Phase
-    type: string
-  - JSONPath: .spec.source.pod
-    description: The name of the source Pod.
-    name: Source-Pod
-    priority: 10
-    type: string
-  - JSONPath: .spec.destination.pod
-    description: The name of the destination Pod.
-    name: Destination-Pod
-    priority: 10
-    type: string
-  - JSONPath: .spec.destination.ip
-    description: The IP address of the destination.
-    name: Destination-IP
-    priority: 10
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: ops.antrea.tanzu.vmware.com
   names:
     kind: Traceflow
@@ -445,20 +536,104 @@ spec:
     shortNames:
     - tf
     singular: traceflow
-  preserveUnknownFields: false
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            destination:
-              oneOf:
-              - required:
+  versions:
+  - additionalPrinterColumns:
+    - JSONPath: .status.phase
+      description: The phase of the Traceflow.
+      name: Phase
+      type: string
+    - JSONPath: .spec.source.pod
+      description: The name of the source Pod.
+      name: Source-Pod
+      priority: 10
+      type: string
+    - JSONPath: .spec.destination.pod
+      description: The name of the destination Pod.
+      name: Destination-Pod
+      priority: 10
+      type: string
+    - JSONPath: .spec.destination.ip
+      description: The IP address of the destination.
+      name: Destination-IP
+      priority: 10
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              destination:
+                oneOf:
+                - required:
+                  - pod
+                  - namespace
+                - required:
+                  - ip
+                properties:
+                  ip:
+                    format: ipv4
+                    type: string
+                  namespace:
+                    type: string
+                  pod:
+                    type: string
+                type: object
+              packet:
+                properties:
+                  ipHeader:
+                    properties:
+                      flags:
+                        type: integer
+                      protocol:
+                        type: integer
+                      srcIP:
+                        format: ipv4
+                        type: string
+                      ttl:
+                        type: integer
+                    type: object
+                  transportHeader:
+                    properties:
+                      icmp:
+                        properties:
+                          id:
+                            type: integer
+                          sequence:
+                            type: integer
+                        type: object
+                      tcp:
+                        properties:
+                          dstPort:
+                            type: integer
+                          flags:
+                            type: integer
+                          srcPort:
+                            type: integer
+                        type: object
+                      udp:
+                        properties:
+                          dstPort:
+                            type: integer
+                          srcPort:
+                            type: integer
+                        type: object
+                    type: object
+                type: object
+              source:
+                properties:
+                  namespace:
+                    type: string
+                  pod:
+                    type: string
+                required:
                 - pod
                 - namespace
+<<<<<<< HEAD
               - required:
                 - service
                 - namespace
@@ -478,110 +653,65 @@ spec:
             packet:
               properties:
                 ipHeader:
-                  properties:
-                    flags:
-                      type: integer
-                    protocol:
-                      type: integer
-                    srcIP:
-                      format: ipv4
-                      type: string
-                    ttl:
-                      type: integer
-                  type: object
-                transportHeader:
-                  properties:
-                    icmp:
-                      properties:
-                        id:
-                          type: integer
-                        sequence:
-                          type: integer
-                      type: object
-                    tcp:
-                      properties:
-                        dstPort:
-                          type: integer
-                        flags:
-                          type: integer
-                        srcPort:
-                          type: integer
-                      type: object
-                    udp:
-                      properties:
-                        dstPort:
-                          type: integer
-                        srcPort:
-                          type: integer
-                      type: object
-                  type: object
-              type: object
-            source:
-              properties:
-                namespace:
-                  type: string
-                pod:
-                  type: string
-              required:
-              - pod
-              - namespace
-              type: object
-          required:
-          - source
-          - destination
-          type: object
-        status:
-          properties:
-            dataplaneTag:
-              type: integer
-            phase:
-              type: string
-            reason:
-              type: string
-            results:
-              items:
-                properties:
-                  node:
-                    type: string
-                  observations:
-                    items:
-                      properties:
-                        action:
-                          type: string
-                        component:
-                          type: string
-                        componentInfo:
-                          type: string
-                        dstMAC:
-                          type: string
-                        networkPolicy:
-                          type: string
-                        pod:
-                          type: string
-                        translatedDstIP:
-                          type: string
-                        translatedSrcIP:
-                          type: string
-                        ttl:
-                          type: integer
-                        tunnelDstIP:
-                          type: string
-                      type: object
-                    type: array
-                  role:
-                    type: string
-                  timestamp:
-                    type: integer
+=======
                 type: object
-              type: array
-          type: object
-      required:
-      - spec
-      type: object
-  versions:
-  - name: v1alpha1
+            required:
+            - source
+            - destination
+            type: object
+          status:
+            properties:
+              dataplaneTag:
+                type: integer
+              phase:
+                type: string
+              reason:
+                type: string
+              results:
+                items:
+>>>>>>> 960197f... Run make manifest
+                  properties:
+                    node:
+                      type: string
+                    observations:
+                      items:
+                        properties:
+                          action:
+                            type: string
+                          component:
+                            type: string
+                          componentInfo:
+                            type: string
+                          dstMAC:
+                            type: string
+                          networkPolicy:
+                            type: string
+                          pod:
+                            type: string
+                          translatedDstIP:
+                            type: string
+                          translatedSrcIP:
+                            type: string
+                          ttl:
+                            type: integer
+                          tunnelDstIP:
+                            type: string
+                        type: object
+                      type: array
+                    role:
+                      type: string
+                    timestamp:
+                      type: integer
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -80,25 +80,92 @@ spec:
     schema:
       openAPIV3Schema:
         properties:
-          appliedTo:
-            items:
-              properties:
-                namespaceSelector:
-                  x-kubernetes-preserve-unknown-fields: true
-                podSelector:
-                  x-kubernetes-preserve-unknown-fields: true
-              type: object
-            type: array
-          ingress:
-            items:
-              egress:
+          spec:
+            properties:
+              appliedTo:
                 items:
+                  properties:
+                    namespaceSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                    podSelector:
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                type: array
+              ingress:
+                items:
+                  egress:
+                    items:
+                      properties:
+                        action:
+                          enum:
+                          - Allow
+                          - Drop
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          type: array
+                        to:
+                          items:
+                            properties:
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                              podSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
                   properties:
                     action:
                       enum:
                       - Allow
                       - Drop
                       type: string
+                    from:
+                      items:
+                        from:
+                          items:
+                            properties:
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                              podSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        properties:
+                          ipBlock:
+                            properties:
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
                     ports:
                       items:
                         properties:
@@ -108,82 +175,18 @@ spec:
                             type: string
                         type: object
                       type: array
-                    to:
-                      items:
-                        properties:
-                          ipBlock:
-                            properties:
-                              cidr:
-                                format: cidr
-                                type: string
-                            type: object
-                          namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                          podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                      type: array
                   required:
                   - action
                   type: object
                 type: array
-              properties:
-                action:
-                  enum:
-                  - Allow
-                  - Drop
-                  type: string
-                from:
-                  items:
-                    from:
-                      items:
-                        properties:
-                          ipBlock:
-                            properties:
-                              cidr:
-                                format: cidr
-                                type: string
-                            type: object
-                          namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                          podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                      type: array
-                    properties:
-                      ipBlock:
-                        properties:
-                          port:
-                            x-kubernetes-int-or-string: true
-                          protocol:
-                            type: string
-                        type: object
-                      namespaceSelector:
-                        x-kubernetes-preserve-unknown-fields: true
-                      podSelector:
-                        x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                  type: array
-                ports:
-                  items:
-                    properties:
-                      port:
-                        x-kubernetes-int-or-string: true
-                      protocol:
-                        type: string
-                    type: object
-                  type: array
-              required:
-              - action
-              type: object
-            type: array
-          priority:
-            format: float
-            maximum: 10000
-            minimum: 1
-            type: number
-          tier:
-            type: string
+              priority:
+                format: float
+                maximum: 10000
+                minimum: 1
+                type: number
+              tier:
+                type: string
+            type: object
         type: object
     served: true
     storage: true

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -53,22 +53,6 @@ metadata:
     app: antrea
   name: clusternetworkpolicies.security.antrea.tanzu.vmware.com
 spec:
-<<<<<<< HEAD
-  additionalPrinterColumns:
-  - JSONPath: .spec.tier
-    description: The Tier to which this ClusterNetworkPolicy belongs to.
-    name: Tier
-    type: string
-  - JSONPath: .spec.priority
-    description: The Priority of this ClusterNetworkPolicy relative to other policies.
-    format: float
-    name: Priority
-    type: number
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
-=======
->>>>>>> 960197f... Run make manifest
   group: security.antrea.tanzu.vmware.com
   names:
     kind: ClusterNetworkPolicy
@@ -78,6 +62,7 @@ spec:
     - acnp
     singular: clusternetworkpolicy
   scope: Cluster
+<<<<<<< HEAD
 <<<<<<< HEAD
   validation:
     openAPIV3Schema:
@@ -177,203 +162,14 @@ spec:
           - priority
           type: object
       type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  labels:
-    app: antrea
-  name: externalentities.core.antrea.tanzu.vmware.com
-spec:
-  group: core.antrea.tanzu.vmware.com
-  names:
-    kind: ExternalEntity
-    plural: externalentities
-    shortNames:
-    - ee
-    singular: externalentity
-  preserveUnknownFields: false
-  scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            endpoints:
-              items:
-                properties:
-                  ip:
-                    format: ipv4
-                    type: string
-                  name:
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        name:
-                          type: string
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                type: object
-              type: array
-            externalNode:
-              type: string
-          type: object
-      type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  labels:
-    app: antrea
-  name: networkpolicies.security.antrea.tanzu.vmware.com
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.tier
-    description: The Tier to which this Antrea NetworkPolicy belongs to.
-    name: Tier
-    type: string
-  - JSONPath: .spec.priority
-    description: The Priority of this Antrea NetworkPolicy relative to other policies.
-    format: float
-    name: Priority
-    type: number
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
-  group: security.antrea.tanzu.vmware.com
-  names:
-    kind: NetworkPolicy
-    plural: networkpolicies
-    shortNames:
-    - netpol
-    - anp
-    singular: networkpolicy
-  preserveUnknownFields: false
-  scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            appliedTo:
-              items:
-                properties:
-                  podSelector:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                type: object
-              type: array
-            egress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                  to:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            ingress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  from:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            priority:
-              format: float
-              maximum: 10000
-              minimum: 1
-              type: number
-            tier:
-              enum:
-              - Emergency
-              - SecurityOps
-              - NetworkOps
-              - Platform
-              - Application
-              type: string
-          required:
-          - appliedTo
-          - priority
-          type: object
-      type: object
 =======
->>>>>>> 960197f... Run make manifest
+>>>>>>> 3c3b508... Resolve conflicts
   versions:
   - additionalPrinterColumns:
+    - description: The Tier to which this ClusterNetworkPolicy belongs to.
+      jsonPath: .spec.tier
+      name: Tier
+      type: string
     - description: The Priority of this ClusterNetworkPolicy relative to other policies.
       format: float
       jsonPath: .spec.priority
@@ -401,7 +197,9 @@ spec:
                 items:
                   properties:
                     action:
-                      pattern: \bAllow|\bDrop
+                      enum:
+                      - Allow
+                      - Drop
                       type: string
                     ports:
                       items:
@@ -435,7 +233,9 @@ spec:
                 items:
                   properties:
                     action:
-                      pattern: \bAllow|\bDrop
+                      enum:
+                      - Allow
+                      - Drop
                       type: string
                     from:
                       items:
@@ -470,6 +270,205 @@ spec:
                 maximum: 10000
                 minimum: 1
                 type: number
+              tier:
+                enum:
+                - Emergency
+                - SecurityOps
+                - NetworkOps
+                - Platform
+                - Application
+                type: string
+            required:
+            - appliedTo
+            - priority
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app: antrea
+  name: externalentities.core.antrea.tanzu.vmware.com
+spec:
+  group: core.antrea.tanzu.vmware.com
+  names:
+    kind: ExternalEntity
+    plural: externalentities
+    shortNames:
+    - ee
+    singular: externalentity
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              endpoints:
+                items:
+                  properties:
+                    ip:
+                      format: ipv4
+                      type: string
+                    name:
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              externalNode:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app: antrea
+  name: networkpolicies.security.antrea.tanzu.vmware.com
+spec:
+  group: security.antrea.tanzu.vmware.com
+  names:
+    kind: NetworkPolicy
+    plural: networkpolicies
+    shortNames:
+    - netpol
+    - anp
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Tier to which this Antrea NetworkPolicy belongs to.
+      jsonPath: .spec.tier
+      name: Tier
+      type: string
+    - description: The Priority of this Antrea NetworkPolicy relative to other policies.
+      format: float
+      jsonPath: .spec.priority
+      name: Priority
+      type: number
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              appliedTo:
+                items:
+                  properties:
+                    podSelector:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                type: array
+              egress:
+                items:
+                  properties:
+                    action:
+                      enum:
+                      - Allow
+                      - Drop
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      items:
+                        properties:
+                          externalEntitySelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                items:
+                  properties:
+                    action:
+                      enum:
+                      - Allow
+                      - Drop
+                      type: string
+                    from:
+                      items:
+                        properties:
+                          externalEntitySelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          ipBlock:
+                            properties:
+                              cidr:
+                                format: cidr
+                                type: string
+                            type: object
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              priority:
+                format: float
+                maximum: 10000
+                minimum: 1
+                type: number
+              tier:
+                enum:
+                - Emergency
+                - SecurityOps
+                - NetworkOps
+                - Platform
+                - Application
+                type: string
             required:
             - appliedTo
             - priority
@@ -573,6 +572,9 @@ spec:
                   - pod
                   - namespace
                 - required:
+                  - service
+                  - namespace
+                - required:
                   - ip
                 properties:
                   ip:
@@ -581,6 +583,8 @@ spec:
                   namespace:
                     type: string
                   pod:
+                    type: string
+                  service:
                     type: string
                 type: object
               packet:
@@ -633,27 +637,6 @@ spec:
                 required:
                 - pod
                 - namespace
-<<<<<<< HEAD
-              - required:
-                - service
-                - namespace
-              - required:
-                - ip
-              properties:
-                ip:
-                  format: ipv4
-                  type: string
-                namespace:
-                  type: string
-                pod:
-                  type: string
-                service:
-                  type: string
-              type: object
-            packet:
-              properties:
-                ipHeader:
-=======
                 type: object
             required:
             - source
@@ -669,7 +652,6 @@ spec:
                 type: string
               results:
                 items:
->>>>>>> 960197f... Run make manifest
                   properties:
                     node:
                       type: string

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -374,12 +374,12 @@ spec:
 >>>>>>> 960197f... Run make manifest
   versions:
   - additionalPrinterColumns:
-    - JSONPath: .spec.priority
-      description: The Priority of this ClusterNetworkPolicy relative to other policies.
+    - description: The Priority of this ClusterNetworkPolicy relative to other policies.
       format: float
+      jsonPath: .spec.priority
       name: Priority
       type: number
-    - JSONPath: .metadata.creationTimestamp
+    - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
     name: v1alpha1
@@ -539,26 +539,26 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - JSONPath: .status.phase
-      description: The phase of the Traceflow.
+    - description: The phase of the Traceflow.
+      jsonPath: .status.phase
       name: Phase
       type: string
-    - JSONPath: .spec.source.pod
-      description: The name of the source Pod.
+    - description: The name of the source Pod.
+      jsonPath: .spec.source.pod
       name: Source-Pod
       priority: 10
       type: string
-    - JSONPath: .spec.destination.pod
-      description: The name of the destination Pod.
+    - description: The name of the destination Pod.
+      jsonPath: .spec.destination.pod
       name: Destination-Pod
       priority: 10
       type: string
-    - JSONPath: .spec.destination.ip
-      description: The IP address of the destination.
+    - description: The IP address of the destination.
+      jsonPath: .spec.destination.ip
       name: Destination-IP
       priority: 10
       type: string
-    - JSONPath: .metadata.creationTimestamp
+    - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
     name: v1alpha1

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -278,76 +278,28 @@ spec:
         openAPIV3Schema:
           type: object
           properties:
-            tier:
-              type: string
-            priority:
-              type: number
-              format: float
-              # Ensure that Spec.Priority field is between 1 and 10000
-              minimum: 1.0
-              maximum: 10000.0
-            appliedTo:
-              type: array
-              items:
-                type: object
-                # Ensure that Spec.AppliedTo does not allow IPBlock field
-                properties:
-                  podSelector:
-                    x-kubernetes-preserve-unknown-fields: true
-                  namespaceSelector:
-                    x-kubernetes-preserve-unknown-fields: true
-            ingress:
-              type: array
-              items:
-                type: object
-                required:
-                  - action
-                properties:
-                  # Ensure that Action field allows only ALLOW and DROP values
-                  action:
-                    type: string
-                    enum: ['Allow', 'Drop']
-                  ports:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        protocol:
-                          type: string
-                        port:
-                          x-kubernetes-int-or-string: true
-                  from:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          type: object
-                          properties:
-                            protocol:
-                              type: string
-                            port:
-                              x-kubernetes-int-or-string: true
-                      from:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
-                            namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
-                            ipBlock:
-                              type: object
-                              properties:
-                                cidr:
-                                  type: string
-                                  format: cidr
-                egress:
+            spec:
+              type: object
+              properties:
+                tier:
+                  type: string
+                priority:
+                  type: number
+                  format: float
+                  # Ensure that Spec.Priority field is between 1 and 10000
+                  minimum: 1.0
+                  maximum: 10000.0
+                appliedTo:
+                  type: array
+                  items:
+                    type: object
+                    # Ensure that Spec.AppliedTo does not allow IPBlock field
+                    properties:
+                      podSelector:
+                        x-kubernetes-preserve-unknown-fields: true
+                      namespaceSelector:
+                        x-kubernetes-preserve-unknown-fields: true
+                ingress:
                   type: array
                   items:
                     type: object
@@ -367,7 +319,7 @@ spec:
                               type: string
                             port:
                               x-kubernetes-int-or-string: true
-                      to:
+                      from:
                         type: array
                         items:
                           type: object
@@ -379,9 +331,60 @@ spec:
                             ipBlock:
                               type: object
                               properties:
-                                cidr:
+                                protocol:
                                   type: string
-                                  format: cidr
+                                port:
+                                  x-kubernetes-int-or-string: true
+                          from:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                podSelector:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                namespaceSelector:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                ipBlock:
+                                  type: object
+                                  properties:
+                                    cidr:
+                                      type: string
+                                      format: cidr
+                    egress:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - action
+                        properties:
+                          # Ensure that Action field allows only ALLOW and DROP values
+                          action:
+                            type: string
+                            enum: ['Allow', 'Drop']
+                          ports:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                protocol:
+                                  type: string
+                                port:
+                                  x-kubernetes-int-or-string: true
+                          to:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                podSelector:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                namespaceSelector:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                ipBlock:
+                                  type: object
+                                  properties:
+                                    cidr:
+                                      type: string
+                                      format: cidr
   scope: Cluster
   names:
     plural: clusternetworkpolicies

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -9,6 +9,10 @@ spec:
     - name: v1beta1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
   scope: Cluster
   names:
     plural: antreacontrollerinfos
@@ -27,6 +31,10 @@ spec:
     - name: v1beta1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
   scope: Cluster
   names:
     plural: antreaagentinfos
@@ -45,6 +53,155 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+      additionalPrinterColumns:
+        - JSONPath: .status.phase
+          description: The phase of the Traceflow.
+          name: Phase
+          type: string
+        - JSONPath: .spec.source.pod
+          description: The name of the source Pod.
+          name: Source-Pod
+          type: string
+          priority: 10
+        - JSONPath: .spec.destination.pod
+          description: The name of the destination Pod.
+          name: Destination-Pod
+          type: string
+          priority: 10
+        - JSONPath: .spec.destination.ip
+          description: The IP address of the destination.
+          name: Destination-IP
+          type: string
+          priority: 10
+        - JSONPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              required:
+                - source
+                - destination
+              properties:
+                source:
+                  type: object
+                  required:
+                    - pod
+                    - namespace
+                  properties:
+                    pod:
+                      type: string
+                    namespace:
+                      type: string
+                destination:
+                  type: object
+                  properties:
+                    pod:
+                      type: string
+                    service:
+                      type: string
+                    namespace:
+                      type: string
+                    ip:
+                      type: string
+                      format: ipv4
+                  oneOf:
+                    - required: ["pod", "namespace"]
+                    - required: ["service", "namespace"]
+                    - required: ["ip"]
+                packet:
+                  type: object
+                  properties:
+                    ipHeader:
+                      type: object
+                      properties:
+                        srcIP:
+                          type: string
+                          format: ipv4
+                        protocol:
+                          type: integer
+                        ttl:
+                          type: integer
+                        flags:
+                          type: integer
+                    transportHeader:
+                      type: object
+                      properties:
+                        icmp:
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                            sequence:
+                              type: integer
+                        udp:
+                          type: object
+                          properties:
+                            srcPort:
+                              type: integer
+                            dstPort:
+                              type: integer
+                        tcp:
+                          type: object
+                          properties:
+                            srcPort:
+                              type: integer
+                            dstPort:
+                              type: integer
+                            flags:
+                              type: integer
+            status:
+              type: object
+              properties:
+                reason:
+                  type: string
+                dataplaneTag:
+                  type: integer
+                phase:
+                  type: string
+                results:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      node:
+                        type: string
+                      role:
+                        type: string
+                      timestamp:
+                        type: integer
+                      observations:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            component:
+                              type: string
+                            componentInfo:
+                              type: string
+                            action:
+                              type: string
+                            pod:
+                              type: string
+                            dstMAC:
+                              type: string
+                            networkPolicy:
+                              type: string
+                            ttl:
+                              type: integer
+                            translatedSrcIP:
+                              type: string
+                            translatedDstIP:
+                              type: string
+                            tunnelDstIP:
+                              type: string
+      subresources:
+        status: {}
   scope: Cluster
   names:
     plural: traceflows
@@ -52,157 +209,6 @@ spec:
     kind: Traceflow
     shortNames:
       - tf
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: The phase of the Traceflow.
-    name: Phase
-    type: string
-  - JSONPath: .spec.source.pod
-    description: The name of the source Pod.
-    name: Source-Pod
-    type: string
-    priority: 10
-  - JSONPath: .spec.destination.pod
-    description: The name of the destination Pod.
-    name: Destination-Pod
-    type: string
-    priority: 10
-  - JSONPath: .spec.destination.ip
-    description: The IP address of the destination.
-    name: Destination-IP
-    type: string
-    priority: 10
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
-  # Prune any unknown fields
-  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      required:
-        - spec
-      properties:
-        spec:
-          type: object
-          required:
-            - source
-            - destination
-          properties:
-            source:
-              type: object
-              required:
-                - pod
-                - namespace
-              properties:
-                pod:
-                  type: string
-                namespace:
-                  type: string
-            destination:
-              type: object
-              properties:
-                pod:
-                  type: string
-                service:
-                  type: string
-                namespace:
-                  type: string
-                ip:
-                  type: string
-                  format: ipv4
-              oneOf:
-                - required: ["pod", "namespace"]
-                - required: ["service", "namespace"]
-                - required: ["ip"]
-            packet:
-              type: object
-              properties:
-                ipHeader:
-                  type: object
-                  properties:
-                    srcIP:
-                      type: string
-                      format: ipv4
-                    protocol:
-                      type: integer
-                    ttl:
-                      type: integer
-                    flags:
-                      type: integer
-                transportHeader:
-                  type: object
-                  properties:
-                    icmp:
-                      type: object
-                      properties:
-                        id:
-                          type: integer
-                        sequence:
-                          type: integer
-                    udp:
-                      type: object
-                      properties:
-                        srcPort:
-                          type: integer
-                        dstPort:
-                          type: integer
-                    tcp:
-                      type: object
-                      properties:
-                        srcPort:
-                          type: integer
-                        dstPort:
-                          type: integer
-                        flags:
-                          type: integer
-        status:
-          type: object
-          properties:
-            reason:
-              type: string
-            dataplaneTag:
-              type: integer
-            phase:
-              type: string
-            results:
-              type: array
-              items:
-                type: object
-                properties:
-                  node:
-                    type: string
-                  role:
-                    type: string
-                  timestamp:
-                    type: integer
-                  observations:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        component:
-                          type: string
-                        componentInfo:
-                          type: string
-                        action:
-                          type: string
-                        pod:
-                          type: string
-                        dstMAC:
-                          type: string
-                        networkPolicy:
-                          type: string
-                        ttl:
-                          type: integer
-                        translatedSrcIP:
-                          type: string
-                        translatedDstIP:
-                          type: string
-                        tunnelDstIP:
-                          type: string
-  subresources:
-    status: {} 
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -247,7 +253,7 @@ spec:
             description:
               type: string
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusternetworkpolicies.security.antrea.tanzu.vmware.com
@@ -257,39 +263,21 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
-  scope: Cluster
-  names:
-    plural: clusternetworkpolicies
-    singular: clusternetworkpolicy
-    kind: ClusterNetworkPolicy
-    shortNames:
-      # Short name cnp is deprecated and will be removed in 0.12 release
-      - cnp
-      - acnp
-  # Prune any unknown fields
-  preserveUnknownFields: false
-  additionalPrinterColumns:
-  - name: Tier
-    type: string
-    description: The Tier to which this ClusterNetworkPolicy belongs to.
-    JSONPath: .spec.tier
-  - name: Priority
-    type: number
-    format: float
-    description: The Priority of this ClusterNetworkPolicy relative to other policies.
-    JSONPath: .spec.priority
-  - name: Age
-    type: date
-    JSONPath: .metadata.creationTimestamp
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          # Ensure that Spec.AppliedTo and Spec.Priority fields are set
-          required:
-            - appliedTo
-            - priority
+      additionalPrinterColumns:
+       - name: Tier
+         type: string
+         description: The Tier to which this ClusterNetworkPolicy belongs to.
+         jsonPath: .spec.tier
+       - name: Priority
+         type: number
+         format: float
+         description: The Priority of this ClusterNetworkPolicy relative to other policies.
+         jsonPath: .spec.priority
+       - name: Age
+         type: date
+         jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
           type: object
           properties:
             tier:
@@ -342,46 +330,71 @@ spec:
                         ipBlock:
                           type: object
                           properties:
-                            cidr:
+                            protocol:
                               type: string
-                              format: cidr
-            egress:
-              type: array
-              items:
-                type: object
-                required:
-                  - action
-                properties:
-                  # Ensure that Action field allows only ALLOW and DROP values
-                  action:
-                    type: string
-                    enum: ['Allow', 'Drop']
-                  ports:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        protocol:
-                          type: string
-                        port:
-                          x-kubernetes-int-or-string: true
-                  to:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
+                            port:
+                              x-kubernetes-int-or-string: true
+                      from:
+                        type: array
+                        items:
                           type: object
                           properties:
-                            cidr:
+                            podSelector:
+                              x-kubernetes-preserve-unknown-fields: true
+                            namespaceSelector:
+                              x-kubernetes-preserve-unknown-fields: true
+                            ipBlock:
+                              type: object
+                              properties:
+                                cidr:
+                                  type: string
+                                  format: cidr
+                egress:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - action
+                    properties:
+                      # Ensure that Action field allows only ALLOW and DROP values
+                      action:
+                        type: string
+                        enum: ['Allow', 'Drop']
+                      ports:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            protocol:
                               type: string
-                              format: cidr
+                            port:
+                              x-kubernetes-int-or-string: true
+                      to:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            podSelector:
+                              x-kubernetes-preserve-unknown-fields: true
+                            namespaceSelector:
+                              x-kubernetes-preserve-unknown-fields: true
+                            ipBlock:
+                              type: object
+                              properties:
+                                cidr:
+                                  type: string
+                                  format: cidr
+  scope: Cluster
+  names:
+    plural: clusternetworkpolicies
+    singular: clusternetworkpolicy
+    kind: ClusterNetworkPolicy
+    shortNames:
+      # Short name cnp is deprecated and will be removed in 0.12 release
+      - cnp
+      - acnp
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.security.antrea.tanzu.vmware.com
@@ -391,6 +404,122 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+      additionalPrinterColumns:
+        - name: Tier
+          type: string
+          description: The Tier to which this Antrea NetworkPolicy belongs to.
+          jsonPath: .spec.tier
+        - name: Priority
+          type: number
+          format: float
+          description: The Priority of this Antrea NetworkPolicy relative to other policies.
+          jsonPath: .spec.priority
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              # Ensure that Spec.AppliedTo and Spec.Priority fields are set
+              required:
+                - appliedTo
+                - priority
+              type: object
+              properties:
+                tier:
+                  type: string
+                  enum: ['Emergency', 'SecurityOps', 'NetworkOps', 'Platform', 'Application']
+                priority:
+                  type: number
+                  format: float
+                  # Ensure that Spec.Priority field is between 1 and 10000
+                  minimum: 1.0
+                  maximum: 10000.0
+                appliedTo:
+                  type: array
+                  items:
+                    type: object
+                    # Ensure that Spec.AppliedTo does not allow NamespaceSelector/IPBlock field
+                    properties:
+                      podSelector:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                ingress:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - action
+                    properties:
+                      # Ensure that Action field allows only ALLOW and DROP values
+                      action:
+                        type: string
+                        enum: ['Allow', 'Drop']
+                      ports:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            protocol:
+                              type: string
+                            port:
+                              x-kubernetes-int-or-string: true
+                      from:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            podSelector:
+                              x-kubernetes-preserve-unknown-fields: true
+                            namespaceSelector:
+                              x-kubernetes-preserve-unknown-fields: true
+                            externalEntitySelector:
+                              x-kubernetes-preserve-unknown-fields: true
+                            ipBlock:
+                              type: object
+                              properties:
+                                cidr:
+                                  type: string
+                                  format: cidr
+                egress:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - action
+                    properties:
+                      # Ensure that Action field allows only ALLOW and DROP values
+                      action:
+                        type: string
+                        enum: ['Allow', 'Drop']
+                      ports:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            protocol:
+                              type: string
+                            port:
+                              x-kubernetes-int-or-string: true
+                      to:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            podSelector:
+                              x-kubernetes-preserve-unknown-fields: true
+                            namespaceSelector:
+                              x-kubernetes-preserve-unknown-fields: true
+                            externalEntitySelector:
+                              x-kubernetes-preserve-unknown-fields: true
+                            ipBlock:
+                              type: object
+                              properties:
+                                cidr:
+                                  type: string
+                                  format: cidr
   scope: Namespaced
   names:
     plural: networkpolicies
@@ -400,126 +529,8 @@ spec:
       # Short name netpol is deprecated and will be removed in 0.12 release
       - netpol
       - anp
-  # Prune any unknown fields
-  preserveUnknownFields: false
-  additionalPrinterColumns:
-    - name: Tier
-      type: string
-      description: The Tier to which this Antrea NetworkPolicy belongs to.
-      JSONPath: .spec.tier
-    - name: Priority
-      type: number
-      format: float
-      description: The Priority of this Antrea NetworkPolicy relative to other policies.
-      JSONPath: .spec.priority
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          # Ensure that Spec.AppliedTo and Spec.Priority fields are set
-          required:
-            - appliedTo
-            - priority
-          type: object
-          properties:
-            tier:
-              type: string
-              enum: ['Emergency', 'SecurityOps', 'NetworkOps', 'Platform', 'Application']
-            priority:
-              type: number
-              format: float
-              # Ensure that Spec.Priority field is between 1 and 10000
-              minimum: 1.0
-              maximum: 10000.0
-            appliedTo:
-              type: array
-              items:
-                type: object
-                # Ensure that Spec.AppliedTo does not allow NamespaceSelector/IPBlock field
-                properties:
-                  podSelector:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-            ingress:
-              type: array
-              items:
-                type: object
-                required:
-                  - action
-                properties:
-                  # Ensure that Action field allows only ALLOW and DROP values
-                  action:
-                    type: string
-                    enum: ['Allow', 'Drop']
-                  ports:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        protocol:
-                          type: string
-                        port:
-                          x-kubernetes-int-or-string: true
-                  from:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          type: object
-                          properties:
-                            cidr:
-                              type: string
-                              format: cidr
-            egress:
-              type: array
-              items:
-                type: object
-                required:
-                  - action
-                properties:
-                  # Ensure that Action field allows only ALLOW and DROP values
-                  action:
-                    type: string
-                    enum: ['Allow', 'Drop']
-                  ports:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        protocol:
-                          type: string
-                        port:
-                          x-kubernetes-int-or-string: true
-                  to:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          type: object
-                          properties:
-                            cidr:
-                              type: string
-                              format: cidr
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: externalentities.core.antrea.tanzu.vmware.com
@@ -529,6 +540,36 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                endpoints:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      ip:
+                        type: string
+                        format: ipv4
+                      name:
+                        type: string
+                      ports:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            protocol:
+                              type: string
+                            port:
+                              x-kubernetes-int-or-string: true
+                            name:
+                              type: string
+                externalNode:
+                  type: string
   scope: Namespaced
   names:
     plural: externalentities
@@ -536,35 +577,3 @@ spec:
     kind: ExternalEntity
     shortNames:
       - ee
-  # Prune any unknown fields
-  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          properties:
-            endpoints:
-              type: array
-              items:
-                type: object
-                properties:
-                  ip:
-                    type: string
-                    format: ipv4
-                  name:
-                    type: string
-                  ports:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        protocol:
-                          type: string
-                        port:
-                          x-kubernetes-int-or-string: true
-                        name:
-                          type: string
-            externalNode:
-              type: string

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -54,26 +54,26 @@ spec:
       served: true
       storage: true
       additionalPrinterColumns:
-        - JSONPath: .status.phase
+        - jsonPath: .status.phase
           description: The phase of the Traceflow.
           name: Phase
           type: string
-        - JSONPath: .spec.source.pod
+        - jsonPath: .spec.source.pod
           description: The name of the source Pod.
           name: Source-Pod
           type: string
           priority: 10
-        - JSONPath: .spec.destination.pod
+        - jsonPath: .spec.destination.pod
           description: The name of the destination Pod.
           name: Destination-Pod
           type: string
           priority: 10
-        - JSONPath: .spec.destination.ip
+        - jsonPath: .spec.destination.ip
           description: The IP address of the destination.
           name: Destination-IP
           type: string
           priority: 10
-        - JSONPath: .metadata.creationTimestamp
+        - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
       schema:
@@ -264,18 +264,18 @@ spec:
       served: true
       storage: true
       additionalPrinterColumns:
-       - name: Tier
-         type: string
-         description: The Tier to which this ClusterNetworkPolicy belongs to.
-         jsonPath: .spec.tier
-       - name: Priority
-         type: number
-         format: float
-         description: The Priority of this ClusterNetworkPolicy relative to other policies.
-         jsonPath: .spec.priority
-       - name: Age
-         type: date
-         jsonPath: .metadata.creationTimestamp
+        - name: Tier
+          type: string
+          description: The Tier to which this ClusterNetworkPolicy belongs to.
+          jsonPath: .spec.tier
+        - name: Priority
+          type: number
+          format: float
+          description: The Priority of this ClusterNetworkPolicy relative to other policies.
+          jsonPath: .spec.priority
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
       schema:
         openAPIV3Schema:
           type: object

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -220,6 +220,29 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+      additionalPrinterColumns:
+        - name: Priority
+          type: integer
+          description: The Priority of this Tier relative to other Tiers.
+          jsonPath: .spec.priority
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              required:
+                - priority
+              type: object
+              properties:
+                priority:
+                  type: integer
+                  minimum: 0
+                  maximum: 255
+                description:
+                  type: string
   scope: Cluster
   names:
     plural: tiers
@@ -227,31 +250,6 @@ spec:
     kind: Tier
     shortNames:
       - tr
-  # Prune any unknown fields
-  preserveUnknownFields: false
-  additionalPrinterColumns:
-  - name: Priority
-    type: integer
-    description: The Priority of this Tier relative to other Tiers.
-    JSONPath: .spec.priority
-  - name: Age
-    type: date
-    JSONPath: .metadata.creationTimestamp
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          required:
-            - priority
-          type: object
-          properties:
-            priority:
-              type: integer
-              minimum: 0
-              maximum: 255
-            description:
-              type: string
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -35,7 +35,7 @@ spec:
     shortNames:
       - aai
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: traceflows.ops.antrea.tanzu.vmware.com
@@ -204,7 +204,7 @@ spec:
   subresources:
     status: {} 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: tiers.security.antrea.tanzu.vmware.com

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: antreacontrollerinfos.clusterinformation.antrea.tanzu.vmware.com
@@ -17,7 +17,7 @@ spec:
     shortNames:
       - aci
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: antreaagentinfos.clusterinformation.antrea.tanzu.vmware.com


### PR DESCRIPTION
apiVersion v1beta1 has been deprecated for CRDs in favor of v1.
This PR takes care of updating versions of all the CRDs available.
In addition to the version update, this PR also ensures strict schema validation for the following CRDs:
- traceflow
- clusternetworkpolicy
- networkpolicy
- externalentity
- tier

Related-Issue: #684 