### PR TITLE
[CI][IPv6] Update integration branch

### DIFF
--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -123,7 +123,7 @@
           node: 'antrea-test-node'
           description: 'This is the {test_name} test for {name}.'
           branches:
-          - ipv6
+          - ${{sha1}}
           builders:
           - builder-integration
           trigger_phrase: null


### PR DESCRIPTION
ipv6 -> ${sha1}
Currently every build checks out the TOT code on vmware-tanzu/antrea ipv6 branch instead of the commit in the PR.