### PR TITLE
Traceflow: check that AntreaProxy is enabled for ClusterIP destinations

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -150,7 +150,8 @@ func run(o *Options) error {
 			ovsBridgeClient,
 			ifaceStore,
 			networkConfig,
-			nodeConfig)
+			nodeConfig,
+			serviceCIDRNet)
 	}
 
 	// podUpdates is a channel for receiving Pod updates from CNIServer and


### PR DESCRIPTION
We already perform that check when a Service name is provided, but I
think we should do it as well for ClusterIP destinations. Otherwise, we
end up with an incorrect Traceflow result.

Logging this in the Agent is not ideal because you have to figure out
which logs to look at, but this is the only thing we can do right now.