### PR TITLE
[IPv6] Add support for IPv6 address in antctl and agent's apiserver

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -90,7 +90,7 @@ func TestInitstore(t *testing.T) {
 	container1, found1 := store.GetContainerInterface(uuid1)
 	if !found1 {
 		t.Errorf("Failed to load OVS port into local store")
-	} else if container1.OFPort != 11 || container1.GetIPv4Addr() == nil || container1.GetIPv4Addr().String() != p1IP || container1.MAC.String() != p1MAC || container1.InterfaceName != "p1" {
+	} else if container1.OFPort != 11 || len(container1.IPs) == 0 || container1.IPs[0].String() != p1IP || container1.MAC.String() != p1MAC || container1.InterfaceName != "p1" {
 		t.Errorf("Failed to load OVS port configuration into local store")
 	}
 	_, found2 := store.GetContainerInterface(uuid2)

--- a/pkg/agent/apiserver/handlers/podinterface/handler.go
+++ b/pkg/agent/apiserver/handlers/podinterface/handler.go
@@ -16,7 +16,9 @@ package podinterface
 
 import (
 	"encoding/json"
+	"net"
 	"net/http"
+	"strings"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
 	"github.com/vmware-tanzu/antrea/pkg/agent/querier"
@@ -40,12 +42,20 @@ func generateResponse(i *interfacestore.InterfaceConfig) Response {
 		PodName:       i.ContainerInterfaceConfig.PodName,
 		PodNamespace:  i.ContainerInterfaceConfig.PodNamespace,
 		InterfaceName: i.InterfaceName,
-		IP:            i.GetIPv4Addr().String(),
+		IP:            getPodIPsStr(i.IPs),
 		MAC:           i.MAC.String(),
 		PortUUID:      i.OVSPortConfig.PortUUID,
 		OFPort:        i.OVSPortConfig.OFPort,
 		ContainerID:   i.ContainerInterfaceConfig.ContainerID,
 	}
+}
+
+func getPodIPsStr(ips []net.IP) string {
+	ipStrs := make([]string, len(ips))
+	for i := range ips {
+		ipStrs[i] = ips[i].String()
+	}
+	return strings.Join(ipStrs, ", ")
 }
 
 // HandleFunc returns the function which can handle queries issued by the pod-interface command,

--- a/pkg/agent/querier/querier.go
+++ b/pkg/agent/querier/querier.go
@@ -196,6 +196,9 @@ func (aq agentQuerier) GetAgentInfo(agentInfo *v1beta1.AntreaAgentInfo, partial 
 		if aq.nodeConfig.PodIPv4CIDR != nil {
 			agentInfo.NodeSubnet = append(agentInfo.NodeSubnet, aq.nodeConfig.PodIPv4CIDR.String())
 		}
+		if aq.nodeConfig.PodIPv6CIDR != nil {
+			agentInfo.NodeSubnet = append(agentInfo.NodeSubnet, aq.nodeConfig.PodIPv6CIDR.String())
+		}
 		agentInfo.OVSInfo.BridgeName = aq.nodeConfig.OVSBridge
 		agentInfo.APIPort = aq.apiPort
 	}

--- a/pkg/agent/querier/querier_test.go
+++ b/pkg/agent/querier/querier_test.go
@@ -124,13 +124,14 @@ func TestAgentQuerierGetAgentInfo(t *testing.T) {
 				OVSBridge:   "br-int",
 				NodeIPAddr:  getIPNet("10.10.0.10"),
 				PodIPv4CIDR: getIPNet("20.20.20.0/24"),
+				PodIPv6CIDR: getIPNet("2001:ab03:cd04:55ef::/64"),
 			},
 			apiPort: 10350,
 			partial: false,
 			expectedAgentInfo: &v1beta1.AntreaAgentInfo{
 				ObjectMeta: v1.ObjectMeta{Name: "foo"},
 				NodeRef:    corev1.ObjectReference{Kind: "Node", Name: "foo"},
-				NodeSubnet: []string{"20.20.20.0/24"},
+				NodeSubnet: []string{"20.20.20.0/24", "2001:ab03:cd04:55ef::/64"},
 				OVSInfo: v1beta1.OVSInfo{
 					Version:    ovsVersion,
 					BridgeName: "br-int",

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -148,13 +148,13 @@ func GetIPWithFamily(ips []net.IP, addrFamily uint8) (net.IP, error) {
 				return ip, nil
 			}
 		}
-		return nil, errors.New("no IP found with the specified AddressFamily")
+		return nil, errors.New("no IP found with IPv6 AddressFamily")
 	} else {
 		for _, ip := range ips {
 			if ip.To4() != nil {
 				return ip, nil
 			}
 		}
-		return nil, errors.New("no IP found with the specified AddressFamily")
+		return nil, errors.New("no IP found with IPv4 AddressFamily")
 	}
 }

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -17,6 +17,7 @@ package util
 import (
 	"crypto/sha1" // #nosec G505: not used for security purposes
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -26,6 +27,9 @@ const (
 	interfaceNameLength   = 15
 	interfacePrefixLength = 8
 	interfaceKeyLength    = interfaceNameLength - (interfacePrefixLength + 1)
+
+	FamilyIPv4 uint8 = 4
+	FamilyIPv6 uint8 = 6
 )
 
 func generateInterfaceName(key string, name string, useHead bool) string {
@@ -135,4 +139,22 @@ func ContainIPv6Addr(ips []net.IP) bool {
 		}
 	}
 	return false
+}
+
+func GetIPWithFamily(ips []net.IP, addrFamily uint8) (net.IP, error) {
+	if addrFamily == FamilyIPv6 {
+		for _, ip := range ips {
+			if ip.To4() == nil {
+				return ip, nil
+			}
+		}
+		return nil, errors.New("no IP found with the specified AddressFamily")
+	} else {
+		for _, ip := range ips {
+			if ip.To4() != nil {
+				return ip, nil
+			}
+		}
+		return nil, errors.New("no IP found with the specified AddressFamily")
+	}
 }

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -299,18 +299,23 @@ var CommandList = &commandList{
 						},
 						{
 							name:      "source",
-							usage:     "Source of the packet. Can be an OVS port name, or a (local or remote) Pod (specified by <Namespace>/<name>), or an IP address. If specified, the source's IP addresss will be used as the tracing packet's source IP address, and the 'nw_src' field should not be added in the 'flow' argument.",
+							usage:     "Source of the packet. Can be an OVS port name, or a (local or remote) Pod (specified by <Namespace>/<name>), or an IP address. If specified, the source's IP address will be used as the tracing packet's source IP address, and the 'nw_src'/'ipv6_src' field should not be added in the 'flow' argument.",
 							shorthand: "S",
 						},
 						{
 							name:      "destination",
-							usage:     "Destination of the packet. Can be an OVS port name, or a (local or remote) Pod or a Service (specified by <Namespace>/<name>), or an IP address. If specified, the destination's IP address (the ClusterIP for a Service) will be used as the tacing packet's destination IP address, and the 'nw_dst' field should not be added in the 'flow' argument.",
+							usage:     "Destination of the packet. Can be an OVS port name, or a (local or remote) Pod or a Service (specified by <Namespace>/<name>), or an IP address. If specified, the destination's IP address (the ClusterIP for a Service) will be used as the tacing packet's destination IP address, and the 'nw_dst'/'ipv6_dst' field should not be added in the 'flow' argument.",
 							shorthand: "D",
 						},
 						{
 							name:      "flow",
 							usage:     "Specify the flow (packet headers) of the tracing packet. Check the flow syntax descriptions in ovs-ofctl(8) manpage.",
 							shorthand: "f",
+						},
+						{
+							name:      "addressFamily",
+							usage:     "Specify the address family fo the packet. Can be 4 (IPv4) or 6 (IPv6). If not specified, the addressFamily will be automatically figured out based on the 'flow'. If no IP address or address family is given in the 'flow', IPv4 is used by default.",
+							shorthand: "F",
 						},
 					},
 					outputType: single,


### PR DESCRIPTION
1. Support using IPv6 address in OVS tracing.
2. Support displaying Node's and Pod's IPv6 address in agent apiserver.