### PR TITLE
Use specific kustomize version when generating manifests

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -991,7 +991,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-g6mm797kch
+  name: antrea-config-dm2mbk47h5
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1097,7 +1097,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-g6mm797kch
+          name: antrea-config-dm2mbk47h5
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1312,7 +1312,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-g6mm797kch
+          name: antrea-config-dm2mbk47h5
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -991,7 +991,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-g6mm797kch
+  name: antrea-config-dm2mbk47h5
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1097,7 +1097,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-g6mm797kch
+          name: antrea-config-dm2mbk47h5
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1170,8 +1170,6 @@ spec:
         command:
         - antrea-agent
         env:
-        - name: ANTREA_CLOUD_EKS
-          value: "true"
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -1184,6 +1182,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: ANTREA_CLOUD_EKS
+          value: "true"
         image: antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1314,7 +1314,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-g6mm797kch
+          name: antrea-config-dm2mbk47h5
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -991,7 +991,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-f72hcg8m78
+  name: antrea-config-4ch79cbmb4
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1097,7 +1097,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-f72hcg8m78
+          name: antrea-config-4ch79cbmb4
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1312,7 +1312,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-f72hcg8m78
+          name: antrea-config-4ch79cbmb4
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -996,7 +996,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-d429bkg4d6
+  name: antrea-config-h69mt672h6
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1111,7 +1111,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-d429bkg4d6
+          name: antrea-config-h69mt672h6
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1173,36 +1173,6 @@ spec:
         component: antrea-agent
     spec:
       containers:
-      - command:
-        - start_ovs_ipsec
-        image: antrea/antrea-ubuntu:latest
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - timeout 5 container_liveness_probe ovs-ipsec
-          initialDelaySeconds: 5
-          periodSeconds: 5
-        name: antrea-ipsec
-        resources:
-          requests:
-            cpu: 50m
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-        volumeMounts:
-        - mountPath: /var/run/openvswitch
-          name: host-var-run-antrea
-          subPath: openvswitch
-        - mountPath: /var/log/openvswitch
-          name: host-var-log-antrea
-          subPath: openvswitch
-        - mountPath: /var/log/strongswan
-          name: host-var-log-antrea
-          subPath: strongswan
       - args:
         - --config
         - /etc/antrea/antrea-agent.conf
@@ -1214,11 +1184,6 @@ spec:
         command:
         - antrea-agent
         env:
-        - name: ANTREA_IPSEC_PSK
-          valueFrom:
-            secretKeyRef:
-              key: psk
-              name: antrea-ipsec
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -1231,6 +1196,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: ANTREA_IPSEC_PSK
+          valueFrom:
+            secretKeyRef:
+              key: psk
+              name: antrea-ipsec
         image: antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1319,6 +1289,36 @@ spec:
         - mountPath: /var/log/openvswitch
           name: host-var-log-antrea
           subPath: openvswitch
+      - command:
+        - start_ovs_ipsec
+        image: antrea/antrea-ubuntu:latest
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - timeout 5 container_liveness_probe ovs-ipsec
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        name: antrea-ipsec
+        resources:
+          requests:
+            cpu: 50m
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+        volumeMounts:
+        - mountPath: /var/run/openvswitch
+          name: host-var-run-antrea
+          subPath: openvswitch
+        - mountPath: /var/log/openvswitch
+          name: host-var-log-antrea
+          subPath: openvswitch
+        - mountPath: /var/log/strongswan
+          name: host-var-log-antrea
+          subPath: strongswan
       hostNetwork: true
       initContainers:
       - command:
@@ -1361,7 +1361,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-d429bkg4d6
+          name: antrea-config-h69mt672h6
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -10,7 +10,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-agent-windows-59cc7mmd6h
+  name: antrea-agent-windows-h7td2mh9gm
   namespace: kube-system
 ---
 apiVersion: v1
@@ -70,7 +70,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-windows-config-ht7fb8gdk8
+  name: antrea-windows-config-4f6g849tgk
   namespace: kube-system
 ---
 apiVersion: apps/v1
@@ -158,11 +158,11 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-windows-config-ht7fb8gdk8
+          name: antrea-windows-config-4f6g849tgk
         name: antrea-windows-config
       - configMap:
           defaultMode: 420
-          name: antrea-agent-windows-59cc7mmd6h
+          name: antrea-agent-windows-h7td2mh9gm
         name: antrea-agent-windows
       - hostPath:
           path: /etc/cni/net.d
@@ -181,7 +181,6 @@ spec:
         name: host
       - hostPath:
           path: \\.\pipe\rancher_wins
