### PR TITLE
Fix Traceflow e2e test to work on a 2-Node cluster

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -81,7 +81,8 @@ kubectl cluster-info
 
 Make sure that your cluster was provisioned and that the Antrea build artifacts
 were pushed to all the nodes. You can then run the tests from the top-level
-directory with `go test -v github.com/vmware-tanzu/antrea/test/e2e` (the `-v` enables verbose output).
+directory with `go test -v -timeout=30m github.com/vmware-tanzu/antrea/test/e2e`
+(the `-v` enables verbose output).
 
 If you are running the test for the first time and are using the scripts we
 provide under `infra/vagrant` to provision your Kubernetes cluster, you will
@@ -90,7 +91,7 @@ therefore need the following steps:
 1. `./infra/vagrant/provision.sh`
 2. `make`
 3. `./infra/vagrant/push_antrea.sh`
-4. `go test -v github.com/vmware-tanzu/antrea/test/e2e`
+4. `go test -v -timeout=30m github.com/vmware-tanzu/antrea/test/e2e`
 
 If you need to test an updated version of Antrea, just run
 `./infra/vagrant/push_antrea.sh` and then run the tests again.

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -50,8 +50,8 @@ func TestTraceflow(t *testing.T) {
 		t.Fatal("Error when enabling Traceflow")
 	}
 
-	node1 := workerNodeName(1)
-	node2 := workerNodeName(2)
+	node1 := nodeName(0)
+	node2 := nodeName(1)
 
 	node1Pods, node1IPs, node1CleanupFn := createTestBusyboxPods(t, data, 2, node1)
 	node2Pods, node2IPs, node2CleanupFn := createTestBusyboxPods(t, data, 1, node2)


### PR DESCRIPTION
workerNodeName(2) implies that the cluster has 3 Nodes

Also include a 30m timeout value in the README instructions for running
e2e tests locally, since we now largely exceed the default 10m value.