### PR TITLE
Fix klogv1 piping to klogv2

### DIFF
--- a/cmd/antctl/main.go
+++ b/cmd/antctl/main.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/component-base/logs"
 
 	"github.com/vmware-tanzu/antrea/pkg/antctl"
 	"github.com/vmware-tanzu/antrea/pkg/log"
@@ -38,21 +37,20 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	// prevent any unexpected output at beginning
-	log.InitKlog()
 	log.Klogv2Flags.Set("logtostderr", "false")
 	log.Klogv2Flags.Set("v", "0")
 	pflag.CommandLine.MarkHidden("log-flush-frequency")
 }
 
 func main() {
-	logs.InitLogs()
-	defer logs.FlushLogs()
+	log.InitKlog()
+	defer log.FlushKlog()
 
 	rand.Seed(time.Now().UTC().UnixNano())
 	antctl.CommandList.ApplyToRootCommand(rootCmd)
 	err := rootCmd.Execute()
 	if err != nil {
-		logs.FlushLogs()
+		log.FlushKlog()
 		os.Exit(1)
 	}
 }

--- a/cmd/antrea-agent/main.go
+++ b/cmd/antrea-agent/main.go
@@ -18,28 +18,22 @@
 package main
 
 import (
-	"flag"
 	"os"
 
 	"github.com/spf13/cobra"
-	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
 
 	"github.com/vmware-tanzu/antrea/pkg/log"
 	"github.com/vmware-tanzu/antrea/pkg/version"
 )
 
-func init() {
-	log.InitKlog()
-}
-
 func main() {
-	logs.InitLogs()
-	defer logs.FlushLogs()
+	log.InitKlog()
+	defer log.FlushKlog()
 
 	command := newAgentCommand()
 	if err := command.Execute(); err != nil {
-		logs.FlushLogs()
+		log.FlushKlog()
 		os.Exit(1)
 	}
 }
