### PR TITLE
Enable debug logging on Prometheus server

### DIFF
--- a/build/yamls/antrea-prometheus.yml
+++ b/build/yamls/antrea-prometheus.yml
@@ -126,6 +126,7 @@ spec:
           args:
             - "--config.file=/etc/prometheus/prometheus.yml"
             - "--storage.tsdb.path=/prometheus/"
+            - "--log.level=debug"
           ports:
             - containerPort: 9090
           volumeMounts:

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -62,6 +62,7 @@ const (
 	antreaYML            string = "antrea.yml"
 	antreaIPSecYML       string = "antrea-ipsec.yml"
 	defaultBridgeName    string = "br-int"
+	monitoringNamespace  string = "monitoring"
 
 	nameSuffixLength int = 8
 )
@@ -969,19 +970,21 @@ func forAllNodes(fn func(nodeName string) error) error {
 	return nil
 }
 
-// forAllAntreaPods invokes the provided function for every Antrea Pod currently running on every Node.
-func (data *TestData) forAllAntreaPods(fn func(nodeName, podName string) error) error {
+// forAllMatchingPodsInNamespace invokes the provided function for every Pod currently running on every Node in a given
+// namespace and which matches labelSelector criteria.
+func (data *TestData) forAllMatchingPodsInNamespace(
+	labelSelector, nsName string, fn func(nodeName string, podName string, nsName string) error) error {
 	for _, node := range clusterInfo.nodes {
 		listOptions := metav1.ListOptions{
-			LabelSelector: "app=antrea",
+			LabelSelector: labelSelector,
 			FieldSelector: fmt.Sprintf("spec.nodeName=%s", node.name),
 		}
-		pods, err := data.clientset.CoreV1().Pods(antreaNamespace).List(context.TODO(), listOptions)
+		pods, err := data.clientset.CoreV1().Pods(nsName).List(context.TODO(), listOptions)
 		if err != nil {
 			return fmt.Errorf("failed to list Antrea Pods on Node '%s': %v", node.name, err)
 		}
 		for _, pod := range pods.Items {
-			if err := fn(node.name, pod.Name); err != nil {
+			if err := fn(node.name, pod.Name, nsName); err != nil {
 				return err
 			}
 		}

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -31,8 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const monitoringNamespace string = "monitoring"
-
 // Agent metrics to validate
 var antreaAgentMetrics = []string{
 	"antrea_agent_egress_networkpolicy_rule_count",


### PR DESCRIPTION
In order to troubleshoot Prometheus e2e testing issues, enable
Prometheus logging to diagnose connectivity problems between Prometheus
and Antrea components.
Also, inclode the monitoring namespace Pod logs (mainly Prometheus server)
within the test output bundle.
