### PR TITLE
Support self-signed certificate rotation

### DIFF
--- a/docs/securing-control-plane.md
+++ b/docs/securing-control-plane.md
@@ -156,3 +156,6 @@ re-distributing the latest CA certificate (if applicable).
 
 If you are using cert-manager to issue the certificate, it will renew the
 certificate before expiry and update the Secret automatically.
+
+If you are using certificates signed by Antrea, Antrea will rotate the
+certificate automatically before expiration.


### PR DESCRIPTION
Addresses issue:   #976 

Provides basic certificate rotation
Currently hard coded to rotate every year minus 1 day.
But allows it to be set for both testing, and to allow for future additions to let user specify rotation period

Provides unit test to verify rotation.