@@ -51,9 +45,6 @@ func newAgentCommand() *cobra.Command {
 		Use:  "antrea-agent",
 		Long: "The Antrea agent runs on each node.",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := log.Klogv2Flags.Parse(os.Args[1:]); err != nil {
-				klog.Fatalf("Failed to parse: %v", err)
-			}
 			klog.Infof("Args: %v", os.Args)
 			log.InitLogFileLimits(cmd.Flags())
 			if err := opts.complete(args); err != nil {
@@ -72,7 +63,5 @@ func newAgentCommand() *cobra.Command {
 	flags := cmd.Flags()
 	opts.addFlags(flags)
 	log.AddFlags(flags)
-	// Install log flags
-	flags.AddGoFlagSet(flag.CommandLine)
 	return cmd
 }

--- a/cmd/antrea-cni/main.go
+++ b/cmd/antrea-cni/main.go
@@ -21,13 +21,8 @@ import (
 	cniversion "github.com/containernetworking/cni/pkg/version"
 
 	"github.com/vmware-tanzu/antrea/pkg/cni"
-	"github.com/vmware-tanzu/antrea/pkg/log"
 	"github.com/vmware-tanzu/antrea/pkg/version"
 )
-
-func init() {
-	log.InitKlog()
-}
 
 func main() {
 	skel.PluginMain(

--- a/cmd/antrea-controller/main.go
+++ b/cmd/antrea-controller/main.go
@@ -18,29 +18,22 @@
 package main
 
 import (
-	"flag"
 	"os"
 
 	"github.com/spf13/cobra"
-	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
 
 	"github.com/vmware-tanzu/antrea/pkg/log"
 	"github.com/vmware-tanzu/antrea/pkg/version"
 )
 
-func init() {
-	log.InitKlog()
-}
-
 func main() {
-	logs.InitLogs()
-	defer logs.FlushLogs()
+	log.InitKlog()
+	defer log.FlushKlog()
 
 	command := newControllerCommand()
-
 	if err := command.Execute(); err != nil {
-		logs.FlushLogs()
+		log.FlushKlog()
 		os.Exit(1)
 	}
 }
@@ -52,9 +45,6 @@ func newControllerCommand() *cobra.Command {
 		Use:  "antrea-controller",
 		Long: "The Antrea Controller.",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := log.Klogv2Flags.Parse(os.Args[1:]); err != nil {
-				klog.Fatalf("Failed to parse: %v", err)
-			}
 			log.InitLogFileLimits(cmd.Flags())
 			if err := opts.complete(args); err != nil {
 				klog.Fatalf("Failed to complete: %v", err)
@@ -72,7 +62,5 @@ func newControllerCommand() *cobra.Command {
 	flags := cmd.Flags()
 	opts.addFlags(flags)
 	log.AddFlags(flags)
-	// Install log flags
-	flags.AddGoFlagSet(flag.CommandLine)
 	return cmd
 }

--- a/pkg/antctl/command_list.go
+++ b/pkg/antctl/command_list.go
@@ -15,6 +15,7 @@
 package antctl
 
 import (
+	"flag"
 	"fmt"
 	"math"
 	"strings"
@@ -24,7 +25,6 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/vmware-tanzu/antrea/pkg/antctl/runtime"
-	"github.com/vmware-tanzu/antrea/pkg/log"
 )
 
 // commandList organizes commands definitions.
@@ -73,12 +73,12 @@ func (cl *commandList) ApplyToRootCommand(root *cobra.Command) {
 		if err != nil {
 			return err
 		}
-		err = log.Klogv2Flags.Set("logtostderr", fmt.Sprint(enableVerbose))
+		err = flag.Set("logtostderr", fmt.Sprint(enableVerbose))
 		if err != nil {
 			return err
 		}
 		if enableVerbose {
-			err := log.Klogv2Flags.Set("v", fmt.Sprint(math.MaxInt32))
+			err := flag.Set("v", fmt.Sprint(math.MaxInt32))
 			if err != nil {
 				return err
 			}

--- a/pkg/log/log_file.go
+++ b/pkg/log/log_file.go
@@ -17,36 +17,37 @@
 package log
 
 import (
+	"bytes"
 	"flag"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/spf13/pflag"
 
-	klogv1 "k8s.io/klog"
-
 	"k8s.io/apimachinery/pkg/util/wait"
+	_ "k8s.io/component-base/logs" // just making import explicit (already imported by k8s libraries)
+	klogv1 "k8s.io/klog"
 	"k8s.io/klog/v2"
 )
 
 const (
-	logToStdErrFlag = "logtostderr"
-	logDirFlag      = "log_dir"
-	logFileFlag     = "log_file"
-	maxSizeFlag     = "log_file_max_size"
-	maxNumFlag      = "log_file_max_num"
+	logToStdErrFlag  = "logtostderr"
+	logDirFlag       = "log_dir"
+	logFileFlag      = "log_file"
+	maxSizeFlag      = "log_file_max_size"
+	maxNumFlag       = "log_file_max_num"
+	logFlushFreqFlag = "log-flush-frequency"
 
 	// Check log file number every 10 mins.
 	logFileCheckInterval = time.Minute * 10
 	// Allowed maximum value for the maximum file size limit.
 	maxMaxSizeMB = 1024 * 100
 
-	outputCallDepth = 6
-	// log prefix that we have to strip out
-	defaultPrefixLength = 53
+	logFlushFreqDefault = 5 * time.Second
 )
 
 var (
@@ -55,9 +56,21 @@ var (
 	logDir        = ""
 
 	executableName = filepath.Base(os.Args[0])
+
+	// Klogv2Flags is the flag set for klog (klogv2).
+	Klogv2Flags flag.FlagSet
+
+	logFlushFreq = logFlushFreqDefault
 )
 
+func init() {
+	klog.InitFlags(&Klogv2Flags)
+}
+
 func AddFlags(fs *pflag.FlagSet) {
+	fs.AddGoFlagSet(&Klogv2Flags)
+	// mimics InitLogs in "k8s.io/component-base/logs"
+	fs.DurationVar(&logFlushFreq, logFlushFreqFlag, logFlushFreqDefault, "Maximum number of seconds between log flushes")
 	fs.Uint16Var(&maxNumArg, maxNumFlag, maxNumArg, "Maximum number of log files per severity level to be kept. Value 0 means unlimited.")
 }
 
@@ -198,53 +211,107 @@ func checkLogFiles() {
 	checkFilesFn(errorLogFiles)
 }
 
-// Support code for klogv2 while klogv1 is still used
-// in third_party and "k8s.io/component-base/logs"
+// Support code for klogv2 while klogv1 is still used in third_party and
+// "k8s.io/component-base/logs", for the K8s Go version we depend on (v0.18.4).
 // TODO: remove when they are upgraded to klogv2.
 
-// klogWriter is used in SetOutputBySeverity call below to redirect
-// any calls to klogv1 to end up in klogv2
+// klogWriter is used in the SetOutput call below to redirect any calls to
+// klogv1 to end up in klogv2
 type klogWriter struct{}
 
+// determineCallDepth is meant to be called by Write and determines the depth of
+// the call stack to reach the original location of the log call.
+func determineCallDepth() int {
+	// based on our knowledge of the code, there are either 5-6 frames we
+	// care about, so 10 is large enough.
+	pcs := make([]uintptr, 10)
+	depth := 1
+	// 1 would be the caller of Callers (determineCallDepth), 2 would be the
+	// caller of determineCallDepth (Write), 3 would be the caller of Write
+	// (thus in the klog package).
+	if numEntries := runtime.Callers(3, pcs); numEntries > 0 {
+		pcs = pcs[:numEntries]
+		frames := runtime.CallersFrames(pcs)
+		for {
+			frame, more := frames.Next()
+			// as soon as we get out of klog.go, we have reached the
+			// actual location of the log call.
+			if !strings.HasSuffix(frame.File, "/klog.go") {
+				return depth
+			}
+			depth++
+			if !more {
+				return -1
+			}
+		}
+	}
+	return -1
+}
+
 func (kw klogWriter) Write(p []byte) (n int, err error) {
-	if len(p) < defaultPrefixLength {
+	// will be either 5 or 6 based on which version of the logging functions
+	// is used (e.g. Info vs Infof).
+	outputCallDepth := determineCallDepth()
+	if outputCallDepth < 0 { // should not happen, but handle "gracefully"
+		return 0, nil
+	}
+
+	// determine and strip klogv1 prefix.
+	prefixIndex := bytes.IndexByte(p, ']')
+	if prefixIndex == -1 || prefixIndex+2 >= len(p) {
 		klog.InfoDepth(outputCallDepth, string(p))
 		return len(p), nil
 	}
+
 	if p[0] == 'I' {
-		klog.InfoDepth(outputCallDepth, string(p[defaultPrefixLength:]))
+		klog.InfoDepth(outputCallDepth, string(p[prefixIndex+2:]))
 	} else if p[0] == 'W' {
-		klog.WarningDepth(outputCallDepth, string(p[defaultPrefixLength:]))
+		klog.WarningDepth(outputCallDepth, string(p[prefixIndex+2:]))
 	} else if p[0] == 'E' {
-		klog.ErrorDepth(outputCallDepth, string(p[defaultPrefixLength:]))
+		klog.ErrorDepth(outputCallDepth, string(p[prefixIndex+2:]))
 	} else if p[0] == 'F' {
-		klog.FatalDepth(outputCallDepth, string(p[defaultPrefixLength:]))
+		klog.FatalDepth(outputCallDepth, string(p[prefixIndex+2:]))
 	} else {
-		klog.InfoDepth(outputCallDepth, string(p[defaultPrefixLength:]))
+		klog.InfoDepth(outputCallDepth, string(p[prefixIndex+2:]))
 	}
+
 	return len(p), nil
 }
 
-// Klogv2Flags The flag file for klog.
-var Klogv2Flags flag.FlagSet
-
-// InitKlog sets up the klog.
-// Redirects klogv1 to klogv2.
+// setUpKlogV1Redirect sets up redirection from klogv1 to
 // TODO: remove once components use klogv2 by default.
-func InitKlog() {
-	klog.InitFlags(&Klogv2Flags)
-	addKlogv2Flags()
+func setUpKlogV1Redirect() {
+	// klogv1 initialization
+	// these flag values will not affect klogv2
 	var klogv1Flags flag.FlagSet
 	klogv1.InitFlags(&klogv1Flags)
 	klogv1Flags.Set("logtostderr", "false")
+	klogv1Flags.Set("alsologtostderr", "false")
 	klogv1Flags.Set("stderrthreshold", "FATAL")
-	klogv1.SetOutputBySeverity("INFO", klogWriter{})
+	klogv1.SetOutput(klogWriter{})
 }
 
-// addKlogv2Flags adds flags used by controller and agent.
-// Used to allow for parsing of flags.
-// TODO: remove once all components use klogv2.
-func addKlogv2Flags() {
-	Klogv2Flags.String("config", "", "Unused.")
-	Klogv2Flags.Uint(maxNumFlag, 0, "Unused.")
+// InitKlog intializes logging with klog.
+// TODO: remove once components use klogv2 by default.
+func InitKlog() {
+	setUpKlogV1Redirect()
+
+	// redirect standard "log" to klog
+	klog.CopyStandardLogTo("INFO")
+
+	// The default flush interval is 5 seconds.
+	// We cannot use wait.Forever(klog.Flush, logFlushFreq) as any
+	// user-provided value would be ignored. We have the same issue with
+	// "k8s.io/component-base/logs" when calling IntLogs() before arguments
+	// are parsed.
+	go func() {
+		for {
+			time.Sleep(logFlushFreq)
+			klog.Flush()
+		}
+	}()
+}
+
+func FlushKlog() {
+	klog.Flush()
 }


### PR DESCRIPTION
Ever since the transition from klogv1 to klogv2, and the addition of
piping code to ensure that logs generated by components still using
klogv1 (like the version of K8s libraries Antrea is using), we have
observed some strange logs:
 * log duplication
 * invalid source file locations in log messages
 * log truncation

This was all caused by some invalid piping code. This commit is an
attempt at fixing this. It also takes a stab at simplifying log
initialization across Antrea components, and adds a unit test for klogv1
piping.

Fixes #1075