### PR TITLE
[IPv6] Change host-local IPAM configuration for IPv6

### DIFF
--- a/pkg/agent/cniserver/interface_configuration_windows.go
+++ b/pkg/agent/cniserver/interface_configuration_windows.go
@@ -89,6 +89,16 @@ func (ic *ifConfigurator) delEndpoint(name string) {
 	ic.epCache.Delete(name)
 }
 
+// findContainerIPConfig finds a valid IPv4 address since IPv6 is not supported for Windows at this stage.
+func findContainerIPConfig(ips []*current.IPConfig) (*current.IPConfig, error) {
+	for _, ipc := range ips {
+		if ipc.Version == "4" {
+			return ipc, nil
+		}
+	}
+	return nil, fmt.Errorf("failed to find a valid IP address")
+}
+
 // configureContainerLink creates a HNSEndpoint for the container using the IPAM result, and then attach it on the container interface.
 func (ic *ifConfigurator) configureContainerLink(
 	podName string,

--- a/pkg/agent/cniserver/ipam/ipam_service.go
+++ b/pkg/agent/cniserver/ipam/ipam_service.go
@@ -26,10 +26,16 @@ import (
 
 var ipamDrivers map[string]IPAMDriver
 
-type IPAMConfig struct {
-	Type    string `json:"type,omitempty"`
-	Subnet  string `json:"subnet,omitempty"`
+type Range struct {
+	Subnet  string `json:"subnet"`
 	Gateway string `json:"gateway,omitempty"`
+}
+
+type RangeSet []Range
+
+type IPAMConfig struct {
+	Type   string     `json:"type,omitempty"`
+	Ranges []RangeSet `json:"ranges,omitempty"`
 }
 
 type IPAMDriver interface {

--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -139,7 +139,7 @@ type CNIConfig struct {
 //     gateway (if missing) based on the subnet and setting the interface pointer to the container
 //     interface
 //   * if there is no default route, add one using the provided default gateway
-func updateResultIfaceConfig(result *current.Result, defaultV4Gateway net.IP) {
+func updateResultIfaceConfig(result *current.Result, defaultGateways []net.IP) {
 	for _, ipc := range result.IPs {
 		// result.Interfaces[0] is host interface, and result.Interfaces[1] is container interface
 		ipc.Interface = current.Int(1)
@@ -150,21 +150,29 @@ func updateResultIfaceConfig(result *current.Result, defaultV4Gateway net.IP) {
 		}
 	}
 
-	foundDefaultRoute := false
-	defaultRouteDst := "0.0.0.0/0"
+	foundV4DefaultRoute := false
+	foundV6DefaultRoute := false
+	defaultV4RouteDst := "0.0.0.0/0"
+	defaultV6RouteDst := "::/0"
 	if result.Routes != nil {
 		for _, rt := range result.Routes {
-			if rt.Dst.String() == defaultRouteDst {
-				foundDefaultRoute = true
-				break
+			if rt.Dst.String() == defaultV4RouteDst {
+				foundV4DefaultRoute = true
+			} else if rt.Dst.String() == defaultV6RouteDst {
+				foundV6DefaultRoute = true
 			}
 		}
 	} else {
 		result.Routes = []*cnitypes.Route{}
 	}
-	if !foundDefaultRoute {
-		_, defaultRouteDstNet, _ := net.ParseCIDR(defaultRouteDst)
-		result.Routes = append(result.Routes, &cnitypes.Route{Dst: *defaultRouteDstNet, GW: defaultV4Gateway})
+	for _, gw := range defaultGateways {
+		if (!foundV4DefaultRoute) && (gw.To4() != nil) {
+			_, defaultV4RouteDstNet, _ := net.ParseCIDR(defaultV4RouteDst)
+			result.Routes = append(result.Routes, &cnitypes.Route{Dst: *defaultV4RouteDstNet, GW: gw})
+		} else if (!foundV6DefaultRoute) && (gw.To4() == nil) {
+			_, defaultV6RouteDstNet, _ := net.ParseCIDR(defaultV6RouteDst)
+			result.Routes = append(result.Routes, &cnitypes.Route{Dst: *defaultV6RouteDstNet, GW: gw})
+		}
 	}
 }
 
@@ -219,12 +227,16 @@ func (s *CNIServer) checkRequestMessage(request *cnipb.CniCmdRequest) (*CNIConfi
 }
 
 func (s *CNIServer) updateLocalIPAMSubnet(cniConfig *CNIConfig) {
-	gwIPv4 := util.GetIPv4Addr(s.nodeConfig.GatewayConfig.IPs)
-	cniConfig.NetworkConfig.IPAM.Gateway = gwIPv4.String()
-	if s.nodeConfig.PodIPv4CIDR != nil {
-		cniConfig.NetworkConfig.IPAM.Subnet = s.nodeConfig.PodIPv4CIDR.String()
-		cniConfig.NetworkConfiguration, _ = json.Marshal(cniConfig.NetworkConfig)
+	for _, gatewayIP := range s.nodeConfig.GatewayConfig.IPs {
+		if (gatewayIP.To4() != nil) && (s.nodeConfig.PodIPv4CIDR != nil) {
+			cniConfig.NetworkConfig.IPAM.Ranges = append(cniConfig.NetworkConfig.IPAM.Ranges,
+				ipam.RangeSet{ipam.Range{Subnet: s.nodeConfig.PodIPv4CIDR.String(), Gateway: gatewayIP.String()}})
+		} else if (gatewayIP.To4() == nil) && (s.nodeConfig.PodIPv6CIDR != nil) {
+			cniConfig.NetworkConfig.IPAM.Ranges = append(cniConfig.NetworkConfig.IPAM.Ranges,
+				ipam.RangeSet{ipam.Range{Subnet: s.nodeConfig.PodIPv6CIDR.String(), Gateway: gatewayIP.String()}})
+		}
 	}
+	cniConfig.NetworkConfiguration, _ = json.Marshal(cniConfig.NetworkConfig)
 }
 
 func (s *CNIServer) generateCNIErrorResponse(cniErrorCode cnipb.ErrorCode, cniErrorMsg string) *cnipb.CniCmdResponse {
@@ -403,8 +415,7 @@ func (s *CNIServer) CmdAdd(ctx context.Context, request *cnipb.CniCmdRequest) (*
 	result.IPs = ipamResult.IPs
 	result.Routes = ipamResult.Routes
 	// Ensure interface gateway setting and mapping relations between result.Interfaces and result.IPs
-	gwIPv4 := util.GetIPv4Addr(s.nodeConfig.GatewayConfig.IPs)
-	updateResultIfaceConfig(result, gwIPv4)
+	updateResultIfaceConfig(result, s.nodeConfig.GatewayConfig.IPs)
 	// Setup pod interfaces and connect to ovs bridge
 	podName := string(cniConfig.K8S_POD_NAME)
 	podNamespace := string(cniConfig.K8S_POD_NAMESPACE)

--- a/pkg/agent/cniserver/server_test.go
+++ b/pkg/agent/cniserver/server_test.go
@@ -59,7 +59,8 @@ var dns = []string{"192.168.100.1"}
 var ips = []string{"10.1.2.100/24,10.1.2.1,4"}
 var args = cniservertest.GenerateCNIArgs(testPodName, testPodNamespace, testPodInfraContainerID)
 var testNodeConfig *config.NodeConfig
-var gwIP net.IP
+var gwIPv4 net.IP
+var gwIPv6 net.IP
 
 func TestLoadNetConfig(t *testing.T) {
 	assert := assert.New(t)
@@ -80,12 +81,20 @@ func TestLoadNetConfig(t *testing.T) {
 	assert.Equal(networkCfg.Name, netCfg.Name)
 	assert.Equal(networkCfg.IPAM.Type, netCfg.IPAM.Type)
 	assert.Equal(
-		netCfg.IPAM.Subnet, testNodeConfig.PodIPv4CIDR.String(),
-		"Network configuration (PodCIDRs) was not updated",
+		netCfg.IPAM.Ranges[0][0].Subnet, testNodeConfig.PodIPv4CIDR.String(),
+		"Network configuration (PodIPv4CIDR) was not updated",
 	)
 	assert.Equal(
-		netCfg.IPAM.Gateway, testNodeConfig.GatewayConfig.IPs[0].String(),
+		netCfg.IPAM.Ranges[0][0].Gateway, testNodeConfig.GatewayConfig.IPs[0].String(),
 		"Network configuration (Gateway IP) was not updated",
+	)
+	assert.Equal(
+		netCfg.IPAM.Ranges[1][0].Subnet, testNodeConfig.PodIPv6CIDR.String(),
+		"Network configuration (PodIPv6CIDR) was not updated",
+	)
+	assert.Equal(
+		netCfg.IPAM.Ranges[1][0].Gateway, testNodeConfig.GatewayConfig.IPs[1].String(),
+		"Network configuration (Gateway IPv6) was not updated",
 	)
 }
 
@@ -334,25 +343,24 @@ func TestParsePrevResultFromRequest(t *testing.T) {
 func TestUpdateResultIfaceConfig(t *testing.T) {
 	require := require.New(t)
 
-	// TODO: it may be better to have a v4 address and a v6 address, as the IPAM plugin will not
-	// return a Result with 2 v4 addresses.
-	testIps := []string{"10.1.2.100/24, ,4", "192.168.1.100/24, 192.168.2.253, 4"}
+	testIps := []string{"192.168.1.100/24, , 4", "fd74:ca9b:172:18::8/64, , 6"}
 
-	require.Equal(gwIP, testNodeConfig.GatewayConfig.IPs[0])
+	require.Equal(gwIPv4, testNodeConfig.GatewayConfig.IPs[0])
+	require.Equal(gwIPv6, testNodeConfig.GatewayConfig.IPs[1])
 
 	t.Run("Gateways updated", func(t *testing.T) {
 		assert := assert.New(t)
 
 		result := ipamtest.GenerateIPAMResult(supportedCNIVersion, testIps, routes, dns)
-		updateResultIfaceConfig(result, gwIP)
+		updateResultIfaceConfig(result, []net.IP{gwIPv4, gwIPv6})
 
 		assert.Len(result.IPs, 2, "Failed to construct result")
 		for _, ipc := range result.IPs {
 			switch ipc.Address.IP.String() {
-			case "10.1.2.100":
-				assert.Equal("10.1.2.1", ipc.Gateway.String())
 			case "192.168.1.100":
-				assert.Equal("192.168.2.253", ipc.Gateway.String())
+				assert.Equal("192.168.1.1", ipc.Gateway.String())
+			case "fd74:ca9b:172:18::8":
+				assert.Equal("fd74:ca9b:172:18::1", ipc.Gateway.String())
 			default:
 				t.Errorf("Unexpected IP address in CNI result")
 			}
@@ -362,17 +370,19 @@ func TestUpdateResultIfaceConfig(t *testing.T) {
 	t.Run("Default route added", func(t *testing.T) {
 		emptyRoutes := []string{}
 		result := ipamtest.GenerateIPAMResult(supportedCNIVersion, testIps, emptyRoutes, dns)
-		updateResultIfaceConfig(result, gwIP)
+		updateResultIfaceConfig(result, []net.IP{gwIPv4, gwIPv6})
 		require.NotEmpty(t, result.Routes)
-		defaultRoute := func() *cnitypes.Route {
-			for _, route := range result.Routes {
-				if route.Dst.String() == "0.0.0.0/0" {
-					return route
-				}
+		require.Equal(2, len(result.Routes))
+		for _, route := range result.Routes {
+			switch route.Dst.String() {
+			case "0.0.0.0/0":
+				require.Equal("192.168.1.1", route.GW.String())
+			case "::/0":
+				require.Equal("fd74:ca9b:172:18::1", route.GW.String())
+			default:
+				t.Errorf("Unexpected Route in CNI result")
 			}
-			return nil
-		}()
-		assert.NotNil(t, defaultRoute.GW)
+		}
 	})
 }
 
@@ -595,9 +605,11 @@ func generateUUID(t *testing.T) string {
 
 func init() {
 	nodeName := "node1"
-	gwIP = net.ParseIP("192.168.1.1")
-	_, nodePodCIDR, _ := net.ParseCIDR("192.168.1.0/24")
+	gwIPv4 = net.ParseIP("192.168.1.1")
+	gwIPv6 = net.ParseIP("fd74:ca9b:172:18::1")
+	_, nodePodCIDRv4, _ := net.ParseCIDR("192.168.1.0/24")
+	_, nodePodCIDRv6, _ := net.ParseCIDR("fd74:ca9b:172:18::/64")
 	gwMAC, _ := net.ParseMAC("00:00:00:00:00:01")
-	gateway := &config.GatewayConfig{Name: "", IPs: []net.IP{gwIP}, MAC: gwMAC}
-	testNodeConfig = &config.NodeConfig{Name: nodeName, PodIPv4CIDR: nodePodCIDR, GatewayConfig: gateway}
+	gateway := &config.GatewayConfig{Name: "", IPs: []net.IP{gwIPv4, gwIPv6}, MAC: gwMAC}
+	testNodeConfig = &config.NodeConfig{Name: nodeName, PodIPv4CIDR: nodePodCIDRv4, PodIPv6CIDR: nodePodCIDRv6, GatewayConfig: gateway}
 }

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -45,8 +45,9 @@ const (
 type GatewayConfig struct {
 	// Name is the name of host gateway, e.g. antrea-gw0.
 	Name string
-	IPs  []net.IP
-	MAC  net.HardwareAddr
+	// TODO: Separate IPs into two IP fields, one IPv4 field and one IPv6 field.
+	IPs []net.IP
+	MAC net.HardwareAddr
 	// LinkIndex is the link index of host gateway.
 	LinkIndex int
 }


### PR DESCRIPTION
1. Add new field Ranges in IPAMConfig for allocating
both IPv4 and IPv6 addresses.

2. Populate subnet and gateway for both IPv4 range and IPv6 range.