### PR TITLE
Adding EKS node init script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ manifest:
 	@echo "===> Generating dev manifest for Antrea <==="
 	$(CURDIR)/hack/generate-manifest.sh --mode dev > build/yamls/antrea.yml
 	$(CURDIR)/hack/generate-manifest.sh --mode dev --ipsec > build/yamls/antrea-ipsec.yml
-	$(CURDIR)/hack/generate-manifest.sh --mode dev --cloud EKS --encap-mode networkPolicyOnly > build/yamls/antrea-eks.yml
+	$(CURDIR)/hack/generate-manifest.sh --mode dev --cloud EKS --encap-mode networkPolicyOnly --proxy > build/yamls/antrea-eks.yml
 	$(CURDIR)/hack/generate-manifest.sh --mode dev --cloud GKE --encap-mode noEncap > build/yamls/antrea-gke.yml
 	$(CURDIR)/hack/generate-manifest.sh --mode dev --cloud AKS --encap-mode networkPolicyOnly --proxy > build/yamls/antrea-aks.yml
 	$(CURDIR)/hack/generate-manifest-octant.sh --mode dev > build/yamls/antrea-octant.yml

--- a/build/yamls/antrea-eks-node-init.yml
+++ b/build/yamls/antrea-eks-node-init.yml
@@ -1,0 +1,80 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  labels:
+    app: antrea
+    component: antrea-node-init
+  name: antrea-node-init
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: antrea
+      component: antrea-node-init
+  template:
+    metadata:
+      labels:
+        app: antrea
+        component: antrea-node-init
+    spec:
+      hostPID: true
+      hostNetwork: true
+      containers:
+        - name: node-init
+          image: gcr.io/google-containers/startup-script:v1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          env:
+          - name: STARTUP_SCRIPT
+            value: |
+              #! /bin/bash
+
+              set -o errexit
+              set -o pipefail
+              set -o nounset
+
+              if [ -f /opt/cni/antrea-node-init-status ]; then
+                  echo "Antrea node init already done. Exiting"
+                  exit
+              fi
+
+              while true; do
+                  cni_conf=$(ls /etc/cni/net.d | head -n1)
+                  if [[ ! -z $cni_conf ]]; then break; fi
+                  echo "Waiting for cni conf file"
+                  sleep 2s
+              done
+              cni_conf="/etc/cni/net.d/$cni_conf"
+
+              while true; do
+                  if grep -sq "antrea" $cni_conf; then break; fi
+                  echo "Waiting for antrea config to be updated"
+                  sleep 2s
+              done
+
+              # Wait for kubelet to register the file update. Default sync time is 5sec
+              # https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/dockershim/network/cni/cni.go#L50
+              sleep 5s
+
+              while true; do
+                  curl localhost:61679 && retry=false || retry=true
+                  if [ $retry == false ]; then break ; fi
+                  sleep 2s
+                  echo "Waiting for aws-k8s-agent"
+              done
+
+              # copied from https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml#L199
+              # Fetch running containers from aws-k8s-agent and kill it
+              echo "\n"
+              for pod in $(curl "localhost:61679/v1/pods" 2> /dev/null | jq -r '. | keys[]'); do
+                  container_name=$(echo "$pod" | awk -F_ ' { print $1 } ')
+                  container_id=$(echo "$pod" | awk -F_ ' { print $3 } ' | cut -c1-12)
+                  echo "Restarting container. Name: ${container_name}, ID: ${container_id}"
+                  docker kill "${container_id}" || true
+              done
+
+              # Save the node init status, to avoid container restart in case of node-init pod restart or worker node reboot
+              touch /opt/cni/antrea-node-init-status
+
+              echo "Node initialization completed"

--- a/docs/eks-installation.md
+++ b/docs/eks-installation.md
@@ -5,6 +5,12 @@ This document describes steps to deploy Antrea in NetworkPolicy only mode to an 
 Assuming you already have an EKS cluster, and have ``KUBECONFIG`` environment variable point to
 the kubeconfig file of that cluster.
 
+With Antrea >=v0.9.0 release, you should apply `antrea-eks-node-init.yaml` before deploying Antrea.
+This would restart existing PODs (except in host network) so that Antrea can also manage it, once installed.
+```
+kubectl apply -f https://raw.githubusercontent.com/vmware-tanzu/antrea/master/build/yamls/antrea-eks-node-init.yml
+```
+
 To deploy a released version of Antrea, pick a version from the
 [list of releases](https://github.com/vmware-tanzu/antrea/releases).
 Note that EKS support was added in release 0.5.0, which means you can not
@@ -20,20 +26,7 @@ deployment yaml at:
 https://raw.githubusercontent.com/vmware-tanzu/antrea/master/build/yamls/antrea-eks.yml
 ```
 
-Based on Kubernetes service cluster IP range, adjust ``serviceCIDR`` values of antrea-agent.conf
-in antrea-eks.yml accordingly, and apply antrea-eks.yml to the EKS cluster.
-
 ```bash
-kubectl apply -f antrea-eks.yaml 
+kubectl apply -f antrea-eks.yaml
 ```
 Now Antrea should be plugged into the EKS CNI and is ready to enforce NetworkPolicy.
-
-### Caveats
-
-Some Pods may already be installed before Antrea deployment. Antrea cannot enforce NetworkPolicy
-on these pre-installed Pods. This may be remedied by restarting the Pods. For example,
-
-```bash
-kubectl scale deployment coredns --replicas 0 -n kube-system
-kubectl scale deployment coredns --replicas 2 -n kube-system
-```


### PR DESCRIPTION
This is temporary solution to handle a race condition with cni chaining mode. Basically if there are existing PODs before Antrea
is installled or in case of scale out if PODs are deployed before Antrea daemonset is applied, those PODs will not be managed by Antrea and hence network policies cannot be applied to those PODs.

With eks node init, pods are restarted once antrea config is detected.

Also updated the ci script and documentation.

Fixes: #869 