### PR TITLE
Fix strongSwan logging configuration

### DIFF
--- a/build/images/ovs/charon-logging.conf
+++ b/build/images/ovs/charon-logging.conf
@@ -1,4 +1,5 @@
-        /var/log/strongswan/charon.log {
+        charon {
+            path = /var/log/strongswan/charon.log
             # default log level for all daemon subsystems
             default = 1
             # flush each line to disk


### PR DESCRIPTION
strongSwan logging configuration is reported as invalid in some OSes
(e.g Ubuntu 16.04) when starting the strongSwan services. It is probably
due to the strongSwan version change after the Antea Docker image is
updated to use Ubuntu 20.04. This commit fixes the strongSwan logging
configuration.