### PR TITLE
Add space for ClusterNetworkPolicy option to align with the others

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -747,7 +747,7 @@ data:
 
     # Enable ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
     # to define security policies which apply to the entire cluster.
-    # ClusterNetworkPolicy: false
+    #  ClusterNetworkPolicy: false
 
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -770,7 +770,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-h7cg6t86ht
+  name: antrea-config-24f6gdd4fb
   namespace: kube-system
 ---
 apiVersion: v1
@@ -876,7 +876,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-h7cg6t86ht
+          name: antrea-config-24f6gdd4fb
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1091,7 +1091,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-h7cg6t86ht
+          name: antrea-config-24f6gdd4fb
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -747,7 +747,7 @@ data:
 
     # Enable ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
     # to define security policies which apply to the entire cluster.
-    # ClusterNetworkPolicy: false
+    #  ClusterNetworkPolicy: false
 
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -770,7 +770,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-h7cg6t86ht
+  name: antrea-config-24f6gdd4fb
   namespace: kube-system
 ---
 apiVersion: v1
@@ -876,7 +876,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-h7cg6t86ht
+          name: antrea-config-24f6gdd4fb
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1093,7 +1093,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-h7cg6t86ht
+          name: antrea-config-24f6gdd4fb
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -747,7 +747,7 @@ data:
 
     # Enable ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
     # to define security policies which apply to the entire cluster.
-    # ClusterNetworkPolicy: false
+    #  ClusterNetworkPolicy: false
 
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -770,7 +770,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-db6h57cm79
+  name: antrea-config-8gtt9dfdgg
   namespace: kube-system
 ---
 apiVersion: v1
@@ -876,7 +876,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-db6h57cm79
+          name: antrea-config-8gtt9dfdgg
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1091,7 +1091,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-db6h57cm79
+          name: antrea-config-8gtt9dfdgg
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -747,7 +747,7 @@ data:
 
     # Enable ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
     # to define security policies which apply to the entire cluster.
-    # ClusterNetworkPolicy: false
+    #  ClusterNetworkPolicy: false
 
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -770,7 +770,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-5tkdbb96c6
+  name: antrea-config-76fcd44cth
   namespace: kube-system
 ---
 apiVersion: v1
@@ -885,7 +885,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-5tkdbb96c6
+          name: antrea-config-76fcd44cth
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1135,7 +1135,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-5tkdbb96c6
+          name: antrea-config-76fcd44cth
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -747,7 +747,7 @@ data:
 
     # Enable ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
     # to define security policies which apply to the entire cluster.
-    # ClusterNetworkPolicy: false
+    #  ClusterNetworkPolicy: false
 
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -770,7 +770,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-hc2t9429cd
+  name: antrea-config-c6467gmm8c
   namespace: kube-system
 ---
 apiVersion: v1
@@ -876,7 +876,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-hc2t9429cd
+          name: antrea-config-c6467gmm8c
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1091,7 +1091,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-hc2t9429cd
+          name: antrea-config-c6467gmm8c
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-controller.conf
+++ b/build/yamls/base/conf/antrea-controller.conf
@@ -5,7 +5,7 @@ featureGates:
 
 # Enable ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
 # to define security policies which apply to the entire cluster.
-# ClusterNetworkPolicy: false
+#  ClusterNetworkPolicy: false
 
 # The port for the antrea-controller APIServer to serve on.
 # Note that if it's set to another value, the `containerPort` of the `api` port of the


### PR DESCRIPTION
Add space for ClusterNetworkPolicy value in controller config to align with the others

Signed-off-by: Yuki Tsuboi <ytsuboi@vmware.com>