### PR TITLE
Add release assets for Windows

### DIFF
--- a/.github/workflows/upload_release_assets.yml
+++ b/.github/workflows/upload_release_assets.yml
@@ -160,3 +160,30 @@ jobs:
         asset_path: ./assets/antrea-windows.yml
         asset_name: antrea-windows.yml
         asset_content_type: application/octet-stream
+    - name: Upload antrea-agent-windows-x86_64.exe
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./assets/antrea-agent.exe
+          asset_name: antrea-agent-windows-x86_64.exe
+          asset_content_type: application/octet-stream
+    - name: Upload antrea-cni-windows-x86_64.exe
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./assets/antrea-cni.exe
+          asset_name: antrea-cni-windows-x86_64.exe
+          asset_content_type: application/octet-stream
+    - name: Upload Start.ps1
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./assets/Start.ps1
+          asset_name: Start.ps1
+          asset_content_type: application/octet-stream

--- a/hack/release/prepare-assets.sh
+++ b/hack/release/prepare-assets.sh
@@ -59,6 +59,9 @@ for build in "${ANTREA_BUILDS[@]}"; do
     BINDIR="$OUTPUT_DIR" make antrea-octant-plugin-release && cd ../..
 done
 
+BINDIR="$OUTPUT_DIR" make windows-bin
+sed "s/AntreaVersion=\"latest\"/AntreaVersion=\"$VERSION\"/" ./hack/windows/Start.ps1 > "$OUTPUT_DIR"/Start.ps1
+
 export IMG_TAG=$VERSION
 
 export IMG_NAME=antrea/antrea-ubuntu


### PR DESCRIPTION
Add following files in release assets for Windows:
- antrea-agent-windows-x86_64.exe
- antrea-cni-windows-x86_64.exe
- Start.ps1: The script can be used to install antrea-agent and
  start it as process manually on Windows worker node.

Signed-off-by: Rui Cao <rcao@vmware.com>