### PR TITLE
[ANP] ExternalEntity support for agent

### DIFF
--- a/pkg/agent/controller/networkpolicy/cache.go
+++ b/pkg/agent/controller/networkpolicy/cache.go
@@ -91,10 +91,10 @@ func hashRule(r *rule) string {
 // It's the struct used by reconciler.
 type CompletedRule struct {
 	*rule
-	// Source Pods of this rule, can't coexist with ToAddresses.
-	FromAddresses v1beta1.GroupMemberPodSet
-	// Destination Pods of this rule, can't coexist with FromAddresses.
-	ToAddresses v1beta1.GroupMemberPodSet
+	// Source GroupMembers of this rule, can't coexist with ToAddresses.
+	FromAddresses v1beta1.GroupMemberSet
+	// Destination GroupMembers of this rule, can't coexist with FromAddresses.
+	ToAddresses v1beta1.GroupMemberSet
 	// Target Pods of this rule.
 	Pods v1beta1.GroupMemberPodSet
 }
@@ -126,8 +126,8 @@ type ruleCache struct {
 
 	addressSetLock sync.RWMutex
 	// addressSetByGroup stores the AddressGroup members.
-	// It is a mapping from group name to a set of Pods.
-	addressSetByGroup map[string]v1beta1.GroupMemberPodSet
+	// It is a mapping from group name to a set of GroupMembers.
+	addressSetByGroup map[string]v1beta1.GroupMemberSet
 
 	policyMapLock sync.RWMutex
 	// policyMap is a map using NetworkPolicy UID as the key.
@@ -248,14 +248,21 @@ func (c *ruleCache) GetAddressGroups() []v1beta1.AddressGroup {
 	var ret []v1beta1.AddressGroup
 	c.addressSetLock.RLock()
 	defer c.addressSetLock.RUnlock()
+
 	for k, v := range c.addressSetByGroup {
 		var pods []v1beta1.GroupMemberPod
-		for _, pod := range v {
-			pods = append(pods, *pod)
+		var groupMembers []v1beta1.GroupMember
+		for _, member := range v {
+			if member.Pod != nil {
+				pods = append(pods, *member.ToGroupMemberPod())
+			} else if member.ExternalEntity != nil {
+				groupMembers = append(groupMembers, *member)
+			}
 		}
 		ret = append(ret, v1beta1.AddressGroup{
-			ObjectMeta: metav1.ObjectMeta{Name: k},
-			Pods:       pods,
+			ObjectMeta:   metav1.ObjectMeta{Name: k},
+			Pods:         pods,
+			GroupMembers: groupMembers,
 		})
 	}
 	return ret
@@ -316,7 +323,7 @@ func newRuleCache(dirtyRuleHandler func(string), podUpdate <-chan v1beta1.PodRef
 	)
 	cache := &ruleCache{
 		podSetByGroup:     make(map[string]v1beta1.GroupMemberPodSet),
-		addressSetByGroup: make(map[string]v1beta1.GroupMemberPodSet),
+		addressSetByGroup: make(map[string]v1beta1.GroupMemberSet),
 		policyMap:         make(map[string]*types.NamespacedName),
 		rules:             rules,
 		dirtyRuleHandler:  dirtyRuleHandler,
@@ -394,19 +401,27 @@ func (c *ruleCache) AddAddressGroup(group *v1beta1.AddressGroup) error {
 }
 
 func (c *ruleCache) addAddressGroupLocked(group *v1beta1.AddressGroup) error {
-	podSet := v1beta1.GroupMemberPodSet{}
+	groupMemberSet := v1beta1.GroupMemberSet{}
 	for i := range group.Pods {
 		// Must not store address of loop iterator variable as it's the same
 		// address taking different values in each loop iteration, otherwise
 		// podSet would eventually contain only the last value.
 		// https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable
-		podSet.Insert(&group.Pods[i])
+		groupMemberSet.Insert(group.Pods[i].ToGroupMember())
 	}
-	oldPodSet, exists := c.addressSetByGroup[group.Name]
-	if exists && oldPodSet.Equal(podSet) {
+	for i := range group.GroupMembers {
+		// Must not store address of loop iterator variable as it's the same
+		// address taking different values in each loop iteration, otherwise
+		// podSet would eventually contain only the last value.
+		// https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable
+		groupMemberSet.Insert(&group.GroupMembers[i])
+	}
+
+	oldGroupMemberSet, exists := c.addressSetByGroup[group.Name]
+	if exists && oldGroupMemberSet.Equal(groupMemberSet) {
 		return nil
 	}
-	c.addressSetByGroup[group.Name] = podSet
+	c.addressSetByGroup[group.Name] = groupMemberSet
 	c.onAddressGroupUpdate(group.Name)
 	return nil
 }
@@ -417,16 +432,23 @@ func (c *ruleCache) PatchAddressGroup(patch *v1beta1.AddressGroupPatch) error {
 	c.addressSetLock.Lock()
 	defer c.addressSetLock.Unlock()
 
-	podSet, exists := c.addressSetByGroup[patch.Name]
+	groupMemberSet, exists := c.addressSetByGroup[patch.Name]
 	if !exists {
 		return fmt.Errorf("AddressGroup %v doesn't exist in cache, can't be patched", patch.Name)
 	}
 	for i := range patch.AddedPods {
-		podSet.Insert(&patch.AddedPods[i])
+		groupMemberSet.Insert(patch.AddedPods[i].ToGroupMember())
 	}
 	for i := range patch.RemovedPods {
-		podSet.Delete(&patch.RemovedPods[i])
+		groupMemberSet.Delete(patch.RemovedPods[i].ToGroupMember())
 	}
+	for i := range patch.AddedGroupMembers {
+		groupMemberSet.Insert(&patch.AddedGroupMembers[i])
+	}
+	for i := range patch.RemovedGroupMembers {
+		groupMemberSet.Delete(&patch.RemovedGroupMembers[i])
+	}
+
 	c.onAddressGroupUpdate(patch.Name)
 	return nil
 }
@@ -675,7 +697,7 @@ func (c *ruleCache) GetCompletedRule(ruleID string) (completedRule *CompletedRul
 	}
 
 	r := obj.(*rule)
-	var fromAddresses, toAddresses v1beta1.GroupMemberPodSet
+	var fromAddresses, toAddresses v1beta1.GroupMemberSet
 	if r.Direction == v1beta1.DirectionIn {
 		fromAddresses, completed = c.unionAddressGroups(r.From.AddressGroups)
 	} else {
@@ -720,11 +742,11 @@ func (c *ruleCache) onAddressGroupUpdate(groupName string) {
 // unionAddressGroups gets the union of addresses of the provided address groups.
 // If any group is not found, nil and false will be returned to indicate the
 // set is not complete yet.
-func (c *ruleCache) unionAddressGroups(groupNames []string) (v1beta1.GroupMemberPodSet, bool) {
+func (c *ruleCache) unionAddressGroups(groupNames []string) (v1beta1.GroupMemberSet, bool) {
 	c.addressSetLock.RLock()
 	defer c.addressSetLock.RUnlock()
 
-	set := v1beta1.NewGroupMemberPodSet()
+	set := v1beta1.NewGroupMemberSet()
 	for _, groupName := range groupNames {
 		curSet, exists := c.addressSetByGroup[groupName]
 		if !exists {

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -165,8 +165,8 @@ func TestAddSingleGroupRule(t *testing.T) {
 	services := []v1beta1.Service{{Protocol: &protocolTCP, Port: &port}}
 	desiredRule := &CompletedRule{
 		rule:          &rule{Direction: v1beta1.DirectionIn, Services: services},
-		FromAddresses: v1beta1.NewGroupMemberPodSet(newAddressGroupMember("1.1.1.1"), newAddressGroupMember("2.2.2.2")),
-		ToAddresses:   v1beta1.NewGroupMemberPodSet(),
+		FromAddresses: v1beta1.NewGroupMemberSet(newAddressGroupMember("1.1.1.1"), newAddressGroupMember("2.2.2.2")),
+		ToAddresses:   v1beta1.NewGroupMemberSet(),
 		Pods:          v1beta1.NewGroupMemberPodSet(newAppliedToGroupMember("pod1", "ns1")),
 	}
 	stopCh := make(chan struct{})
@@ -188,7 +188,7 @@ func TestAddSingleGroupRule(t *testing.T) {
 	assert.Equal(t, 0, controller.GetAppliedToGroupNum())
 
 	// addressGroup1 comes, no rule will be synced due to missing appliedToGroup1 data.
-	addressGroupWatcher.Add(newAddressGroup("addressGroup1", []v1beta1.GroupMemberPod{*newAddressGroupMember("1.1.1.1"), *newAddressGroupMember("2.2.2.2")}))
+	addressGroupWatcher.Add(newAddressGroup("addressGroup1", []v1beta1.GroupMemberPod{*newAddressGroupMemberPod("1.1.1.1"), *newAddressGroupMemberPod("2.2.2.2")}))
 	addressGroupWatcher.Action(watch.Bookmark, nil)
 	select {
 	case ruleID := <-reconciler.updated:
@@ -242,8 +242,8 @@ func TestAddMultipleGroupsRule(t *testing.T) {
 	services := []v1beta1.Service{{Protocol: &protocolTCP, Port: &port}}
 	desiredRule := &CompletedRule{
 		rule:          &rule{Direction: v1beta1.DirectionIn, Services: services},
-		FromAddresses: v1beta1.NewGroupMemberPodSet(newAddressGroupMember("1.1.1.1"), newAddressGroupMember("2.2.2.2"), newAddressGroupMember("3.3.3.3")),
-		ToAddresses:   v1beta1.NewGroupMemberPodSet(),
+		FromAddresses: v1beta1.NewGroupMemberSet(newAddressGroupMember("1.1.1.1"), newAddressGroupMember("2.2.2.2"), newAddressGroupMember("3.3.3.3")),
+		ToAddresses:   v1beta1.NewGroupMemberSet(),
 		Pods:          v1beta1.NewGroupMemberPodSet(newAppliedToGroupMember("pod1", "ns1"), newAppliedToGroupMember("pod2", "ns2")),
 	}
 	stopCh := make(chan struct{})
@@ -251,7 +251,7 @@ func TestAddMultipleGroupsRule(t *testing.T) {
 	go controller.Run(stopCh)
 
 	// addressGroup1 comes, no rule will be synced.
-	addressGroupWatcher.Add(newAddressGroup("addressGroup1", []v1beta1.GroupMemberPod{*newAddressGroupMember("1.1.1.1"), *newAddressGroupMember("2.2.2.2")}))
+	addressGroupWatcher.Add(newAddressGroup("addressGroup1", []v1beta1.GroupMemberPod{*newAddressGroupMemberPod("1.1.1.1"), *newAddressGroupMemberPod("2.2.2.2")}))
 	addressGroupWatcher.Action(watch.Bookmark, nil)
 	// appliedToGroup1 comes, no rule will be synced.
 	appliedToGroupWatcher.Add(newAppliedToGroup("appliedToGroup1", []v1beta1.GroupMemberPod{*newAppliedToGroupMember("pod1", "ns1")}))
@@ -271,7 +271,7 @@ func TestAddMultipleGroupsRule(t *testing.T) {
 	assert.Equal(t, 1, controller.GetAppliedToGroupNum())
 
 	// addressGroup2 comes, no rule will be synced due to missing appliedToGroup2 data.
-	addressGroupWatcher.Add(newAddressGroup("addressGroup2", []v1beta1.GroupMemberPod{*newAddressGroupMember("1.1.1.1"), *newAddressGroupMember("3.3.3.3")}))
+	addressGroupWatcher.Add(newAddressGroup("addressGroup2", []v1beta1.GroupMemberPod{*newAddressGroupMemberPod("1.1.1.1"), *newAddressGroupMemberPod("3.3.3.3")}))
 	select {
 	case ruleID := <-reconciler.updated:
 		t.Fatalf("Expected no update, got %v", ruleID)
@@ -325,7 +325,7 @@ func TestDeleteRule(t *testing.T) {
 	defer close(stopCh)
 	go controller.Run(stopCh)
 
-	addressGroupWatcher.Add(newAddressGroup("addressGroup1", []v1beta1.GroupMemberPod{*newAddressGroupMember("1.1.1.1"), *newAddressGroupMember("2.2.2.2")}))
+	addressGroupWatcher.Add(newAddressGroup("addressGroup1", []v1beta1.GroupMemberPod{*newAddressGroupMemberPod("1.1.1.1"), *newAddressGroupMemberPod("2.2.2.2")}))
 	addressGroupWatcher.Action(watch.Bookmark, nil)
 	appliedToGroupWatcher.Add(newAppliedToGroup("appliedToGroup1", []v1beta1.GroupMemberPod{*newAppliedToGroupMember("pod1", "ns1")}))
 	appliedToGroupWatcher.Action(watch.Bookmark, nil)
@@ -370,14 +370,14 @@ func TestAddNetworkPolicyWithMultipleRules(t *testing.T) {
 	services := []v1beta1.Service{{Protocol: &protocolTCP, Port: &port}}
 	desiredRule1 := &CompletedRule{
 		rule:          &rule{Direction: v1beta1.DirectionIn, Services: services},
-		FromAddresses: v1beta1.NewGroupMemberPodSet(newAddressGroupMember("1.1.1.1"), newAddressGroupMember("2.2.2.2")),
-		ToAddresses:   v1beta1.NewGroupMemberPodSet(),
+		FromAddresses: v1beta1.NewGroupMemberSet(newAddressGroupMember("1.1.1.1"), newAddressGroupMember("2.2.2.2")),
+		ToAddresses:   v1beta1.NewGroupMemberSet(),
 		Pods:          v1beta1.NewGroupMemberPodSet(newAppliedToGroupMember("pod1", "ns1")),
 	}
 	desiredRule2 := &CompletedRule{
 		rule:          &rule{Direction: v1beta1.DirectionOut, Services: services},
-		FromAddresses: v1beta1.NewGroupMemberPodSet(),
-		ToAddresses:   v1beta1.NewGroupMemberPodSet(newAddressGroupMember("3.3.3.3"), newAddressGroupMember("4.4.4.4")),
+		FromAddresses: v1beta1.NewGroupMemberSet(),
+		ToAddresses:   v1beta1.NewGroupMemberSet(newAddressGroupMember("3.3.3.3"), newAddressGroupMember("4.4.4.4")),
 		Pods:          v1beta1.NewGroupMemberPodSet(newAppliedToGroupMember("pod1", "ns1")),
 	}
 	stopCh := make(chan struct{})
@@ -388,8 +388,8 @@ func TestAddNetworkPolicyWithMultipleRules(t *testing.T) {
 	policy1 := getNetworkPolicyWithMultipleRules("policy1", []string{"addressGroup1"}, []string{"addressGroup2"}, []string{"appliedToGroup1"}, services)
 	networkPolicyWatcher.Add(policy1)
 	networkPolicyWatcher.Action(watch.Bookmark, nil)
-	addressGroupWatcher.Add(newAddressGroup("addressGroup1", []v1beta1.GroupMemberPod{*newAddressGroupMember("1.1.1.1"), *newAddressGroupMember("2.2.2.2")}))
-	addressGroupWatcher.Add(newAddressGroup("addressGroup2", []v1beta1.GroupMemberPod{*newAddressGroupMember("3.3.3.3"), *newAddressGroupMember("4.4.4.4")}))
+	addressGroupWatcher.Add(newAddressGroup("addressGroup1", []v1beta1.GroupMemberPod{*newAddressGroupMemberPod("1.1.1.1"), *newAddressGroupMemberPod("2.2.2.2")}))
+	addressGroupWatcher.Add(newAddressGroup("addressGroup2", []v1beta1.GroupMemberPod{*newAddressGroupMemberPod("3.3.3.3"), *newAddressGroupMemberPod("4.4.4.4")}))
 	addressGroupWatcher.Action(watch.Bookmark, nil)
 	appliedToGroupWatcher.Add(newAppliedToGroup("appliedToGroup1", []v1beta1.GroupMemberPod{*newAppliedToGroupMember("pod1", "ns1")}))
 	appliedToGroupWatcher.Action(watch.Bookmark, nil)

--- a/pkg/agent/controller/networkpolicy/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/reconciler.go
@@ -313,8 +313,8 @@ func (r *reconciler) computeOFRulesForAdd(rule *CompletedRule, ofPriority *uint1
 	ofRuleByServicesMap := map[servicesKey]*types.PolicyRule{}
 
 	if rule.Direction == v1beta1.DirectionIn {
-		// Addresses got from source Pod IPs.
-		from1 := podsToOFAddresses(rule.FromAddresses)
+		// Addresses got from source GroupMembers' IPs.
+		from1 := groupMembersToOFAddresses(rule.FromAddresses)
 		// Get addresses that in From IPBlock but not in Except IPBlocks.
 		from2 := ipBlocksToOFAddresses(rule.From.IPBlocks)
 
@@ -336,13 +336,12 @@ func (r *reconciler) computeOFRulesForAdd(rule *CompletedRule, ofPriority *uint1
 		ips := r.getPodIPs(rule.Pods)
 		lastRealized.podIPs = ips
 		from := ipsToOFAddresses(ips)
-
-		podsByServicesMap, servicesMap := groupPodsByServices(rule.Services, rule.ToAddresses)
-		for svcKey, pods := range podsByServicesMap {
+		memberByServicesMap, servicesMap := groupMembersByServices(rule.Services, rule.ToAddresses)
+		for svcKey, members := range memberByServicesMap {
 			ofRuleByServicesMap[svcKey] = &types.PolicyRule{
 				Direction: v1beta1.DirectionOut,
 				From:      from,
-				To:        podsToOFAddresses(pods),
+				To:        groupMembersToOFAddresses(members),
 				Service:   filterUnresolvablePort(servicesMap[svcKey]),
 				Action:    rule.Action,
 				Priority:  ofPriority,
@@ -432,10 +431,10 @@ func (r *reconciler) update(lastRealized *lastRealized, newRule *CompletedRule, 
 	// As rule identifier is calculated from the rule's content, the update can
 	// only happen to Group members.
 	if newRule.Direction == v1beta1.DirectionIn {
-		from1 := podsToOFAddresses(newRule.FromAddresses)
+		from1 := groupMembersToOFAddresses(newRule.FromAddresses)
 		from2 := ipBlocksToOFAddresses(newRule.From.IPBlocks)
-		addedFrom := podsToOFAddresses(newRule.FromAddresses.Difference(lastRealized.FromAddresses))
-		deletedFrom := podsToOFAddresses(lastRealized.FromAddresses.Difference(newRule.FromAddresses))
+		addedFrom := groupMembersToOFAddresses(newRule.FromAddresses.Difference(lastRealized.FromAddresses))
+		deletedFrom := groupMembersToOFAddresses(lastRealized.FromAddresses.Difference(newRule.FromAddresses))
 
 		podsByServicesMap, servicesMap := groupPodsByServices(newRule.Services, newRule.Pods)
 		for svcKey, pods := range podsByServicesMap {
@@ -479,16 +478,16 @@ func (r *reconciler) update(lastRealized *lastRealized, newRule *CompletedRule, 
 		addedFrom := ipsToOFAddresses(newIPs.Difference(lastRealized.podIPs))
 		deletedFrom := ipsToOFAddresses(lastRealized.podIPs.Difference(newIPs))
 
-		podsByServicesMap, servicesMap := groupPodsByServices(newRule.Services, newRule.ToAddresses)
+		memberByServicesMap, servicesMap := groupMembersByServices(newRule.Services, newRule.ToAddresses)
 		// Same as the process in `add`, we must ensure the group for the original services is present
 		// in podsByServicesMap, so that this group won't be removed and its "From" will be updated.
 		svcKey := normalizeServices(newRule.Services)
-		if _, exists := podsByServicesMap[svcKey]; !exists {
-			podsByServicesMap[svcKey] = v1beta1.NewGroupMemberPodSet()
+		if _, exists := memberByServicesMap[svcKey]; !exists {
+			memberByServicesMap[svcKey] = v1beta1.NewGroupMemberSet()
 			servicesMap[svcKey] = newRule.Services
 		}
-		prevPodsByServicesMap, _ := groupPodsByServices(lastRealized.Services, lastRealized.ToAddresses)
-		for svcKey, pods := range podsByServicesMap {
+		prevMembersByServicesMap, _ := groupMembersByServices(lastRealized.Services, lastRealized.ToAddresses)
+		for svcKey, members := range memberByServicesMap {
 			ofID, exists := lastRealized.ofIDs[svcKey]
 			if !exists {
 				ofID, err := r.idAllocator.allocate()
@@ -498,7 +497,7 @@ func (r *reconciler) update(lastRealized *lastRealized, newRule *CompletedRule, 
 				ofRule := &types.PolicyRule{
 					Direction:       v1beta1.DirectionOut,
 					From:            from,
-					To:              podsToOFAddresses(pods),
+					To:              groupMembersToOFAddresses(members),
 					Service:         filterUnresolvablePort(servicesMap[svcKey]),
 					Action:          newRule.Action,
 					Priority:        ofPriority,
@@ -511,8 +510,8 @@ func (r *reconciler) update(lastRealized *lastRealized, newRule *CompletedRule, 
 				}
 				lastRealized.ofIDs[svcKey] = ofID
 			} else {
-				addedTo := podsToOFAddresses(pods.Difference(prevPodsByServicesMap[svcKey]))
-				deletedTo := podsToOFAddresses(prevPodsByServicesMap[svcKey].Difference(pods))
+				addedTo := groupMembersToOFAddresses(members.Difference(prevMembersByServicesMap[svcKey]))
+				deletedTo := groupMembersToOFAddresses(prevMembersByServicesMap[svcKey].Difference(members))
 				if err := r.updateOFRule(ofID, addedFrom, addedTo, deletedFrom, deletedTo, ofPriority); err != nil {
 					return err
 				}
@@ -683,7 +682,7 @@ func groupPodsByServices(services []v1beta1.Service, pods v1beta1.GroupMemberPod
 	resolvedServices := make([]v1beta1.Service, len(services))
 	for podKey, pod := range pods {
 		for i := range services {
-			resolvedServices[i] = *resolveService(&services[i], pod)
+			resolvedServices[i] = *resolveService(&services[i], *pod.ToGroupMember())
 		}
 		svcKey := normalizeServices(resolvedServices)
 		if _, exists := podsByServicesMap[svcKey]; !exists {
@@ -697,6 +696,46 @@ func groupPodsByServices(services []v1beta1.Service, pods v1beta1.GroupMemberPod
 	return podsByServicesMap, servicesMap
 }
 
+// groupMembersByServices groups the provided groupMembers based on their services resolving result.
+// A map of servicesHash to the grouped members and a map of servicesHash to the services resolving result will be returned.
+func groupMembersByServices(services []v1beta1.Service, memberSet v1beta1.GroupMemberSet) (map[servicesKey]v1beta1.GroupMemberSet, map[servicesKey][]v1beta1.Service) {
+	membersByServicesMap := map[servicesKey]v1beta1.GroupMemberSet{}
+	servicesMap := map[servicesKey][]v1beta1.Service{}
+
+	// If there is no named port in services, all members are in same group.
+	namedPortServiceExist := false
+	for _, svc := range services {
+		if svc.Port != nil && svc.Port.Type == intstr.String {
+			namedPortServiceExist = true
+			break
+		}
+	}
+	if !namedPortServiceExist {
+		svcKey := normalizeServices(services)
+		membersByServicesMap[svcKey] = memberSet
+		servicesMap[svcKey] = services
+		return membersByServicesMap, servicesMap
+	}
+	// Reuse the slice to avoid memory reallocations in the following loop. The
+	// optimization makes difference as the number of group members might get up to tens
+	// of thousands.
+	resolvedServices := make([]v1beta1.Service, len(services))
+	for memberKey, member := range memberSet {
+		for i := range services {
+			resolvedServices[i] = *resolveService(&services[i], *member)
+		}
+		svcKey := normalizeServices(resolvedServices)
+		if _, exists := membersByServicesMap[svcKey]; !exists {
+			membersByServicesMap[svcKey] = v1beta1.NewGroupMemberSet()
+			// Copy resolvedServices as it may be updated in next iteration.
+			servicesMap[svcKey] = make([]v1beta1.Service, len(resolvedServices))
+			copy(servicesMap[svcKey], resolvedServices)
+		}
+		membersByServicesMap[svcKey][memberKey] = member
+	}
+	return membersByServicesMap, servicesMap
+}
+
 func ofPortsToOFAddresses(ofPorts sets.Int32) []types.Address {
 	// Must not return nil as it means not restricted by addresses in Openflow implementation.
 	addresses := make([]types.Address, 0, len(ofPorts))
@@ -706,11 +745,13 @@ func ofPortsToOFAddresses(ofPorts sets.Int32) []types.Address {
 	return addresses
 }
 
-func podsToOFAddresses(podSet v1beta1.GroupMemberPodSet) []types.Address {
+func groupMembersToOFAddresses(groupMemberSet v1beta1.GroupMemberSet) []types.Address {
 	// Must not return nil as it means not restricted by addresses in Openflow implementation.
-	addresses := make([]types.Address, 0, len(podSet))
-	for _, p := range podSet {
-		addresses = append(addresses, openflow.NewIPAddress(net.IP(p.IP)))
+	addresses := make([]types.Address, 0, len(groupMemberSet))
+	for _, member := range groupMemberSet {
+		for _, ep := range member.Endpoints {
+			addresses = append(addresses, openflow.NewIPAddress(net.IP(ep.IP)))
+		}
 	}
 	return addresses
 }
@@ -748,8 +789,8 @@ func ipNetToOFAddress(in v1beta1.IPNet) *openflow.IPNetAddress {
 func ipsToOFAddresses(ips sets.String) []types.Address {
 	// Must not return nil as it means not restricted by addresses in Openflow implementation.
 	from := make([]types.Address, 0, len(ips))
-	for ip := range ips {
-		from = append(from, openflow.NewIPAddress(net.ParseIP((ip))))
+	for ipAddr := range ips {
+		from = append(from, openflow.NewIPAddress(net.ParseIP(ipAddr)))
 	}
 	return from
 }
@@ -778,19 +819,21 @@ func filterUnresolvablePort(in []v1beta1.Service) []v1beta1.Service {
 }
 
 // resolveService resolves the port name of the provided service to a port number
-// for the provided Pod.
-func resolveService(service *v1beta1.Service, pod *v1beta1.GroupMemberPod) *v1beta1.Service {
+// for the provided groupMember.
+func resolveService(service *v1beta1.Service, member v1beta1.GroupMember) *v1beta1.Service {
 	// If port is not specified or is already a number, return it as is.
 	if service.Port == nil || service.Port.Type == intstr.Int {
 		return service
 	}
-	for _, port := range pod.Ports {
-		if port.Name == service.Port.StrVal && port.Protocol == *service.Protocol {
-			resolvedPort := intstr.FromInt(int(port.Port))
-			return &v1beta1.Service{Protocol: service.Protocol, Port: &resolvedPort}
+	for _, ep := range member.Endpoints {
+		for _, port := range ep.Ports {
+			if port.Name == service.Port.StrVal && port.Protocol == *service.Protocol {
+				resolvedPort := intstr.FromInt(int(port.Port))
+				return &v1beta1.Service{Protocol: service.Protocol, Port: &resolvedPort}
+			}
 		}
 	}
-	klog.Warningf("Can not resolve port %s for Pod %v", service.Port.StrVal, pod)
+	klog.Warningf("Can not resolve port %s for endpoints %v", service.Port.StrVal, member)
 	// If not resolvable, return it as is.
 	// The Pods that cannot resolve it will be grouped together.
 	return service

--- a/pkg/agent/controller/networkpolicy/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/reconciler_test.go
@@ -33,8 +33,8 @@ import (
 )
 
 var (
-	addressGroup1 = v1beta1.NewGroupMemberPodSet(newAddressGroupMember("1.1.1.1"))
-	addressGroup2 = v1beta1.NewGroupMemberPodSet(newAddressGroupMember("1.1.1.2"))
+	addressGroup1 = v1beta1.NewGroupMemberSet(newAddressGroupMember("1.1.1.1"))
+	addressGroup2 = v1beta1.NewGroupMemberSet(newAddressGroupMember("1.1.1.2"))
 
 	appliedToGroup1                     = v1beta1.NewGroupMemberPodSet(newAppliedToGroupMember("pod1", "ns1"))
 	appliedToGroup2                     = v1beta1.NewGroupMemberPodSet(newAppliedToGroupMember("pod2", "ns1"))

--- a/pkg/apis/networking/v1beta1/sets.go
+++ b/pkg/apis/networking/v1beta1/sets.go
@@ -14,7 +14,9 @@
 
 package v1beta1
 
-import "strings"
+import (
+	"strings"
+)
 
 // groupMemberPodKey is used to uniquely identify GroupMemberPod. Either Pod or
 // IP is used as unique key.
@@ -114,4 +116,129 @@ func (s GroupMemberPodSet) Items() []*GroupMemberPod {
 		res = append(res, item)
 	}
 	return res
+}
+
+// groupMemberKey is used to uniquely identify GroupMember.
+type groupMemberKey string
+
+// GroupMemberSet is a set of GroupMembers.
+// +k8s:openapi-gen=false
+// +k8s:deepcopy-gen=false
+type GroupMemberSet map[groupMemberKey]*GroupMember
+
+// normalizeGroupMember calculates the groupMemberKey of the provided
+// GroupMember based on the Pod's namespaced name or IP.
+func normalizeGroupMember(member *GroupMember) groupMemberKey {
+	// "/" is illegal in Namespace and name so is safe as the delimiter.
+	const delimiter = "/"
+	var b strings.Builder
+	if member.Pod != nil {
+		b.WriteString(member.Pod.Namespace)
+		b.WriteString(delimiter)
+		b.WriteString(member.Pod.Name)
+	} else if member.ExternalEntity != nil {
+		b.WriteString(member.ExternalEntity.Namespace)
+		b.WriteString(delimiter)
+		b.WriteString(member.ExternalEntity.Name)
+	} else if len(member.Endpoints) != 0 {
+		for _, ep := range member.Endpoints {
+			b.Write(ep.IP)
+		}
+	}
+	return groupMemberKey(b.String())
+}
+
+// NewGroupMemberSet builds a GroupMemberSet from a list of GroupMember.
+func NewGroupMemberSet(items ...*GroupMember) GroupMemberSet {
+	m := GroupMemberSet{}
+	m.Insert(items...)
+	return m
+}
+
+// Insert adds items to the set.
+func (s GroupMemberSet) Insert(items ...*GroupMember) {
+	for _, item := range items {
+		s[normalizeGroupMember(item)] = item
+	}
+}
+
+// Delete removes all items from the set.
+func (s GroupMemberSet) Delete(items ...*GroupMember) {
+	for _, item := range items {
+		delete(s, normalizeGroupMember(item))
+	}
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s GroupMemberSet) Has(item *GroupMember) bool {
+	_, contained := s[normalizeGroupMember(item)]
+	return contained
+}
+
+// Difference returns a set of GroupMembers that are not in o.
+func (s GroupMemberSet) Difference(o GroupMemberSet) GroupMemberSet {
+	result := GroupMemberSet{}
+	for key, item := range s {
+		if _, contained := o[key]; !contained {
+			result[key] = item
+		}
+	}
+	return result
+}
+
+// Union returns a new set which includes items in either m or o.
+func (s GroupMemberSet) Union(o GroupMemberSet) GroupMemberSet {
+	result := GroupMemberSet{}
+	for key, item := range s {
+		result[key] = item
+	}
+	for key, item := range o {
+		result[key] = item
+	}
+	return result
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s GroupMemberSet) IsSuperset(o GroupMemberSet) bool {
+	for key := range o {
+		_, contained := s[key]
+		if !contained {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s GroupMemberSet) Equal(o GroupMemberSet) bool {
+	return len(s) == len(o) && s.IsSuperset(o)
+}
+
+// Items returns the slice with contents in random order.
+func (s GroupMemberSet) Items() []*GroupMember {
+	res := make([]*GroupMember, 0, len(s))
+	for _, item := range s {
+		res = append(res, item)
+	}
+	return res
+}
+
+// Conversion functions
+func (g *GroupMember) ToGroupMemberPod() *GroupMemberPod {
+	return &GroupMemberPod{
+		Pod:   g.Pod,
+		IP:    g.Endpoints[0].IP,
+		Ports: g.Endpoints[0].Ports,
+	}
+}
+
+func (p *GroupMemberPod) ToGroupMember() *GroupMember {
+	return &GroupMember{
+		Pod: p.Pod,
+		Endpoints: []Endpoint{
+			{IP: p.IP, Ports: p.Ports},
+		},
+	}
 }


### PR DESCRIPTION
This PR is rebased from and replaces #782. 
It moves ToAddresses/FromAddresses in CompletedRule and AddressSetByGroup in ruleCache to use GroupMemberSet instead of GroupMmeberPodSet. Thus both Pods and ExternalEntities are expressed as GroupMember when in these fields.
Pods in appliedTo field continue be expressed by existing GroupMemberPod, and migration to GroupMember shall
be done in a subsequent PR.