### PR TITLE
Aggregate CNP/ANP access to admin/edit and view ClusterRoles

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -560,6 +560,47 @@ kind: ClusterRole
 metadata:
   labels:
     app: antrea
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: aggregate-security-crds-edit
+rules:
+- apiGroups:
+  - security.antrea.tanzu.vmware.com
+  resources:
+  - clusternetworkpolicies
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: aggregate-security-crds-view
+rules:
+- apiGroups:
+  - security.antrea.tanzu.vmware.com
+  resources:
+  - clusternetworkpolicies
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
   name: antctl
 rules:
 - apiGroups:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -562,7 +562,7 @@ metadata:
     app: antrea
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-  name: aggregate-security-crds-edit
+  name: aggregate-antrea-policies-edit
 rules:
 - apiGroups:
   - security.antrea.tanzu.vmware.com
@@ -584,7 +584,7 @@ metadata:
   labels:
     app: antrea
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-  name: aggregate-security-crds-view
+  name: aggregate-antrea-policies-view
 rules:
 - apiGroups:
   - security.antrea.tanzu.vmware.com

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -560,6 +560,47 @@ kind: ClusterRole
 metadata:
   labels:
     app: antrea
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: aggregate-security-crds-edit
+rules:
+- apiGroups:
+  - security.antrea.tanzu.vmware.com
+  resources:
+  - clusternetworkpolicies
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: aggregate-security-crds-view
+rules:
+- apiGroups:
+  - security.antrea.tanzu.vmware.com
+  resources:
+  - clusternetworkpolicies
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
   name: antctl
 rules:
 - apiGroups:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -562,7 +562,7 @@ metadata:
     app: antrea
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-  name: aggregate-security-crds-edit
+  name: aggregate-antrea-policies-edit
 rules:
 - apiGroups:
   - security.antrea.tanzu.vmware.com
@@ -584,7 +584,7 @@ metadata:
   labels:
     app: antrea
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-  name: aggregate-security-crds-view
+  name: aggregate-antrea-policies-view
 rules:
 - apiGroups:
   - security.antrea.tanzu.vmware.com

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -560,6 +560,47 @@ kind: ClusterRole
 metadata:
   labels:
     app: antrea
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: aggregate-security-crds-edit
+rules:
+- apiGroups:
+  - security.antrea.tanzu.vmware.com
+  resources:
+  - clusternetworkpolicies
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: aggregate-security-crds-view
+rules:
+- apiGroups:
+  - security.antrea.tanzu.vmware.com
+  resources:
+  - clusternetworkpolicies
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
   name: antctl
 rules:
 - apiGroups:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -562,7 +562,7 @@ metadata:
     app: antrea
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-  name: aggregate-security-crds-edit
+  name: aggregate-antrea-policies-edit
 rules:
 - apiGroups:
   - security.antrea.tanzu.vmware.com
@@ -584,7 +584,7 @@ metadata:
   labels:
     app: antrea
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-  name: aggregate-security-crds-view
+  name: aggregate-antrea-policies-view
 rules:
 - apiGroups:
   - security.antrea.tanzu.vmware.com

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -560,6 +560,47 @@ kind: ClusterRole
 metadata:
   labels:
     app: antrea
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: aggregate-security-crds-edit
+rules:
+- apiGroups:
+  - security.antrea.tanzu.vmware.com
+  resources:
+  - clusternetworkpolicies
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: aggregate-security-crds-view
+rules:
+- apiGroups:
+  - security.antrea.tanzu.vmware.com
+  resources:
+  - clusternetworkpolicies
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
   name: antctl
 rules:
 - apiGroups:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -562,7 +562,7 @@ metadata:
     app: antrea
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-  name: aggregate-security-crds-edit
+  name: aggregate-antrea-policies-edit
 rules:
 - apiGroups:
   - security.antrea.tanzu.vmware.com
