### PR TITLE
Increase golangci-lint timeout from 5m to 10m

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # golangci-lint configuration used for CI
 run:
   tests: true
-  timeout: 5m
+  timeout: 10m
   skip-files:
     - ".*\\.pb\\.go"
   skip-dirs-use-default: true


### PR DESCRIPTION
The golangci-lint CI job which runs on macOS often times out, probably
because the VM is a bit slow. We double the timeout to see if it solves
the issue.

Fixes #1174