### PR TITLE
Use Ubuntu 20.04 as base distribution in Antrea Docker image

### DIFF
--- a/.github/workflows/update_ovs_image.yml
+++ b/.github/workflows/update_ovs_image.yml
@@ -15,7 +15,7 @@ jobs:
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        OVS_VERSION: 2.13.0
+        OVS_VERSION: 2.13.1
       run: |
         cd build/images/ovs/
         docker pull antrea/openvswitch-debs:$OVS_VERSION || true

--- a/build/images/Dockerfile.build.ubuntu
+++ b/build/images/Dockerfile.build.ubuntu
@@ -11,7 +11,7 @@ COPY . /antrea
 RUN make antrea-agent antrea-controller antrea-cni antctl-ubuntu
 
 
-FROM antrea/base-ubuntu:2.13.0
+FROM antrea/base-ubuntu:2.13.1
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the Antrea CNI. "

--- a/build/images/Dockerfile.ubuntu
+++ b/build/images/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM antrea/base-ubuntu:2.13.0
+FROM antrea/base-ubuntu:2.13.1
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the Antrea CNI. "

--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -1,5 +1,5 @@
-ARG OVS_VERSION=2.13.0
-FROM ubuntu:18.04 as cni-binaries
+ARG OVS_VERSION=2.13.1
+FROM ubuntu:20.04 as cni-binaries
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget ca-certificates

--- a/build/images/base/build_and_push.sh
+++ b/build/images/base/build_and_push.sh
@@ -24,7 +24,7 @@ function echoerr {
 }
 
 if [ -z "$OVS_VERSION" ]; then
-    echoerr "The OVS_VERSION env variable must be set to a valid value (e.g. 2.13.0)"
+    echoerr "The OVS_VERSION env variable must be set to a valid value (e.g. 2.13.1)"
     exit 1
 fi
 
@@ -32,7 +32,7 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 pushd $THIS_DIR > /dev/null
 
-docker pull ubuntu:18.04
+docker pull ubuntu:20.04
 
 docker pull antrea/openvswitch:$OVS_VERSION
 

--- a/build/images/ovs/Dockerfile
+++ b/build/images/ovs/Dockerfile
@@ -1,24 +1,20 @@
-FROM ubuntu:18.04 as ovs-debs
+FROM ubuntu:20.04 as ovs-debs
 
 # Some patches may not apply cleanly if another version is provided.
-ARG OVS_VERSION=2.13.0
+ARG OVS_VERSION=2.13.1
 
 # Install dependencies for building OVS deb packages
-# We install both python2 and python3 packages (required to build the OVS debs)
-# so that this Dockerfile can be used to build different versions of OVS if
-# needed (python3 is required starting with OVS 2.13.0).
+# We only install python3 packages and we only support building OVS >= 2.13.0.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget curl git ca-certificates build-essential fakeroot graphviz \
-            bzip2 autoconf automake debhelper dh-autoreconf libssl-dev libtool openssl procps \
-            python-all python-twisted-conch python-zopeinterface python-six \
-            python3-all python3-twisted python3-zope.interface \
+    DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends wget curl git ca-certificates build-essential fakeroot graphviz \
+            bzip2 autoconf automake debhelper dh-python dh-autoreconf libssl-dev libtool openssl procps \
+            python3-all python3-twisted python3-zope.interface python3-sphinx \
             libunbound-dev
 
 COPY apply-patches.sh /
 
 # Download OVS source code and build debs
 RUN wget -q -O - https://www.openvswitch.org/releases/openvswitch-$OVS_VERSION.tar.gz  | tar xz -C /tmp && \
-    rm -rf openvswitch-$OVS_VERSION.tar.gz && \
     cd /tmp/openvswitch* && \
     /apply-patches.sh && \
     DEB_BUILD_OPTIONS='parallel=8 nocheck' fakeroot debian/rules binary && \
@@ -28,10 +24,10 @@ RUN wget -q -O - https://www.openvswitch.org/releases/openvswitch-$OVS_VERSION.t
     cd / && rm -rf /tmp/openvswitch*
 
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
-LABEL description="A Docker image based on Ubuntu 18.04 which includes Open vSwitch built from source."
+LABEL description="A Docker image based on Ubuntu 20.04 which includes Open vSwitch built from source."
 
 COPY --from=ovs-debs /tmp/ovs-debs/* /tmp/ovs-debs/
 COPY charon-logging.conf /tmp

--- a/build/images/ovs/README.md
+++ b/build/images/ovs/README.md
@@ -19,7 +19,7 @@ directory. For example:
 
 ```bash
 cd build/images/ovs
-OVS_VERSION=2.13.0 ./build_and_push.sh
+OVS_VERSION=2.13.1 ./build_and_push.sh
 ```
 
 The image will be pushed to Dockerhub as `antrea/openvswitch:$OVS_VERSION`.

--- a/build/images/ovs/build_and_push.sh
+++ b/build/images/ovs/build_and_push.sh
@@ -24,7 +24,7 @@ function echoerr {
 }
 
 if [ -z "$OVS_VERSION" ]; then
-    echoerr "The OVS_VERSION env variable must be set to a valid value (e.g. 2.13.0)"
+    echoerr "The OVS_VERSION env variable must be set to a valid value (e.g. 2.13.1)"
     exit 1
 fi
 
@@ -39,7 +39,7 @@ pushd $THIS_DIR > /dev/null
 # locally.
 # See https://github.com/moby/moby/issues/34715.
 
-docker pull ubuntu:18.04
+docker pull ubuntu:20.04
 
 docker build --target ovs-debs \
        --cache-from antrea/openvswitch-debs:$OVS_VERSION \

--- a/build/images/test/Dockerfile
+++ b/build/images/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM antrea/openvswitch:2.13.0
+FROM antrea/openvswitch:2.13.1
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A Docker image for antrea integration tests."


### PR DESCRIPTION
The main reason for this update is picking up a more recent version of
glibc, as the one that ships with Ubuntu 18.04 can cause OVS to deadlock
(See #1022).

In this PR, we only update the distribution for the "main" Antrea Docker
image; other images, such as the ones we use for testing or for
deploying the Antrea Octant plugin, can be updated later if needed.

This is also a good opportunity to upgrade OVS daemons from 2.13.0 to
2.13.1, since the Docker build had to be updated anyway. For the sake of
simplicity, from now on we will only support building the base
openvswitch Docker image for OVS >= 2.13.0.

Fixes #1022