### PR TITLE
Enhance code coverage report

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -9,3 +9,10 @@ comment:
   require_base: no
   require_head: no
   after_n_builds: 1
+
+ignore:
+  - "**/testing/mock_*.go"
+  - "**/*generate*.go"
+  - "pkg/client"
+  - "**/*.pb.go"
+  - "third_party"


### PR DESCRIPTION
Exclude following files in the coverage report:

- `testing/mock_*.go`
- `*generate*.go`
- `**/*.pb.go`
- `pkg/client/**`
- `third_party/**/*`

Signed-off-by: Weiqiang Tang <weiqiangt@vmware.com>