### PR TITLE
Use DSCP field in IP header as Traceflow DataplaneTag

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -682,8 +682,6 @@ func (c *client) SendTraceflowPacket(
 	inPort uint32,
 	outPort int32) error {
 
-	regName := fmt.Sprintf("%s%d", binding.NxmFieldReg, TraceflowReg)
-
 	packetOutBuilder := c.bridge.BuildPacketOut()
 	parsedSrcMAC, _ := net.ParseMAC(srcMAC)
 	parsedDstMAC, _ := net.ParseMAC(dstMAC)
@@ -728,7 +726,7 @@ func (c *client) SendTraceflowPacket(
 	if outPort != -1 {
 		packetOutBuilder = packetOutBuilder.SetOutport(uint32(outPort))
 	}
-	packetOutBuilder = packetOutBuilder.AddLoadAction(regName, uint64(dataplaneTag), OfTraceflowMarkRange)
+	packetOutBuilder = packetOutBuilder.AddLoadAction(binding.NxmFieldIPTos, uint64(dataplaneTag), OfTraceflowMarkRange)
 
 	packetOutObj := packetOutBuilder.Done()
 	return c.bridge.SendPacketOut(packetOutObj)
@@ -751,7 +749,7 @@ func (c *client) InstallTraceflowFlows(dataplaneTag uint8) error {
 			flows = append(
 				flows,
 				ctx.dropFlow.CopyToBuilder(priorityNormal+2).
-					MatchRegRange(int(TraceflowReg), uint32(dataplaneTag), OfTraceflowMarkRange).
+					MatchIPDscp(dataplaneTag).
 					SetHardTimeout(300).
 					Action().SendToController(1).
 					Done())

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -62,6 +62,7 @@ const (
 	NxmFieldARPOp       = "NXM_OF_ARP_OP"
 	NxmFieldReg         = "NXM_NX_REG"
 	NxmFieldTunMetadata = "NXM_NX_TUN_METADATA"
+	NxmFieldIPTos       = "NXM_OF_IP_TOS"
 )
 
 const (


### PR DESCRIPTION
This commit uses DSCP field in IP header as Traceflow DataplaneTag, replacing the usage of an option TLV in the Geneve header.

This feature is to support Traceflow for other encap protocols and no encap mode. Also, it might get wrong dataplane tag when OVS decapsulate a geneve packet with tun_metadata0.