### PR TITLE
antctl traceflow improvement and bug fix

### DIFF
--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -325,8 +325,8 @@ The required options for this command
 are `source` and `destination`, which consist of namespace and pod, service or IP. The command supports
 yaml and json output. If users want a non blocking operation, an option: `--wait=false` can
 be added to start the traceflow without waiting for result. Then, the deletion operation
-will not be conducted. Besides, users can specify header protocol (ICMP, TCP and UDP) and
-source/destination ports.
+will not be conducted. Besides, users can specify header protocol (ICMP, TCP and UDP),
+source/destination ports and TCP flags.
 
 e.g.
 ```bash

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -303,7 +303,7 @@ var CommandList = &commandList{
 						},
 						{
 							name:      "destination",
-							usage:     "Destination of the packet. Can be an OVS port name, or a (local or remote) Pod or a Service (specified by <Namespace>/<name>), or an IP address. If specified, the destination's IP address (the ClusterIP for a Service) will be used as the tacing packet's destination IP address, and the 'nw_dst' field should not be added in the 'flow' argument.",
+							usage:     "Destination of the packet. Can be an OVS port name, or a (local or remote) Pod or a Service (specified by <Namespace>/<name>). If there are both a Pod and a Service matching the destination name in a Namespace, the Pod will be set as the destination. It can also be an IP address. If specified, the destination's IP address (the ClusterIP for a Service) will be used as the tacing packet's destination IP address, and the 'nw_dst' field should not be added in the 'flow' argument.",
 							shorthand: "D",
 						},
 						{

--- a/pkg/antctl/raw/traceflow/command.go
+++ b/pkg/antctl/raw/traceflow/command.go
@@ -75,7 +75,7 @@ func init() {
   Start a Traceflow from busybox0 to destination IP, source is in Namespace default
   $antctl traceflow -S busybox0 -D 123.123.123.123
   Start a Traceflow from busybox0 to destination Service, source and destination are in Namespace default
-  $antctl traceflow -S busybox0 -D svc0
+  $antctl traceflow -S busybox0 -D svc0 -f tcp,tcp_dst=80,tcp_flags=2
   Start a Traceflow from busybox0 in Namespace ns0 to busybox1 in Namespace ns1, output type is json
   $antctl traceflow -S ns0/busybox0 -D ns1/busybox1 -o json
   Start a Traceflow from busybox0 to busybox1, with TCP header and 80 as destination port
@@ -88,7 +88,7 @@ func init() {
 	Command.Flags().StringVarP(&option.destination, "destination", "D", "", "destination of the Traceflow: Namespace/Pod, Pod, Namespace/Service, Service or IP")
 	Command.Flags().StringVarP(&option.outputType, "output", "o", "yaml", "output type: yaml (default), json")
 	Command.Flags().BoolVarP(&option.waiting, "wait", "", true, "if false, command returns without retrieving results")
-	Command.Flags().StringVarP(&option.flow, "flow", "f", "", "specify the flow (packet headers) of the Traceflow packet")
+	Command.Flags().StringVarP(&option.flow, "flow", "f", "", "specify the flow (packet headers) of the Traceflow packet, including tcp_src, tcp_dst, tcp_flags, udp_src, udp_dst")
 }
 
 func runE(cmd *cobra.Command, _ []string) error {
@@ -256,6 +256,12 @@ func parseFlow() (*v1alpha1.Packet, error) {
 			pkt.TransportHeader.TCP = new(v1alpha1.TCPHeader)
 		}
 		pkt.TransportHeader.TCP.DstPort = int32(r)
+	}
+	if r, ok := fields["tcp_flags"]; ok {
+		if pkt.TransportHeader.TCP == nil {
+			pkt.TransportHeader.TCP = new(v1alpha1.TCPHeader)
+		}
+		pkt.TransportHeader.TCP.Flags = int32(r)
 	}
 	if r, ok := fields["udp_src"]; ok {
 		pkt.TransportHeader.UDP = new(v1alpha1.UDPHeader)

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -127,6 +127,7 @@ func TestTraceflow(t *testing.T) {
 						TransportHeader: v1alpha1.TransportHeader{
 							TCP: &v1alpha1.TCPHeader{
 								DstPort: 80,
+								Flags:   2,
 							},
 						},
 					},
@@ -177,6 +178,7 @@ func TestTraceflow(t *testing.T) {
 						TransportHeader: v1alpha1.TransportHeader{
 							TCP: &v1alpha1.TCPHeader{
 								DstPort: 80,
+								Flags:   2,
 							},
 						},
 					},
@@ -425,26 +427,26 @@ func TestTraceflow(t *testing.T) {
 					return
 				}
 				if len(tc.expectedResults) == 1 {
-					if err = compareObservations(tc.expectedResults[0], tf.Status.Results[0], t); err != nil {
+					if err = compareObservations(tc.expectedResults[0], tf.Status.Results[0]); err != nil {
 						t.Fatal(err)
 						return
 					}
 				} else {
 					if tf.Status.Results[0].Observations[0].Component == v1alpha1.SpoofGuard {
-						if err = compareObservations(tc.expectedResults[0], tf.Status.Results[0], t); err != nil {
+						if err = compareObservations(tc.expectedResults[0], tf.Status.Results[0]); err != nil {
 							t.Fatal(err)
 							return
 						}
-						if err = compareObservations(tc.expectedResults[1], tf.Status.Results[1], t); err != nil {
+						if err = compareObservations(tc.expectedResults[1], tf.Status.Results[1]); err != nil {
 							t.Fatal(err)
 							return
 						}
 					} else {
-						if err = compareObservations(tc.expectedResults[0], tf.Status.Results[1], t); err != nil {
+						if err = compareObservations(tc.expectedResults[0], tf.Status.Results[1]); err != nil {
 							t.Fatal(err)
 							return
 						}
-						if err = compareObservations(tc.expectedResults[1], tf.Status.Results[0], t); err != nil {
+						if err = compareObservations(tc.expectedResults[1], tf.Status.Results[0]); err != nil {
 							t.Fatal(err)
 							return
 						}
@@ -503,7 +505,7 @@ func (data *TestData) enableTraceflow(t *testing.T) error {
 }
 
 // compareObservations compares expected results and actual results.
-func compareObservations(expected v1alpha1.NodeResult, actual v1alpha1.NodeResult, t *testing.T) error {
+func compareObservations(expected v1alpha1.NodeResult, actual v1alpha1.NodeResult) error {
 	if expected.Node != actual.Node {
 		return fmt.Errorf("NodeResult should be on %s, but is on %s", expected.Node, actual.Node)
 	}


### PR DESCRIPTION
* Add config for TCP flags in antctl traceflow
* Tell users that Pod will be set as destination when it shares the same name with a Service.

Fixes: #1126
Enhances: #1077