### PR TITLE
[IPv6] Handle dual stack NodeSubnet for monitoring CRD

### DIFF
--- a/pkg/agent/apiserver/handlers/agentinfo/handler.go
+++ b/pkg/agent/apiserver/handlers/agentinfo/handler.go
@@ -32,7 +32,7 @@ type AntreaAgentInfoResponse struct {
 	Version                     string                              `json:"version,omitempty"`                     // Antrea binary version
 	PodRef                      corev1.ObjectReference              `json:"podRef,omitempty"`                      // The Pod that Antrea Agent is running in
 	NodeRef                     corev1.ObjectReference              `json:"nodeRef,omitempty"`                     // The Node that Antrea Agent is running in
-	NodeSubnet                  []string                            `json:"nodeSubnet,omitempty"`                  // Node subnet
+	NodeSubnets                 []string                            `json:"nodeSubnets,omitempty"`                 // Node subnets
 	OVSInfo                     v1beta1.OVSInfo                     `json:"ovsInfo,omitempty"`                     // OVS Information
 	NetworkPolicyControllerInfo v1beta1.NetworkPolicyControllerInfo `json:"networkPolicyControllerInfo,omitempty"` // Antrea Agent NetworkPolicy information
 	LocalPodNum                 int32                               `json:"localPodNum,omitempty"`                 // The number of Pods which the agent is in charge of
@@ -53,7 +53,7 @@ func HandleFunc(aq querier.AgentQuerier) http.HandlerFunc {
 			NetworkPolicyControllerInfo: agentInfo.NetworkPolicyControllerInfo,
 			LocalPodNum:                 agentInfo.LocalPodNum,
 			AgentConditions:             agentInfo.AgentConditions,
-			NodeSubnet:                  agentInfo.NodeSubnet,
+			NodeSubnets:                 agentInfo.NodeSubnets,
 		}
 		err := json.NewEncoder(w).Encode(info)
 		if err != nil {
@@ -89,7 +89,7 @@ func (r AntreaAgentInfoResponse) GetTableRow(maxColumnLength int) []string {
 	return []string{r.PodRef.Namespace + "/" + r.PodRef.Name,
 		r.NodeRef.Name,
 		r.GetAgentConditionStr(),
-		common.GenerateTableElementWithSummary(r.NodeSubnet, maxColumnLength),
+		common.GenerateTableElementWithSummary(r.NodeSubnets, maxColumnLength),
 		common.Int32ToString(r.NetworkPolicyControllerInfo.NetworkPolicyNum),
 		common.Int32ToString(r.NetworkPolicyControllerInfo.AddressGroupNum),
 		common.Int32ToString(r.NetworkPolicyControllerInfo.AppliedToGroupNum),

--- a/pkg/agent/querier/querier.go
+++ b/pkg/agent/querier/querier.go
@@ -193,12 +193,15 @@ func (aq agentQuerier) GetAgentInfo(agentInfo *v1beta1.AntreaAgentInfo, partial 
 		agentInfo.Version = querier.GetVersion()
 		agentInfo.PodRef = querier.GetSelfPod()
 		agentInfo.NodeRef = querier.GetSelfNode(true, aq.nodeConfig.Name)
+		// Make a new string slice instead of appending agentInfo.NodeSubnets directly to avoid duplicate CIDRs.
+		nodeSubnets := make([]string, 0)
 		if aq.nodeConfig.PodIPv4CIDR != nil {
-			agentInfo.NodeSubnet = append(agentInfo.NodeSubnet, aq.nodeConfig.PodIPv4CIDR.String())
+			nodeSubnets = append(nodeSubnets, aq.nodeConfig.PodIPv4CIDR.String())
 		}
 		if aq.nodeConfig.PodIPv6CIDR != nil {
-			agentInfo.NodeSubnet = append(agentInfo.NodeSubnet, aq.nodeConfig.PodIPv6CIDR.String())
+			nodeSubnets = append(nodeSubnets, aq.nodeConfig.PodIPv6CIDR.String())
 		}
+		agentInfo.NodeSubnets = nodeSubnets
 		agentInfo.OVSInfo.BridgeName = aq.nodeConfig.OVSBridge
 		agentInfo.APIPort = aq.apiPort
 	}

--- a/pkg/agent/querier/querier_test.go
+++ b/pkg/agent/querier/querier_test.go
@@ -81,9 +81,9 @@ func TestAgentQuerierGetAgentInfo(t *testing.T) {
 			apiPort: 10350,
 			partial: false,
 			expectedAgentInfo: &v1beta1.AntreaAgentInfo{
-				ObjectMeta: v1.ObjectMeta{Name: "foo"},
-				NodeRef:    corev1.ObjectReference{Kind: "Node", Name: "foo"},
-				NodeSubnet: nil,
+				ObjectMeta:  v1.ObjectMeta{Name: "foo"},
+				NodeRef:     corev1.ObjectReference{Kind: "Node", Name: "foo"},
+				NodeSubnets: []string{},
 				OVSInfo: v1beta1.OVSInfo{
 					Version:    ovsVersion,
 					BridgeName: "br-int",
@@ -129,9 +129,9 @@ func TestAgentQuerierGetAgentInfo(t *testing.T) {
 			apiPort: 10350,
 			partial: false,
 			expectedAgentInfo: &v1beta1.AntreaAgentInfo{
-				ObjectMeta: v1.ObjectMeta{Name: "foo"},
-				NodeRef:    corev1.ObjectReference{Kind: "Node", Name: "foo"},
-				NodeSubnet: []string{"20.20.20.0/24", "2001:ab03:cd04:55ef::/64"},
+				ObjectMeta:  v1.ObjectMeta{Name: "foo"},
+				NodeRef:     corev1.ObjectReference{Kind: "Node", Name: "foo"},
+				NodeSubnets: []string{"20.20.20.0/24", "2001:ab03:cd04:55ef::/64"},
 				OVSInfo: v1beta1.OVSInfo{
 					Version:    ovsVersion,
 					BridgeName: "br-int",

--- a/pkg/antctl/command_definition_test.go
+++ b/pkg/antctl/command_definition_test.go
@@ -100,7 +100,7 @@ kube-system/antrea-controller-55b9bcd59f-h9ll4 node-master Healthy 1            
 					Kind: "Node",
 					Name: "node-worker",
 				},
-				NodeSubnet: []string{"192.168.1.0/24", "192.168.1.1/24"},
+				NodeSubnets: []string{"192.168.1.0/24", "192.168.1.1/24"},
 				OVSInfo: v1beta1.OVSInfo{
 					Version:    "1.0",
 					BridgeName: "br-int",

--- a/pkg/apis/clusterinformation/v1beta1/types.go
+++ b/pkg/apis/clusterinformation/v1beta1/types.go
@@ -29,7 +29,7 @@ type AntreaAgentInfo struct {
 	Version                     string                      `json:"version,omitempty"`                     // Antrea binary version
 	PodRef                      corev1.ObjectReference      `json:"podRef,omitempty"`                      // The Pod that Antrea Agent is running in
 	NodeRef                     corev1.ObjectReference      `json:"nodeRef,omitempty"`                     // The Node that Antrea Agent is running in
-	NodeSubnet                  []string                    `json:"nodeSubnet,omitempty"`                  // Node subnet
+	NodeSubnets                 []string                    `json:"nodeSubnets,omitempty"`                 // Node subnets
 	OVSInfo                     OVSInfo                     `json:"ovsInfo,omitempty"`                     // OVS Information
 	NetworkPolicyControllerInfo NetworkPolicyControllerInfo `json:"networkPolicyControllerInfo,omitempty"` // Antrea Agent NetworkPolicy information
 	LocalPodNum                 int32                       `json:"localPodNum,omitempty"`                 // The number of Pods which the agent is in charge of

--- a/pkg/apis/clusterinformation/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/clusterinformation/v1beta1/zz_generated.deepcopy.go
@@ -46,8 +46,8 @@ func (in *AntreaAgentInfo) DeepCopyInto(out *AntreaAgentInfo) {
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	out.PodRef = in.PodRef
 	out.NodeRef = in.NodeRef
-	if in.NodeSubnet != nil {
-		in, out := &in.NodeSubnet, &out.NodeSubnet
+	if in.NodeSubnets != nil {
+		in, out := &in.NodeSubnets, &out.NodeSubnets
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/pkg/apiserver/openapi/zz_generated.openapi.go
+++ b/pkg/apiserver/openapi/zz_generated.openapi.go
@@ -405,7 +405,7 @@ func schema_pkg_apis_clusterinformation_v1beta1_AntreaAgentInfo(ref common.Refer
 							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
-					"nodeSubnet": {
+					"nodeSubnets": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The Node that Antrea Agent is running in",
 							Type:        []string{"array"},
@@ -421,7 +421,7 @@ func schema_pkg_apis_clusterinformation_v1beta1_AntreaAgentInfo(ref common.Refer
 					},
 					"ovsInfo": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Node subnet",
+							Description: "Node subnets",
 							Ref:         ref("github.com/vmware-tanzu/antrea/pkg/apis/clusterinformation/v1beta1.OVSInfo"),
 						},
 					},

--- a/pkg/controller/querier/querier.go
+++ b/pkg/controller/querier/querier.go
@@ -41,7 +41,7 @@ func NewControllerQuerier(networkPolicyInfoQuerier querier.ControllerNetworkPoli
 	return &controllerQuerier{networkPolicyInfoQuerier: networkPolicyInfoQuerier, apiPort: apiPort}
 }
 
-// GetNodeSubnet gets current network policy info querier.
+// getNetworkPolicyInfoQuerier gets current network policy info querier.
 func (cq controllerQuerier) getNetworkPolicyInfoQuerier() querier.ControllerNetworkPolicyInfoQuerier {
 	return cq.networkPolicyInfoQuerier
 }

--- a/plugins/octant/cmd/antrea-octant-plugin/antrea_info.go
+++ b/plugins/octant/cmd/antrea-octant-plugin/antrea_info.go
@@ -34,7 +34,7 @@ const (
 	nodeCol           = "Node"
 	serviceCol        = "Service"
 	clusterInfoCrdCol = "Monitoring CRD"
-	subnetCol         = "NodeSubnet"
+	subnetsCol        = "NodeSubnets"
 	bridgeCol         = "OVS Bridge"
 	podNumCol         = "Local Pod Num"
 	heartbeatCol      = "Last Heartbeat Time"
@@ -101,14 +101,14 @@ func (p *antreaOctantPlugin) getAgentTable(request service.Request) *component.T
 				"/overview/namespace/"+agent.PodRef.Namespace+"/workloads/pods/"+agent.PodRef.Name),
 			nodeCol: component.NewLink(agent.NodeRef.Name, agent.NodeRef.Name,
 				"/cluster-overview/nodes/"+agent.NodeRef.Name),
-			subnetCol: component.NewText(strings.Join(agent.NodeSubnet, ", ")),
-			bridgeCol: component.NewText(agent.OVSInfo.BridgeName),
-			podNumCol: component.NewText(strconv.Itoa(int(agent.LocalPodNum))),
+			subnetsCol: component.NewText(strings.Join(agent.NodeSubnets, ", ")),
+			bridgeCol:  component.NewText(agent.OVSInfo.BridgeName),
+			podNumCol:  component.NewText(strconv.Itoa(int(agent.LocalPodNum))),
 			clusterInfoCrdCol: component.NewLink(agent.Name, agent.Name,
 				"/cluster-overview/custom-resources/antreaagentinfos.clusterinformation.antrea.tanzu.vmware.com/v1beta1/"+agent.Name),
 			heartbeatCol: component.NewText(agent.AgentConditions[0].LastHeartbeatTime.String()),
 		})
 	}
-	agentCols := component.NewTableCols(versionCol, podCol, nodeCol, subnetCol, bridgeCol, podNumCol, clusterInfoCrdCol, heartbeatCol)
+	agentCols := component.NewTableCols(versionCol, podCol, nodeCol, subnetsCol, bridgeCol, podNumCol, clusterInfoCrdCol, heartbeatCol)
 	return component.NewTableWithRows(agentTitle, "We couldn't find any Antrea agents!", agentCols, agentRows)
 }


### PR DESCRIPTION
To avoid duplicate CIDRs, this patch makes a new string slice for dual stack
node subnet instead of appending agentInfo.NodeSubnet directly.