### PR TITLE
Use enums instead of regex for NP CRD actions

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -85,7 +85,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   ports:
                     items:
@@ -119,7 +121,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   from:
                     items:
@@ -269,7 +273,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   ports:
                     items:
@@ -303,7 +309,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   from:
                     items:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -85,7 +85,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   ports:
                     items:
@@ -119,7 +121,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   from:
                     items:
@@ -269,7 +273,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   ports:
                     items:
@@ -303,7 +309,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   from:
                     items:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -85,7 +85,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   ports:
                     items:
@@ -119,7 +121,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   from:
                     items:
@@ -269,7 +273,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   ports:
                     items:
@@ -303,7 +309,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   from:
                     items:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -85,7 +85,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   ports:
                     items:
@@ -119,7 +121,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   from:
                     items:
@@ -269,7 +273,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   ports:
                     items:
@@ -303,7 +309,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   from:
                     items:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -85,7 +85,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   ports:
                     items:
@@ -119,7 +121,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   from:
                     items:
@@ -269,7 +273,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   ports:
                     items:
@@ -303,7 +309,9 @@ spec:
               items:
                 properties:
                   action:
-                    pattern: \bAllow|\bDrop
+                    enum:
+                    - Allow
+                    - Drop
                     type: string
                   from:
                     items:

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -276,7 +276,7 @@ spec:
                   # Ensure that Action field allows only ALLOW and DROP values
                   action:
                     type: string
-                    pattern: '\bAllow|\bDrop'
+                    enum: ['Allow', 'Drop']
                   ports:
                     type: array
                     items:
@@ -311,7 +311,7 @@ spec:
                   # Ensure that Action field allows only ALLOW and DROP values
                   action:
                     type: string
-                    pattern: '\bAllow|\bDrop'
+                    enum: ['Allow', 'Drop']
                   ports:
                     type: array
                     items:
@@ -408,7 +408,7 @@ spec:
                   # Ensure that Action field allows only ALLOW and DROP values
                   action:
                     type: string
-                    pattern: '\bAllow|\bDrop'
+                    enum: ['Allow', 'Drop']
                   ports:
                     type: array
                     items:
@@ -443,7 +443,7 @@ spec:
                   # Ensure that Action field allows only ALLOW and DROP values
                   action:
                     type: string
-                    pattern: '\bAllow|\bDrop'
+                    enum: ['Allow', 'Drop']
                   ports:
                     type: array
                     items:


### PR DESCRIPTION
Update ClusterNetworkPolicy and Antrea NetworkPolicy CRD yaml to take "Allow" and "Drop" actions as enum.