### PR TITLE
Fix indent in ClusterNetworkPolicy example

### DIFF
--- a/docs/network-policy.md
+++ b/docs/network-policy.md
@@ -128,7 +128,7 @@ spec:
       - action: Drop
         to:
           - ipBlock:
-            cidr: 10.0.10.0/24
+              cidr: 10.0.10.0/24
         ports:
           - protocol: TCP
             port: 5978


### PR DESCRIPTION
cidr is a sub-field of ipBlock, it must be indented.