### PR TITLE
Update cloud deployment yamls and documentation

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -911,10 +911,6 @@ data:
     # for the GRE tunnel type.
     #enableIPSecTunnel: false
 
-    # CIDR Range for services in cluster. It's required to support egress network policy, should
-    # be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
-    #serviceCIDR: 10.96.0.0/12
-
     # Determines how traffic is encapsulated. It has the following options
     # encap(default): Inter-node Pod traffic is always encapsulated and Pod to outbound traffic is masqueraded.
     # noEncap: Inter-node Pod traffic is not encapsulated, but Pod to outbound traffic is masqueraded.
@@ -995,7 +991,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-82k8dfgm25
+  name: antrea-config-g6mm797kch
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1101,7 +1097,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-82k8dfgm25
+          name: antrea-config-g6mm797kch
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1316,7 +1312,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-82k8dfgm25
+          name: antrea-config-g6mm797kch
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -911,10 +911,6 @@ data:
     # for the GRE tunnel type.
     #enableIPSecTunnel: false
 
-    # CIDR Range for services in cluster. It's required to support egress network policy, should
-    # be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
-    #serviceCIDR: 10.96.0.0/12
-
     # Determines how traffic is encapsulated. It has the following options
     # encap(default): Inter-node Pod traffic is always encapsulated and Pod to outbound traffic is masqueraded.
     # noEncap: Inter-node Pod traffic is not encapsulated, but Pod to outbound traffic is masqueraded.
@@ -995,7 +991,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-82k8dfgm25
+  name: antrea-config-g6mm797kch
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1101,7 +1097,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-82k8dfgm25
+          name: antrea-config-g6mm797kch
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1318,7 +1314,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-82k8dfgm25
+          name: antrea-config-g6mm797kch
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -911,10 +911,6 @@ data:
     # for the GRE tunnel type.
     #enableIPSecTunnel: false
 
-    # CIDR Range for services in cluster. It's required to support egress network policy, should
-    # be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
-    #serviceCIDR: 10.96.0.0/12
-
     # Determines how traffic is encapsulated. It has the following options
     # encap(default): Inter-node Pod traffic is always encapsulated and Pod to outbound traffic is masqueraded.
     # noEncap: Inter-node Pod traffic is not encapsulated, but Pod to outbound traffic is masqueraded.
@@ -995,7 +991,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-2h2c8fdk6c
+  name: antrea-config-f72hcg8m78
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1101,7 +1097,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-2h2c8fdk6c
+          name: antrea-config-f72hcg8m78
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1316,7 +1312,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-2h2c8fdk6c
+          name: antrea-config-f72hcg8m78
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -911,8 +911,9 @@ data:
     # for the GRE tunnel type.
     enableIPSecTunnel: true
 
-    # CIDR Range for services in cluster. It's required to support egress network policy, should
-    # be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
+    # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
+    # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
+    # AntreaProxy is enabled, this parameter is not needed and will be ignored if provided.
     #serviceCIDR: 10.96.0.0/12
 
     # Determines how traffic is encapsulated. It has the following options
@@ -995,7 +996,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-b8c78852mt
+  name: antrea-config-d429bkg4d6
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1110,7 +1111,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-b8c78852mt
+          name: antrea-config-d429bkg4d6
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1360,7 +1361,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-b8c78852mt
+          name: antrea-config-d429bkg4d6
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -42,8 +42,9 @@ data:
     # also adjust MTU to accommodate for tunnel encapsulation overhead.
     #defaultMTU: 1450
 
-    # CIDR Range for services in cluster. It's required to support egress network policy, should
-    # be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
+    # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
+    # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
+    # AntreaProxy is enabled, this parameter is not needed and will be ignored if provided.
     #serviceCIDR: 10.96.0.0/12
 
     # The port for the antrea-agent APIServer to serve on.
@@ -69,7 +70,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-windows-config-k24chf74ct
+  name: antrea-windows-config-ht7fb8gdk8
   namespace: kube-system
 ---
 apiVersion: apps/v1
