### PR TITLE
[IPv6] Handle Spec.PodCIDR with IPv6 CIDR

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -630,7 +630,11 @@ func (i *Initializer) initNodeLocalConfig() error {
 		klog.Errorf("Failed to parse subnet from CIDR string %s: %v", node.Spec.PodCIDR, err)
 		return err
 	}
-	i.nodeConfig.PodIPv4CIDR = localSubnet
+	if localSubnet.IP.To4() != nil {
+		i.nodeConfig.PodIPv4CIDR = localSubnet
+	} else {
+		i.nodeConfig.PodIPv6CIDR = localSubnet
+	}
 	return nil
 }
 


### PR DESCRIPTION
For IPv6 single stack case, node.Spec.PodCIDR is
configured with IPv6 CIDR. This patch handles the case
and sets nodeConfig.PodIPv6CIDR with parsed CIDR.