### PR TITLE
Revert "klogv2 upgrade and klogv1 redirect (#966)"

### DIFF
--- a/ci/clair-scan/main.go
+++ b/ci/clair-scan/main.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"encoding/json"
 	"flag"

--- a/ci/clair-scan/notify.go
+++ b/ci/clair-scan/notify.go
@@ -24,7 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ses"
 	"gopkg.in/gomail.v2"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 )
 
 const (

--- a/cmd/antctl/main.go
+++ b/cmd/antctl/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"flag"
 	"math/rand"
 	"os"
 	"path"
@@ -25,7 +26,6 @@ import (
 	"k8s.io/component-base/logs"
 
 	"github.com/vmware-tanzu/antrea/pkg/antctl"
-	"github.com/vmware-tanzu/antrea/pkg/log"
 )
 
 var commandName = path.Base(os.Args[0])
@@ -38,9 +38,8 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	// prevent any unexpected output at beginning
-	log.InitKlog()
-	log.Klogv2Flags.Set("logtostderr", "false")
-	log.Klogv2Flags.Set("v", "0")
+	flag.Set("logtostderr", "false")
+	flag.Set("v", "0")
 	pflag.CommandLine.MarkHidden("log-flush-frequency")
 }
 

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent"
 	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver"

--- a/cmd/antrea-agent/main.go
+++ b/cmd/antrea-agent/main.go
@@ -23,15 +23,11 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/component-base/logs"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/log"
 	"github.com/vmware-tanzu/antrea/pkg/version"
 )