@@ -584,7 +584,7 @@ metadata:
   labels:
     app: antrea
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-  name: aggregate-security-crds-view
+  name: aggregate-antrea-policies-view
 rules:
 - apiGroups:
   - security.antrea.tanzu.vmware.com

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -560,6 +560,47 @@ kind: ClusterRole
 metadata:
   labels:
     app: antrea
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: aggregate-security-crds-edit
+rules:
+- apiGroups:
+  - security.antrea.tanzu.vmware.com
+  resources:
+  - clusternetworkpolicies
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: aggregate-security-crds-view
+rules:
+- apiGroups:
+  - security.antrea.tanzu.vmware.com
+  resources:
+  - clusternetworkpolicies
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
   name: antctl
 rules:
 - apiGroups:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -562,7 +562,7 @@ metadata:
     app: antrea
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-  name: aggregate-security-crds-edit
+  name: aggregate-antrea-policies-edit
 rules:
 - apiGroups:
   - security.antrea.tanzu.vmware.com
@@ -584,7 +584,7 @@ metadata:
   labels:
     app: antrea
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-  name: aggregate-security-crds-view
+  name: aggregate-antrea-policies-view
 rules:
 - apiGroups:
   - security.antrea.tanzu.vmware.com

--- a/build/yamls/base/crds-rbac.yml
+++ b/build/yamls/base/crds-rbac.yml
@@ -1,0 +1,25 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregate-security-crds-edit
+  labels:
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["security.antrea.tanzu.vmware.com"]
+  resources: ["clusternetworkpolicies", "networkpolicies"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-security-crds-view
+  labels:
+    # Add these permissions to the "view" default role.
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups: ["security.antrea.tanzu.vmware.com"]
+  resources: ["clusternetworkpolicies", "networkpolicies"]
+  verbs: ["get", "list", "watch"]

--- a/build/yamls/base/crds-rbac.yml
+++ b/build/yamls/base/crds-rbac.yml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: aggregate-security-crds-edit
+  name: aggregate-antrea-policies-edit
   labels:
     # Add these permissions to the "admin" and "edit" default roles.
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -15,7 +15,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: aggregate-security-crds-view
+  name: aggregate-antrea-policies-view
   labels:
     # Add these permissions to the "view" default role.
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/build/yamls/base/kustomization.yml
+++ b/build/yamls/base/kustomization.yml
@@ -1,5 +1,6 @@
 resources:
 - crds.yml
+- crds-rbac.yml
 - antctl.yml
 - controller-rbac.yml
 - controller.yml

--- a/docs/network-policy.md
+++ b/docs/network-policy.md
@@ -17,6 +17,7 @@
   - [Ordering based on Tier priority](#ordering-based-on-tier-priority)
   - [Ordering based on policy priority](#ordering-based-on-policy-priority)
   - [Rule enforcement based on priorities](#rule-enforcement-based-on-priorities)
+- [RBAC](#rbac)
 - [Notes](#notes)
 
 ## Summary
@@ -325,6 +326,19 @@ This translates to the following order:
 Once a rule is matched, it is executed based on the action set. If none of the
 policy rules match, the packet is then enforced for rules created for K8s NP.
 Hence, Antrea Policy CRDs take precedence over K8s NP.
+
+## RBAC
+
+Antrea Policy CRDs are meant for admins to manage the security of their
+cluster. Thus, access to manage these CRDs must be granted to subjects which
+have the authority to outline the security policies for the cluster and/or
+Namespaces. On cluster initialization, Antrea grants the permissions to edit
+these CRDs with `admin` and the `edit` ClusterRole. In addition to this, Antrea
+also grants the permission to view these CRDs with the `view` ClusterRole.
+Cluster admins can therefore grant these ClusterRoles to any subject who may
+be responsible to manage the Antrea Policy CRDs. The admins may also decide to
+share the `view` ClusterRole to a wider range of subjects to allow them to read
+the policies that may affect their workloads.
 
 ## Notes
 


### PR DESCRIPTION
Aggregate the CRUD permissions to "admin" and "edit" ClusterRoles so that any user granted these roles may have edit permissions. In addition to this, aggregate the READ-ONLY permissions to "view" ClusterRole, so that any user granted this role may be able to view the CNP/ANP resources.