### PR TITLE
Only copy relevant fields from ofctrl.Flow in ToBuilder()

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -739,7 +739,7 @@ func (c *client) InstallTraceflowFlows(dataplaneTag uint8) error {
 		if ctx.dropFlow != nil {
 			flows = append(
 				flows,
-				ctx.dropFlow.CopyToBuilder(priorityNormal+2).
+				ctx.dropFlow.CopyToBuilder(priorityNormal+2, false).
 					MatchRegRange(int(TraceflowReg), uint32(dataplaneTag), OfTraceflowMarkRange).
 					SetHardTimeout(300).
 					Action().SendToController(1).

--- a/pkg/agent/openflow/network_policy.go
+++ b/pkg/agent/openflow/network_policy.go
@@ -262,7 +262,7 @@ func (ctx *conjMatchFlowContext) createOrUpdateConjunctiveMatchFlow(actions []*c
 	}
 
 	// Modify the existing Openflow entry and reset the actions.
-	flowBuilder := ctx.flow.CopyToBuilder(0)
+	flowBuilder := ctx.flow.CopyToBuilder(0, false)
 	for _, act := range actions {
 		flowBuilder.Action().Conjunction(act.conjID, act.clauseID, act.nClause)
 	}
@@ -1182,9 +1182,7 @@ func (c *client) getMatchFlowUpdates(conj *policyRuleConjunction, newPriority ui
 	for _, c := range allClause {
 		for _, ctx := range c.matches {
 			f := ctx.flow
-			updatedFlow := f.ToBuilder().
-				MatchPriority(newPriority).
-				Done()
+			updatedFlow := f.CopyToBuilder(newPriority, true).Done()
 			add = append(add, updatedFlow)
 			del = append(del, f)
 		}
@@ -1247,9 +1245,7 @@ func (c *client) updateConjunctionMatchFlows(conj *policyRuleConjunction, newPri
 		for i, ctx := range clause.matches {
 			delete(c.globalConjMatchFlowCache, ctx.generateGlobalMapKey())
 			f := ctx.flow
-			updatedFlow := f.ToBuilder().
-				MatchPriority(newPriority).
-				Done()
+			updatedFlow := f.CopyToBuilder(newPriority, true).Done()
 			clause.matches[i].flow = updatedFlow
 			clause.matches[i].priority = &newPriority
 		}
@@ -1279,10 +1275,7 @@ func (c *client) calculateFlowUpdates(updates map[uint16]uint16, table binding.T
 				if flowPriority == original {
 					// The OF flow was created at the priority which need to be re-installed
 					// at the NewPriority now
-					updatedFlow := actionFlow.
-						ToBuilder().
-						MatchPriority(newPriority).
-						Done()
+					updatedFlow := actionFlow.CopyToBuilder(newPriority, true).Done()
 					addFlows = append(addFlows, updatedFlow)
 					delFlows = append(delFlows, actionFlow)
 					// Store the actionFlow update to the policyRuleConjunction and update all

--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -486,7 +486,7 @@ func newMockRuleFlowBuilder(ctrl *gomock.Controller) *mocks.MockFlowBuilder {
 	ruleFlowBuilder.EXPECT().Action().Return(ruleAction).AnyTimes()
 	ruleFlow = mocks.NewMockFlow(ctrl)
 	ruleFlowBuilder.EXPECT().Done().Return(ruleFlow).AnyTimes()
-	ruleFlow.EXPECT().CopyToBuilder(gomock.Any()).Return(ruleFlowBuilder).AnyTimes()
+	ruleFlow.EXPECT().CopyToBuilder(gomock.Any(), gomock.Any()).Return(ruleFlowBuilder).AnyTimes()
 	ruleFlow.EXPECT().FlowPriority().Return(uint16(priorityNormal)).AnyTimes()
 	ruleFlow.EXPECT().MatchString().Return("").AnyTimes()
 	return ruleFlowBuilder

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -152,11 +152,10 @@ type Flow interface {
 	// Returns the flow priority associated with OFEntry
 	FlowPriority() uint16
 	MatchString() string
-	// CopyToBuilder returns a new FlowBuilder that copies the matches of the Flow, but does not copy the actions. It
-	// resets the priority of the new FlowBuilder if the provided value is not 0.
-	CopyToBuilder(priority uint16) FlowBuilder
-	// ToBuilder returns a new FlowBuilder with all the contents of the original Flow
-	ToBuilder() FlowBuilder
+	// CopyToBuilder returns a new FlowBuilder that copies the matches of the Flow.
+	// It copies the original actions of the Flow only if copyActions is set to true, and
+	// resets the priority in the new FlowBuilder if the provided priority is not 0.
+	CopyToBuilder(priority uint16, copyActions bool) FlowBuilder
 }
 
 type Action interface {

--- a/pkg/ovs/openflow/ofctrl_flow.go
+++ b/pkg/ovs/openflow/ofctrl_flow.go
@@ -111,36 +111,23 @@ func (f *ofFlow) GetBundleMessage(entryOper OFOperation) (ofctrl.OpenFlowModMess
 }
 
 // CopyToBuilder returns a new FlowBuilder that copies the table, protocols,
-// matches, and CookieID of the Flow, but does not copy the actions,
-// and other private status fields of the ofctrl.Flow, e.g. "realized" and
-// "isInstalled". Reset the priority in the new FlowBuilder if it is provided.
-func (f *ofFlow) CopyToBuilder(priority uint16) FlowBuilder {
-	newFlow := ofFlow{
-		table: f.table,
-		Flow: &ofctrl.Flow{
-			Table:      f.Flow.Table,
-			CookieID:   f.Flow.CookieID,
-			CookieMask: f.Flow.CookieMask,
-			Match:      f.Flow.Match,
-		},
-		matchers: f.matchers,
-		protocol: f.protocol,
-	}
-	if priority > 0 {
-		newFlow.Flow.Match.Priority = priority
-	}
-	return &ofFlowBuilder{newFlow}
-}
-
-// ToBuilder returns a new FlowBuilder with all the contents of the original Flow.
-func (f *ofFlow) ToBuilder() FlowBuilder {
+// matches, and CookieID of the Flow, but does not copy private status fields
+// of the ofctrl.Flow, e.g. "realized" and "isInstalled". It copies the
+// original actions of the Flow only if copyActions is set to true, and
+// resets the priority in the new FlowBuilder if it is provided.
+func (f *ofFlow) CopyToBuilder(priority uint16, copyActions bool) FlowBuilder {
 	flow := &ofctrl.Flow{
 		Table:      f.Flow.Table,
 		CookieID:   f.Flow.CookieID,
 		CookieMask: f.Flow.CookieMask,
 		Match:      f.Flow.Match,
 	}
-	f.Flow.CopyActionsToNewFlow(flow)
+	if copyActions {
+		f.Flow.CopyActionsToNewFlow(flow)
+	}
+	if priority > 0 {
+		flow.Match.Priority = priority
+	}
 	newFlow := ofFlow{
 		table:    f.table,
 		Flow:     flow,

--- a/pkg/ovs/openflow/ofctrl_flow.go
+++ b/pkg/ovs/openflow/ofctrl_flow.go
@@ -134,11 +134,16 @@ func (f *ofFlow) CopyToBuilder(priority uint16) FlowBuilder {
 
 // ToBuilder returns a new FlowBuilder with all the contents of the original Flow.
 func (f *ofFlow) ToBuilder() FlowBuilder {
-	// TODO: use exported fields from ofFlow and remove nolint:govet
-	flow := *f.Flow //nolint:govet
+	flow := &ofctrl.Flow{
+		Table:      f.Flow.Table,
+		CookieID:   f.Flow.CookieID,
+		CookieMask: f.Flow.CookieMask,
+		Match:      f.Flow.Match,
+	}
+	f.Flow.CopyActionsToNewFlow(flow)
 	newFlow := ofFlow{
 		table:    f.table,
-		Flow:     &flow,
+		Flow:     flow,
 		matchers: f.matchers,
 		protocol: f.protocol,
 	}

--- a/pkg/ovs/openflow/ofctrl_flow_test.go
+++ b/pkg/ovs/openflow/ofctrl_flow_test.go
@@ -22,10 +22,10 @@ func TestCopyToBuilder(t *testing.T) {
 		LoadToMark(uint32(12345)).
 		MoveToLabel(NxmFieldSrcMAC, &Range{0, 47}, &Range{0, 47}).CTDone().
 		Done()
-	newFlow := oriFlow.CopyToBuilder(0)
+	newFlow := oriFlow.CopyToBuilder(0, false)
 	assert.Equal(t, oriFlow.MatchString(), newFlow.Done().MatchString())
 	assert.Equal(t, oriFlow.(*ofFlow).Match, newFlow.Done().(*ofFlow).Match)
 	newPriority := uint16(200)
-	newFlow2 := oriFlow.CopyToBuilder(newPriority)
+	newFlow2 := oriFlow.CopyToBuilder(newPriority, false)
 	assert.Equal(t, newPriority, newFlow2.Done().(*ofFlow).Match.Priority)
 }

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -406,17 +406,17 @@ func (mr *MockFlowMockRecorder) Add() *gomock.Call {
 }
 
 // CopyToBuilder mocks base method
-func (m *MockFlow) CopyToBuilder(arg0 uint16) openflow.FlowBuilder {
+func (m *MockFlow) CopyToBuilder(arg0 uint16, arg1 bool) openflow.FlowBuilder {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CopyToBuilder", arg0)
+	ret := m.ctrl.Call(m, "CopyToBuilder", arg0, arg1)
 	ret0, _ := ret[0].(openflow.FlowBuilder)
 	return ret0
 }
 
 // CopyToBuilder indicates an expected call of CopyToBuilder
-func (mr *MockFlowMockRecorder) CopyToBuilder(arg0 interface{}) *gomock.Call {
+func (mr *MockFlowMockRecorder) CopyToBuilder(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyToBuilder", reflect.TypeOf((*MockFlow)(nil).CopyToBuilder), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyToBuilder", reflect.TypeOf((*MockFlow)(nil).CopyToBuilder), arg0, arg1)
 }
 
 // Delete mocks base method
@@ -514,20 +514,6 @@ func (m *MockFlow) Reset() {
 func (mr *MockFlowMockRecorder) Reset() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockFlow)(nil).Reset))
-}
-
-// ToBuilder mocks base method
-func (m *MockFlow) ToBuilder() openflow.FlowBuilder {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ToBuilder")
-	ret0, _ := ret[0].(openflow.FlowBuilder)
-	return ret0
-}
-
-// ToBuilder indicates an expected call of ToBuilder
-func (mr *MockFlowMockRecorder) ToBuilder() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToBuilder", reflect.TypeOf((*MockFlow)(nil).ToBuilder))
 }
 
 // Type mocks base method


### PR DESCRIPTION
This PR will properly fix CNP E2E test failures. It depends on PR #1065. 