### PR TITLE
[IPv6] Add support for dual-stack when using kube-proxy for Service

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -966,7 +966,8 @@ data:
     featureGates:
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
-    # Service traffic.
+    # Service traffic. Antrea proxy doesn't support an IPv6 only cluster or a Dual-Stack cluster
+    # before PR #1102[https://github.com/vmware-tanzu/antrea/pull/1102] is merged.
       AntreaProxy: true
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
@@ -1091,7 +1092,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-c5t898htbb
+  name: antrea-config-4c8bb4f97d
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1198,7 +1199,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-c5t898htbb
+          name: antrea-config-4c8bb4f97d
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1414,7 +1415,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-c5t898htbb
+          name: antrea-config-4c8bb4f97d
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -966,7 +966,8 @@ data:
     featureGates:
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
-    # Service traffic.
+    # Service traffic. Antrea proxy doesn't support an IPv6 only cluster or a Dual-Stack cluster
+    # before PR #1102[https://github.com/vmware-tanzu/antrea/pull/1102] is merged.
       AntreaProxy: true
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
@@ -1091,7 +1092,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-c5t898htbb
+  name: antrea-config-4c8bb4f97d
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1198,7 +1199,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-c5t898htbb
+          name: antrea-config-4c8bb4f97d
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1416,7 +1417,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-c5t898htbb
+          name: antrea-config-4c8bb4f97d
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -966,7 +966,8 @@ data:
     featureGates:
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
-    # Service traffic.
+    # Service traffic. Antrea proxy doesn't support an IPv6 only cluster or a Dual-Stack cluster
+    # before PR #1102[https://github.com/vmware-tanzu/antrea/pull/1102] is merged.
       AntreaProxy: true
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
@@ -1091,7 +1092,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-t47k4gbhkb
+  name: antrea-config-g86thkg7c9
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1198,7 +1199,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-t47k4gbhkb
+          name: antrea-config-g86thkg7c9
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1414,7 +1415,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-t47k4gbhkb
+          name: antrea-config-g86thkg7c9
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -966,7 +966,8 @@ data:
     featureGates:
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
-    # Service traffic.
+    # Service traffic. Antrea proxy doesn't support an IPv6 only cluster or a Dual-Stack cluster
+    # before PR #1102[https://github.com/vmware-tanzu/antrea/pull/1102] is merged.
     #  AntreaProxy: false
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
@@ -1096,7 +1097,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-4k2khg5c24
+  name: antrea-config-mcd9664ghf
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1212,7 +1213,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-4k2khg5c24
+          name: antrea-config-mcd9664ghf
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1463,7 +1464,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-4k2khg5c24
+          name: antrea-config-mcd9664ghf
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -966,7 +966,8 @@ data:
     featureGates:
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
-    # Service traffic.
+    # Service traffic. Antrea proxy doesn't support an IPv6 only cluster or a Dual-Stack cluster
+    # before PR #1102[https://github.com/vmware-tanzu/antrea/pull/1102] is merged.
     #  AntreaProxy: false
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
@@ -1096,7 +1097,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-b8h2ghckdc
+  name: antrea-config-6mf8hc86cg
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1203,7 +1204,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-b8h2ghckdc
+          name: antrea-config-6mf8hc86cg
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1419,7 +1420,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-b8h2ghckdc
+          name: antrea-config-6mf8hc86cg
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -2,7 +2,8 @@
 featureGates:
 # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
 # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
-# Service traffic.
+# Service traffic. Antrea proxy doesn't support an IPv6 only cluster or a Dual-Stack cluster
+# before PR #1102[https://github.com/vmware-tanzu/antrea/pull/1102] is merged.
 #  AntreaProxy: false
 
 # Enable traceflow which provides packet tracing feature to diagnose network issue.

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -96,6 +96,12 @@ func run(o *Options) error {
 		features.DefaultFeatureGate.Enabled(features.AntreaPolicy))
 
 	_, serviceCIDRNet, _ := net.ParseCIDR(o.config.ServiceCIDR)
