### PR TITLE
Enable verbose logging through generate-manifest.sh

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1141,6 +1141,7 @@ spec:
         - --alsologtostderr
         - --log_file_max_size=100
         - --log_file_max_num=4
+        - --v=0
         command:
         - antrea-controller
         env:
@@ -1267,6 +1268,7 @@ spec:
         - --alsologtostderr
         - --log_file_max_size=100
         - --log_file_max_num=4
+        - --v=0
         command:
         - antrea-agent
         env:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1141,6 +1141,7 @@ spec:
         - --alsologtostderr
         - --log_file_max_size=100
         - --log_file_max_num=4
+        - --v=0
         command:
         - antrea-controller
         env:
@@ -1267,6 +1268,7 @@ spec:
         - --alsologtostderr
         - --log_file_max_size=100
         - --log_file_max_num=4
+        - --v=0
         command:
         - antrea-agent
         env:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1141,6 +1141,7 @@ spec:
         - --alsologtostderr
         - --log_file_max_size=100
         - --log_file_max_num=4
+        - --v=0
         command:
         - antrea-controller
         env:
@@ -1267,6 +1268,7 @@ spec:
         - --alsologtostderr
         - --log_file_max_size=100
         - --log_file_max_num=4
+        - --v=0
         command:
         - antrea-agent
         env:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1155,6 +1155,7 @@ spec:
         - --alsologtostderr
         - --log_file_max_size=100
         - --log_file_max_num=4
+        - --v=0
         command:
         - antrea-controller
         env:
@@ -1281,6 +1282,7 @@ spec:
         - --alsologtostderr
         - --log_file_max_size=100
         - --log_file_max_num=4
+        - --v=0
         command:
         - antrea-agent
         env:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1146,6 +1146,7 @@ spec:
         - --alsologtostderr
         - --log_file_max_size=100
         - --log_file_max_num=4
+        - --v=0
         command:
         - antrea-controller
         env:
@@ -1272,6 +1273,7 @@ spec:
         - --alsologtostderr
         - --log_file_max_size=100
         - --log_file_max_num=4
+        - --v=0
         command:
         - antrea-agent
         env:

--- a/build/yamls/base/agent.yml
+++ b/build/yamls/base/agent.yml
@@ -69,7 +69,7 @@ spec:
               cpu: "200m"
           command: ["antrea-agent"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).
-          args: ["--config", "/etc/antrea/antrea-agent.conf", "--logtostderr=false", "--log_dir=/var/log/antrea", "--alsologtostderr", "--log_file_max_size=100", "--log_file_max_num=4"]
+          args: ["--config", "/etc/antrea/antrea-agent.conf", "--logtostderr=false", "--log_dir=/var/log/antrea", "--alsologtostderr", "--log_file_max_size=100", "--log_file_max_num=4", "--v=0"]
           env:
             # Provide pod and node information for clusterinformation CRD.
             - name: POD_NAME

--- a/build/yamls/base/controller.yml
+++ b/build/yamls/base/controller.yml
@@ -80,7 +80,7 @@ spec:
               cpu: "200m"
           command: ["antrea-controller"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).
-          args: ["--config", "/etc/antrea/antrea-controller.conf", "--logtostderr=false", "--log_dir=/var/log/antrea", "--alsologtostderr", "--log_file_max_size=100", "--log_file_max_num=4"]
+          args: ["--config", "/etc/antrea/antrea-controller.conf", "--logtostderr=false", "--log_dir=/var/log/antrea", "--alsologtostderr", "--log_file_max_size=100", "--log_file_max_num=4", "--v=0"]
           env:
             # Provide pod and node information for clusterinformation CRD.
             - name: POD_NAME

--- a/build/yamls/patches/dev/agentVerboseLog.yml
+++ b/build/yamls/patches/dev/agentVerboseLog.yml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: antrea-agent
+spec:
+  template:
+    spec:
+      containers:
+        - name: antrea-agent
+          args: ["--config", "/etc/antrea/antrea-agent.conf", "--logtostderr=false", "--log_dir=/var/log/antrea", "--alsologtostderr", "--log_file_max_size=100", "--log_file_max_num=4", "--v=4"]
+

--- a/build/yamls/patches/dev/controllerVerboseLog.yml
+++ b/build/yamls/patches/dev/controllerVerboseLog.yml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: antrea-controller
+spec:
+  template:
+    spec:
+      containers:
+        - name: antrea-controller
+          args: ["--config", "/etc/antrea/antrea-controller.conf", "--logtostderr=false", "--log_dir=/var/log/antrea", "--alsologtostderr", "--log_file_max_size=100", "--log_file_max_num=4", "--v=4"]
+

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -38,6 +38,14 @@ The Open vSwitch daemon logs for each `antrea-agent` Pod are also stored on the
 persistent storage of the corresponding node (i.e. the node on which the Pod is
 scheduled), under `/var/log/antrea/openvswitch`.
 
+To increase the log level for the `antrea-agent` and the `antrea-controller`, you
+can edit the `--v=0` arg in the Antrea manifest to a desired level.
+Alternatively, you can generate an Antrea manifest with increased log level of
+4 (maximum debug level) using `generate_manifest.sh`:
+```
+hack/generate-manifest.sh --mode dev --verbose-log
+```  
+
 ## Accessing the antrea-controller API
 
 antrea-controller runs as a Deployment, exposes its API via a Service and


### PR DESCRIPTION
This patch enables verbose logging for antrea-agent and
antrea-controller when generate manifest. This will help in
troubleshooting with increased log level.

I felt troubleshooting info for incrementing log-level for antrea-agent and antrea-controller is lacking right now. I thought providing an antrea manifest through generate-manifest.sh with increased log-level is one way to help troubleshooting for developers/users. There could be an efficient approach instead of using antrea-conf configMap. Please comment on what you think. 

If this approach looks ok, I will update the troubleshooting doc as part of this PR.