### PR TITLE
Change Controller to Support EnableLogging

### DIFF
--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -83,6 +83,8 @@ spec:
                   action:
                     pattern: \bAllow|\bDrop
                     type: string
+                  enableLogging:
+                    type: boolean
                   ports:
                     items:
                       properties:
@@ -117,6 +119,8 @@ spec:
                   action:
                     pattern: \bAllow|\bDrop
                     type: string
+                  enableLogging:
+                    type: boolean
                   from:
                     items:
                       properties:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -83,6 +83,8 @@ spec:
                   action:
                     pattern: \bAllow|\bDrop
                     type: string
+                  enableLogging:
+                    type: boolean
                   ports:
                     items:
                       properties:
@@ -117,6 +119,8 @@ spec:
                   action:
                     pattern: \bAllow|\bDrop
                     type: string
+                  enableLogging:
+                    type: boolean
                   from:
                     items:
                       properties:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -83,6 +83,8 @@ spec:
                   action:
                     pattern: \bAllow|\bDrop
                     type: string
+                  enableLogging:
+                    type: boolean
                   ports:
                     items:
                       properties:
@@ -117,6 +119,8 @@ spec:
                   action:
                     pattern: \bAllow|\bDrop
                     type: string
+                  enableLogging:
+                    type: boolean
                   from:
                     items:
                       properties:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -83,6 +83,8 @@ spec:
                   action:
                     pattern: \bAllow|\bDrop
                     type: string
+                  enableLogging:
+                    type: boolean
                   ports:
                     items:
                       properties:
@@ -117,6 +119,8 @@ spec:
                   action:
                     pattern: \bAllow|\bDrop
                     type: string
+                  enableLogging:
+                    type: boolean
                   from:
                     items:
                       properties:
@@ -735,7 +739,7 @@ data:
 
     # Enable ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
     # to define security policies which apply to the entire cluster.
-    # ClusterNetworkPolicy: false
+    ClusterNetworkPolicy: true
 
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -291,6 +291,8 @@ spec:
                             cidr:
                               type: string
                               format: cidr
+                  enableLogging:
+                    type: boolean
             egress:
               type: array
               items:
@@ -326,3 +328,5 @@ spec:
                             cidr:
                               type: string
                               format: cidr
+                  enableLogging:
+                    type: boolean

--- a/pkg/apis/networking/types.go
+++ b/pkg/apis/networking/types.go
@@ -187,6 +187,9 @@ type NetworkPolicyRule struct {
 	// action “nil” defaults to Allow action, which would be the case for rules created for
 	// K8s Network Policy.
 	Action *secv1alpha1.RuleAction
+	// EnableLogging is used to indicate if agent should generate logs
+	// when rules are matched. Should be default to false.
+	EnableLogging bool
 }
 
 // Protocol defines network protocols supported for things like container ports.

--- a/pkg/apis/networking/v1beta1/types.go
+++ b/pkg/apis/networking/v1beta1/types.go
@@ -194,6 +194,9 @@ type NetworkPolicyRule struct {
 	// action “nil” defaults to Allow action, which would be the case for rules created for
 	// K8s Network Policy.
 	Action *secv1alpha1.RuleAction `json:"action,omitempty" protobuf:"bytes,6,opt,name=action,casttype=github.com/vmware-tanzu/antrea/pkg/apis/security/v1alpha1.RuleAction"`
+	// EnableLogging is used to indicate if agent should generate logs
+	// when rules are matched. Should be default to false.
+	EnableLogging bool `json:"enableLogging"`
 }
 
 // Protocol defines network protocols supported for things like container ports.

--- a/pkg/apis/security/v1alpha1/types.go
+++ b/pkg/apis/security/v1alpha1/types.go
@@ -71,6 +71,9 @@ type Rule struct {
 	// destinations.
 	// +optional
 	To []NetworkPolicyPeer `json:"to"`
+	// EnableLogging is used to indicate if agent should generate logs
+	// when rules are matched. Should be default to false.
+	EnableLogging bool `json:"enableLogging"`
 }
 
 // NetworkPolicyPeer describes the grouping selector of workloads.

--- a/pkg/controller/networkpolicy/clusternetworkpolicy.go
+++ b/pkg/controller/networkpolicy/clusternetworkpolicy.go
@@ -240,6 +240,7 @@ func (n *NetworkPolicyController) processClusterNetworkPolicy(cnp *secv1alpha1.C
 			Services:  toAntreaServicesForCRD(ingressRule.Ports),
 			Action:    ingressRule.Action,
 			Priority:  int32(idx),
+			EnableLogging: ingressRule.EnableLogging,
 		})
 	}
 	// Compute NetworkPolicyRule for Egress Rule.
@@ -251,6 +252,7 @@ func (n *NetworkPolicyController) processClusterNetworkPolicy(cnp *secv1alpha1.C
 			Services:  toAntreaServicesForCRD(egressRule.Ports),
 			Action:    egressRule.Action,
 			Priority:  int32(idx),
+			EnableLogging: egressRule.EnableLogging,
 		})
 	}
 	internalNetworkPolicy := &antreatypes.NetworkPolicy{

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -528,6 +528,7 @@ func (n *NetworkPolicyController) processNetworkPolicy(np *networkingv1.NetworkP
 			Services:  toAntreaServices(ingressRule.Ports),
 			Priority:  defaultRulePriority,
 			Action:    &defaultAction,
+			EnableLogging: false,
 		})
 	}
 	// Compute NetworkPolicyRule for Egress Rule.
@@ -539,6 +540,7 @@ func (n *NetworkPolicyController) processNetworkPolicy(np *networkingv1.NetworkP
 			Services:  toAntreaServices(egressRule.Ports),
 			Priority:  defaultRulePriority,
 			Action:    &defaultAction,
+			EnableLogging: false,
 		})
 	}
 


### PR DESCRIPTION
## Related Issue
[Antrea ClusterNetworkPolicy CRDs should support audit logging](https://github.com/vmware-tanzu/antrea/issues/1007)
## Problem
Need to add a new field to YAML spec for the new `enableLogging` field.
## Solution
Add the field in base/crd.yml under ClusterNetworkPolicy.
Change network policy controller correspondingly to process the new spec.