### PR TITLE
Add antrea-kind.yml manifest to release assets

### DIFF
--- a/.github/workflows/upload_release_assets.yml
+++ b/.github/workflows/upload_release_assets.yml
@@ -142,6 +142,15 @@ jobs:
         asset_path: ./assets/antrea-gke.yml
         asset_name: antrea-gke.yml
         asset_content_type: application/octet-stream
+    - name: Upload antrea-kind.yml
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./assets/antrea-kind.yml
+        asset_name: antrea-kind.yml
+        asset_content_type: application/octet-stream
     - name: Upload antrea-octant.yml
       uses: actions/upload-release-asset@v1
       env:

--- a/docs/kind.md
+++ b/docs/kind.md
@@ -5,20 +5,33 @@ hosts. On macOS, support for Kind requires the use of Docker Desktop, instead of
 the legacy [Docker
 Toolbox](https://docs.docker.com/docker-for-mac/docker-toolbox/).
 
+To deploy a released version of Antrea on an existing Kind cluster, you can use:
+
+```bash
+# "fix" the host's veth interfaces (for the different Kind Nodes)
+kind get nodes | xargs ./hack/kind-fix-networking.sh
+# deploy Antrea
+kubectl apply -f https://github.com/vmware-tanzu/antrea/releases/download/<TAG>/antrea-kind.yml
+```
+
 ## Create a Kind cluster and deploy Antrea in a few seconds
 
 ### Quick two Node Kind cluster setup
 
 To create a two worker Node cluster with Antrea installed using scripts, do
-```
+
+```bash
 ./ci/kind/kind-setup.sh create CLUSTER_NAME
 ```
+
 kind-setup.sh allows users to specify the number of worker Nodes, the docker
 bridge networks/subnets connected to worker Nodes, and some docker images to be
 pre-loaded in each Node. For more information on usage, run:
- ```
+
+ ```bash
 ./ci/kind/kind-setup.sh help
 ```
+
 Above is the short cut to a Kind setup with Antrea. Read further in order to
 setup a Kind cluster manually.
 
@@ -27,6 +40,7 @@ setup a Kind cluster manually.
 The only requirement is to use a Kind configuration file which disables the
 Kubernetes default CNI (`kubenet`). For example, your configuration file may
 look like this:
+
 ```yaml
 kind: Cluster
 apiVersion: kind.sigs.k8s.io/v1alpha3
@@ -41,6 +55,7 @@ nodes:
 
 Once you have created your configuration file (let's call it `kind-config.yml`),
 create your cluster with:
+
 ```bash
 kind create cluster --config kind-config.yml
 ```
@@ -63,6 +78,7 @@ kind load docker-image antrea/antrea-ubuntu:latest
 
 After a few seconds you should be able to observe the following when running
 `kubectl get -n kube-system pods -l app=antrea`:
+
 ```bash
 NAME                                 READY   STATUS    RESTARTS   AGE
 antrea-agent-dgsfs                   2/2     Running   0          8m56s

--- a/hack/release/prepare-assets.sh
+++ b/hack/release/prepare-assets.sh
@@ -70,6 +70,7 @@ export IMG_NAME=antrea/antrea-ubuntu
 ./hack/generate-manifest.sh --mode release --cloud EKS --encap-mode networkPolicyOnly > "$OUTPUT_DIR"/antrea-eks.yml
 ./hack/generate-manifest.sh --mode release --cloud GKE --encap-mode noEncap > "$OUTPUT_DIR"/antrea-gke.yml
 ./hack/generate-manifest.sh --mode release --cloud AKS --encap-mode networkPolicyOnly > "$OUTPUT_DIR"/antrea-aks.yml
+./hack/generate-manifest.sh --mode release --kind > "$OUTPUT_DIR"/antrea-kind.yml
 
 export IMG_NAME=antrea/octant-antrea-ubuntu
 ./hack/generate-manifest-octant.sh --mode release > "$OUTPUT_DIR"/antrea-octant.yml


### PR DESCRIPTION
This may help avoid issues where users try to use the default YAML
manifest on Kind clusters. Documentation is updated accordingly.

Fixes #1103

antrea-kind.yml was manually added to v0.9.0 assets