### PR TITLE
[Windows] Update OVS package checksum

### DIFF
--- a/hack/windows/Install-OVS.ps1
+++ b/hack/windows/Install-OVS.ps1
@@ -9,7 +9,7 @@ $ErrorActionPreference = "Stop"
 # meantime, we use a SHA256 hash to ensure that the downloaded archive is
 # correct.
 $OVSDownloadURL = "http://downloads.antrea.io/ovs/ovs-2.13.1-win64.zip"
-$OVSPublishedHash = 'BC927E2DE8560F2F0D8C2FCCD6D69DE3D7F4C2C032BF81658D082AA7583B241D'
+$OVSPublishedHash = '7E8364D684CC37417D70281354AA55987F52F143BF2DA162B6728A24E6B67546'
 $OVSDownloadDir = [System.IO.Path]::GetDirectoryName($myInvocation.MyCommand.Definition)
 $InstallLog = "$OVSDownloadDir\install.log"
 $OVSZip = "$OVSDownloadDir\ovs-win64.zip"


### PR DESCRIPTION
Previously we use OVS package build from OVS branch_2.13.
Now OVS 2.13.1 is officially released. We build a new OVS
package from the released version.

This patch updates the sha256sum of OVS package.

Signed-off-by: Rui Cao <rcao@vmware.com>