### PR TITLE
 Use resourceVersion=0 as an option in the List request

### DIFF
--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -601,8 +601,11 @@ func (s *CNIServer) interceptCheck(_ *CNIConfig) (*cnipb.CniCmdResponse, error) 
 // K8s apiserver and replay the necessary flows.
 func (s *CNIServer) reconcile() error {
 	klog.Infof("Reconciliation for CNI server")
+	// For performance reasons, use ResourceVersion="0" in the ListOptions to ensure the request is served from
+	// the watch cache in kube-apiserver.
 	pods, err := s.kubeClient.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{
-		FieldSelector: "spec.nodeName=" + s.nodeConfig.Name,
+		FieldSelector:   "spec.nodeName=" + s.nodeConfig.Name,
+		ResourceVersion: "0",
 	})
 	if err != nil {
 		return fmt.Errorf("failed to list Pods running on Node %s: %v", s.nodeConfig.Name, err)

--- a/pkg/antctl/raw/supportbundle/command.go
+++ b/pkg/antctl/raw/supportbundle/command.go
@@ -281,14 +281,14 @@ func downloadAll(agentClients map[string]*rest.RESTClient, controllerClient *res
 func createAgentClients(k8sClientset kubernetes.Interface, antreaClientset antrea.Interface, cfgTmpl *rest.Config, nameFilter string) (map[string]*rest.RESTClient, error) {
 	clients := map[string]*rest.RESTClient{}
 	nodeAgentInfoMap := map[string]string{}
-	agentInfoList, err := antreaClientset.ClusterinformationV1beta1().AntreaAgentInfos().List(context.TODO(), metav1.ListOptions{})
+	agentInfoList, err := antreaClientset.ClusterinformationV1beta1().AntreaAgentInfos().List(context.TODO(), metav1.ListOptions{ResourceVersion: "0"})
 	if err != nil {
 		return nil, err
 	}
 	for _, agentInfo := range agentInfoList.Items {
 		nodeAgentInfoMap[agentInfo.NodeRef.Name] = fmt.Sprint(agentInfo.APIPort)
 	}
-	nodeList, err := k8sClientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: option.labelSelector})
+	nodeList, err := k8sClientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: option.labelSelector, ResourceVersion: "0"})
 	if err != nil {
 		return nil, err
 	}
