### PR TITLE
Periodically check timeout of running Traceflow requests

### DIFF
--- a/pkg/controller/traceflow/controller.go
+++ b/pkg/controller/traceflow/controller.go
@@ -40,11 +40,17 @@ import (
 const (
 	// Set resyncPeriod to 0 to disable resyncing.
 	resyncPeriod time.Duration = 0
+
 	// How long to wait before retrying the processing of a traceflow.
 	minRetryDelay = 5 * time.Second
 	maxRetryDelay = 300 * time.Second
+
 	// Default number of workers processing traceflow request.
 	defaultWorkers = 4
+
+	// Traceflow timeout period.
+	timeoutDuration      = 2 * time.Minute
+	timeoutCheckInterval = timeoutDuration / 2
 
 	// Min and max data plane tag for traceflow. dataplaneTag=0 means it's not a Traceflow packet.
 	// dataplaneTag=15 is reserved.
@@ -53,11 +59,6 @@ const (
 
 	// PodIP index name for Pod cache.
 	podIPIndex = "podIP"
-)
-
-var (
-	// Traceflow timeout period.
-	timeout = (300 * time.Second).Seconds()
 )
 
 // Controller is for traceflow.
@@ -139,6 +140,10 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 		}
 	}
 
+	go func() {
+		wait.Until(c.checkTraceflowTimeout, timeoutCheckInterval, stopCh)
+	}()
+
 	for i := 0; i < defaultWorkers; i++ {
 		go wait.Until(c.worker, time.Second, stopCh)
 	}
@@ -167,6 +172,21 @@ func (c *Controller) deleteTraceflow(old interface{}) {
 // in order to read and process a message on the workqueue.
 func (c *Controller) worker() {
 	for c.processTraceflowItem() {
+	}
+}
+
+func (c *Controller) checkTraceflowTimeout() {
+	c.runningTraceflowsMutex.Lock()
+	tfs := make([]string, 0, len(c.runningTraceflows))
+	for _, tfName := range c.runningTraceflows {
+		tfs = append(tfs, tfName)
+	}
+	c.runningTraceflowsMutex.Unlock()
+
+	for _, tfName := range tfs {
+		// Re-post all running Traceflow requests to the work queue to
+		// be processed and checked for timeout.
+		c.queue.Add(tfName)
 	}
 }
 
@@ -226,8 +246,6 @@ func (c *Controller) syncTraceflow(traceflowName string) error {
 		err = c.startTraceflow(tf)
 	case opsv1alpha1.Running:
 		err = c.checkTraceflowStatus(tf)
-	default:
-		c.deallocateTagForTF(tf)
 	}
 	return err
 }
@@ -277,10 +295,12 @@ func (c *Controller) checkTraceflowStatus(tf *opsv1alpha1.Traceflow) error {
 		}
 	}
 	if sender && receiver {
+		c.deallocateTagForTF(tf)
 		return c.updateTraceflowStatus(tf, opsv1alpha1.Succeeded, "", 0)
 	}
-	if time.Now().UTC().Sub(tf.CreationTimestamp.UTC()).Seconds() > timeout {
-		return c.updateTraceflowStatus(tf, opsv1alpha1.Failed, "traceflow timeout", 0)
+	if time.Now().UTC().Sub(tf.CreationTimestamp.UTC()) > timeoutDuration {
+		c.deallocateTagForTF(tf)
+		return c.updateTraceflowStatus(tf, opsv1alpha1.Failed, "Traceflow timeout", 0)
 	}
 	return nil
 }
