### PR TITLE
Optimizing PriorityAssigner for batch priority registrations

### DIFF
--- a/pkg/agent/controller/networkpolicy/priority_test.go
+++ b/pkg/agent/controller/networkpolicy/priority_test.go
@@ -153,10 +153,10 @@ func TestGetInsertionPoint(t *testing.T) {
 		{
 			"upper-bound",
 			[]types.Priority{p1120, p1121, p1130},
-			[]uint16{PriorityTopCNP, PriorityTopCNP - 1, PriorityTopCNP - 2},
+			[]uint16{PolicyTopPriority, PolicyTopPriority - 1, PolicyTopPriority - 2},
 			p110,
-			PriorityTopCNP - 2,
-			PriorityTopCNP + 1,
+			PolicyTopPriority - 2,
+			PolicyTopPriority + 1,
 			false,
 		},
 	}
@@ -189,35 +189,35 @@ func TestReassignPriorities(t *testing.T) {
 		{
 			"sift-down-at-upper-bound",
 			[]types.Priority{p191, p193},
-			[]uint16{PriorityTopCNP, PriorityTopCNP - 1},
+			[]uint16{PolicyTopPriority, PolicyTopPriority - 1},
 			[]types.Priority{p190, p192},
-			[]uint16{PriorityTopCNP + 1, PriorityTopCNP - 1},
-			[]uint16{PriorityTopCNP, PriorityTopCNP - 2},
+			[]uint16{PolicyTopPriority + 1, PolicyTopPriority - 1},
+			[]uint16{PolicyTopPriority, PolicyTopPriority - 2},
 			[]map[uint16]uint16{
 				{
-					PriorityTopCNP:     PriorityTopCNP - 1,
-					PriorityTopCNP - 1: PriorityTopCNP - 2,
+					PolicyTopPriority:     PolicyTopPriority - 1,
+					PolicyTopPriority - 1: PolicyTopPriority - 2,
 				},
 				{
-					PriorityTopCNP - 2: PriorityTopCNP - 3,
+					PolicyTopPriority - 2: PolicyTopPriority - 3,
 				},
 			},
 		},
 		{
 			"sift-up-at-lower-bound",
 			[]types.Priority{p1130, p1120},
-			[]uint16{PriorityBottomCNP, PriorityBottomCNP + 1},
+			[]uint16{PolicyBottomPriority, PolicyBottomPriority + 1},
 			[]types.Priority{p1121, p1131},
-			[]uint16{PriorityBottomCNP + 1, PriorityBottomCNP},
-			[]uint16{PriorityBottomCNP + 1, PriorityBottomCNP},
+			[]uint16{PolicyBottomPriority + 1, PolicyBottomPriority},
+			[]uint16{PolicyBottomPriority + 1, PolicyBottomPriority},
 			[]map[uint16]uint16{
 				{
-					PriorityBottomCNP + 1: PriorityBottomCNP + 2,
+					PolicyBottomPriority + 1: PolicyBottomPriority + 2,
 				},
 				{
-					PriorityBottomCNP:     PriorityBottomCNP + 1,
-					PriorityBottomCNP + 1: PriorityBottomCNP + 2,
-					PriorityBottomCNP + 2: PriorityBottomCNP + 3,
+					PolicyBottomPriority:     PolicyBottomPriority + 1,
+					PolicyBottomPriority + 1: PolicyBottomPriority + 2,
+					PolicyBottomPriority + 2: PolicyBottomPriority + 3,
 				},
 			},
 		},
@@ -348,11 +348,11 @@ func generatePriorities(start, end int32) []types.Priority {
 
 func TestRegisterAllOFPriorities(t *testing.T) {
 	pa := newPriorityAssigner(InitialOFPrioritySingleTierPerTable)
-	maxPriorities := generatePriorities(int32(PriorityBottomCNP), int32(PriorityTopCNP))
+	maxPriorities := generatePriorities(int32(PolicyBottomPriority), int32(PolicyTopPriority))
 	err := pa.RegisterPriorities(maxPriorities)
 	assert.Equalf(t, nil, err, "Error occurred in registering max number of allowed priorities")
 
-	extraPriority := types.Priority{TierPriority: 1, PolicyPriority: 5, RulePriority: int32(PriorityTopCNP) - int32(PriorityBottomCNP) + 1}
+	extraPriority := types.Priority{TierPriority: 1, PolicyPriority: 5, RulePriority: int32(PolicyTopPriority) - int32(PolicyBottomPriority) + 1}
 	_, _, _, err = pa.GetOFPriority(extraPriority)
 	assert.Errorf(t, err, "Error should be raised after max number of priorities are registered")
 }

--- a/pkg/agent/types/networkpolicy.go
+++ b/pkg/agent/types/networkpolicy.go
@@ -77,6 +77,18 @@ func (p *Priority) Less(p2 Priority) bool {
 	return p.TierPriority > p2.TierPriority
 }
 
+func (p *Priority) Equals(p2 Priority) bool {
+	return p.TierPriority == p2.TierPriority && p.PolicyPriority == p2.PolicyPriority && p.RulePriority == p2.RulePriority
+}
+
+// ByPriority sorts a list of Priority by their relative TierPriority, PolicyPriority and RulePriority, in that order.
+// It implements sort.Interface.
+type ByPriority []Priority
+
+func (bp ByPriority) Len() int           { return len(bp) }
+func (bp ByPriority) Swap(i, j int)      { bp[i], bp[j] = bp[j], bp[i] }
+func (bp ByPriority) Less(i, j int) bool { return bp[i].Less(bp[j]) }
+
 type RuleMetric struct {
 	Bytes, Packets, Sessions uint64
 }


### PR DESCRIPTION
This PR aims to fix #1093 
In cases of batch priority registration, two known states can be taken advantage of:
 1) The ofPriority <-> Priority mapping is empty at the time batch registration is called, since it is only used in agent restart case.
2) All the Priorities that needs to be registered are readily available, unlike in the async reconcile case after agent starts, where each Priority registration is independent.

To utilize those two properties, the RegisterPriorities function is refactored in the following way: it first sorts and dedups the Priorities that needs to be registered. Then, starting from the highest Priority, it gets the insertionPoint of that Priority and evaluates if there are enough OpenFlow priorities left (from lowest ofPriority allowed on the table to insertionPoint) to be assigned to the remaining Priorities. If so, it assigns insertionPoint to that Priority and leaves the same question to the next Priority in line. Else, it starts allocating all consecutive ofPriority from the bottom-up to all the remaining Priorities.

With this optimization, the runtime of the added testcase (which is to test registering all the available ofPriorities in the table and requires quite some priority reassignments if registered asynchronously) improved from 49s 630ms to 80ms.  