### PR TITLE
Change prometheus metrics type from summary to histogram

### DIFF
--- a/pkg/controller/metrics/prometheus.go
+++ b/pkg/controller/metrics/prometheus.go
@@ -38,20 +38,20 @@ var (
 		Help:           "The total number of internal-networkpolicy processed",
 		StabilityLevel: metrics.STABLE,
 	})
-	DurationAppliedToGroupSyncing = metrics.NewSummary(&metrics.SummaryOpts{
+	DurationAppliedToGroupSyncing = metrics.NewHistogram(&metrics.HistogramOpts{
 		Name:           "antrea_controller_applied_to_group_sync_duration_milliseconds",
 		Help:           "The duration of syncing applied-to-group",
-		StabilityLevel: metrics.STABLE,
+		StabilityLevel: metrics.ALPHA,
 	})
-	DurationAddressGroupSyncing = metrics.NewSummary(&metrics.SummaryOpts{
+	DurationAddressGroupSyncing = metrics.NewHistogram(&metrics.HistogramOpts{
 		Name:           "antrea_controller_address_group_sync_duration_milliseconds",
 		Help:           "The duration of syncing address-group",
-		StabilityLevel: metrics.STABLE,
+		StabilityLevel: metrics.ALPHA,
 	})
-	DurationInternalNetworkPolicySyncing = metrics.NewSummary(&metrics.SummaryOpts{
+	DurationInternalNetworkPolicySyncing = metrics.NewHistogram(&metrics.HistogramOpts{
 		Name:           "antrea_controller_network_policy_sync_duration_milliseconds",
 		Help:           "The duration of syncing internal-networkpolicy",
-		StabilityLevel: metrics.STABLE,
+		StabilityLevel: metrics.ALPHA,
 	})
 	LengthAppliedToGroupQueue = metrics.NewGauge(&metrics.GaugeOpts{
 		Name:           "antrea_controller_length_applied_to_group_queue",


### PR DESCRIPTION
Fix #905

The summary types are tagged for deprecation, Kubernetes recommended to use histograms instead of summaries. The main advantages of histogram types are aggregation and inexpensive. In this commit, we changed three Antrea controller metrics from summary to histogram type. They are DurationAppliedToGroupSyncing, DurationAddressGroupSyncing, and DurationInternalNetworkPolicySyncing.

Did the manually test to check the type of these metrics using following commands:

1. `make`
2. `./test/e2e/infra/vagrant/push_antrea.sh --prometheus`
3. `kubectl exec -it <antrea_controller_pod> -n kube-system -- bash`
4. `TOKEN=$(cat /var/run/antrea/apiserver/loopback-client-token)`
5. `curl --insecure --header "Authorization: Bearer $TOKEN" https://127.0.0.1:10349/metrics`

Test results:
`# HELP antrea_controller_applied_to_group_sync_duration_milliseconds [ALPHA] The duration of syncing applied-to-group`
`# TYPE antrea_controller_applied_to_group_sync_duration_milliseconds histogram`
`# HELP antrea_controller_address_group_sync_duration_milliseconds [ALPHA] The duration of syncing address-group`
`# TYPE antrea_controller_address_group_sync_duration_milliseconds histogram`
`# HELP antrea_controller_network_policy_sync_duration_milliseconds [ALPHA] The duration of syncing internal-networkpolicy`
`# TYPE antrea_controller_network_policy_sync_duration_milliseconds histogram`