+	var serviceCIDRNetv6 *net.IPNet
+	// Todo: use FeatureGate to check if IPv6 is enabled and then read configuration item "ServiceCIDRv6".
+	if o.config.ServiceCIDRv6 != "" {
+		_, serviceCIDRNetv6, _ = net.ParseCIDR(o.config.ServiceCIDRv6)
+	}
+
 	_, encapMode := config.GetTrafficEncapModeFromStr(o.config.TrafficEncapMode)
 	networkConfig := &config.NetworkConfig{
 		TunnelType:        ovsconfig.TunnelType(o.config.TunnelType),
@@ -121,6 +127,7 @@ func run(o *Options) error {
 		o.config.HostGateway,
 		o.config.DefaultMTU,
 		serviceCIDRNet,
+		serviceCIDRNetv6,
 		networkConfig,
 		features.DefaultFeatureGate.Enabled(features.AntreaProxy))
 	err = agentInitializer.Initialize()

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -68,6 +68,11 @@ type AgentConfig struct {
 	// AntreaProxy is enabled, this parameter is not needed and will be ignored if provided.
 	// Default is 10.96.0.0/12
 	ServiceCIDR string `yaml:"serviceCIDR,omitempty"`
+	// ClusterIP CIDR range for IPv6 Services. It's required when using kube-proxy to provide IPv6 Service in a Dual-Stack
+	// cluster or an IPv6 only cluster. The value should be the same as the configuration for kube-apiserver specified by
+	// --service-cluster-ip-range. When AntreaProxy is enabled, this parameter is not needed.
+	// No default value for this field.
+	ServiceCIDRv6 string `yaml:"serviceCIDRv6,omitempty"`
 	// Whether or not to enable IPSec (ESP) encryption for Pod traffic across Nodes. IPSec encryption
 	// is supported only for the GRE tunnel type. Antrea uses Preshared Key (PSK) for IKE
 	// authentication. When IPSec tunnel is enabled, the PSK value must be passed to Antrea Agent

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -84,7 +84,13 @@ func (o *Options) validate(args []string) error {
 	// Validate service CIDR configuration
 	_, _, err := net.ParseCIDR(o.config.ServiceCIDR)
 	if err != nil {
-		return fmt.Errorf("service CIDR %s is invalid", o.config.ServiceCIDR)
+		return fmt.Errorf("Service CIDR %s is invalid", o.config.ServiceCIDR)
+	}
+	if o.config.ServiceCIDRv6 != "" {
+		_, _, err := net.ParseCIDR(o.config.ServiceCIDRv6)
+		if err != nil {
+			return fmt.Errorf("Service CIDR v6 %s is invalid", o.config.ServiceCIDRv6)
+		}
 	}
 	if o.config.TunnelType != ovsconfig.VXLANTunnel && o.config.TunnelType != ovsconfig.GeneveTunnel &&
 		o.config.TunnelType != ovsconfig.GRETunnel && o.config.TunnelType != ovsconfig.STTTunnel {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -64,6 +64,7 @@ type Initializer struct {
 	hostGateway     string // name of gateway port on the OVS bridge
 	mtu             int
 	serviceCIDR     *net.IPNet // K8s Service ClusterIP CIDR
+	serviceCIDRv6   *net.IPNet // K8s Service ClusterIP CIDR in IPv6
 	networkConfig   *config.NetworkConfig
 	nodeConfig      *config.NodeConfig
 	enableProxy     bool
@@ -79,6 +80,7 @@ func NewInitializer(
 	hostGateway string,
 	mtu int,
 	serviceCIDR *net.IPNet,
+	serviceCIDRv6 *net.IPNet,
 	networkConfig *config.NetworkConfig,
 	enableProxy bool) *Initializer {
 	return &Initializer{
@@ -91,6 +93,7 @@ func NewInitializer(
 		hostGateway:     hostGateway,
 		mtu:             mtu,
 		serviceCIDR:     serviceCIDR,
+		serviceCIDRv6:   serviceCIDRv6,
 		networkConfig:   networkConfig,
 		enableProxy:     enableProxy,
 	}
@@ -313,8 +316,8 @@ func (i *Initializer) initOpenFlowPipeline() error {
 		// from local Pods to any Service address can be forwarded to the host gateway interface
 		// correctly. Otherwise packets might be dropped by egress rules before they are DNATed to
 		// backend Pods.
-		if err := i.ofClient.InstallClusterServiceCIDRFlows(i.serviceCIDR, gateway.MAC, gatewayOFPort); err != nil {
-			klog.Errorf("Failed to setup openflow entries for Cluster Service CIDR %s: %v", i.serviceCIDR, err)
+		if err := i.ofClient.InstallClusterServiceCIDRFlows([]*net.IPNet{i.serviceCIDR, i.serviceCIDRv6}, gateway.MAC, gatewayOFPort); err != nil {
+			klog.Errorf("Failed to setup OpenFlow entries for Service CIDRss: %v", err)
 			return err
 		}
 	} else {

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -51,7 +51,7 @@ type Client interface {
 	// InstallClusterServiceCIDRFlows sets up the appropriate flows so that traffic can reach
 	// the different Services running in the Cluster. This method needs to be invoked once with
 	// the Cluster Service CIDR as a parameter.
-	InstallClusterServiceCIDRFlows(serviceNet *net.IPNet, gatewayMAC net.HardwareAddr, gatewayOFPort uint32) error
+	InstallClusterServiceCIDRFlows(serviceNets []*net.IPNet, gatewayMAC net.HardwareAddr, gatewayOFPort uint32) error
 
 	// InstallClusterServiceFlows sets up the appropriate flows so that traffic can reach
 	// the different Services running in the Cluster. This method needs to be invoked once.
@@ -470,23 +470,22 @@ func (c *client) InstallClusterServiceFlows() error {
 	return nil
 }
 
-func (c *client) InstallClusterServiceCIDRFlows(serviceNet *net.IPNet, gatewayMAC net.HardwareAddr, gatewayOFPort uint32) error {
-	flow := c.serviceCIDRDNATFlow(serviceNet, gatewayMAC, gatewayOFPort)
-	if err := c.ofEntryOperations.Add(flow); err != nil {
+func (c *client) InstallClusterServiceCIDRFlows(serviceNets []*net.IPNet, gatewayMAC net.HardwareAddr, gatewayOFPort uint32) error {
+	flows := c.serviceCIDRDNATFlows(serviceNets, gatewayMAC, gatewayOFPort)
+	if err := c.ofEntryOperations.AddAll(flows); err != nil {
 		return err
 	}
-	c.defaultServiceFlows = []binding.Flow{flow}
+	c.defaultServiceFlows = flows
 	return nil
 }
 
 func (c *client) InstallGatewayFlows(gatewayAddrs []net.IP, gatewayMAC net.HardwareAddr, gatewayOFPort uint32) error {
 	flows := []binding.Flow{
 		c.gatewayClassifierFlow(gatewayOFPort, cookie.Default),
-		c.ctRewriteDstMACFlow(gatewayMAC, cookie.Default),
 		c.l2ForwardCalcFlow(gatewayMAC, gatewayOFPort, cookie.Default),
 	}
-	hasIPv6Addr := util.ContainIPv6Addr(gatewayAddrs)
-	flows = append(flows, c.gatewayIPSpoofGuardFlows(gatewayOFPort, hasIPv6Addr, cookie.Default)...)
+	hasV4, hasV6 := util.CheckAddressFamilies(gatewayAddrs)
+	flows = append(flows, c.gatewayIPSpoofGuardFlows(gatewayOFPort, hasV4, hasV6, cookie.Default)...)
 
 	// Add ARP SpoofGuard flow for local gateway interface.
 	gwIPv4 := util.GetIPv4Addr(gatewayAddrs)
@@ -495,7 +494,7 @@ func (c *client) InstallGatewayFlows(gatewayAddrs []net.IP, gatewayMAC net.Hardw
 	}
 	// Add flow to ensure the liveness check packet could be forwarded correctly.
 	flows = append(flows, c.localProbeFlow(gatewayAddrs, cookie.Default)...)
-
+	flows = append(flows, c.ctRewriteDstMACFlow(gatewayMAC, hasV4, hasV6, cookie.Default)...)
 	// In NoEncap , no traffic from tunnel port
 	if c.encapMode.SupportsEncap() {
 		flows = append(flows, c.l3ToGatewayFlow(gatewayAddrs, gatewayMAC, cookie.Default)...)

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -238,7 +238,7 @@ func (mr *MockClientMockRecorder) InstallBridgeUplinkFlows(arg0, arg1 interface{
 }
 
 // InstallClusterServiceCIDRFlows mocks base method
-func (m *MockClient) InstallClusterServiceCIDRFlows(arg0 *net.IPNet, arg1 net.HardwareAddr, arg2 uint32) error {
+func (m *MockClient) InstallClusterServiceCIDRFlows(arg0 []*net.IPNet, arg1 net.HardwareAddr, arg2 uint32) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstallClusterServiceCIDRFlows", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -44,6 +44,7 @@ type Client struct {
 }
 
 // NewClient returns a route client.
+// Todo: remove param serviceCIDR after kube-proxy is replaced by Antrea Proxy completely.
 func NewClient(serviceCIDR *net.IPNet, encapMode config.TrafficEncapModeType) (*Client, error) {
 	nr := netroute.New()
 	return &Client{

--- a/pkg/agent/util/iptables/iptables.go
+++ b/pkg/agent/util/iptables/iptables.go
@@ -50,23 +50,33 @@ const (
 var restoreWaitSupportedMinVersion = semver.Version{Major: 1, Minor: 6, Patch: 2}
 
 type Client struct {
-	ipt  *iptables.IPTables
-	ip6t *iptables.IPTables
-	// restoreWaitSupported indicates whether iptables-restore supports --wait flag.
+	ipts []*iptables.IPTables
+	// restoreWaitSupported indicates whether iptables-restore (or ip6tables-restore) supports --wait flag.
 	restoreWaitSupported bool
-	enableIPv6           bool
 }
 
-func New() (*Client, error) {
-	ipt, err := iptables.New()
-	if err != nil {
-		return nil, fmt.Errorf("error creating IPTables instance: %v", err)
+func New(enableIPV4, enableIPV6 bool) (*Client, error) {
+	var ipts []*iptables.IPTables
+	var restoreWaitSupported bool
+	if enableIPV4 {
+		ipt, err := iptables.New()
+		if err != nil {
+			return nil, fmt.Errorf("error creating IPTables instance: %v", err)
+		}
+		ipts = append(ipts, ipt)
+		restoreWaitSupported = isRestoreWaitSupported(ipt)
 	}
-	ip6t, err := iptables.NewWithProtocol(iptables.ProtocolIPv6)
-	if err != nil {
-		return nil, fmt.Errorf("error creating IPTables instance for IPv6: %v", err)
+	if enableIPV6 {
+		ip6t, err := iptables.NewWithProtocol(iptables.ProtocolIPv6)
+		if err != nil {
+			return nil, fmt.Errorf("error creating IPTables instance for IPv6: %v", err)
+		}
+		ipts = append(ipts, ip6t)
+		if !restoreWaitSupported {
+			restoreWaitSupported = isRestoreWaitSupported(ip6t)
+		}
 	}
-	return &Client{ipt: ipt, ip6t: ip6t, restoreWaitSupported: isRestoreWaitSupported(ipt)}, nil
+	return &Client{ipts: ipts, restoreWaitSupported: restoreWaitSupported}, nil
 }
 
 func isRestoreWaitSupported(ipt *iptables.IPTables) bool {
@@ -77,8 +87,8 @@ func isRestoreWaitSupported(ipt *iptables.IPTables) bool {
 
 // ensureChain checks if target chain already exists, creates it if not.
 func (c *Client) EnsureChain(table string, chain string) error {
-	ipts := c.getIptablesInstances()
-	for _, ipt := range ipts {
+	for idx := range c.ipts {
+		ipt := c.ipts[idx]
 		oriChains, err := ipt.ListChains(table)
 		if err != nil {
 			return fmt.Errorf("error listing existing chains in table %s: %v", table, err)
@@ -94,18 +104,10 @@ func (c *Client) EnsureChain(table string, chain string) error {
 	return nil
 }
 
-func (c *Client) getIptablesInstances() []*iptables.IPTables {
-	ipts := []*iptables.IPTables{c.ipt}
-	if c.enableIPv6 {
-		ipts = append(ipts, c.ip6t)
-	}
-	return ipts
-}
-
 // ensureRule checks if target rule already exists, appends it if not.
 func (c *Client) EnsureRule(table string, chain string, ruleSpec []string) error {
-	ipts := c.getIptablesInstances()
-	for _, ipt := range ipts {
+	for idx := range c.ipts {
+		ipt := c.ipts[idx]
 		exist, err := ipt.Exists(table, chain, ruleSpec...)
 		if err != nil {
 			return fmt.Errorf("error checking if rule %v exists in table %s chain %s: %v", ruleSpec, table, chain, err)
@@ -163,11 +165,23 @@ func (c *Client) Restore(data []byte, flush bool, useIPv6 bool) error {
 
 // Save calls iptables-saves to dump chains and tables in iptables.
 func (c *Client) Save() ([]byte, error) {
-	return exec.Command("iptables-save", "-c").CombinedOutput()
-}
-
-func (c *Client) SetIPv6Supported(val bool) {
-	c.enableIPv6 = val
+	var output []byte
+	for idx := range c.ipts {
+		var cmd string
+		ipt := c.ipts[idx]
+		switch ipt.Proto() {
+		case iptables.ProtocolIPv6:
+			cmd = "ip6tables-save"
+		default:
+			cmd = "iptables-save"
+		}
+		data, err := exec.Command(cmd, "-c").CombinedOutput()
+		if err != nil {
+			return nil, err
+		}
+		output = append(output, data...)
+	}
+	return output, nil
 }
 
 func contains(chains []string, targetChain string) bool {

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -132,13 +132,15 @@ func GetIPv4Addr(ips []net.IP) net.IP {
 	return nil
 }
 
-func ContainIPv6Addr(ips []net.IP) bool {
+func CheckAddressFamilies(ips []net.IP) (hasV4, hasV6 bool) {
 	for _, ip := range ips {
-		if ip.To4() == nil {
-			return true
+		if ip.To4() != nil {
+			hasV4 = true
+		} else {
+			hasV6 = true
 		}
 	}
-	return false
+	return
 }
 
 func GetIPWithFamily(ips []net.IP, addrFamily uint8) (net.IP, error) {

--- a/pkg/support/dump_others.go
+++ b/pkg/support/dump_others.go
@@ -52,7 +52,8 @@ func (d *agentDumper) DumpHostNetworkInfo(basedir string) error {
 }
 
 func (d *agentDumper) dumpIPTables(basedir string) error {
-	c, err := iptables.New()
+	nodeConfig := d.aq.GetNodeConfig()
+	c, err := iptables.New(nodeConfig.PodIPv4CIDR != nil, nodeConfig.PodIPv6CIDR != nil)
 	if err != nil {
 		return err
 	}

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -84,7 +84,14 @@ type testConfig struct {
 	tunnelOFPort uint32
 	serviceCIDR  *net.IPNet
 	globalMAC    net.HardwareAddr
+	enableIPv6   bool
+	enableIPv4   bool
 }
+
+var (
+	_, podIPv4CIDR, _ = net.ParseCIDR("192.168.1.0/24")
+	_, podIPv6CIDR, _ = net.ParseCIDR("fd74:ca9b:172:19::/64")
+)
 
 func TestConnectivityFlows(t *testing.T) {
 	// Initialize ovs metrics (Prometheus) to test them
@@ -224,10 +231,17 @@ func testReplayFlows(t *testing.T) {
 }
 
 func testInitialize(t *testing.T, config *testConfig) {
-	if _, err := c.Initialize(roundInfo, &config1.NodeConfig{}, config1.TrafficEncapModeEncap, config1.HostGatewayOFPort); err != nil {
+	nodeConfig := &config1.NodeConfig{}
+	if config.enableIPv4 {
+		nodeConfig.PodIPv4CIDR = podIPv4CIDR
+	}
+	if config.enableIPv6 {
+		nodeConfig.PodIPv6CIDR = podIPv6CIDR
+	}
+	if _, err := c.Initialize(roundInfo, nodeConfig, config1.TrafficEncapModeEncap, config1.HostGatewayOFPort); err != nil {
 		t.Errorf("Failed to initialize openflow client: %v", err)
 	}
-	for _, tableFlow := range prepareDefaultFlows() {
+	for _, tableFlow := range prepareDefaultFlows(config) {
 		ofTestUtils.CheckFlowExists(t, ovsCtlClient, tableFlow.tableID, true, tableFlow.flows)
 	}
 	checkOVSFlowMetrics(t, c)
@@ -432,6 +446,7 @@ func TestIPv6ConnectivityFlows(t *testing.T) {
 		testInitialize,
 		testInstallNodeFlows,
 		testInstallPodFlows,
+		testInstallGatewayFlows,
 		testUninstallPodFlows,
 		testUninstallNodeFlows,
 	} {
@@ -633,6 +648,8 @@ func prepareConfiguration() *testConfig {
 		tunnelOFPort: uint32(2),
 		serviceCIDR:  serviceCIDR,
 		globalMAC:    vMAC,
+		enableIPv4:   true,
+		enableIPv6:   false,
 	}
 }
 
@@ -669,6 +686,8 @@ func prepareIPv6Configuration() *testConfig {
 		tunnelOFPort: uint32(2),
 		serviceCIDR:  serviceCIDR,
 		globalMAC:    vMAC,
+		enableIPv4:   false,
+		enableIPv6:   true,
 	}
 }
 
@@ -755,15 +774,6 @@ func prepareGatewayFlows(gwIPs []net.IP, gwMAC net.HardwareAddr, gwOFPort uint32
 			},
 		},
 		{
-			uint8(31),
-			[]*ofTestUtils.ExpectFlow{
-				{
-					MatchStr: "priority=200,ct_state=-new+trk,ct_mark=0x20,ip",
-					ActStr:   fmt.Sprintf("load:0x%s->NXM_OF_ETH_DST[],goto_table:42", strings.Replace(gwMAC.String(), ":", "", -1)),
-				},
-			},
-		},
-		{
 			uint8(80),
 			[]*ofTestUtils.ExpectFlow{
 				{
@@ -775,9 +785,11 @@ func prepareGatewayFlows(gwIPs []net.IP, gwMAC net.HardwareAddr, gwOFPort uint32
 	}
 
 	for _, gwIP := range gwIPs {
-		var ipProtoStr string
+		var ipProtoStr, nwSrcStr, nwDstStr string
 		if gwIP.To4() != nil {
 			ipProtoStr = "ip"
+			nwSrcStr = "nw_src"
+			nwDstStr = "nw_dst"
 			flows = append(flows,
 				expectTableFlows{
 					uint8(10),
@@ -794,13 +806,15 @@ func prepareGatewayFlows(gwIPs []net.IP, gwMAC net.HardwareAddr, gwOFPort uint32
 				})
 		} else {
 			ipProtoStr = "ipv6"
+			nwSrcStr = "ipv6_src"
+			nwDstStr = "ipv6_dst"
 		}
 		flows = append(flows,
 			expectTableFlows{
 				uint8(70),
 				[]*ofTestUtils.ExpectFlow{
 					{
-						MatchStr: fmt.Sprintf("priority=200,%s,dl_dst=%s,nw_dst=%s", ipProtoStr, vMAC.String(), gwIP.String()),
+						MatchStr: fmt.Sprintf("priority=200,%s,dl_dst=%s,%s=%s", ipProtoStr, vMAC.String(), nwDstStr, gwIP.String()),
 						ActStr:   fmt.Sprintf("set_field:%s->eth_dst,goto_table:80", gwMAC.String()),
 					},
 				},
@@ -809,8 +823,17 @@ func prepareGatewayFlows(gwIPs []net.IP, gwMAC net.HardwareAddr, gwOFPort uint32
 				tableID: uint8(90),
 				flows: []*ofTestUtils.ExpectFlow{
 					{
-						MatchStr: fmt.Sprintf("priority=210,%s,nw_src=%s", ipProtoStr, gwIP.String()),
+						MatchStr: fmt.Sprintf("priority=210,%s,%s=%s", ipProtoStr, nwSrcStr, gwIP.String()),
 						ActStr:   "goto_table:105",
+					},
+				},
+			},
+			expectTableFlows{
+				uint8(31),
+				[]*ofTestUtils.ExpectFlow{
+					{
+						MatchStr: fmt.Sprintf("priority=200,ct_state=-new+trk,ct_mark=0x20,%s", ipProtoStr),
+						ActStr:   fmt.Sprintf("load:0x%s->NXM_OF_ETH_DST[],goto_table:42", strings.Replace(gwMAC.String(), ":", "", -1)),
 					},
 				},
 			},
@@ -879,8 +902,37 @@ func prepareServiceHelperFlows() []expectTableFlows {
 	}
 }
 
-func prepareDefaultFlows() []expectTableFlows {
+func prepareDefaultFlows(config *testConfig) []expectTableFlows {
+	table31Flows := expectTableFlows{
+		tableID: 31,
+		flows:   []*ofTestUtils.ExpectFlow{{MatchStr: "priority=0", ActStr: "resubmit(,40),resubmit(,41)"}},
+	}
+	table105Flows := expectTableFlows{
+		tableID: 105,
+		flows:   []*ofTestUtils.ExpectFlow{{MatchStr: "priority=0", ActStr: "goto_table:106"}},
+	}
+	if config.enableIPv4 {
+		table31Flows.flows = append(table31Flows.flows,
+			&ofTestUtils.ExpectFlow{MatchStr: "priority=210,ct_state=-new+trk,ct_mark=0x20,ip,reg0=0x1/0xffff", ActStr: "goto_table:42"},
+			&ofTestUtils.ExpectFlow{MatchStr: "priority=190,ct_state=+inv+trk,ip", ActStr: "drop"},
+		)
+		table105Flows.flows = append(table105Flows.flows,
+			&ofTestUtils.ExpectFlow{MatchStr: "priority=200,ct_state=+new+trk,ip,reg0=0x1/0xffff", ActStr: "ct(commit,table=106,zone=65520,exec(load:0x20->NXM_NX_CT_MARK[])"},
+			&ofTestUtils.ExpectFlow{MatchStr: "priority=190,ct_state=+new+trk,ip", ActStr: "ct(commit,table=106,zone=65520)"},
+		)
+	}
+	if config.enableIPv6 {
+		table31Flows.flows = append(table31Flows.flows,
+			&ofTestUtils.ExpectFlow{MatchStr: "priority=210,ct_state=-new+trk,ct_mark=0x20,ipv6,reg0=0x1/0xffff", ActStr: "goto_table:42"},
+			&ofTestUtils.ExpectFlow{MatchStr: "priority=190,ct_state=+inv+trk,ipv6", ActStr: "drop"},
+		)
+		table105Flows.flows = append(table105Flows.flows,
+			&ofTestUtils.ExpectFlow{MatchStr: "priority=200,ct_state=+new+trk,ipv6,reg0=0x1/0xffff", ActStr: "ct(commit,table=106,zone=65510,exec(load:0x20->NXM_NX_CT_MARK[])"},
+			&ofTestUtils.ExpectFlow{MatchStr: "priority=190,ct_state=+new+trk,ipv6", ActStr: "ct(commit,table=106,zone=65510)"},
+		)
+	}
 	return []expectTableFlows{
+		table31Flows, table105Flows,
 		{
 			uint8(0),
 			[]*ofTestUtils.ExpectFlow{{MatchStr: "priority=0", ActStr: "drop"}},
@@ -900,14 +952,6 @@ func prepareDefaultFlows() []expectTableFlows {
 			uint8(30),
 			[]*ofTestUtils.ExpectFlow{
 				{MatchStr: "priority=200,ip", ActStr: "ct(table=31,zone=65520,nat)"},
-			},
-		},
-		{
-			uint8(31),
-			[]*ofTestUtils.ExpectFlow{
-				{MatchStr: "priority=210,ct_state=-new+trk,ct_mark=0x20,ip,reg0=0x1/0xffff", ActStr: "goto_table:42"},
-				{MatchStr: "priority=190,ct_state=+inv+trk,ip", ActStr: "drop"},
-				{MatchStr: "priority=0", ActStr: "resubmit(,40),resubmit(,41)"},
 			},
 		},
 		{
@@ -945,13 +989,6 @@ func prepareDefaultFlows() []expectTableFlows {
 		{
 			uint8(101),
 			[]*ofTestUtils.ExpectFlow{{MatchStr: "priority=0", ActStr: "goto_table:105"}},
-		},
-		{
-			uint8(105),
-			[]*ofTestUtils.ExpectFlow{
-				{MatchStr: "priority=200,ct_state=+new+trk,ip,reg0=0x1/0xffff", ActStr: "ct(commit,table=106,zone=65520,exec(load:0x20->NXM_NX_CT_MARK[])"},
-				{MatchStr: "priority=190,ct_state=+new+trk,ip", ActStr: "ct(commit,table=106,zone=65520)"},
-				{MatchStr: "priority=0", ActStr: "goto_table:106"}},
 		},
 		{
 			uint8(110),


### PR DESCRIPTION
1. Add a config item for IPv6 Serivce CIDR if using kube-proxy to
   provide Service functions.
2. Output IPv6 traffic from host gateway if its destination is a
   Service address.
3. Use ct_mark to identify Service traffic and output the reply
   packet to the host gateway to ensure the DNAT processing in iptables.