-
-func init() {
-	log.InitKlog()
-}
 
 func main() {
 	logs.InitLogs()
@@ -51,10 +47,6 @@ func newAgentCommand() *cobra.Command {
 		Use:  "antrea-agent",
 		Long: "The Antrea agent runs on each node.",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := log.Klogv2Flags.Parse(os.Args[1:]); err != nil {
-				klog.Fatalf("Failed to parse: %v", err)
-			}
-			klog.Infof("Args: %v", os.Args)
 			log.InitLogFileLimits(cmd.Flags())
 			if err := opts.complete(args); err != nil {
 				klog.Fatalf("Failed to complete: %v", err)

--- a/cmd/antrea-cni/main.go
+++ b/cmd/antrea-cni/main.go
@@ -21,13 +21,8 @@ import (
 	cniversion "github.com/containernetworking/cni/pkg/version"
 
 	"github.com/vmware-tanzu/antrea/pkg/cni"
-	"github.com/vmware-tanzu/antrea/pkg/log"
 	"github.com/vmware-tanzu/antrea/pkg/version"
 )
-
-func init() {
-	log.InitKlog()
-}
 
 func main() {
 	skel.PluginMain(

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -27,7 +27,7 @@ import (
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 	aggregatorclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 
 	"github.com/vmware-tanzu/antrea/pkg/apiserver"

--- a/cmd/antrea-controller/main.go
+++ b/cmd/antrea-controller/main.go
@@ -23,15 +23,11 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/component-base/logs"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/log"
 	"github.com/vmware-tanzu/antrea/pkg/version"
 )
-
-func init() {
-	log.InitKlog()
-}
 
 func main() {
 	logs.InitLogs()
@@ -52,9 +48,6 @@ func newControllerCommand() *cobra.Command {
 		Use:  "antrea-controller",
 		Long: "The Antrea Controller.",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := log.Klogv2Flags.Parse(os.Args[1:]); err != nil {
-				klog.Fatalf("Failed to parse: %v", err)
-			}
 			log.InitLogFileLimits(cmd.Flags())
 			if err := opts.complete(args); err != nil {
 				klog.Fatalf("Failed to complete: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -53,10 +53,9 @@ require (
 	k8s.io/client-go v0.18.4
 	k8s.io/component-base v0.18.4
 	k8s.io/klog v1.0.0
-	k8s.io/klog/v2 v2.0.0
 	k8s.io/kube-aggregator v0.18.4
 	k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6
-	k8s.io/utils v0.0.0-20200414100711-2df71ebbae66
+	k8s.io/utils v0.0.0-20200410111917-5770800c2500
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -136,7 +136,6 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
-github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
@@ -573,15 +572,13 @@ k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUc
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
-k8s.io/klog/v2 v2.0.0 h1:Foj74zO6RbjjP4hBEKjnYtjjAhGg4jNynUdYF6fJrok=
-k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/kube-aggregator v0.18.4 h1:OoQD9bbA+blyhcppPMCEabngLaJ/PJNc4ksNr8tyIzY=
 k8s.io/kube-aggregator v0.18.4/go.mod h1:xOVy4wqhpivXCt07Diwdms2gonG+SONVx+1e7O+GfC0=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 h1:Oh3Mzx5pJ+yIumsAD0MOECPVeXsVot0UkiaCGVyfGQY=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
-k8s.io/utils v0.0.0-20200414100711-2df71ebbae66 h1:Ly1Oxdu5p5ZFmiVT71LFgeZETvMfZ1iBIGeOenT2JeM=
-k8s.io/utils v0.0.0-20200414100711-2df71ebbae66/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
+k8s.io/utils v0.0.0-20200410111917-5770800c2500 h1:iwoQwtHT3aQtbNKwKlQ2HdCTxv3thi/Tog6lLqIpdO8=
+k8s.io/utils v0.0.0-20200410111917-5770800c2500/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7 h1:uuHDyjllyzRyCIvvn0OBjiRB0SgBZGqHNYAmjR7fO50=

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/cniserver"
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Microsoft/hcsshim"
 	"github.com/rakelkar/gonetsh/netroute"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"

--- a/pkg/agent/apiserver/handlers/agentinfo/handler.go
+++ b/pkg/agent/apiserver/handlers/agentinfo/handler.go
@@ -19,7 +19,7 @@ import (
 	"net/http"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/querier"
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/common"

--- a/pkg/agent/apiserver/handlers/ovsflows/handler.go
+++ b/pkg/agent/apiserver/handlers/ovsflows/handler.go
@@ -19,7 +19,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
 	"github.com/vmware-tanzu/antrea/pkg/agent/querier"

--- a/pkg/agent/apiserver/handlers/ovstracing/handler.go
+++ b/pkg/agent/apiserver/handlers/ovstracing/handler.go
@@ -25,7 +25,7 @@ import (
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver/handlers"
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/component-base/config"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	cert "github.com/vmware-tanzu/antrea/pkg/apiserver/certificate"
 	"github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned"

--- a/pkg/agent/cniserver/interface_configuration_linux.go
+++ b/pkg/agent/cniserver/interface_configuration_linux.go
@@ -28,7 +28,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util/arping"

--- a/pkg/agent/cniserver/interface_configuration_windows.go
+++ b/pkg/agent/cniserver/interface_configuration_windows.go
@@ -27,7 +27,7 @@ import (
 	"github.com/Microsoft/hcsshim"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"
 	cnipb "github.com/vmware-tanzu/antrea/pkg/apis/cni/v1beta1"

--- a/pkg/agent/cniserver/ipam/ipam_delegator.go
+++ b/pkg/agent/cniserver/ipam/ipam_delegator.go
@@ -22,7 +22,7 @@ import (
 	"github.com/containernetworking/cni/pkg/invoke"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 )
 
 const (

--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -24,7 +24,7 @@ import (
 	"github.com/containernetworking/cni/pkg/version"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"

--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -30,7 +30,7 @@ import (
 	"google.golang.org/grpc"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/cniserver/ipam"
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"

--- a/pkg/agent/cniserver/server_windows.go
+++ b/pkg/agent/cniserver/server_windows.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"github.com/containernetworking/cni/pkg/types/current"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 )
 
 const infraContainerNetNS = "none"

--- a/pkg/agent/controller/networkpolicy/cache.go
+++ b/pkg/agent/controller/networkpolicy/cache.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/metrics"
 	"github.com/vmware-tanzu/antrea/pkg/apis/networking/v1beta1"

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent"
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"

--- a/pkg/agent/controller/networkpolicy/priority.go
+++ b/pkg/agent/controller/networkpolicy/priority.go
@@ -19,7 +19,7 @@ import (
 	"math"
 	"sort"
 
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/types"
 )

--- a/pkg/agent/controller/networkpolicy/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/reconciler.go
@@ -24,7 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -30,7 +30,7 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"

--- a/pkg/agent/controller/traceflow/packetin.go
+++ b/pkg/agent/controller/traceflow/packetin.go
@@ -26,7 +26,7 @@ import (
 	"github.com/contiv/ofnet/ofctrl"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
 	opsv1alpha1 "github.com/vmware-tanzu/antrea/pkg/apis/ops/v1alpha1"

--- a/pkg/agent/controller/traceflow/traceflow_controller.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller.go
@@ -31,7 +31,7 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"

--- a/pkg/agent/flowexporter/connections/connections.go
+++ b/pkg/agent/flowexporter/connections/connections.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/flowexporter"
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"

--- a/pkg/agent/flowexporter/connections/conntrack_linux.go
+++ b/pkg/agent/flowexporter/connections/conntrack_linux.go
@@ -20,7 +20,7 @@ import (
 	"net"
 
 	"github.com/ti-mo/conntrack"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/flowexporter"

--- a/pkg/agent/metrics/prometheus.go
+++ b/pkg/agent/metrics/prometheus.go
@@ -17,7 +17,7 @@ package metrics
 import (
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/util/env"
 )

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -20,7 +20,7 @@ import (
 	"net"
 
 	"github.com/contiv/ofnet/ofctrl"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow/cookie"

--- a/pkg/agent/openflow/network_policy.go
+++ b/pkg/agent/openflow/network_policy.go
@@ -19,7 +19,7 @@ import (
 	"net"
 	"strconv"
 
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/types"
 	"github.com/vmware-tanzu/antrea/pkg/apis/networking/v1beta1"

--- a/pkg/agent/openflow/packetin.go
+++ b/pkg/agent/openflow/packetin.go
@@ -17,7 +17,7 @@ package openflow
 import (
 	"github.com/contiv/ofnet/ofctrl"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 )
 
 type ofpPacketInReason uint

--- a/pkg/agent/proxy/endpoints.go
+++ b/pkg/agent/proxy/endpoints.go
@@ -22,7 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/proxy/types"
 	k8sproxy "github.com/vmware-tanzu/antrea/third_party/proxy"

--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
 	"github.com/vmware-tanzu/antrea/pkg/agent/proxy/types"

--- a/pkg/agent/proxy/proxier_linux.go
+++ b/pkg/agent/proxy/proxier_linux.go
@@ -18,7 +18,7 @@ package proxy
 import (
 	"net"
 
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
 )

--- a/pkg/agent/proxy/proxier_windows.go
+++ b/pkg/agent/proxy/proxier_windows.go
@@ -18,7 +18,7 @@ package proxy
 import (
 	"net"
 
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
 )

--- a/pkg/agent/querier/querier.go
+++ b/pkg/agent/querier/querier.go
@@ -20,7 +20,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"

--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -25,7 +25,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/rakelkar/gonetsh/netroute"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"

--- a/pkg/agent/route/route_windows_test.go
+++ b/pkg/agent/route/route_windows_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/rakelkar/gonetsh/netroute"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 )

--- a/pkg/agent/util/iptables/iptables.go
+++ b/pkg/agent/util/iptables/iptables.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/coreos/go-iptables/iptables"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 )
 
 const (

--- a/pkg/agent/util/net_linux.go
+++ b/pkg/agent/util/net_linux.go
@@ -25,7 +25,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 )
 
 // GetNetLink returns dev link from name.

--- a/pkg/agent/util/net_windows.go
+++ b/pkg/agent/util/net_windows.go
@@ -28,7 +28,7 @@ import (
 	ps "github.com/benmoss/go-powershell"
 	"github.com/benmoss/go-powershell/backend"
 	"github.com/containernetworking/plugins/pkg/ip"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 )
 
 const (

--- a/pkg/agent/util/sysctl/sysctl_linux.go
+++ b/pkg/agent/util/sysctl/sysctl_linux.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 )
 
 const (

--- a/pkg/agent/util/winfirewall/winfirewall.go
+++ b/pkg/agent/util/winfirewall/winfirewall.go
@@ -21,7 +21,7 @@ import (
 	"net"
 	"strings"
 
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"
 )

--- a/pkg/antctl/command_definition.go
+++ b/pkg/antctl/command_definition.go
@@ -29,7 +29,7 @@ import (
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/antctl/runtime"
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/common"

--- a/pkg/antctl/command_list.go
+++ b/pkg/antctl/command_list.go
@@ -15,16 +15,16 @@
 package antctl
 
 import (
+	"flag"
 	"fmt"
 	"math"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/antctl/runtime"
-	"github.com/vmware-tanzu/antrea/pkg/log"
 )
 
 // commandList organizes commands definitions.
@@ -73,12 +73,12 @@ func (cl *commandList) ApplyToRootCommand(root *cobra.Command) {
 		if err != nil {
 			return err
 		}
-		err = log.Klogv2Flags.Set("logtostderr", fmt.Sprint(enableVerbose))
+		err = flag.Set("logtostderr", fmt.Sprint(enableVerbose))
 		if err != nil {
 			return err
 		}
 		if enableVerbose {
-			err := log.Klogv2Flags.Set("v", fmt.Sprint(math.MaxInt32))
+			err := flag.Set("v", fmt.Sprint(math.MaxInt32))
 			if err != nil {
 				return err
 			}

--- a/pkg/antctl/raw/supportbundle/command.go
+++ b/pkg/antctl/raw/supportbundle/command.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	agentapiserver "github.com/vmware-tanzu/antrea/pkg/agent/apiserver"
 	"github.com/vmware-tanzu/antrea/pkg/agent/controller/noderoute"

--- a/pkg/antctl/transform/controllerinfo/transform.go
+++ b/pkg/antctl/transform/controllerinfo/transform.go
@@ -20,7 +20,7 @@ import (
 	"io/ioutil"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/common"
 	clusterinfo "github.com/vmware-tanzu/antrea/pkg/apis/clusterinformation/v1beta1"

--- a/pkg/antctl/transform/version/transform.go
+++ b/pkg/antctl/transform/version/transform.go
@@ -20,7 +20,7 @@ import (
 	"io/ioutil"
 
 	k8sversion "k8s.io/apimachinery/pkg/version"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	clusterinfov1beta1 "github.com/vmware-tanzu/antrea/pkg/apis/clusterinformation/v1beta1"
 	antreaversion "github.com/vmware-tanzu/antrea/pkg/version"

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/informers"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/apis/networking"
 	networkinginstall "github.com/vmware-tanzu/antrea/pkg/apis/networking/install"

--- a/pkg/apiserver/certificate/cacert_controller.go
+++ b/pkg/apiserver/certificate/cacert_controller.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 	"k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 
 	"github.com/vmware-tanzu/antrea/pkg/util/env"

--- a/pkg/apiserver/certificate/certificate.go
+++ b/pkg/apiserver/certificate/certificate.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 	"k8s.io/apiserver/pkg/server/options"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 	"k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 
 	"github.com/vmware-tanzu/antrea/pkg/util/env"

--- a/pkg/apiserver/registry/system/supportbundle/rest.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/registry/rest"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 	"k8s.io/utils/exec"
 
 	agentquerier "github.com/vmware-tanzu/antrea/pkg/agent/querier"

--- a/pkg/apiserver/storage/ram/store.go
+++ b/pkg/apiserver/storage/ram/store.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	antreastorage "github.com/vmware-tanzu/antrea/pkg/apiserver/storage"
 )

--- a/pkg/apiserver/storage/ram/watch.go
+++ b/pkg/apiserver/storage/ram/watch.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/apiserver/storage"
 )

--- a/pkg/controller/metrics/prometheus.go
+++ b/pkg/controller/metrics/prometheus.go
@@ -17,7 +17,7 @@ package metrics
 import (
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/util/env"
 )

--- a/pkg/controller/networkpolicy/clusternetworkpolicy.go
+++ b/pkg/controller/networkpolicy/clusternetworkpolicy.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/apis/networking"
 	secv1alpha1 "github.com/vmware-tanzu/antrea/pkg/apis/security/v1alpha1"

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -42,7 +42,7 @@ import (
 	networkinglisters "k8s.io/client-go/listers/networking/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/apis/networking"
 	secv1alpha1 "github.com/vmware-tanzu/antrea/pkg/apis/security/v1alpha1"

--- a/pkg/controller/traceflow/controller.go
+++ b/pkg/controller/traceflow/controller.go
@@ -30,7 +30,7 @@ import (
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	opsv1alpha1 "github.com/vmware-tanzu/antrea/pkg/apis/ops/v1alpha1"
 	"github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned"

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	componentbaseconfig "k8s.io/component-base/config"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 	aggregatorclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 
 	crdclientset "github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned"

--- a/pkg/log/log_file.go
+++ b/pkg/log/log_file.go
@@ -17,7 +17,6 @@
 package log
 
 import (
-	"flag"
 	"os"
 	"path/filepath"
 	"sort"
@@ -26,10 +25,8 @@ import (
 
 	"github.com/spf13/pflag"
 
-	klogv1 "k8s.io/klog"
-
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 )
 
 const (
@@ -43,10 +40,6 @@ const (
 	logFileCheckInterval = time.Minute * 10
 	// Allowed maximum value for the maximum file size limit.
 	maxMaxSizeMB = 1024 * 100
-
-	outputCallDepth = 6
-	// log prefix that we have to strip out
-	defaultPrefixLength = 53
 )
 
 var (
@@ -196,55 +189,4 @@ func checkLogFiles() {
 	checkFilesFn(infoLogFiles)
 	checkFilesFn(warningLogFiles)
 	checkFilesFn(errorLogFiles)
-}
-
-// Support code for klogv2 while klogv1 is still used
-// in third_party and "k8s.io/component-base/logs"
-// TODO: remove when they are upgraded to klogv2.
-
-// klogWriter is used in SetOutputBySeverity call below to redirect
-// any calls to klogv1 to end up in klogv2
-type klogWriter struct{}
-
-func (kw klogWriter) Write(p []byte) (n int, err error) {
-	if len(p) < defaultPrefixLength {
-		klog.InfoDepth(outputCallDepth, string(p))
-		return len(p), nil
-	}
-	if p[0] == 'I' {
-		klog.InfoDepth(outputCallDepth, string(p[defaultPrefixLength:]))
-	} else if p[0] == 'W' {
-		klog.WarningDepth(outputCallDepth, string(p[defaultPrefixLength:]))
-	} else if p[0] == 'E' {
-		klog.ErrorDepth(outputCallDepth, string(p[defaultPrefixLength:]))
-	} else if p[0] == 'F' {
-		klog.FatalDepth(outputCallDepth, string(p[defaultPrefixLength:]))
-	} else {
-		klog.InfoDepth(outputCallDepth, string(p[defaultPrefixLength:]))
-	}
-	return len(p), nil
-}
-
-// Klogv2Flags The flag file for klog.
-var Klogv2Flags flag.FlagSet
-
-// InitKlog sets up the klog.
-// Redirects klogv1 to klogv2.
-// TODO: remove once components use klogv2 by default.
-func InitKlog() {
-	klog.InitFlags(&Klogv2Flags)
-	addKlogv2Flags()
-	var klogv1Flags flag.FlagSet
-	klogv1.InitFlags(&klogv1Flags)
-	klogv1Flags.Set("logtostderr", "false")
-	klogv1Flags.Set("stderrthreshold", "FATAL")
-	klogv1.SetOutputBySeverity("INFO", klogWriter{})
-}
-
-// addKlogv2Flags adds flags used by controller and agent.
-// Used to allow for parsing of flags.
-// TODO: remove once all components use klogv2.
-func addKlogv2Flags() {
-	Klogv2Flags.String("config", "", "Unused.")
-	Klogv2Flags.Uint(maxNumFlag, 0, "Unused.")
 }

--- a/pkg/log/log_file_test.go
+++ b/pkg/log/log_file_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/component-base/logs"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 )
 
 const oneMB = 1 * 1024 * 1024
@@ -82,8 +82,6 @@ func TestKlogFileLimits(t *testing.T) {
 	testMaxNum := 2
 	args := []string{"--logtostderr=false", "--log_dir=" + testLogDir, "--log_file_max_size=1",
 		fmt.Sprintf("--log_file_max_num=%d", testMaxNum)}
-	InitKlog()
-	Klogv2Flags.Parse(args)
 	testFlags.Parse(args)
 	InitLogFileLimits(testFlags)
 	logs.InitLogs()

--- a/pkg/monitor/agent.go
+++ b/pkg/monitor/agent.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	agentquerier "github.com/vmware-tanzu/antrea/pkg/agent/querier"
 	"github.com/vmware-tanzu/antrea/pkg/apis/clusterinformation/v1beta1"

--- a/pkg/monitor/controller.go
+++ b/pkg/monitor/controller.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/apis/clusterinformation/v1beta1"
 	clientset "github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned"

--- a/pkg/ovs/openflow/ofctrl_bridge.go
+++ b/pkg/ovs/openflow/ofctrl_bridge.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/contiv/libOpenflow/openflow13"
 	"github.com/contiv/ofnet/ofctrl"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/metrics"
 )

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -23,7 +23,7 @@ import (
 	"github.com/TomCodeLV/OVSDB-golang-lib/pkg/dbtransaction"
 	"github.com/TomCodeLV/OVSDB-golang-lib/pkg/helpers"
 	"github.com/TomCodeLV/OVSDB-golang-lib/pkg/ovsdb"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 )
 
 const defaultOVSDBFile = "db.sock"

--- a/pkg/signals/signals.go
+++ b/pkg/signals/signals.go
@@ -19,7 +19,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 )
 
 var (

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -18,7 +18,7 @@ import (
 	"os"
 	"strconv"
 
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 )
 
 // nodeNameEnvKey is environment variable.

--- a/plugins/octant/go.sum
+++ b/plugins/octant/go.sum
@@ -699,6 +699,7 @@ k8s.io/kube-openapi v0.0.0-20200403204345-e1beb1bd0f35/go.mod h1:NwPpO8COeh/j9Q9
 k8s.io/metrics v0.19.0-alpha.3 h1:yaNKYWeDbSsbqrahEoTC3uToQ1vQrsTTRCU5yN+8zzw=
 k8s.io/metrics v0.19.0-alpha.3/go.mod h1:Hz5d4337SWr2LZAlD63I6Paz+zMclbjAxPS0cb4HFts=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
+k8s.io/utils v0.0.0-20200410111917-5770800c2500/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200414100711-2df71ebbae66 h1:Ly1Oxdu5p5ZFmiVT71LFgeZETvMfZ1iBIGeOenT2JeM=
 k8s.io/utils v0.0.0-20200414100711-2df71ebbae66/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=


### PR DESCRIPTION
This reverts commit 211852902046d004b05a74a177ec06285e8426e7.

The code to redirect klogv1 to klogv2 (the version of the K8s libraries
we use - 0.18.4 - still use klogv1) is incorrect, leading to truncated
log messages, or log messages with incorrect source file information.

Since the code to fix it is pretty complex (see
https://github.com/vmware-tanzu/antrea/pull/1082) and there is no
apparent benefit to using klogv2 in Antrea, we are just reverting the
commit which switched from klogv1 to klogv2. When we update to a more
recent version of the k8s Golang libraries, we will transition Antrea to
klogv2 as well.

Note that one dependency (k8s.io/utils) was already using klogv2. We
rolled back the version of that dependency by a couple commits in go.mod
to ensure that none of the software is using klogv2.

Fixes #1075