@@ -288,9 +308,7 @@ func (c *Controller) checkTraceflowStatus(tf *opsv1alpha1.Traceflow) error {
 func (c *Controller) updateTraceflowStatus(tf *opsv1alpha1.Traceflow, phase opsv1alpha1.TraceflowPhase, reason string, dataPlaneTag uint8) error {
 	update := tf.DeepCopy()
 	update.Status.Phase = phase
-	if phase == opsv1alpha1.Running {
-		update.Status.DataplaneTag = dataPlaneTag
-	}
+	update.Status.DataplaneTag = dataPlaneTag
 	if reason != "" {
 		update.Status.Reason = reason
 	}

--- a/pkg/controller/traceflow/controller_test.go
+++ b/pkg/controller/traceflow/controller_test.go
@@ -1,0 +1,159 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package traceflow
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	ops "github.com/vmware-tanzu/antrea/pkg/apis/ops/v1alpha1"
+	"github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned"
+	fakeversioned "github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned/fake"
+	crdinformers "github.com/vmware-tanzu/antrea/pkg/client/informers/externalversions"
+)
+
+var alwaysReady = func() bool { return true }
+
+const informerDefaultResync time.Duration = 30 * time.Second
+
+type traceflowController struct {
+	*Controller
+	client             versioned.Interface
+	informerFactory    informers.SharedInformerFactory
+	crdInformerFactory crdinformers.SharedInformerFactory
+}
+
+func newController() *traceflowController {
+	client := fake.NewSimpleClientset()
+	crdClient := newCRDClientset()
+	informerFactory := informers.NewSharedInformerFactory(client, informerDefaultResync)
+	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, informerDefaultResync)
+	controller := NewTraceflowController(crdClient,
+		informerFactory.Core().V1().Pods(),
+		crdInformerFactory.Ops().V1alpha1().Traceflows())
+	controller.traceflowListerSynced = alwaysReady
+	return &traceflowController{
+		controller,
+		crdClient,
+		informerFactory,
+		crdInformerFactory,
+	}
+}
+
+func TestTraceflow(t *testing.T) {
+	// Use shorter timeout.
+	timeoutDuration = 2 * time.Second
+	timeoutCheckInterval = timeoutDuration / 2
+
+	tfc := newController()
+	stopCh := make(chan struct{})
+	tfc.crdInformerFactory.Start(stopCh)
+	go tfc.Run(stopCh)
+
+	numRunningTraceflows := func() int {
+		tfc.runningTraceflowsMutex.Lock()
+		defer tfc.runningTraceflowsMutex.Unlock()
+		return len(tfc.runningTraceflows)
+	}
+
+	tf1 := ops.Traceflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "tf1", UID: "uid1"},
+		Spec: ops.TraceflowSpec{
+			Source:      ops.Source{Namespace: "ns1", Pod: "pod1"},
+			Destination: ops.Destination{Namespace: "ns2", Pod: "pod2"},
+		},
+	}
+
+	tfc.client.OpsV1alpha1().Traceflows().Create(context.TODO(), &tf1, metav1.CreateOptions{})
+	res, _ := tfc.waitForTraceflow("tf1", ops.Running, time.Second)
+	assert.NotNil(t, res)
+	// DataplaneTag should be allocated by Controller.
+	assert.True(t, res.Status.DataplaneTag > 0)
+	assert.Equal(t, numRunningTraceflows(), 1)
+
+	// Test Controller handling of successful Traceflow.
+	res.Status.Results = []ops.NodeResult{
+		// Sender
+		{
+			Observations: []ops.Observation{{Component: ops.SpoofGuard}},
+		},
+		// Receiver
+		{
+			Observations: []ops.Observation{{Action: ops.Delivered}},
+		},
+	}
+	tfc.client.OpsV1alpha1().Traceflows().Update(context.TODO(), res, metav1.UpdateOptions{})
+	res, _ = tfc.waitForTraceflow("tf1", ops.Succeeded, time.Second)
+	assert.NotNil(t, res)
+	// DataplaneTag should be deallocated by Controller.
+	assert.True(t, res.Status.DataplaneTag == 0)
+	assert.Equal(t, numRunningTraceflows(), 0)
+	tfc.client.OpsV1alpha1().Traceflows().Delete(context.TODO(), "tf1", metav1.DeleteOptions{})
+
+	// Test Traceflow timeout.
+	startTime := time.Now()
+	tfc.client.OpsV1alpha1().Traceflows().Create(context.TODO(), &tf1, metav1.CreateOptions{})
+	res, _ = tfc.waitForTraceflow("tf1", ops.Running, time.Second)
+	assert.NotNil(t, res)
+	res, _ = tfc.waitForTraceflow("tf1", ops.Failed, timeoutDuration*2)
+	assert.NotNil(t, res)
+	assert.True(t, time.Now().Sub(startTime) >= timeoutDuration)
+	assert.Equal(t, res.Status.Reason, traceflowTimeout)
+	assert.True(t, res.Status.DataplaneTag == 0)
+	assert.Equal(t, numRunningTraceflows(), 0)
+
+	close(stopCh)
+}
+
+func (tfc *traceflowController) waitForTraceflow(name string, phase ops.TraceflowPhase, timeout time.Duration) (*ops.Traceflow, error) {
+	var tf *ops.Traceflow
+	var err error
+	if err = wait.Poll(100*time.Millisecond, timeout, func() (bool, error) {
+		tf, err = tfc.client.OpsV1alpha1().Traceflows().Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil || tf.Status.Phase != phase {
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		return nil, err
+	}
+	return tf, nil
+}
+
+func newCRDClientset() *fakeversioned.Clientset {
+	client := fakeversioned.NewSimpleClientset()
+
+	client.PrependReactor("create", "traceflows", k8stesting.ReactionFunc(func(action k8stesting.Action) (bool, runtime.Object, error) {
+		tf := action.(k8stesting.CreateAction).GetObject().(*ops.Traceflow)
+
+		// Fake client does not set CreationTimestamp.
+		if tf.ObjectMeta.CreationTimestamp == (metav1.Time{}) {
+			tf.ObjectMeta.CreationTimestamp.Time = time.Now()
+		}
+
+		return false, tf, nil
+	}))
+
+	return client
+}


### PR DESCRIPTION
Check if running Traceflow requests are timeout every 1 minute.
Change the Traceflow timeout period to 2 minutes.
Deallocate DP tag after a Traceflow request succeeds or is timeout.