### PR TITLE
Check AntreaProxy must be enabled for noEncap, hybrid, policyOnly modes

### DIFF
--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -92,8 +92,13 @@ func (o *Options) validate(args []string) error {
 	if !ok {
 		return fmt.Errorf("TrafficEncapMode %s is unknown", o.config.TrafficEncapMode)
 	}
-	if encapMode.SupportsNoEncap() && o.config.EnableIPSecTunnel {
-		return fmt.Errorf("IPSec tunnel may only be enabled on %s mode", config.TrafficEncapModeEncap)
+	if encapMode.SupportsNoEncap() {
+		if !features.DefaultFeatureGate.Enabled(features.AntreaProxy) {
+			return fmt.Errorf("Mode %s requires AntreaProxy to be enabled", o.config.TrafficEncapMode)
+		}
+		if o.config.EnableIPSecTunnel {
+			return fmt.Errorf("IPSec tunnel may only be enabled on %s mode", config.TrafficEncapModeEncap)
+		}
 	}
 	if o.config.OVSDatapathType == ovsconfig.OVSDatapathNetdev && features.DefaultFeatureGate.Enabled(features.FlowExporter) {
 		return fmt.Errorf("FlowExporter feature is not supported for OVS datapath type %s", o.config.OVSDatapathType)


### PR DESCRIPTION
These modes work with AntreaProxy only and do not support kube-proxy
any more.