### PR TITLE
Optimize groupPodsByServices and hash functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/contiv/libOpenflow v0.0.0-20200424005919-3a6722c98962
 	github.com/contiv/ofnet v0.0.0-00010101000000-000000000000
 	github.com/coreos/go-iptables v0.4.5
-	github.com/davecgh/go-spew v1.1.1
 	github.com/elazarl/goproxy v0.0.0-20190911111923-ecfe977594f1 // indirect
 	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
 	github.com/go-openapi/spec v0.19.3

--- a/pkg/apis/networking/sets_test.go
+++ b/pkg/apis/networking/sets_test.go
@@ -1,0 +1,27 @@
+package networking
+
+import (
+	"net"
+	"testing"
+)
+
+func BenchmarkNormalizeGroupMemberPod(b *testing.B) {
+	pod := &GroupMemberPod{Pod: &PodReference{Namespace: "foo", Name: "bar"}, IP: IPAddress(net.ParseIP("1.1.1.1"))}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		normalizeGroupMemberPod(pod)
+	}
+}
+
+func BenchmarkInsert(b *testing.B) {
+	pod := &GroupMemberPod{Pod: &PodReference{Namespace: "foo", Name: "bar"}, IP: IPAddress(net.ParseIP("1.1.1.1"))}
+	pods := NewGroupMemberPodSet()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pods.Insert(pod)
+	}
+}

--- a/pkg/apis/networking/v1beta1/sets.go
+++ b/pkg/apis/networking/v1beta1/sets.go
@@ -14,37 +14,29 @@
 
 package v1beta1
 
-import (
-	"crypto/md5" // #nosec G501: not used for security purposes
-	"encoding/hex"
+import "strings"
 
-	"github.com/davecgh/go-spew/spew"
-)
-
-var (
-	printer = spew.ConfigState{
-		Indent:         " ",
-		SortKeys:       true,
-		DisableMethods: true,
-		SpewKeys:       true,
-	}
-)
-
-// groupMemberPodHash is used to uniquely identify GroupMemberPod. Only Pod and
-// IP field are included as unique identifiers.
-type groupMemberPodHash string
+// groupMemberPodKey is used to uniquely identify GroupMemberPod. Either Pod or
+// IP is used as unique key.
+type groupMemberPodKey string
 
 // GroupMemberPodSet is a set of GroupMemberPods.
-type GroupMemberPodSet map[groupMemberPodHash]*GroupMemberPod
+type GroupMemberPodSet map[groupMemberPodKey]*GroupMemberPod
 
-// hashGroupMemberPod uses the spew library which follows pointers and prints
-// actual values of the nested objects to ensure the hash does not change when
-// a pointer changes.
-func hashGroupMemberPod(pod *GroupMemberPod) groupMemberPodHash {
-	hasher := md5.New() // #nosec G401: not used for security purposes
-	hashObj := GroupMemberPod{Pod: pod.Pod, IP: pod.IP}
-	printer.Fprintf(hasher, "%#v", hashObj)
-	return groupMemberPodHash(hex.EncodeToString(hasher.Sum(nil)[0:]))
+// normalizeGroupMemberPod calculates the groupMemberPodKey of the provided
+// GroupMemberPod based on the Pod's namespaced name or IP.
+func normalizeGroupMemberPod(pod *GroupMemberPod) groupMemberPodKey {
+	// "/" is illegal in Namespace and name so is safe as the delimiter.
+	const delimiter = "/"
+	var b strings.Builder
+	if pod.Pod != nil {
+		b.WriteString(pod.Pod.Namespace)
+		b.WriteString(delimiter)
+		b.WriteString(pod.Pod.Name)
+	} else if len(pod.IP) != 0 {
+		b.Write(pod.IP)
+	}
+	return groupMemberPodKey(b.String())
 }
 
 // NewGroupMemberPodSet builds a GroupMemberPodSet from a list of GroupMemberPod.
@@ -57,20 +49,20 @@ func NewGroupMemberPodSet(items ...*GroupMemberPod) GroupMemberPodSet {
 // Insert adds items to the set.
 func (s GroupMemberPodSet) Insert(items ...*GroupMemberPod) {
 	for _, item := range items {
-		s[hashGroupMemberPod(item)] = item
+		s[normalizeGroupMemberPod(item)] = item
 	}
 }
 
 // Delete removes all items from the set.
 func (s GroupMemberPodSet) Delete(items ...*GroupMemberPod) {
 	for _, item := range items {
-		delete(s, hashGroupMemberPod(item))
+		delete(s, normalizeGroupMemberPod(item))
 	}
 }
 
 // Has returns true if and only if item is contained in the set.
 func (s GroupMemberPodSet) Has(item *GroupMemberPod) bool {
-	_, contained := s[hashGroupMemberPod(item)]
+	_, contained := s[normalizeGroupMemberPod(item)]
 	return contained
 }
 


### PR DESCRIPTION
When a NetworkPolicy rule had ports specified and had a large AddressGroup which has tens of thousands of Pods, it took quite a little CPU time to execute groupPodsByServices in antrea-agent. And if the rule applied to Pods across all Nodes, it would lead to CPU usage burst of the cluster, affecting the healthy of the whole cluster.

This patch optimizes several key functions in the following way:
1. For groupPodsByServices, if the rule has only numbered port, it returns the result with a fast path without iterating all Pods.
2. For groupPodsByServices, reuse the slice to avoid memory reallocations in the loop.
3. For hashServices and hashGroupMemberPod, construct the string with strings.Builder instead of using the spew library.

The improvement according to benchmark:
Before:
|  Test |  Time  | Memory  |  Allocs | 
|---|---|---|---|
| BenchmarkHashGroupMemberPod-4 |                     10907 ns/op |             920 B/op |        47 allocs/op |
| BenchmarkInsert-4 |                                 11006 ns/op    |         920 B/op    |    47 allocs/op |
|BenchmarkHashServices-4               |            13636 ns/op       |     1008 B/op    |      56 allocs/op  |
|BenchmarkGroupPodsByServicesWithNamedPort-4      |   969610858 ns/op    |      81247860 B/op    |  3652470 allocs/op  |
|BenchmarkGroupPodsByServicesWithoutNamedPort-4    |  952734680 ns/op   |       78859480 B/op     | 3552528 allocs/op  |

After:
|  Test |  Time  | Memory  |  Allocs | 
|---|---|---|---|
 |BenchmarkHashGroupMemberPod-4        |              111 ns/op         |       8 B/op        |   1 allocs/op |
 |BenchmarkInsert-4         |                         184 ns/op          |     8 B/op   |        1 allocs/op |
 |BenchmarkHashServices-4             |               472 ns/op       |        56 B/op       |    6 allocs/op |
 |BenchmarkGroupPodsByServicesWithNamedPort-4   |     72067961 ns/op     |     8844037 B/op   |   301967 allocs/op |
 |BenchmarkGroupPodsByServicesWithoutNamedPort-4   |  686 ns/op      |         704 B/op    |      8 allocs/op |

Fixes #1041