@@ -370,7 +370,7 @@ func getClusterInfo(k8sClient kubernetes.Interface) (io.Reader, error) {
 	}
 
 	g.Go(func() error {
-		pods, err := k8sClient.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+		pods, err := k8sClient.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{ResourceVersion: "0"})
 		if err != nil {
 			return err
 		}
@@ -380,7 +380,7 @@ func getClusterInfo(k8sClient kubernetes.Interface) (io.Reader, error) {
 		return nil
 	})
 	g.Go(func() error {
-		nodes, err := k8sClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		nodes, err := k8sClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{ResourceVersion: "0"})
 		if err != nil {
 			return err
 		}
@@ -390,7 +390,7 @@ func getClusterInfo(k8sClient kubernetes.Interface) (io.Reader, error) {
 		return nil
 	})
 	g.Go(func() error {
-		deployments, err := k8sClient.AppsV1().Deployments(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+		deployments, err := k8sClient.AppsV1().Deployments(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{ResourceVersion: "0"})
 		if err != nil {
 			return err
 		}
@@ -400,7 +400,7 @@ func getClusterInfo(k8sClient kubernetes.Interface) (io.Reader, error) {
 		return nil
 	})
 	g.Go(func() error {
-		replicas, err := k8sClient.AppsV1().ReplicaSets(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+		replicas, err := k8sClient.AppsV1().ReplicaSets(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{ResourceVersion: "0"})
 		if err != nil {
 			return err
 		}
@@ -410,7 +410,7 @@ func getClusterInfo(k8sClient kubernetes.Interface) (io.Reader, error) {
 		return nil
 	})
 	g.Go(func() error {
-		daemonsets, err := k8sClient.AppsV1().DaemonSets(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+		daemonsets, err := k8sClient.AppsV1().DaemonSets(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{ResourceVersion: "0"})
 		if err != nil {
 			return err
 		}
@@ -420,7 +420,7 @@ func getClusterInfo(k8sClient kubernetes.Interface) (io.Reader, error) {
 		return nil
 	})
 	g.Go(func() error {
-		configs, err := k8sClient.CoreV1().ConfigMaps(metav1.NamespaceSystem).List(context.TODO(), metav1.ListOptions{LabelSelector: "app=antrea"})
+		configs, err := k8sClient.CoreV1().ConfigMaps(metav1.NamespaceSystem).List(context.TODO(), metav1.ListOptions{LabelSelector: "app=antrea", ResourceVersion: "0"})
 		if err != nil {
 			return err
 		}

--- a/pkg/monitor/controller.go
+++ b/pkg/monitor/controller.go
@@ -127,7 +127,9 @@ func (monitor *controllerMonitor) updateControllerCRD(partial bool) (*v1beta1.An
 }
 
 func (monitor *controllerMonitor) deleteStaleAgentCRDs() {
-	crds, err := monitor.client.ClusterinformationV1beta1().AntreaAgentInfos().List(context.TODO(), metav1.ListOptions{})
+	crds, err := monitor.client.ClusterinformationV1beta1().AntreaAgentInfos().List(context.TODO(), metav1.ListOptions{
+		ResourceVersion: "0",
+	})
 	if err != nil {
 		klog.Errorf("Failed to list agent monitoring CRDs: %v", err)
 		return

--- a/plugins/octant/cmd/antrea-octant-plugin/antrea_info.go
+++ b/plugins/octant/cmd/antrea-octant-plugin/antrea_info.go
@@ -59,7 +59,9 @@ func agentHandler(request service.Request) (component.ContentResponse, error) {
 
 // getControllerTable gets the table for displaying Controller information
 func getControllerTable(request service.Request) *component.Table {
-	controllers, err := client.ClusterinformationV1beta1().AntreaControllerInfos().List(context.TODO(), v1.ListOptions{})
+	controllers, err := client.ClusterinformationV1beta1().AntreaControllerInfos().List(context.TODO(), v1.ListOptions{
+		ResourceVersion: "0",
+	})
 	if err != nil {
 		log.Fatalf("Failed to get AntreaControllerInfos %v", err)
 	}
@@ -84,7 +86,9 @@ func getControllerTable(request service.Request) *component.Table {
 
 // getAgentTable gets the table for displaying Agent information.
 func getAgentTable(request service.Request) *component.Table {
-	agents, err := client.ClusterinformationV1beta1().AntreaAgentInfos().List(context.TODO(), v1.ListOptions{})
+	agents, err := client.ClusterinformationV1beta1().AntreaAgentInfos().List(context.TODO(), v1.ListOptions{
+		ResourceVersion: "0",
+	})
 	if err != nil {
 		log.Fatalf("Failed to get AntreaAgentInfos %v", err)
 	}

--- a/plugins/octant/cmd/antrea-octant-plugin/traceflow.go
+++ b/plugins/octant/cmd/antrea-octant-plugin/traceflow.go
@@ -332,7 +332,7 @@ func traceflowHandler(request service.Request) (component.ContentResponse, error
 // getTfTable gets the table for displaying Traceflow information
 func getTfTable(request service.Request) *component.Table {
 	ctx := context.Background()
-	tfs, err := client.OpsV1alpha1().Traceflows().List(ctx, v1.ListOptions{})
+	tfs, err := client.OpsV1alpha1().Traceflows().List(ctx, v1.ListOptions{ResourceVersion: "0"})
 	if err != nil {
 		log.Fatalf("Failed to get Traceflows %v", err)
 		return nil


### PR DESCRIPTION
1. Use resourceVersion=0 to ensure the "List" request is served from the watch
   cache in kube-apiserver, but not from the remote storage. This options is
   added in CNIServer.reconcile, CRD monitor in Antrea Controller, and antctl
   commands.
2. The SharedInformerFactory adds resourceVersion in the request automatically,
   so no needs to add this option in the requests for Node and Service/Endpoints.

Fixes #1044 