### PR TITLE
Fix uint-string conversions

### DIFF
--- a/pkg/agent/openflow/network_policy.go
+++ b/pkg/agent/openflow/network_policy.go
@@ -988,7 +988,7 @@ func (c *policyRuleConjunction) getAllFlowKeys() []string {
 }
 
 func (c *client) getPolicyRuleConjunction(ruleID uint32) *policyRuleConjunction {
-	conj, found, _ := c.policyCache.GetByKey(string(ruleID))
+	conj, found, _ := c.policyCache.GetByKey(fmt.Sprint(ruleID))
 	if !found {
 		return nil
 	}
@@ -1305,7 +1305,7 @@ func (c *client) ReassignFlowPriorities(updates map[uint16]uint16, table binding
 		return err
 	}
 	for conjID, actionUpdates := range conjFlowUpdates {
-		originalConj, _, _ := c.policyCache.GetByKey(string(conjID))
+		originalConj, _, _ := c.policyCache.GetByKey(fmt.Sprint(conjID))
 		conj := originalConj.(*policyRuleConjunction)
 		updatedConj := c.updateConjunctionActionFlows(conj, actionUpdates)
 		c.updateConjunctionMatchFlows(updatedConj, actionUpdates.newPriority)

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -1315,7 +1315,7 @@ func (c *client) serviceEndpointGroup(groupID binding.GroupIDType, withSessionAf
 // policyConjKeyFuncKeyFunc knows how to get key of a *policyRuleConjunction.
 func policyConjKeyFunc(obj interface{}) (string, error) {
 	conj := obj.(*policyRuleConjunction)
-	return string(conj.id), nil
+	return fmt.Sprint(conj.id), nil
 }
 
 // priorityIndexFunc knows how to get priority of actionFlows in a *policyRuleConjunction.


### PR DESCRIPTION
Conversion from uint32 to string yields a string of one rune, not a
string of digits.

Fix #1162.

Signed-off-by: Weiqiang Tang <weiqiangt@vmware.com>