### PR TITLE
Fix changes in ofctrl_flow.go that breaks CNP priority re-assignment

### DIFF
--- a/pkg/ovs/openflow/ofctrl_flow.go
+++ b/pkg/ovs/openflow/ofctrl_flow.go
@@ -132,11 +132,13 @@ func (f *ofFlow) CopyToBuilder(priority uint16) FlowBuilder {
 	return &ofFlowBuilder{newFlow}
 }
 
-// ToBuilder returns a new FlowBuilder with all the contents of the original Flow
+// ToBuilder returns a new FlowBuilder with all the contents of the original Flow.
 func (f *ofFlow) ToBuilder() FlowBuilder {
+	// TODO: use exported fields from ofFlow and remove nolint:govet
+	flow := *f.Flow //nolint:govet
 	newFlow := ofFlow{
 		table:    f.table,
-		Flow:     f.Flow,
+		Flow:     &flow,
 		matchers: f.matchers,
 		protocol: f.protocol,
 	}


### PR DESCRIPTION
This PR fixes an issue introduced by #1023. The change of embedded struct ofctrl.Flow to embedded pointer in ofFlow has caused the priority reassignments to not function properly. CNP reconciler updates a flow's priority by deleting the old flow and create a new one at the updated priority. After the pointer change, delFlow and addFlow point to the same flow and cause the operation to fail.