### PR TITLE
Add "Has Changes" Github action

### DIFF
--- a/ci/gh-actions/has-changes/Dockerfile
+++ b/ci/gh-actions/has-changes/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:20.04
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="A Docker-based Github action to determine if changes were made outside of a provided path exclusion list."
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git jq && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/ci/gh-actions/has-changes/README.md
+++ b/ci/gh-actions/has-changes/README.md
@@ -1,0 +1,26 @@
+# "Has Changes" Docker Action
+
+This action sets a boolean output (`has_changes`) if the diff (`push` or
+`pull_request` event) includes changes outside of a provided list of paths.
+
+## Inputs
+
+The list of paths to exclude. The action will use Bash pattern matching, so
+wildcards (`*`) are supported.
+
+## Outputs
+
+### `has_changes`
+
+Whether ('yes' or 'no') the diff includes changes outside of the provided list
+of paths.
+
+## Example usage
+
+```yaml
+uses: vmware-tanzu/antrea/ci/gh-actions/has-changes@master
+with:
+  args: docs *.md ci
+```
+
+Make sure to checkout the repo first.

--- a/ci/gh-actions/has-changes/action.yml
+++ b/ci/gh-actions/has-changes/action.yml
@@ -1,0 +1,9 @@
+# action.yml
+name: 'Has Changes'
+description: 'Checks if diff includes changes outside of a provided path exclusion list'
+outputs:
+  has_changes:
+    description: 'Whether (yes/no) the diff includes changes'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/ci/gh-actions/has-changes/entrypoint.sh
+++ b/ci/gh-actions/has-changes/entrypoint.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+read -r -a PATTERNS <<< "$*"
+
+cat "$GITHUB_EVENT_PATH"
+
+PR_BASE_SHA=$(jq -r '.pull_request.base.sha' "$GITHUB_EVENT_PATH")
+BEFORE=$(jq -r '.before' "$GITHUB_EVENT_PATH")
+if [[ $PR_BASE_SHA != "" && $PR_BASE_SHA != "null" ]]; then # PR events
+    SHA=$PR_BASE_SHA
+elif [[ $BEFORE != "" && $BEFORE != "null" ]]; then # push events
+    SHA=$BEFORE
+else
+    echo "This does not appear to be a PR or a push event"
+    echo "Setting 'has_changes' to 'yes'"
+    echo "::set-output name=has_changes::yes"
+    exit 0
+fi
+echo "BASE SHA: $SHA"
+
+CHANGED_FILES=$(git diff --name-only "$SHA" HEAD) || rc=$?
+
+if [[ $rc -ne 0 ]]; then
+    echo "Error when running 'git diff'"
+    echo "This is expected when the repo was not checked-out properly, or after a force push"
+    echo "Setting 'has_changes' to 'yes'"
+    echo "::set-output name=has_changes::yes"
+    exit 0
+fi
+
+echo "CHANGED_FILES are:"
+echo "$CHANGED_FILES"
+
+has_changes=false
+for changed_file in $CHANGED_FILES; do
+    matched=false
+    for pattern in "${PATTERNS[@]}"; do
+        if [[ "$changed_file" == $pattern ]]; then
+            matched=true
+            break
+        fi
+    done
+    if ! $matched; then
+        has_changes=true
+        break
+    fi
+done
+
+if $has_changes; then
+    echo "Setting 'has_changes' to 'yes'"
+    echo "::set-output name=has_changes::yes"
+else
+    echo "Setting 'has_changes' to 'no'"
+    echo "::set-output name=has_changes::no"
+fi


### PR DESCRIPTION
This action can be used to determine whether a "diff" includes changes
to files whose paths are not part of a provided exclusion list.

A "diff" is defined as:
 * for a PR, the diff between the base SHA and the HEAD
 * for a push, the diff between the last SHA that was previously pushed
   to the branch and the HEAD

This action can be used to avoid running Kind tests for documentation
PRs. Unlike the "paths-ignore" option for Github workflows, we will
return a success status even when the tests are being skipped.