### PR TITLE
Increase watch timeout for Antrea apiserver

### DIFF
--- a/pkg/apiserver/storage/ram/watch.go
+++ b/pkg/apiserver/storage/ram/watch.go
@@ -119,14 +119,14 @@ func (w *storeWatcher) process(ctx context.Context, initEvents []storage.Interna
 		select {
 		case event, ok := <-w.input:
 			if !ok {
-				klog.Info("The input channel had been closed, stopping process")
+				klog.V(4).Info("The input channel has been closed, stopping process for watcher")
 				return
 			}
 			if event.GetResourceVersion() > resourceVersion {
 				w.sendWatchEvent(event, false)
 			}
 		case <-ctx.Done():
-			klog.Info("The context had been canceled, stopping process")
+			klog.V(4).Info("The context has been canceled, stopping process for watcher")
 			return
 		}
 	}


### PR DESCRIPTION
From the default 1800s (30 mins) to 2 hours.
I believe this may be a good idea for clusters with a large number of
Nodes and a large number of NetworkPolicies. K8s documentation also
recommends using a large value in production after verifying that
clients handle watch termination gracefully.

The verbosity level of the Controller log messages in case of watch
termination is also reduced to fix #1036. Unfortunetly there is no easy
way to make these log messages more useful (e.g. by correlating the
watcher object to the client).