-          type: null
         name: wins
   updateStrategy:
     type: RollingUpdate

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -996,7 +996,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-64fmb8kc28
+  name: antrea-config-mh8ghcmbh6
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1102,7 +1102,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-64fmb8kc28
+          name: antrea-config-mh8ghcmbh6
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1317,7 +1317,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-64fmb8kc28
+          name: antrea-config-mh8ghcmbh6
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -37,8 +37,9 @@ In 'release' mode, environment variables IMG_NAME and IMG_TAG must be set.
 
 This tool uses kustomize (https://github.com/kubernetes-sigs/kustomize) to generate manifests for
 Antrea. You can set the KUSTOMIZE environment variable to the path of the kustomize binary you want
-us to use. Otherwise we will look for kustomize in your PATH and your GOPATH. If we cannot find
-kustomize there, we will try to install it."
+us to use. Otherwise we will download the appropriate version of the kustomize binary and use
+it (this is the recommended approach since different versions of kustomize may create different
+output YAMLs)."
 
 function print_usage {
     echoerr "$_usage"

--- a/hack/verify-kustomize.sh
+++ b/hack/verify-kustomize.sh
@@ -14,45 +14,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-_GOPATH_BIN="$(go env GOPATH)/bin"
-_MIN_KUSTOMIZE_VERSION="v3.3.0"
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+_BINDIR="$THIS_DIR/.bin"
+# Must be an exact match, as the generated YAMLs may not be consistent across
+# versions
+_KUSTOMIZE_VERSION="v3.8.2"
 
-# Ensure the kustomize tool exists and is a viable version, or installs it
+# Ensure the kustomize tool exists and is the correct version, or installs it
 verify_kustomize() {
-    # If kustomize is not available on the path, get it.
-    local kustomize="$(PATH=$PATH:$_GOPATH_BIN command -v kustomize)"
-    if [ ! -x "$kustomize" ]; then
-        local ostype=""
-        if [[ "$OSTYPE" == "linux-gnu" ]]; then
-            ostype="linux"
-        elif [[ "$OSTYPE" == "darwin"* ]]; then
-            ostype="darwin"
-        else
-            >&2 echo "Unsupported OS type $OSTYPE"
-            return 1
+    # Check if there is already a kustomize binary in $_BINDIR and if yes, check
+    # if the version matches the expected one.
+    local kustomize="$(PATH=$_BINDIR command -v kustomize)"
+    if [ -x "$kustomize" ]; then
+        # Verify version if kustomize was already installed.
+        local kustomize_version="$($kustomize version --short)"
+        # Should work with:
+        #  - kustomize/v3.3.0
+        #  - {kustomize/v3.8.2  2020-08-29T17:44:01Z  }
+        kustomize_version="${kustomize_version##*/}"
+        kustomize_version="${kustomize_version%% *}"
+        if [ "${kustomize_version}" == "${_KUSTOMIZE_VERSION}" ]; then
+            # If version is exact match, stop here.
+            echo "$kustomize"
+            return 0
         fi
-        >&2 echo "Installing kustomize"
-        local kustomize_url="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${_MIN_KUSTOMIZE_VERSION}/kustomize_${_MIN_KUSTOMIZE_VERSION}_${ostype}_amd64.tar.gz"
-        curl -sLo kustomize.tar.gz "${kustomize_url}" || return 1
-        mkdir -p "$_GOPATH_BIN" || return 1
-        tar -xzf kustomize.tar.gz -C "$_GOPATH_BIN" || return 1
-        rm -f kustomize.tar.gz
-        kustomize="$_GOPATH_BIN/kustomize"
-        echo "$kustomize"
-        return 0
+        >&2 echo "Detected kustomize version ($kustomize_version) does not match expected one ($_KUSTOMIZE_VERSION), installing correct version"
     fi
-
-    # Verify version if kustomize was already installed.
-    local kustomize_version="$($kustomize version --short)"
-    kustomize_version="${kustomize_version##*/}"
-    if [ "${kustomize_version}" == "${_MIN_KUSTOMIZE_VERSION}" ]; then
-        # If version is exact match, stop here.
-        echo "$kustomize"
-        return 0
+    local ostype=""
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+        ostype="linux"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        ostype="darwin"
+    else
+        >&2 echo "Unsupported OS type $OSTYPE"
+        return 1
     fi
-    if [[ "${_MIN_KUSTOMIZE_VERSION}" != $(echo -e "${_MIN_KUSTOMIZE_VERSION}\n${kustomize_version}" | sort -V | head -n1) ]]; then
-        >&2 echo "Your version of kustomize is not recent enough, please install version ${_MIN_KUSTOMIZE_VERSION}"
-        return 2
-    fi
+    >&2 echo "Installing kustomize"
+    local kustomize_url="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${_KUSTOMIZE_VERSION}/kustomize_${_KUSTOMIZE_VERSION}_${ostype}_amd64.tar.gz"
+    curl -sLo kustomize.tar.gz "${kustomize_url}" || return 1
+    mkdir -p "$_BINDIR" || return 1
+    tar -xzf kustomize.tar.gz -C "$_BINDIR" || return 1
+    rm -f kustomize.tar.gz
+    kustomize="$_BINDIR/kustomize"
     echo "$kustomize"
+    return 0
 }


### PR DESCRIPTION
Ensure that we use the desired version of kustomize even when there is
already an installation of kustomize. This is important because in
v3.8.0, kustomize stopped using apimachinery by default and switched
to its own library (kyaml) for K8s resource YAML manipulation. Because
of this change, the generated YAMLs are different: fields within objects
may be ordered differently, and the latest kustomize generally does a
better job dropping empty fields. We set the desired version to v3.8.2.

No action should be required from Antrea developers. The next time they
run `make manifest` locally, the correct version of kustomize will be
downloaded under `./hack/.bin`.

Fixes #975
Fixes #1017