### PR TITLE
[IPv6] Extend e2e tests for dual-stack

### DIFF
--- a/test/e2e/bandwidth_test.go
+++ b/test/e2e/bandwidth_test.go
@@ -27,6 +27,7 @@ const iperfPort = 5201
 // TestBenchmarkBandwidthIntraNode runs the bandwidth benchmark between Pods on same node.
 func TestBenchmarkBandwidthIntraNode(t *testing.T) {
 	skipIfNotBenchmarkTest(t)
+	skipIfNotIPv4Cluster(t)
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)
@@ -41,10 +42,11 @@ func TestBenchmarkBandwidthIntraNode(t *testing.T) {
 	if err := data.createPodOnNode("perftest-b", masterNodeName(), perftoolImage, nil, nil, nil, []v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}, false); err != nil {
 		t.Fatalf("Error when creating the perftest server Pod: %v", err)
 	}
-	podBIP, err := data.podWaitForIP(defaultTimeout, "perftest-b", testNamespace)
+	podBIPs, err := data.podWaitForIPs(defaultTimeout, "perftest-b", testNamespace)
 	if err != nil {
 		t.Fatalf("Error when getting the perftest server Pod's IP: %v", err)
 	}
+	podBIP := podBIPs.ipv4.String()
 	stdout, _, err := data.runCommandFromPod(testNamespace, "perftest-a", "perftool", []string{"bash", "-c", fmt.Sprintf("iperf3 -c %s|grep sender|awk '{print $7,$8}'", podBIP)})
 	if err != nil {
 		t.Fatalf("Error when running iperf3 client: %v", err)

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -46,6 +46,18 @@ func skipIfNumNodesLessThan(tb testing.TB, required int) {
 	}
 }
 