@@ -157,7 +158,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-windows-config-k24chf74ct
+          name: antrea-windows-config-ht7fb8gdk8
         name: antrea-windows-config
       - configMap:
           defaultMode: 420

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -911,8 +911,9 @@ data:
     # for the GRE tunnel type.
     #enableIPSecTunnel: false
 
-    # CIDR Range for services in cluster. It's required to support egress network policy, should
-    # be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
+    # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
+    # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
+    # AntreaProxy is enabled, this parameter is not needed and will be ignored if provided.
     #serviceCIDR: 10.96.0.0/12
 
     # Determines how traffic is encapsulated. It has the following options
@@ -995,7 +996,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-5g6h28c5m5
+  name: antrea-config-64fmb8kc28
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1101,7 +1102,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-5g6h28c5m5
+          name: antrea-config-64fmb8kc28
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1316,7 +1317,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-5g6h28c5m5
+          name: antrea-config-64fmb8kc28
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -47,8 +47,9 @@ featureGates:
 # for the GRE tunnel type.
 #enableIPSecTunnel: false
 
-# CIDR Range for services in cluster. It's required to support egress network policy, should
-# be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
+# ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
+# set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
+# AntreaProxy is enabled, this parameter is not needed and will be ignored if provided.
 #serviceCIDR: 10.96.0.0/12
 
 # Determines how traffic is encapsulated. It has the following options

--- a/build/yamls/windows/base/conf/antrea-agent.conf
+++ b/build/yamls/windows/base/conf/antrea-agent.conf
@@ -24,8 +24,9 @@ featureGates:
 # also adjust MTU to accommodate for tunnel encapsulation overhead.
 #defaultMTU: 1450
 
