### PR TITLE
Fix aks manifest YAML not up-to-date

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -46,6 +46,10 @@ metadata:
   name: clusternetworkpolicies.security.antrea.tanzu.vmware.com
 spec:
   additionalPrinterColumns:
+  - JSONPath: .spec.tier
+    description: The Tier to which this ClusterNetworkPolicy belongs to.
+    name: Tier
+    type: string
   - JSONPath: .spec.priority
     description: The Priority of this ClusterNetworkPolicy relative to other policies.
     format: float
@@ -150,6 +154,14 @@ spec:
               maximum: 10000
               minimum: 1
               type: number
+            tier:
+              enum:
+              - Emergency
+              - SecurityOps
+              - NetworkOps
+              - Platform
+              - Application
+              type: string
           required:
           - appliedTo
           - priority

--- a/ci/check-manifest.sh
+++ b/ci/check-manifest.sh
@@ -29,6 +29,8 @@ YAMLS=(
     "build/yamls/antrea.yml"
     "build/yamls/antrea-ipsec.yml"
     "build/yamls/antrea-eks.yml"
+    "build/yamls/antrea-gke.yml"
+    "build/yamls/antrea-aks.yml"
     "build/yamls/antrea-octant.yml"
     "build/yamls/antrea-windows.yml"
 )


### PR DESCRIPTION
antrea-aks.yml is not up-to-date due to a merge conflict, and because antrea-gke.yml and antrea-aks.yml are not checked by CI so they were not detected.