+func skipIfNotIPv4Cluster(tb testing.TB) {
+	if clusterInfo.podV4NetworkCIDR == "" {
+		tb.Skipf("Skipping test as it requires IPv4 addresses but the IPv4 network CIDR is not set")
+	}
+}
+
+func skipIfIPv6Cluster(tb testing.TB) {
+	if clusterInfo.podV6NetworkCIDR != "" {
+		tb.Skipf("Skipping test as it is not supported in IPv6 cluster")
+	}
+}
+
 func ensureAntreaRunning(tb testing.TB, data *TestData) error {
 	tb.Logf("Applying Antrea YAML")
 	if err := data.deployAntrea(); err != nil {
@@ -94,12 +106,14 @@ func setupTestWithIPFIXCollector(tb testing.TB) (*TestData, error) {
 	if err := data.createPodOnNode("ipfix-collector", masterNodeName(), ipfixCollectorImage, nil, nil, nil, nil, true); err != nil {
 		tb.Fatalf("Error when creating the ipfix collector Pod: %v", err)
 	}
-	ipfixCollectorIP, err := data.podWaitForIP(defaultTimeout, "ipfix-collector", testNamespace)
+	ipfixCollectorIP, err := data.podWaitForIPs(defaultTimeout, "ipfix-collector", testNamespace)
 	if err != nil {
 		tb.Fatalf("Error when waiting to get ipfix collector Pod IP: %v", err)
 	}
 	tb.Logf("Applying Antrea YAML with ipfix collector address")
-	if err := data.deployAntreaFlowExporter(ipfixCollectorIP + ":" + ipfixCollectorPort + ":tcp"); err != nil {
+	// TODO: Deploy the collector using IPv6 address after flow_exporter supports IPv6.
+	ipStr := ipfixCollectorIP.ipv4.String()
+	if err := data.deployAntreaFlowExporter(ipStr + ":" + ipfixCollectorPort + ":tcp"); err != nil {
 		return data, err
 	}
 	tb.Logf("Checking CoreDNS deployment")
@@ -259,7 +273,7 @@ func deletePodWrapper(tb testing.TB, data *TestData, name string) {
 // Node. createTestBusyboxPods returns the cleanupFn function which can be used to delete the
 // created Pods. Pods are created in parallel to reduce the time required to run the tests.
 func createTestBusyboxPods(tb testing.TB, data *TestData, num int, nodeName string) (
-	podNames []string, podIPs []string, cleanupFn func(),
+	podNames []string, podIPs []*PodIPs, cleanupFn func(),
 ) {
 	cleanupFn = func() {
 		var wg sync.WaitGroup
@@ -275,22 +289,22 @@ func createTestBusyboxPods(tb testing.TB, data *TestData, num int, nodeName stri
 
 	type podData struct {
 		podName string
-		podIP   string
+		podIP   *PodIPs
 		err     error
 	}
 
-	createPodAndGetIP := func() (string, string, error) {
+	createPodAndGetIP := func() (string, *PodIPs, error) {
 		podName := randName("test-pod-")
 
 		tb.Logf("Creating a busybox test Pod '%s' and waiting for IP", podName)
 		if err := data.createBusyboxPodOnNode(podName, nodeName); err != nil {
 			tb.Errorf("Error when creating busybox test Pod '%s': %v", podName, err)
-			return "", "", err
+			return "", nil, err
 		}
 
-		if podIP, err := data.podWaitForIP(defaultTimeout, podName, testNamespace); err != nil {
+		if podIP, err := data.podWaitForIPs(defaultTimeout, podName, testNamespace); err != nil {
 			tb.Errorf("Error when waiting for IP for Pod '%s': %v", podName, err)
-			return podName, "", err
+			return podName, nil, err
 		} else {
 			return podName, podIP, nil
 		}

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -17,7 +17,6 @@ package e2e
 import (
 	"encoding/hex"
 	"fmt"
-	"net"
 	"strings"
 	"testing"
 	"time"
@@ -51,6 +50,10 @@ func proxyEnabled(data *TestData) (bool, error) {
 }
 
 func TestProxyServiceSessionAffinity(t *testing.T) {
+	// TODO: add check for IPv6 address after Antrea Proxy supports IPv6
+	skipIfIPv6Cluster(t)
+	skipIfNotIPv4Cluster(t)
+	skipIfProviderIs(t, "kind", "#881 Does not work in Kind, needs to be investigated.")
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)
@@ -61,7 +64,7 @@ func TestProxyServiceSessionAffinity(t *testing.T) {
 
 	nodeName := nodeName(1)
 	require.NoError(t, data.createNginxPod("nginx", nodeName))
-	nginxIP, err := data.podWaitForIP(defaultTimeout, "nginx", testNamespace)
+	nginxIP, err := data.podWaitForIPs(defaultTimeout, "nginx", testNamespace)
 	require.NoError(t, err)
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, "nginx", testNamespace))
 	svc, err := data.createNginxClusterIPService(true)
@@ -83,13 +86,17 @@ func TestProxyServiceSessionAffinity(t *testing.T) {
 	table40Output, _, err := data.runCommandFromPod(metav1.NamespaceSystem, agentName, "antrea-agent", []string{"ovs-ofctl", "dump-flows", defaultBridgeName, "table=40"})
 	require.NoError(t, err)
 	require.Contains(t, table40Output, fmt.Sprintf("nw_dst=%s,tp_dst=80", svc.Spec.ClusterIP))
-	require.Contains(t, table40Output, fmt.Sprintf("load:0x%s->NXM_NX_REG3[]", strings.TrimLeft(hex.EncodeToString(net.ParseIP(nginxIP).To4()), "0")))
+	// TODO: add check for IPv6 address after Antrea Proxy is supported with IPv6
+	require.Contains(t, table40Output, fmt.Sprintf("load:0x%s->NXM_NX_REG3[]", strings.TrimLeft(hex.EncodeToString(nginxIP.ipv4.To4()), "0")))
 	for _, ingressIP := range ingressIPs {
 		require.Contains(t, table40Output, fmt.Sprintf("nw_dst=%s,tp_dst=80", ingressIP))
 	}
 }
 
 func TestProxyHairpin(t *testing.T) {
+	// TODO: add check for IPv6 address after Antrea Proxy supports IPv6
+	skipIfIPv6Cluster(t)
+	skipIfNotIPv4Cluster(t)
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)
@@ -109,6 +116,9 @@ func TestProxyHairpin(t *testing.T) {
 }
 
 func TestProxyEndpointLifeCycle(t *testing.T) {
+	// TODO: add check for IPv6 address after Antrea Proxy supports IPv6
+	skipIfIPv6Cluster(t)
+	skipIfNotIPv4Cluster(t)
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)
@@ -119,12 +129,14 @@ func TestProxyEndpointLifeCycle(t *testing.T) {
 
 	nodeName := nodeName(1)
 	require.NoError(t, data.createNginxPod("nginx", nodeName))
-	nginxIP, err := data.podWaitForIP(defaultTimeout, "nginx", testNamespace)
+	nginxIPs, err := data.podWaitForIPs(defaultTimeout, "nginx", testNamespace)
 	require.NoError(t, err)
 	_, err = data.createNginxClusterIPService(false)
 	require.NoError(t, err)
 	agentName, err := data.getAntreaPodOnNode(nodeName)
 	require.NoError(t, err)
+	// TODO: Add support for IPv6 address after Antrea Proxy in IPv6 is supported
+	nginxIP := nginxIPs.ipv4.String()
 
 	keywords := map[int]string{
 		42: fmt.Sprintf("nat(dst=%s:80)", nginxIP), // endpointNATTable
@@ -146,6 +158,9 @@ func TestProxyEndpointLifeCycle(t *testing.T) {
 }
 
 func TestProxyServiceLifeCycle(t *testing.T) {
+	// TODO: add check for IPv6 address after Antrea Proxy supports IPv6
+	skipIfIPv6Cluster(t)
+	skipIfNotIPv4Cluster(t)
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)
@@ -156,8 +171,10 @@ func TestProxyServiceLifeCycle(t *testing.T) {
 
 	nodeName := nodeName(1)
 	require.NoError(t, data.createNginxPod("nginx", nodeName))
-	nginxIP, err := data.podWaitForIP(defaultTimeout, "nginx", testNamespace)
+	nginxIPs, err := data.podWaitForIPs(defaultTimeout, "nginx", testNamespace)
 	require.NoError(t, err)
+	// TODO: Add support for IPv6 address after Antrea Proxy in IPv6 is supported
+	nginxIP := nginxIPs.ipv4.String()
 	svc, err := data.createNginxClusterIPService(false)
 	require.NoError(t, err)
 	ingressIPs := []string{"169.254.169.253", "169.254.169.254"}
@@ -182,7 +199,8 @@ func TestProxyServiceLifeCycle(t *testing.T) {
 		},
 	}
 
-	groupKeyword := fmt.Sprintf("load:0x%s->NXM_NX_REG3[],load:0x%x->NXM_NX_REG4[0..15],load:0x2->NXM_NX_REG4[16..18]", strings.TrimLeft(string(hex.EncodeToString(net.ParseIP(nginxIP).To4())), "0"), 80)
+	// TODO : add check for IPv6 address after Antrea Proxy is supported with IPv6
+	groupKeyword := fmt.Sprintf("load:0x%s->NXM_NX_REG3[],load:0x%x->NXM_NX_REG4[0..15],load:0x2->NXM_NX_REG4[16..18]", strings.TrimLeft(hex.EncodeToString(nginxIPs.ipv4.To4()), "0"), 80)
 	groupOutput, _, err := data.runCommandFromPod(metav1.NamespaceSystem, agentName, "antrea-agent", []string{"ovs-ofctl", "dump-groups", defaultBridgeName})
 	require.NoError(t, err)
 	require.Contains(t, groupOutput, groupKeyword)

--- a/test/e2e/supportbundle_test.go
+++ b/test/e2e/supportbundle_test.go
@@ -70,8 +70,15 @@ func testSupportBundle(name string, t *testing.T) {
 	// Acquire token.
 	token, err := getAccessToken(podName, fmt.Sprintf("antrea-%s", name), tokenPath, data)
 	require.NoError(t, err)
-	podIP, err := data.podWaitForIP(defaultTimeout, podName, metav1.NamespaceSystem)
+	podIP, err := data.podWaitForIPs(defaultTimeout, podName, metav1.NamespaceSystem)
 	require.NoError(t, err)
+
+	for _, podIPStr := range podIP.ipStrings {
+		getAndCheckSupportBundle(t, name, podIPStr, podPort, token, data)
+	}
+}
+
+func getAndCheckSupportBundle(t *testing.T, name, podIP, podPort, token string, data *TestData) {
 	// Setup clients.
 	localConfig := rest.CopyConfig(data.kubeConfig)
 	localConfig.Host = net.JoinHostPort(podIP, podPort)
@@ -131,6 +138,7 @@ func testSupportBundle(name string, t *testing.T) {
 	bundle, err = clients.SystemV1beta1().SupportBundles().Get(context.TODO(), name, metav1.GetOptions{})
 	require.NoError(t, err)
 	require.Equal(t, systemv1beta1.SupportBundleStatusNone, bundle.Status)
+
 }
 
 func TestSupportBundleController(t *testing.T) {


### PR DESCRIPTION
1. Add e2e cases for IPAM allocation in dual-stack.
2. Add e2e cases for connectivity, including same Node and different Node cases.