### PR TITLE
Fix check failure in integration test

### DIFF
--- a/build/images/test/Dockerfile
+++ b/build/images/test/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A Docker image for antrea integration tests."
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends iproute2 iptables ipset make wget gcc libc6-dev ca-certificates && \
+    apt-get install -y --no-install-recommends iproute2 iptables ipset make wget gcc libc6-dev ca-certificates git && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
 ENV GO_VERSION=1.13.12


### PR DESCRIPTION
The Github action "Integration tests" always raises a check failure "git is not available, binaries will not include git SHA" and displays it on the "Files changed" board, which is a little distracting.

This patch fixes it by adding the required git tool to the test image.