### PR TITLE
[CI] Add IPv6 branch to white list target

### DIFF
--- a/ci/jenkins/jobs/job-templates.yaml
+++ b/ci/jenkins/jobs/job-templates.yaml
@@ -36,7 +36,7 @@
         org-list: '{org_list}'
         permit-all: '{trigger_permit_all}'
         trigger-phrase: '{trigger_phrase}'
-        white-list-target-branches: []
+        white-list-target-branches: '{white_list_target_branches}'
         white-list: '{white_list}'
         status-context: '{status_context}'
         status-url: '{status_url}'

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -55,6 +55,7 @@
             - builder-list-tests:
                 org_repo: '{org_repo}'
           trigger_phrase: null
+          white_list_target_branches: []
           allow_whitelist_orgs_as_admins: false
           admin_list: []
           org_list: []
@@ -109,6 +110,8 @@
           builders:
           - builder-integration
           trigger_phrase: null
+          white_list_target_branches:
+          - ipv6
           allow_whitelist_orgs_as_admins: false
           admin_list: []
           org_list: []
@@ -148,6 +151,7 @@
           builders:
             - builder-pending-label
           trigger_phrase: null
+          white_list_target_branches: []
           allow_whitelist_orgs_as_admins: false
           admin_list: []
           org_list: []
@@ -175,6 +179,7 @@
             - builder-e2e
             - builder-workload-cluster-cleanup
           trigger_phrase: ^(?!Thanks for your PR).*/test-(e2e|all).*
+          white_list_target_branches: []
           allow_whitelist_orgs_as_admins: true
           admin_list: '{antrea_admin_list}'
           org_list: '{antrea_org_list}'
@@ -215,6 +220,7 @@
           only_trigger_phrase: true
           trigger_permit_all: false
           trigger_phrase: ^(?!Thanks for your PR).*/skip-(e2e|all).*
+          white_list_target_branches: []
           status_context: jenkins-e2e
           status_url: --none--
           success_status: Skipped test. Mark as succeeded.
@@ -233,6 +239,7 @@
           builders:
             - builder-pending-label
           trigger_phrase: null
+          white_list_target_branches: []
           allow_whitelist_orgs_as_admins: false
           admin_list: []
           org_list: []
@@ -263,6 +270,7 @@
                 skip_regex: '\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]'
             - builder-workload-cluster-cleanup
           trigger_phrase: ^(?!Thanks for your PR).*/test-(conformance|all).*
+          white_list_target_branches: []
           allow_whitelist_orgs_as_admins: true
           admin_list: '{antrea_admin_list}'
           org_list: '{antrea_org_list}'
@@ -303,6 +311,7 @@
           only_trigger_phrase: true
           trigger_permit_all: false
           trigger_phrase: ^(?!Thanks for your PR).*/skip-(conformance|all).*
+          white_list_target_branches: []
           status_context: jenkins-conformance
           status_url: --none--
           success_status: Skipped test. Mark as succeeded.
@@ -327,6 +336,7 @@
                 skip_regex: ''
             - builder-workload-cluster-cleanup
           trigger_phrase: .*/test-(whole-conformance).*
+          white_list_target_branches: []
           allow_whitelist_orgs_as_admins: true
           admin_list: '{antrea_admin_list}'
           org_list: '{antrea_org_list}'
@@ -367,6 +377,7 @@
           only_trigger_phrase: true
           trigger_permit_all: false
           trigger_phrase: .*/skip-(whole-conformance).*
+          white_list_target_branches: []
           status_context: jenkins-whole-conformance
           status_url: --none--
           success_status: Skipped test. Mark as succeeded.
@@ -385,6 +396,7 @@
           builders:
             - builder-pending-label
           trigger_phrase: null
+          white_list_target_branches: []
           allow_whitelist_orgs_as_admins: false
           admin_list: []
           org_list: []
@@ -415,6 +427,7 @@
                 skip_regex: 'SKIP_NO_TESTCASE'
             - builder-workload-cluster-cleanup
           trigger_phrase: ^(?!Thanks for your PR).*/test-(networkpolicy|all).*
+          white_list_target_branches: []
           allow_whitelist_orgs_as_admins: true
           admin_list: '{antrea_admin_list}'
           org_list: '{antrea_org_list}'
@@ -455,6 +468,7 @@
           only_trigger_phrase: true
           trigger_permit_all: false
           trigger_phrase: ^(?!Thanks for your PR).*/skip-(networkpolicy|all).*
+          white_list_target_branches: []
           status_context: jenkins-networkpolicy
           status_url: --none--
           success_status: Skipped test. Mark as succeeded.


### PR DESCRIPTION
The change in SCM is not enough. GHPRB needs to set ipv6 branch as white list target as well. Add white_list_target_branches field in jobs to let jenkins-integration runs in ipv6 branch only.