### PR TITLE
Enable linter goimports to tidy imports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,10 @@ run:
     - ".*\\.pb\\.go"
   skip-dirs-use-default: true
 
+linters-settings:
+  goimports:
+    local-prefixes: github.com/vmware-tanzu/antrea
+
 linters:
   disable-all: true
   enable:
@@ -14,3 +18,4 @@ linters:
     - deadcode
     - staticcheck
     - gosec
+    - goimports

--- a/cmd/antrea-cni/main.go
+++ b/cmd/antrea-cni/main.go
@@ -17,12 +17,12 @@ package main
 import (
 	"fmt"
 
+	"github.com/containernetworking/cni/pkg/skel"
+	cniversion "github.com/containernetworking/cni/pkg/version"
+
 	"github.com/vmware-tanzu/antrea/pkg/cni"
 	"github.com/vmware-tanzu/antrea/pkg/log"
 	"github.com/vmware-tanzu/antrea/pkg/version"
-
-	"github.com/containernetworking/cni/pkg/skel"
-	cni_version "github.com/containernetworking/cni/pkg/version"
 )
 
 func init() {
@@ -34,7 +34,7 @@ func main() {
 		cni.ActionAdd.Request,
 		cni.ActionCheck.Request,
 		cni.ActionDel.Request,
-		cni_version.All,
+		cniversion.All,
 		fmt.Sprintf("Antrea CNI %s", version.GetFullVersionWithRuntimeInfo()),
 	)
 }

--- a/pkg/agent/cniserver/ipam/ipam_service.go
+++ b/pkg/agent/cniserver/ipam/ipam_service.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/containernetworking/cni/pkg/invoke"
 	"github.com/containernetworking/cni/pkg/types/current"
+
 	cnipb "github.com/vmware-tanzu/antrea/pkg/apis/cni/v1beta1"
 )
 

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ip"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
@@ -115,16 +115,16 @@ func NewNodeRouteController(
 }
 
 // enqueueNode adds an object to the controller work queue
