### PR TITLE
Upload antrea-aks.yml manifest automatically to release assets

### DIFF
--- a/.github/workflows/upload_release_assets.yml
+++ b/.github/workflows/upload_release_assets.yml
@@ -142,6 +142,15 @@ jobs:
         asset_path: ./assets/antrea-gke.yml
         asset_name: antrea-gke.yml
         asset_content_type: application/octet-stream
+    - name: Upload antrea-aks.yml
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./assets/antrea-aks.yml
+        asset_name: antrea-aks.yml
+        asset_content_type: application/octet-stream
     - name: Upload antrea-kind.yml
       uses: actions/upload-release-asset@v1
       env:


### PR DESCRIPTION
Manifest is generated by prepare-assets.sh but was not uploaded.