### PR TITLE
Deprecate prometheus run time info metrics

### DIFF
--- a/build/yamls/antrea-prometheus.yml
+++ b/build/yamls/antrea-prometheus.yml
@@ -89,6 +89,8 @@ data:
         - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_container_name]
           action: keep
           regex: kube-system;antrea-controller
+        - source_labels: [__meta_kubernetes_pod_node_name, __meta_kubernetes_pod_name]
+          target_label: instance
 
     # Scrape Antrea Agents metrics
       - job_name: 'antrea-agents'
@@ -103,6 +105,8 @@ data:
         - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_container_name]
           action: keep
           regex: kube-system;antrea-agent
+        - source_labels: [__meta_kubernetes_pod_node_name, __meta_kubernetes_pod_name]
+          target_label: instance
 ---
 # Prometheus Server deployment
 apiVersion: apps/v1

--- a/docs/prometheus-integration.md
+++ b/docs/prometheus-integration.md
@@ -69,7 +69,10 @@ rules:
 
 ### Antrea Components Scraping configuration
 Add the following jobs to Prometheus scraping configuration to enable metrics
-collection from Antrea components
+collection from Antrea components. Antrea Agent metrics endpoint is exposed through
+Antrea apiserver on `apiport` config parameter given in `antrea-agent.conf` (default
+value is 10350). Antrea Controller metrics endpoint is exposed through Antrea apiserver
+on `apiport` config parameter given in `antrea-controller.conf` (default value is 10349). 
 
 #### Controller Scraping
 ```yaml
@@ -85,6 +88,8 @@ relabel_configs:
 - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_container_name]
   action: keep
   regex: kube-system;antrea-controller
+- source_labels: [__meta_kubernetes_pod_node_name, __meta_kubernetes_pod_name]
+  target_label: instance
 ```
 
 #### Agent Scraping
@@ -101,6 +106,8 @@ relabel_configs:
 - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_container_name]
   action: keep
   regex: kube-system;antrea-agent
+- source_labels: [__meta_kubernetes_pod_node_name, __meta_kubernetes_pod_name]
+  target_label: instance
 ```
 For further reference see the enclosed 
 [configuration file](/build/yamls/antrea-prometheus.yml).

--- a/pkg/agent/metrics/prometheus.go
+++ b/pkg/agent/metrics/prometheus.go
@@ -103,20 +103,19 @@ func InitializePrometheusMetrics() {
 	if err != nil {
 		klog.Errorf("Failed to retrieve agent K8S node name: %v", err)
 	}
-
-	gaugeHost := metrics.NewGauge(&metrics.GaugeOpts{
-		Name: "antrea_agent_runtime_info",
-		Help: "Antrea agent runtime info , defined as labels. The value of the gauge is always set to 1.",
-
-		ConstLabels:    metrics.Labels{"k8s_nodename": nodeName, "k8s_podname": env.GetPodName()},
-		StabilityLevel: metrics.STABLE,
+	deprecatedGaugeHost := metrics.NewGauge(&metrics.GaugeOpts{
+		Name:              "antrea_agent_runtime_info",
+		Help:              "Antrea agent runtime info (Deprecated since Antrea 0.10.0), defined as labels. The value of the gauge is always set to 1.",
+		ConstLabels:       metrics.Labels{"k8s_nodename": nodeName, "k8s_podname": env.GetPodName()},
+		StabilityLevel:    metrics.STABLE,
+		DeprecatedVersion: "0.10.0",
 	})
-	if err := legacyregistry.Register(gaugeHost); err != nil {
+	if err := legacyregistry.Register(deprecatedGaugeHost); err != nil {
 		klog.Error("Failed to register antrea_agent_runtime_info with Prometheus")
 	}
 	// This must be after registering the metrics.Gauge as it is lazily instantiated
 	// and will not measure anything unless the collector is first registered.
-	gaugeHost.Set(1)
+	deprecatedGaugeHost.Set(1)
 
 	InitializePodMetrics()
 	InitializeNetworkPolicyMetrics()

--- a/pkg/controller/metrics/prometheus.go
+++ b/pkg/controller/metrics/prometheus.go
@@ -72,24 +72,26 @@ var (
 
 // Initialize Prometheus metrics collection.
 func InitializePrometheusMetrics() {
+	klog.Info("Initializing prometheus metrics")
+
 	nodeName, err := env.GetNodeName()
 	if err != nil {
 		klog.Errorf("Failed to retrieve controller K8S node name: %v", err)
 	}
-
-	klog.Info("Initializing prometheus metrics")
-	gaugeHost := metrics.NewGauge(&metrics.GaugeOpts{
-		Name:           "antrea_controller_runtime_info",
-		Help:           "Antrea controller runtime info, defined as labels. The value of the gauge is always set to 1.",
-		ConstLabels:    metrics.Labels{"k8s_nodename": nodeName, "k8s_podname": env.GetPodName()},
-		StabilityLevel: metrics.STABLE,
+	deprecatedGaugeHost := metrics.NewGauge(&metrics.GaugeOpts{
+		Name:              "antrea_controller_runtime_info",
+		Help:              "Antrea controller runtime info (Deprecated since Antrea 0.10.0), defined as labels. The value of the gauge is always set to 1.",
+		ConstLabels:       metrics.Labels{"k8s_nodename": nodeName, "k8s_podname": env.GetPodName()},
+		StabilityLevel:    metrics.STABLE,
+		DeprecatedVersion: "0.10.0",
 	})
-	if err = legacyregistry.Register(gaugeHost); err != nil {
+	if err = legacyregistry.Register(deprecatedGaugeHost); err != nil {
 		klog.Errorf("Failed to register antrea_controller_runtime_info with Prometheus: %s", err.Error())
 	}
 	// This must be after registering the metrics.Gauge as it is lazily instantiated
 	// and will not measure anything unless the collector is first registered.
-	gaugeHost.Set(1)
+	deprecatedGaugeHost.Set(1)
+
 	if err := legacyregistry.Register(OpsAppliedToGroupProcessed); err != nil {
 		klog.Errorf("Failed to register antrea_controller_applied_to_group_processed with Prometheus: %s", err.Error())
 	}


### PR DESCRIPTION
Deprecate run time info metrics that provide node name and pod name
from Antrea 0.10.0. These metrics will be removed Antrea 0.11.0. Added
deprecation policy for the Prometheus metric in Antrea documentation.
    
In addition, antrea-prometheus.yaml is changed to add nodename and
pod name to the instance label instead of the default IP:port. This will help
with promql queries to search for metrics on a specific node or pod.