-// obj could be an *v1.Node, or a DeletionFinalStateUnknown item.
+// obj could be an *corev1.Node, or a DeletionFinalStateUnknown item.
 func (c *Controller) enqueueNode(obj interface{}) {
-	node, isNode := obj.(*v1.Node)
+	node, isNode := obj.(*corev1.Node)
 	if !isNode {
 		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			klog.Errorf("Received unexpected object: %v", obj)
 			return
 		}
-		node, ok = deletedState.Obj.(*v1.Node)
+		node, ok = deletedState.Obj.(*corev1.Node)
 		if !ok {
 			klog.Errorf("DeletedFinalStateUnknown contains non-Node object: %v", deletedState.Obj)
 			return
@@ -384,7 +384,7 @@ func (c *Controller) deleteNodeRoute(nodeName string) error {
 	return nil
 }
 
-func (c *Controller) addNodeRoute(nodeName string, node *v1.Node) error {
+func (c *Controller) addNodeRoute(nodeName string, node *corev1.Node) error {
 	if _, installed := c.installedNodes.Load(nodeName); installed {
 		// Route is already added for this Node.
 		return nil
@@ -523,15 +523,15 @@ func ParseTunnelInterfaceConfig(
 
 // GetNodeAddr gets the available IP address of a Node. GetNodeAddr will first try to get the
 // NodeInternalIP, then try to get the NodeExternalIP.
-func GetNodeAddr(node *v1.Node) (net.IP, error) {
-	addresses := make(map[v1.NodeAddressType]string)
+func GetNodeAddr(node *corev1.Node) (net.IP, error) {
+	addresses := make(map[corev1.NodeAddressType]string)
 	for _, addr := range node.Status.Addresses {
 		addresses[addr.Type] = addr.Address
 	}
 	var ipAddrStr string
-	if internalIP, ok := addresses[v1.NodeInternalIP]; ok {
+	if internalIP, ok := addresses[corev1.NodeInternalIP]; ok {
 		ipAddrStr = internalIP
-	} else if externalIP, ok := addresses[v1.NodeExternalIP]; ok {
+	} else if externalIP, ok := addresses[corev1.NodeExternalIP]; ok {
 		ipAddrStr = externalIP
 	} else {
 		return nil, fmt.Errorf("node %s has neither external ip nor internal ip", node.Name)

--- a/pkg/agent/controller/traceflow/traceflow_controller.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
@@ -291,7 +291,7 @@ func (c *Controller) injectPacket(tf *opsv1alpha1.Traceflow) error {
 			dstMAC = dstPodInterfaces[0].MAC.String()
 			dstIP = dstPodInterfaces[0].IP.String()
 		} else {
-			dstPod, err := c.kubeClient.CoreV1().Pods(tf.Spec.Destination.Namespace).Get(context.TODO(), tf.Spec.Destination.Pod, v1.GetOptions{})
+			dstPod, err := c.kubeClient.CoreV1().Pods(tf.Spec.Destination.Namespace).Get(context.TODO(), tf.Spec.Destination.Pod, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
@@ -367,7 +367,7 @@ func (c *Controller) errorTraceflowCRD(tf *opsv1alpha1.Traceflow, reason string)
 	}
 	patchData := Traceflow{Status: opsv1alpha1.TraceflowStatus{Phase: tf.Status.Phase, Reason: reason}}
 	payloads, _ := json.Marshal(patchData)
-	return c.traceflowClient.OpsV1alpha1().Traceflows().Patch(context.TODO(), tf.Name, types.MergePatchType, payloads, v1.PatchOptions{}, "status")
+	return c.traceflowClient.OpsV1alpha1().Traceflows().Patch(context.TODO(), tf.Name, types.MergePatchType, payloads, metav1.PatchOptions{}, "status")
 }
 
 // Deallocate tag from cache. Ignore DataplaneTag == 0 which is invalid case.

--- a/pkg/apiserver/certificate/cacert_controller.go
+++ b/pkg/apiserver/certificate/cacert_controller.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 	"k8s.io/client-go/kubernetes"
@@ -109,7 +109,7 @@ func (c *CACertController) syncCACert() error {
 func (c *CACertController) syncAPIServices(caCert []byte) error {
 	klog.Info("Syncing CA certificate with APIServices")
 	for _, name := range apiServiceNames {
-		apiService, err := c.aggregatorClient.ApiregistrationV1().APIServices().Get(context.TODO(), name, v1.GetOptions{})
+		apiService, err := c.aggregatorClient.ApiregistrationV1().APIServices().Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("error getting APIService %s: %v", name, err)
 		}
@@ -117,7 +117,7 @@ func (c *CACertController) syncAPIServices(caCert []byte) error {
 			continue
 		}
 		apiService.Spec.CABundle = caCert
-		if _, err := c.aggregatorClient.ApiregistrationV1().APIServices().Update(context.TODO(), apiService, v1.UpdateOptions{}); err != nil {
+		if _, err := c.aggregatorClient.ApiregistrationV1().APIServices().Update(context.TODO(), apiService, metav1.UpdateOptions{}); err != nil {
 			return fmt.Errorf("error updating antrea CA cert of APIService %s: %v", name, err)
 		}
 	}
@@ -129,7 +129,7 @@ func (c *CACertController) syncConfigMap(caCert []byte) error {
 	klog.Info("Syncing CA certificate with ConfigMap")
 	// Use the Antrea Pod Namespace for the CA cert ConfigMap.
 	caConfigMapNamespace := GetCAConfigMapNamespace()
-	caConfigMap, err := c.client.CoreV1().ConfigMaps(caConfigMapNamespace).Get(context.TODO(), CAConfigMapName, v1.GetOptions{})
+	caConfigMap, err := c.client.CoreV1().ConfigMaps(caConfigMapNamespace).Get(context.TODO(), CAConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("error getting ConfigMap %s: %v", CAConfigMapName, err)
 	}
@@ -139,7 +139,7 @@ func (c *CACertController) syncConfigMap(caCert []byte) error {
 	caConfigMap.Data = map[string]string{
 		CAConfigMapKey: string(caCert),
 	}
-	if _, err := c.client.CoreV1().ConfigMaps(caConfigMapNamespace).Update(context.TODO(), caConfigMap, v1.UpdateOptions{}); err != nil {
+	if _, err := c.client.CoreV1().ConfigMaps(caConfigMapNamespace).Update(context.TODO(), caConfigMap, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("error updating ConfigMap %s: %v", CAConfigMapName, err)
 	}
 	return nil

--- a/pkg/apiserver/registry/networkpolicy/addressgroup/rest.go
+++ b/pkg/apiserver/registry/networkpolicy/addressgroup/rest.go
@@ -19,7 +19,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -57,7 +57,7 @@ func (r *REST) NewList() runtime.Object {
 	return &networking.AddressGroupList{}
 }
 
-func (r *REST) Get(ctx context.Context, name string, options *v1.GetOptions) (runtime.Object, error) {
+func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	addressGroup, exists, err := r.addressGroupStore.Get(name)
 	if err != nil {
 		return nil, errors.NewInternalError(err)
@@ -89,6 +89,6 @@ func (r *REST) Watch(ctx context.Context, options *internalversion.ListOptions) 
 	return r.addressGroupStore.Watch(ctx, key, label, field)
 }
 
-func (r *REST) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*v1.Table, error) {
+func (r *REST) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
 	return rest.NewDefaultTableConvertor(networking.Resource("addressgroup")).ConvertToTable(ctx, obj, tableOptions)
 }

--- a/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest.go
+++ b/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest.go
@@ -19,7 +19,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -57,7 +57,7 @@ func (r *REST) NewList() runtime.Object {
 	return &networking.AppliedToGroupList{}
 }
 
-func (r *REST) Get(ctx context.Context, name string, options *v1.GetOptions) (runtime.Object, error) {
+func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	appliedToGroup, exists, err := r.appliedToGroupStore.Get(name)
 	if err != nil {
 		return nil, errors.NewInternalError(err)
@@ -89,6 +89,6 @@ func (r *REST) Watch(ctx context.Context, options *internalversion.ListOptions) 
 	return r.appliedToGroupStore.Watch(ctx, key, label, field)
 }
 
-func (r *REST) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*v1.Table, error) {
+func (r *REST) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
 	return rest.NewDefaultTableConvertor(networking.Resource("appliedtogroup")).ConvertToTable(ctx, obj, tableOptions)
 }

--- a/pkg/apiserver/registry/networkpolicy/networkpolicy/rest.go
+++ b/pkg/apiserver/registry/networkpolicy/networkpolicy/rest.go
@@ -19,7 +19,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/endpoints/request"
@@ -59,7 +59,7 @@ func (r *REST) NewList() runtime.Object {
 	return &networking.NetworkPolicyList{}
 }
 
-func (r *REST) Get(ctx context.Context, name string, options *v1.GetOptions) (runtime.Object, error) {
+func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	ns, ok := request.NamespaceFrom(ctx)
 	if !ok || len(ns) == 0 {
 		return nil, errors.NewBadRequest("Namespace parameter required.")
@@ -107,6 +107,6 @@ func (r *REST) Watch(ctx context.Context, options *internalversion.ListOptions) 
 	return r.networkPolicyStore.Watch(ctx, key, label, field)
 }
 
-func (r *REST) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*v1.Table, error) {
+func (r *REST) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
 	return rest.NewDefaultTableConvertor(networking.Resource("networkpolicy")).ConvertToTable(ctx, obj, tableOptions)
 }

--- a/pkg/apiserver/registry/system/controllerinfo/rest.go
+++ b/pkg/apiserver/registry/system/controllerinfo/rest.go
@@ -19,7 +19,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
 
@@ -59,7 +59,7 @@ func (r *REST) getControllerInfo() *clusterinfo.AntreaControllerInfo {
 	return info
 }
 
-func (r *REST) Get(ctx context.Context, name string, options *v1.GetOptions) (runtime.Object, error) {
+func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	info := r.getControllerInfo()
 	// The provided name should match the AntreaControllerInfo.Name.
 	if info.Name != name {
@@ -82,6 +82,6 @@ func (r *REST) NamespaceScoped() bool {
 	return false
 }
 
-func (r *REST) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*v1.Table, error) {
+func (r *REST) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
 	return rest.NewDefaultTableConvertor(system.Resource("clusterinfos")).ConvertToTable(ctx, obj, tableOptions)
 }

--- a/pkg/controller/networkpolicy/networkpolicy_controller_perf_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_perf_test.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -47,9 +47,9 @@ NAMESPACES   PODS    NETWORK-POLICIES    TIME(s)    MEMORY(M)    EXECUTIONS    E
 The metrics are not accurate under the race detector, and will be skipped when testing with "-race".
 */
 func TestInitXLargeScaleWithSmallNamespaces(t *testing.T) {
-	getObjects := func() ([]*v1.Namespace, []*networkingv1.NetworkPolicy, []*v1.Pod) {
+	getObjects := func() ([]*corev1.Namespace, []*networkingv1.NetworkPolicy, []*corev1.Pod) {
 		namespace := rand.String(8)
-		namespaces := []*v1.Namespace{
+		namespaces := []*corev1.Namespace{
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: namespace, Labels: map[string]string{"app": namespace}},
 			},
@@ -99,26 +99,26 @@ func TestInitXLargeScaleWithSmallNamespaces(t *testing.T) {
 				},
 			},
 		}
-		pods := []*v1.Pod{
+		pods := []*corev1.Pod{
 			{
 				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod1", UID: types.UID(uuid.New().String()), Labels: map[string]string{"app-1": "scale-1"}},
-				Spec:       v1.PodSpec{NodeName: getRandomNodeName()},
-				Status:     v1.PodStatus{PodIP: getRandomIP()},
+				Spec:       corev1.PodSpec{NodeName: getRandomNodeName()},
+				Status:     corev1.PodStatus{PodIP: getRandomIP()},
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod2", UID: types.UID(uuid.New().String()), Labels: map[string]string{"app-1": "scale-1"}},
-				Spec:       v1.PodSpec{NodeName: getRandomNodeName()},
-				Status:     v1.PodStatus{PodIP: getRandomIP()},
+				Spec:       corev1.PodSpec{NodeName: getRandomNodeName()},
+				Status:     corev1.PodStatus{PodIP: getRandomIP()},
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod3", UID: types.UID(uuid.New().String()), Labels: map[string]string{"app-2": "scale-2"}},
-				Spec:       v1.PodSpec{NodeName: getRandomNodeName()},
-				Status:     v1.PodStatus{PodIP: getRandomIP()},
+				Spec:       corev1.PodSpec{NodeName: getRandomNodeName()},
+				Status:     corev1.PodStatus{PodIP: getRandomIP()},
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod4", UID: types.UID(uuid.New().String()), Labels: map[string]string{"app-2": "scale-2"}},
-				Spec:       v1.PodSpec{NodeName: getRandomNodeName()},
-				Status:     v1.PodStatus{PodIP: getRandomIP()},
+				Spec:       corev1.PodSpec{NodeName: getRandomNodeName()},
+				Status:     corev1.PodStatus{PodIP: getRandomIP()},
 			},
 		}
 		return namespaces, networkPolicies, pods
@@ -127,7 +127,7 @@ func TestInitXLargeScaleWithSmallNamespaces(t *testing.T) {
 	testComputeNetworkPolicy(t, 10*time.Second, namespaces, networkPolicies, pods)
 }
 
-func testComputeNetworkPolicy(t *testing.T, maxExecutionTime time.Duration, namespaces []*v1.Namespace, networkPolicies []*networkingv1.NetworkPolicy, pods []*v1.Pod) {
+func testComputeNetworkPolicy(t *testing.T, maxExecutionTime time.Duration, namespaces []*corev1.Namespace, networkPolicies []*networkingv1.NetworkPolicy, pods []*corev1.Pod) {
 	objs := make([]runtime.Object, 0, len(namespaces)+len(networkPolicies)+len(pods))
 	for i := range namespaces {
 		objs = append(objs, namespaces[i])
@@ -264,10 +264,10 @@ func getRandomNodeName() string {
 }
 
 // getXObjects calls the provided getObjectsFunc x times and aggregate the objects.
-func getXObjects(x int, getObjectsFunc func() ([]*v1.Namespace, []*networkingv1.NetworkPolicy, []*v1.Pod)) ([]*v1.Namespace, []*networkingv1.NetworkPolicy, []*v1.Pod) {
-	var namespaces []*v1.Namespace
+func getXObjects(x int, getObjectsFunc func() ([]*corev1.Namespace, []*networkingv1.NetworkPolicy, []*corev1.Pod)) ([]*corev1.Namespace, []*networkingv1.NetworkPolicy, []*corev1.Pod) {
+	var namespaces []*corev1.Namespace
 	var networkPolicies []*networkingv1.NetworkPolicy
-	var pods []*v1.Pod
+	var pods []*corev1.Pod
 	for i := 0; i < x; i++ {
 		newNamespaces, newNetworkPolicies, newPods := getObjectsFunc()
 		namespaces = append(namespaces, newNamespaces...)

--- a/pkg/controller/traceflow/controller.go
+++ b/pkg/controller/traceflow/controller.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -236,7 +236,7 @@ func (c *Controller) checkTraceflowStatus(tf *opsv1alpha1.Traceflow) (retry bool
 	}
 	if sender && receiver {
 		tf.Status.Phase = opsv1alpha1.Succeeded
-		_, err = c.client.OpsV1alpha1().Traceflows().UpdateStatus(context.TODO(), tf, v1.UpdateOptions{})
+		_, err = c.client.OpsV1alpha1().Traceflows().UpdateStatus(context.TODO(), tf, metav1.UpdateOptions{})
 		return
 	}
 	if time.Now().UTC().Sub(tf.CreationTimestamp.UTC()).Seconds() > timeout {
@@ -256,7 +256,7 @@ func (c *Controller) runningTraceflowCRD(tf *opsv1alpha1.Traceflow, dataPlaneTag
 	}
 	patchData := Traceflow{Status: opsv1alpha1.TraceflowStatus{Phase: tf.Status.Phase, DataplaneTag: dataPlaneTag}}
 	payloads, _ := json.Marshal(patchData)
-	return c.client.OpsV1alpha1().Traceflows().Patch(context.TODO(), tf.Name, types.MergePatchType, payloads, v1.PatchOptions{}, "status")
+	return c.client.OpsV1alpha1().Traceflows().Patch(context.TODO(), tf.Name, types.MergePatchType, payloads, metav1.PatchOptions{}, "status")
 }
 
 func (c *Controller) errorTraceflowCRD(tf *opsv1alpha1.Traceflow, reason string) (*opsv1alpha1.Traceflow, error) {
@@ -267,7 +267,7 @@ func (c *Controller) errorTraceflowCRD(tf *opsv1alpha1.Traceflow, reason string)
 	}
 	patchData := Traceflow{Status: opsv1alpha1.TraceflowStatus{Phase: tf.Status.Phase, Reason: reason}}
 	payloads, _ := json.Marshal(patchData)
-	return c.client.OpsV1alpha1().Traceflows().Patch(context.TODO(), tf.Name, types.MergePatchType, payloads, v1.PatchOptions{}, "status")
+	return c.client.OpsV1alpha1().Traceflows().Patch(context.TODO(), tf.Name, types.MergePatchType, payloads, metav1.PatchOptions{}, "status")
 }
 
 func (c *Controller) occupyTag(tf *opsv1alpha1.Traceflow) error {

--- a/pkg/monitor/controller.go
+++ b/pkg/monitor/controller.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"time"
 
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -143,14 +143,14 @@ func (monitor *controllerMonitor) deleteStaleAgentCRDs() {
 }
 
 func (monitor *controllerMonitor) deleteStaleAgentCRD(old interface{}) {
-	node, ok := old.(*v1.Node)
+	node, ok := old.(*corev1.Node)
 	if !ok {
 		tombstone, ok := old.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			klog.Errorf("Error decoding object when deleting Node, invalid type: %v", old)
 			return
 		}
-		node, ok = tombstone.Obj.(*v1.Node)
+		node, ok = tombstone.Obj.(*corev1.Node)
 		if !ok {
 			klog.Errorf("Error decoding object tombstone when deleting Node, invalid type: %v", tombstone.Obj)
 			return

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 )
@@ -101,8 +101,8 @@ func (data *TestData) testHostPortPodConnectivity(t *testing.T) {
 	}
 	defer deletePodWrapper(t, data, hpPodName)
 	// Retrieve the IP Address of the Node on which the Pod is scheduled.
-	hpPod, err := data.podWaitFor(defaultTimeout, hpPodName, testNamespace, func(pod *v1.Pod) (bool, error) {
-		return pod.Status.Phase == v1.PodRunning, nil
+	hpPod, err := data.podWaitFor(defaultTimeout, hpPodName, testNamespace, func(pod *corev1.Pod) (bool, error) {
+		return pod.Status.Phase == corev1.PodRunning, nil
 	})
 	if err != nil {
 		t.Fatalf("Error when waiting for Pod '%s': %v", hpPodName, err)

--- a/test/e2e/performance_test.go
+++ b/test/e2e/performance_test.go
@@ -24,11 +24,10 @@ import (
 	"time"
 
 	"golang.org/x/exp/rand"
-	"k8s.io/apimachinery/pkg/util/wait"
-
 	corev1 "k8s.io/api/core/v1"
 	networkv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (

--- a/test/e2e/providers/kind.go
+++ b/test/e2e/providers/kind.go
@@ -16,10 +16,11 @@ package providers
 
 import (
 	"fmt"
-	"github.com/vmware-tanzu/antrea/test/e2e/providers/exec"
 	"os"
 	"path"
 	"strings"
+
+	"github.com/vmware-tanzu/antrea/test/e2e/providers/exec"
 )
 
 type KindProvider struct {

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -100,10 +100,10 @@ func TestProxyHairpin(t *testing.T) {
 	skipIfProxyDisabled(t, data)
 
 	nodeName := nodeName(1)
-	err = data.createPodOnNode("busybox", nodeName, "busybox", []string{"nc", "-lk", "-p", "80"}, nil, nil, []v1.ContainerPort{{ContainerPort: 80, Protocol: v1.ProtocolTCP}})
+	err = data.createPodOnNode("busybox", nodeName, "busybox", []string{"nc", "-lk", "-p", "80"}, nil, nil, []corev1.ContainerPort{{ContainerPort: 80, Protocol: corev1.ProtocolTCP}})
 	require.NoError(t, err)
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, "busybox", testNamespace))
-	svc, err := data.createService("busybox", 80, 80, map[string]string{"antrea-e2e": "busybox"}, false, v1.ServiceTypeClusterIP)
+	svc, err := data.createService("busybox", 80, 80, map[string]string{"antrea-e2e": "busybox"}, false, corev1.ServiceTypeClusterIP)
 	require.NoError(t, err)
 	stdout, stderr, err := data.runCommandFromPod(testNamespace, "busybox", busyboxContainerName, []string{"nc", svc.Spec.ClusterIP, "80", "-w", "1", "-e", "ls", "/"})
 	require.NoError(t, err, fmt.Sprintf("stdout: %s\n, stderr: %s", stdout, stderr))

--- a/test/e2e/reachability.go
+++ b/test/e2e/reachability.go
@@ -16,9 +16,10 @@ package e2e
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"strings"
 )
 
 type Pod string

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	networkingv1 "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -328,11 +327,11 @@ func TestTraceflow(t *testing.T) {
 			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
-				if _, err := data.crdClient.OpsV1alpha1().Traceflows().Create(context.TODO(), tc.tf, v1.CreateOptions{}); err != nil {
+				if _, err := data.crdClient.OpsV1alpha1().Traceflows().Create(context.TODO(), tc.tf, metav1.CreateOptions{}); err != nil {
 					t.Fatalf("Error when creating traceflow: %v", err)
 				}
 				defer func() {
-					if err := data.crdClient.OpsV1alpha1().Traceflows().Delete(context.TODO(), tc.tf.Name, v1.DeleteOptions{}); err != nil {
+					if err := data.crdClient.OpsV1alpha1().Traceflows().Delete(context.TODO(), tc.tf.Name, metav1.DeleteOptions{}); err != nil {
 						t.Errorf("Error when deleting traceflow: %v", err)
 					}
 				}()
@@ -381,7 +380,7 @@ func (data *TestData) waitForTraceflow(name string, phase v1alpha1.TraceflowPhas
 	var tf *v1alpha1.Traceflow
 	var err error
 	if err = wait.PollImmediate(1*time.Second, 15*time.Second, func() (bool, error) {
-		tf, err = data.crdClient.OpsV1alpha1().Traceflows().Get(context.TODO(), name, v1.GetOptions{})
+		tf, err = data.crdClient.OpsV1alpha1().Traceflows().Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil || tf.Status.Phase != phase {
 			return false, nil
 		}

--- a/test/e2e/utils/cnpspecbuilder.go
+++ b/test/e2e/utils/cnpspecbuilder.go
@@ -16,7 +16,6 @@ package utils
 
 import (
 	v1 "k8s.io/api/core/v1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 

--- a/test/e2e/utils/networkpolicyspecbuilder.go
+++ b/test/e2e/utils/networkpolicyspecbuilder.go
@@ -17,7 +17,6 @@ package utils
 import (
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )


### PR DESCRIPTION
goimports makes imports deterministic, putting them in 3 sections:
builtin, 3rd-party, local packages. It saves reviewers's effort to
comment the order of imports.

It doesn't allow imports named "v1" unless the alias name is specified
as "v1", this patch adds the parent packages of v1 packages as the
prefix of the import names.

Fixes #1038