### PR TITLE
Update conformance test scripts for cloud CI

### DIFF
--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -411,7 +411,7 @@
               #!/bin/bash
               source /home/ubuntu/.bashrc
               sudo ./ci/test-conformance-eks.sh --aws-access-key ${{AWS_ACCESS_KEY}} --aws-secret-key ${{AWS_SECRET_KEY}} \
-                --cluster-name ${{JOB_NAME}}-${{BUILD_NUMBER}} --log-mode detail --setup-only
+                --cluster-name ${{JOB_NAME}}-${{BUILD_NUMBER}} --log-mode detail --setup-and-test-only
           triggers:
           - timed: H H */2 * *
           publishers:
@@ -468,7 +468,7 @@
               ${{GCLOUD_PATH}} auth activate-service-account --key-file=${{GCLOUD_KEY_PATH}}
               sudo ./ci/test-conformance-gke.sh --cluster-name antrea-gke-${{BUILD_NUMBER}} \
                 --k8s-version 1.16.11-gke.5 --svc-account antrea-gcp@antrea.iam.gserviceaccount.com \
-                --gcloud-path ${{GCLOUD_PATH}} --log-mode detail --setup-only
+                --gcloud-path ${{GCLOUD_PATH}} --log-mode detail --setup-and-test-only
           triggers:
           - timed: H H */2 * *
           publishers:
@@ -516,7 +516,7 @@
               source /home/ubuntu/.bashrc
               sudo ./ci/test-conformance-aks.sh --azure-app-id ${{AZURE_APP_ID}} --azure-password ${{AZURE_PASSWORD}} \
                 --azure-tenant-id ${{AZURE_TENANT_ID}} --cluster-name ${{JOB_NAME}}-${{BUILD_NUMBER}} \
-                --log-mode detail --setup-only
+                --log-mode detail --setup-and-test-only
           triggers:
           - timed: H H */2 * *
           publishers:

--- a/docs/gke-installation.md
+++ b/docs/gke-installation.md
@@ -32,17 +32,15 @@ on both VPC-native Enable/Disable modes.
 You can use any method to create a GKE cluster (gcloud SDK, gcloud Console, etc). The example
 given here is using the Google Cloud SDK.
 
-**Note:** Antrea is supported on Ubuntu Nodes only for GKE cluster. Also, it is a must to select service
-CIDR at the time of cluster deployment.
+**Note:** Antrea is supported on Ubuntu Nodes only for GKE cluster.
 
 1. Create a GKE cluster
 
     ```bash
     export GKE_ZONE="us-west1"
     export GKE_HOST="UBUNTU"
-    export GKE_SERVICE_CIDR="10.94.0.0/16"
     gcloud container --project $GKE_PROJECT clusters create cluster1 --image-type $GKE_HOST \
-       --zone $GKE_ZONE --enable-ip-alias --services-ipv4-cidr $GKE_SERVICE_CIDR
+       --zone $GKE_ZONE --enable-ip-alias
     ```
 
 2. Access your cluster


### PR DESCRIPTION
- Remove manual MTU and serviceCIDR setting in antrea-gke.yml thanks to auto MTU discovery and Antrea-proxy.
- Fix the issue where "failure" will be printed even when conformance tests pass.
- Add option to specify "setup-only" and "setup-test-only", in case user wants to use the script for bringing up a EKS/GKE/AKS cluster for manual testing.