-# CIDR Range for services in cluster. It's required to support egress network policy, should
-# be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
+# ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
+# set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
+# AntreaProxy is enabled, this parameter is not needed and will be ignored if provided.
 #serviceCIDR: 10.96.0.0/12
 
 # The port for the antrea-agent APIServer to serve on.

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -63,8 +63,9 @@ type AgentConfig struct {
 	// as /host/proc in the antrea-agent container). When running antrea-agent as a process,
 	// hostProcPathPrefix should be set to "/" in the YAML config.
 	HostProcPathPrefix string `yaml:"hostProcPathPrefix,omitempty"`
-	// CIDR Range for services in cluster. It's required to support egress network policy, should
-	// be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
+	// ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
+	// set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
+	// AntreaProxy is enabled, this parameter is not needed and will be ignored if provided.
 	// Default is 10.96.0.0/12
 	ServiceCIDR string `yaml:"serviceCIDR,omitempty"`
 	// Whether or not to enable IPSec (ESP) encryption for Pod traffic across Nodes. IPSec encryption

--- a/docs/aks-installation.md
+++ b/docs/aks-installation.md
@@ -48,32 +48,30 @@ You can use any method to create an AKS cluster. The example given here is using
 1. Prepare the Cluster Nodes
 
     Deploy ``antrea-node-init`` DaemonSet to enable ``azure cni`` to operate in transparent mode.
-
     ```bash
     kubectl apply -f https://raw.githubusercontent.com/vmware-tanzu/antrea/master/build/yamls/antrea-aks-node-init.yml
     ```
 
-2. Download Antrea YAML
+2. Deploy Antrea
 
-    Deploy a released version of Antrea from the [list of releases](https://github.com/vmware-tanzu/antrea/releases).
-Note that AKS support was added in release 0.9.0, which means you cannot pick a release older than 0.9.0.
-For any given release `<TAG>` (e.g. `v0.9.0`), get the Antrea AKS deployment yaml at:
+    To deploy a released version of Antrea, pick a deployment manifest from the
+[list of releases](https://github.com/vmware-tanzu/antrea/releases).
+Note that AKS support was added in release 0.9.0, which means you cannot
+pick a release older than 0.9.0. For any given release `<TAG>` (e.g. `v0.9.0`),
+you can deploy Antrea as follows:
+    ```bash
+    kubectl apply -f https://github.com/vmware-tanzu/antrea/releases/download/<TAG>/antrea-aks.yml
+    ```
 
-    ````
-    https://github.com/vmware-tanzu/antrea/releases/download/<TAG>/antrea-aks.yml
-    ````
+    To deploy the latest version of Antrea (built from the master branch), use the
+checked-in [deployment yaml](/build/yamls/antrea-aks.yml):
+    ```bash
+    kubectl apply -f https://raw.githubusercontent.com/vmware-tanzu/antrea/master/build/yamls/antrea-aks.yml
+    ```
 
-    To deploy the latest version of Antrea (built from the master branch) to AKS, get the Antrea AKS deployment yaml at:
-
-    ````
-    https://raw.githubusercontent.com/vmware-tanzu/antrea/master/build/yamls/antrea-aks.yml
-    ````
-
-3. Deploy Antrea
-
-    Deploy Antrea using `kubectl apply -f antrea-aks.yml`. It will deploy a single replica of Antrea controller to the AKS cluster
-and deploy Antrea agent to every Node. After a successful deployment you should be able to see these Pods running in your cluster:
-
+    The command will deploy a single replica of Antrea controller to the AKS
+cluster and deploy Antrea agent to every Node. After a successful deployment
+you should be able to see these Pods running in your cluster:
     ```bash
     $ kubectl get pods --namespace kube-system  -l app=antrea
     NAME                                 READY   STATUS    RESTARTS   AGE
@@ -84,10 +82,9 @@ and deploy Antrea agent to every Node. After a successful deployment you should 
     antrea-node-init-mqsqr               1/1     Running   0          2m
     ```
 
-4. Restart remaining Pods
+3. Restart remaining Pods
 
     Once Antrea is up and running, restart all Pods in all Namespaces (kube-system, etc) so they can be managed by Antrea.
-
     ```bash
     kubectl delete pods -n kube-system $(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{ print $1 }')
     pod "coredns-544d979687-96xm9" deleted

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,65 +10,11 @@
 Use `antrea-agent -h` to see complete options.
 
 ### Configuration
-```yaml
-# clientConnection specifies the kubeconfig file and client connection settings for the agent
-# to communicate with the apiserver.
-#clientConnection:
-  # Path of the kubeconfig file that is used to configure access to a K8s cluster.
-  # If not specified, InClusterConfig will be used.
-  #kubeconfig: <PATH_TO_KUBE_CONF>
-
-# antreaClientConnection specifies the kubeconfig file and client connection settings for the
-# agent to communicate with the Antrea Controller apiserver.
-#antreaClientConnection:
-  # Path of the kubeconfig file that is used to configure access to the Antrea Controller
-  # apiserver. If not specified, InClusterConfig will be used.
-  #kubeconfig: <PATH_TO_ANTREA_KUBE_CONF>
-
-# Name of the OpenVSwitch bridge antrea-agent will create and use.
-# Make sure it doesn't conflict with your existing OpenVSwitch bridges.
-#ovsBridge: br-int
-
-# Datapath type to use for the OpenVSwitch bridge created by Antrea. Supported values are:
-# - system
-# - netdev
-# 'system' is the default value and corresponds to the kernel datapath. Use 'netdev' to run
-# OVS in userspace mode. Userspace mode requires the tun device driver to be available.
-#ovsDatapathType: system
-
-# Name of the gateway interface for the local Pod subnet. antrea-agent will create the interface on the OVS bridge.
-# Make sure it doesn't conflict with your existing interfaces.
-#hostGateway: antrea-gw0
-
-# Encapsulation mode for communication between Pods across Nodes, supported values:
-# - geneve (default)
-# - vxlan
-# - gre
-# - stt
-#tunnelType: geneve
-
-# Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
-# for the GRE tunnel type.
-#enableIPSecTunnel: false
-
-# Default MTU to use for the host gateway interface and the network interface of each Pod.
-# If omitted, antrea-agent will discover the MTU of the Node's primary interface and
-# also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
-#defaultMTU: 1450
-
-# CIDR Range for services in cluster. It's required to support egress network policy, should
-# be set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver.
-#serviceCIDR: 10.96.0.0/12
-
-# Mount location of the /proc directory. The default is "/host", which is appropriate when
-# antrea-agent is run as part of the Antrea DaemonSet (and the host's /proc directory is mounted
-# as /host/proc in the antrea-agent container). When running antrea-agent as a process,
-# hostProcPathPrefix should be set to "/" in the YAML config.
-#hostProcPathPrefix: /host
-
-# The port for the antrea-agent APIServer to serve on.
-#apiPort: 10350
-```
+The `antrea-agent` configuration file specifies the agent configuration
+parameters. For all the agent configuration parameters of a Linux Node, refer to
+this [base configuration file](/build/yamls/base/conf/antrea-agent.conf).
+For all the configuration parameters of a Windows Node, refer to this [base
+configuration file](/build/yamls/windows/base/conf/antrea-agent.conf)
 
 ## antrea-controller
 
@@ -80,26 +26,9 @@ Use `antrea-agent -h` to see complete options.
 Use `antrea-controller -h` to see complete options.
 
 ### Configuration
-```yaml
-# clientConnection specifies the kubeconfig file and client connection settings for the 
-# controller to communicate with the apiserver.
-clientConnection:
-  # Path of the kubeconfig file that is used to configure access to a K8s cluster.
-  # If not specified, InClusterConfig will be used, which handles API host discovery and authentication automatically.
-  #kubeconfig: <PATH_TO_KUBE_CONF>
-
-# The port for the antrea-controller APIServer to serve on.
-#apiPort: 10349
-
-# Indicates whether to use auto-generated self-signed TLS certificate.
-# If false, A Secret named "antrea-controller-tls" must be provided with the following keys:
-#   ca.crt: <CA certificate>
-#   tls.crt: <TLS certificate>
-#   tls.key: <TLS private key>
-# And the Secret must be mounted to directory "/var/run/antrea/antrea-controller-tls" of the
-# antrea-controller container.
-#selfSignedCert: true
-```
+The `antrea-controller` configuration file specifies the controller
+configuration parameters. For all the controller configuration parameters,
+refer to this [base configuration file](/build/yamls/base/conf/antrea-controller.conf).
 
 ## CNI configuration
 

--- a/docs/eks-installation.md
+++ b/docs/eks-installation.md
@@ -6,27 +6,25 @@ Assuming you already have an EKS cluster, and have ``KUBECONFIG`` environment va
 the kubeconfig file of that cluster.
 
 With Antrea >=v0.9.0 release, you should apply `antrea-eks-node-init.yaml` before deploying Antrea.
-This would restart existing PODs (except in host network) so that Antrea can also manage it, once installed.
+This will restart existing Pods (except those in host network), so that Antrea can also manage them
+(i.e. enforce NetworkPolicies on them) once it is installed.
 ```
 kubectl apply -f https://raw.githubusercontent.com/vmware-tanzu/antrea/master/build/yamls/antrea-eks-node-init.yml
 ```
 
-To deploy a released version of Antrea, pick a version from the
+To deploy a released version of Antrea, pick a deployment manifest from the
 [list of releases](https://github.com/vmware-tanzu/antrea/releases).
-Note that EKS support was added in release 0.5.0, which means you can not
+Note that EKS support was added in release 0.5.0, which means you cannot
 pick a release older than 0.5.0. For any given release `<TAG>` (e.g. `v0.5.0`),
-get the Antrea EKS deployment yaml at:
-```
-https://github.com/vmware-tanzu/antrea/releases/download/<TAG>/antrea-eks.yml
-```
-
-To deploy the latest version of Antrea (built from the master branch) to EKS, get the Antrea EKS
-deployment yaml at:
-```
-https://raw.githubusercontent.com/vmware-tanzu/antrea/master/build/yamls/antrea-eks.yml
-```
-
+you can deploy Antrea as follows:
 ```bash
-kubectl apply -f antrea-eks.yaml
+kubectl apply -f https://github.com/vmware-tanzu/antrea/releases/download/<TAG>/antrea-eks.yml
 ```
+
+To deploy the latest version of Antrea (built from the master branch), use the
+checked-in [deployment yaml](/build/yamls/antrea-eks.yml):
+```bash
+kubectl apply -f https://raw.githubusercontent.com/vmware-tanzu/antrea/master/build/yamls/antrea-eks.yml
+```
+
 Now Antrea should be plugged into the EKS CNI and is ready to enforce NetworkPolicy.

--- a/docs/gke-installation.md
+++ b/docs/gke-installation.md
@@ -73,35 +73,30 @@ assign this permission.
 1. Prepare the Cluster Nodes
 
     Deploy ``antrea-node-init`` DaemonSet to enable ``kubelet`` to operate in CNI mode.
-
     ```bash
     kubectl apply -f https://raw.githubusercontent.com/vmware-tanzu/antrea/master/build/yamls/antrea-gke-node-init.yml
     ```
 
-2. Download and Update Antrea YAML
+2. Deploy Antrea
 
-    Deploy a released version of Antrea from the [list of releases](https://github.com/vmware-tanzu/antrea/releases).
-Note that GKE support was added in release 0.5.0, which means you cannot pick a release older than 0.5.0.
-For any given release `<TAG>` (e.g. `v0.5.0`), get the Antrea GKE deployment yaml at:
+    To deploy a released version of Antrea, pick a deployment manifest from the
+[list of releases](https://github.com/vmware-tanzu/antrea/releases).
+Note that GKE support was added in release 0.5.0, which means you cannot
+pick a release older than 0.5.0. For any given release `<TAG>` (e.g. `v0.5.0`),
+you can deploy Antrea as follows:
+    ```bash
+    kubectl apply -f https://github.com/vmware-tanzu/antrea/releases/download/<TAG>/antrea-gke.yml
+    ```
 
-    ````
-    https://github.com/vmware-tanzu/antrea/releases/download/<TAG>/antrea-gke.yml
-    ````
+    To deploy the latest version of Antrea (built from the master branch), use the
+checked-in [deployment yaml](/build/yamls/antrea-gke.yml):
+    ```bash
+    kubectl apply -f https://raw.githubusercontent.com/vmware-tanzu/antrea/master/build/yamls/antrea-gke.yml
+    ```
 
-    To deploy the latest version of Antrea (built from the master branch) to GKE, get the Antrea GKE deployment yaml at:
-
-    ````
-    https://raw.githubusercontent.com/vmware-tanzu/antrea/master/build/yamls/antrea-gke.yml
-    ````
-
-    Update ``serviceCIDR`` value of antrea-agent.conf in antrea-gke.yml with GKE_SERVICE_CIDR selected at the time of
-    deploying GKE cluster.
-
-3. Deploy Antrea
-
-    Deploy Antrea using `kubectl apply -f antrea-gke.yml`. It will deploy a single replica of Antrea controller to the GKE cluster
-and deploy Antrea agent to every Node. After a successful deployment you should be able to see these Pods running in your cluster:
-
+    The command will deploy a single replica of Antrea controller to the GKE
+cluster and deploy Antrea agent to every Node. After a successful deployment
+you should be able to see these Pods running in your cluster:
     ```bash
     $ kubectl get pods --namespace kube-system  -l app=antrea -o wide
     NAME                                READY   STATUS    RESTARTS   AGE   IP              NODE                                      NOMINATED NODE   READINESS GATES
@@ -110,10 +105,9 @@ and deploy Antrea agent to every Node. After a successful deployment you should 
     antrea-controller-5f9985c59-5crt6   1/1     Running   0          46s   10.138.15.209   gke-cluster1-default-pool-93d7da1c-rkbm   <none>           <none>
     ```
 
-4. Restart remaining Pods
+3. Restart remaining Pods
 
     Once Antrea is up and running, restart all Pods in all Namespaces (kube-system, etc) so they can be managed by Antrea.
-
     ```bash
     $ kubectl delete pods -n kube-system $(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{ print $1 }')
     pod "event-exporter-v0.2.5-7df89f4b8f-cm5r5" deleted


### PR DESCRIPTION
Remove the serviceCIDR parameter for AKS, EKS, GKE clusters, as
AntreaProxy is always enabled for them and the serviceCIDR parameter
is useless.
Also update configuration.md and the cloud installation documents.