### PR TITLE
Always use latest supported master version when setting up GKE cluster

### DIFF
--- a/ci/jenkins/README.md
+++ b/ci/jenkins/README.md
@@ -58,7 +58,7 @@ should be deleted. This ensures that all tests are run on a clean testbed.
     
   |  K8s Version   |     Node OS     | VPC Native Mode (on by default) |  Status  |
   | :------------: | :-------------: | :-----------------------------: |:-------: |
-  | 1.16.11-gke.5  |     Ubuntu      |  On                             |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-gke-conformance-net-policy)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-gke-conformance-net-policy/)|
+  | 1.16.13-gke.1  |     Ubuntu      |  On                             |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-gke-conformance-net-policy)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-gke-conformance-net-policy/)|
   
 * [AKS conformance/network policy [bi-daily]](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-aks-conformance-net-policy/)
   community tests on AKS cluster using sonobuoy, focusing on "Conformance" and "Feature:NetworkPolicy", skipping the same regexes as in job __conformance__ above.\

--- a/ci/test-conformance-gke.sh
+++ b/ci/test-conformance-gke.sh
@@ -42,7 +42,7 @@ and create the project to be used for cluster with \`gcloud projects create\`.
 
         --cluster-name        The cluster name to be used for the generated GKE cluster. Must be specified if not run in Jenkins environment.
         --kubeconfig          Path to save kubeconfig of generated EKS cluster.
-        --k8s-version         GKE K8s cluster version. Defaults to 1.15.11-gke.11.
+        --k8s-version         GKE K8s cluster version. Defaults to the latest supported master version documented at https://cloud.google.com/kubernetes-engine/docs/release-notes.
         --svc-account         Service acount name if logged in with service account. Use --user instead if logged in with gcloud auth login.
         --user                Email address if logged in with user account. Use --svc-account instead if logged in with service account.
         --gke-project         The GKE project to be used. Needs to be pre-created before running the script.
@@ -140,7 +140,7 @@ fi
 function setup_gke() {
 
     if [[ -z ${K8S_VERSION+x} ]]; then
-        K8S_VERSION="1.15.12-gke.3"
+        K8S_VERSION=$(${GCLOUD_PATH} container get-server-config --zone ${GKE_ZONE} | awk '/validMasterVersions/{getline;print}' | cut -c3- )
     fi
 
     echo "=== This cluster to be created is named: ${CLUSTER} ==="


### PR DESCRIPTION
Supported cluster master versions tends to be updated periodically and originally supported versions might be invalidated. Jenkins jobs should query the latest version available before setting up the cluster.

Fixes #1169 