### PR TITLE
[IPsec] Apply a patch to upgrade Python2 code in ovs ovs-monitor-ipsec

### DIFF
--- a/build/images/ovs/apply-patches.sh
+++ b/build/images/ovs/apply-patches.sh
@@ -73,6 +73,11 @@ curl https://github.com/openvswitch/ovs/commit/3c18bb0fe9f23308061217f72e2245f0e
 curl https://github.com/openvswitch/ovs/commit/fe175ac17352ceb2dbc9958112b4b1bc114d82f0.patch | \
     git apply
 
+# The OVS ovs-monitor-ipsec script has a Python3 shebang but still includes some Python2-specific code.
+# Until the patch which fixes the script is merged upstream, we apply it here, or Antrea IPsec support will be broken.
+curl https://github.com/lzhecheng/ovs/commit/869b06356e389079861962160e864df609d033e5.patch | \
+    git apply
+
 # OVS hardcodes the installation path to /usr/lib/python3.7/dist-packages/ but this location
 # does not seem to be in the Python path in Ubuntu 20.04. There may be a better way to do this,
 # but this seems like an acceptable workaround.


### PR DESCRIPTION
It is a workaround before upstream/ovs code update in ovs-monitor-ipsec.

```
#cat /var/log/antrea/openvswitch/ovs-monitor-ipsec.log
2020-08-06T10:38:36.455Z |  17 | ovs-monitor-ipsec | INFO | Tunnel stbed7-1-5b3e08 disappeared from OVSDB
2020-08-06T10:38:36.456Z |  18 | ovs-monitor-ipsec | INFO | Tunnel stbed7-2-b2a7f3 disappeared from OVSDB
2020-08-06T10:38:36.457Z |  19 | ovs-monitor-ipsec | INFO | Refreshing StrongSwan configuration
2020-08-06T10:38:36.573Z |  2  | daemon | INFO | pid 61 died, exit status 0, exiting
2020-08-06T10:38:53.25.Z |  0  | ovs-monitor-ipsec | INFO | Restarting StrongSwan
2020-08-06T10:38:55.201Z |  2  | reconnect | INFO | unix:/var/run/openvswitch/db.sock: connecting...
2020-08-06T10:38:55.202Z |  5  | reconnect | INFO | unix:/var/run/openvswitch/db.sock: connected
2020-08-06T10:38:55.284Z |  10 | ovs-monitor-ipsec | INFO | Tunnel stbed7-1-5b3e08 appeared in OVSDB
2020-08-06T10:38:55.285Z |  12 | ovs-monitor-ipsec | INFO | Tunnel stbed7-2-b2a7f3 appeared in OVSDB
2020-08-06T10:38:55.286Z |  14 | ovs-monitor-ipsec | INFO | Refreshing StrongSwan configuration
```