### PR TITLE
Add cookbook on how to use Antrea with Multus

### DIFF
--- a/docs/cookbooks/multus/README.md
+++ b/docs/cookbooks/multus/README.md
@@ -1,0 +1,328 @@
+# Using Antrea with Multus
+
+This guide will describe how to use Project Antrea with
+[Multus](https://github.com/intel/multus-cni), in order to attach multiple
+network interfaces to Pods. In this scenario, Antrea is used for the default
+network, i.e. it is the CNI plugin which provisions the "primary" network
+interface ("eth0") for each Pod. For the sake of this guide, we will use the
+[macvlan](https://github.com/containernetworking/plugins/tree/master/plugins/main/macvlan)
+CNI plugin to provision secondary network interfaces for selected Pods, but
+similar steps should apply for other plugins as well,
+e.g. [ipvlan](https://github.com/containernetworking/plugins/tree/master/plugins/main/ipvlan).
+
+## Prerequisites
+
+The only prerequisites are:
+ * a K8s cluster (Linux Nodes) running a K8s version supported by Antrea. At the
+   time of writing, we recommend version 1.16 or later. Typically the cluster
+   needs to be running on a network infrastructure that you control. For
+   example, using macvlan networking will not work on public clouds like AWS.
+ * [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+
+All the required software will be deployed using YAML manifests, and the
+corresponding container images will be downloaded from public registries.
+
+macvlan requires the network to be able to handle "promiscuous mode", as the
+same physical interface / virtual adapter ends up being assigned multiple MAC
+addresses. When using a virtual network for the Nodes, some configuration
+changes are usually required, which depend on the virtualization technology. For
+example:
+ * when using VirtualBox and [Internal
+   Networking](https://www.virtualbox.org/manual/ch06.html#network_internal),
+   set the `Promiscuous Mode` to `Allow All`
+ * when using VMware Fusion, enable "promiscuous mode" in the guest (Node) for
+   the appropriate interface (e.g. using `ifconfig`); this may prompt for your
+   password on the host unless you uncheck `Require authentication to enter
+   promiscuous mode` in the Network Preferences
+
+This needs to be done for every Node VM, so it's best if you can automate this
+when provisioning your VMs.
+
+### Suggested test cluster
+
+If you need to create a K8s cluster to test this guide, we suggest you create
+one by following [these
+steps](https://github.com/vmware-tanzu/antrea/tree/master/test/e2e#creating-the-test-kubernetes-cluster-with-vagrant). You
+will need to use a slightly modified Vagrantfile, which you can find
+[here](test/Vagrantfile). Note that this Vagrantfile will create 3 VMs on your
+machine, and each VM will be allocated 2GB of memory, so make sure you have
+enough memory available. You can create the cluster with the following steps:
+
+```bash
+git clone https://github.com/vmware-tanzu/antrea.git
+cd antrea
+cp docs/cookbooks/multus/test/Vagrantfile test/e2e/infra/vagrant/
+cd test/e2e/infra/vagrant
+./infra/vagrant/provision.sh
+```
+
+The last command will take around 10 to 15 minutes to complete. After that, your
+cluster is ready and you can set the `KUBECONFIG` environment variable in order
+to use `kubectl`:
+
+```bash
+export KUBECONFIG=`pwd`/infra/vagrant/playbook/kube/config
+kubectl cluster-info
+```
+
+The cluster that you have created by following these steps is the one we will
+use as an example in this guide.
+
+## Practical steps
+
+### Step 1: Deploying Antrea
+
+```bash
+kubectl apply -f https://github.com/vmware-tanzu/antrea/releases/download/v0.9.2/antrea.yml
+```
+
+You may also choose a different [Antrea
+version](https://github.com/vmware-tanzu/antrea/releases).
+
+### Step 2: Deploy Multus as a DaemonSet
+
+```bash
+git clone https://github.com/intel/multus-cni.git && cd multus-cni
+cat ./images/multus-daemonset.yml | kubectl apply -f -
+```
+
+### Step 3: Create a NetworkAttachmentDefinition
+
+Make sure that you are using the correct interface name for `"master"`: it
+should be the name of the Node's network interface (e.g. `eth0`) that you want
+to use as the parent interface for the macvlan secondary Pod interfaces. If you
+are using our [test cluster], `enp0s9` is the correct value.
+
+```bash
+cat <<EOF | kubectl create -f -
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: macvlan-conf
+spec:
+  config: '{
+      "cniVersion": "0.3.0",
+      "type": "macvlan",
+      "master": "enp0s9",
+      "mode": "bridge",
+      "ipam": {
+        "type": "dhcp"
+      }
+    }'
+EOF
+```
+
+The above definition assumes that DHCP will be used to assign IP addresses to
+the macvlan secondary interfaces. For an alternative solution using the
+[whereabouts] project, please refer to this
+[section](#using-whereabouts-for-ipam).
+
+### Step 4 (optional): Create a macvlan subinterface on each Node
+
+This step is required if you want the Node to be able to communicate with the
+Pods using the secondary network:
+
+```bash
+wget https://raw.githubusercontent.com/vmware-tanzu/antrea/master/docs/cookbooks/multus/resources/macvlan-host-init.yml
+# edit file as needed
+kubectl apply -f macvlan-host-init.yml
+```
+
+If you are using our [test cluster], no edits are required and you can apply the
+file as is. Otherwise, make sure that you replace `enp0s9` with the name of the
+parent network interface.
+
+This manifest will create a DaemonSet that will run a bash script once on every
+Node. It will:
+ * Enable promiscuous mode on the parent interface using `ifconfig`; if using a
+   virtual network for the Nodes, this does not replace enabling promiscuous
+   mode for the virtual adapters
+ * Create a macvlan subinterface for the Node
+ * Move the IP address from the parent interface to the new subinterface
+
+### Step 5: Run a DHCP server
+
+This step is very dependent on the underlying Node network. If the network to
+which the macvlan parent interface belongs already uses DHCP, then you can skip
+this step. Otherwise (e.g. the parent interface on the Nodes were assigned
+statically), you may want to deploy a DHCP server in the K8s cluster,
+and use it to assign IP addresses to the macvlan secondary interfaces. In
+particular, this is the case if you are using our [test cluster].
+
+Note that in order to deploy the DHCP server in-cluster, [step-4] is
+required. You can then apply the following manifest after making the necessary
+edits:
+
+```bash
+wget https://raw.githubusercontent.com/vmware-tanzu/antrea/master/docs/cookbooks/multus/resources/dhcp-server.yml
+# edit file as needed
+kubectl apply -f dhcp-server.yml
+```
+
+Once again, if you are using our [test cluster], no edits are required and you
+can apply the file as is. Otherwise, make sure that you edit the
+`dhcp-server-conf` ConfigMap at the top of the file: the
+[dhcpd.conf](https://man.openbsd.org/dhcpd.conf.5) configuration data needs to
+be correct for our use case. You will need to ensure that the subnet matches the
+parent interface's network and that the range of allocatable addresses does not
+include the IP addresses assigned to the parent interfaces.
+
+### Step 6: Run the DHCP daemons
+
+When using the [dhcp
+plugin](https://github.com/containernetworking/plugins/tree/master/plugins/ipam/dhcp)
+to assign IP addresses to Pod interfaces, a separate daemon needs to runone ach
+Node, which will notably ensure that local DHCP leases are renewed
+periodically. To deploy the DHCP daemon (as a DaemonSet), you can use the
+following command:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/vmware-tanzu/antrea/master/docs/cookbooks/multus/resources/dhcp-daemon.yml
+```
+
+No edits to the manifest should be required, regardless of which K8s cluster you
+are using.
+
+### Testing
+
+To test that the secondary interfaces are functional, you can create Pods with
+the `k8s.v1.cni.cncf.io/networks: macvlan-conf` annotation. We suggest creating
+a set of Pods (as a Deployment) which all request a macvlan secondary interface,
+using the provided manifest:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/vmware-tanzu/antrea/master/docs/cookbooks/multus/resources/test.yml
+```
+
+You can then `kubectl exec` into the Pods to inspect the networking
+configuration and have Pods ping each other using the secondary network.
+
+``` bash
+$ kubectl get pods -o wide
+NAME                        READY   STATUS    RESTARTS   AGE   IP           NODE                NOMINATED NODE   READINESS GATES
+samplepod-7956c4498-65v6m   1/1     Running   0          68s   10.10.2.10   k8s-node-worker-2   <none>           <none>
+samplepod-7956c4498-9dz98   1/1     Running   0          68s   10.10.1.12   k8s-node-worker-1   <none>           <none>
+samplepod-7956c4498-ghrdg   1/1     Running   0          68s   10.10.1.13   k8s-node-worker-1   <none>           <none>
+samplepod-7956c4498-n65bn   1/1     Running   0          68s   10.10.2.12   k8s-node-worker-2   <none>           <none>
+samplepod-7956c4498-q6vp2   1/1     Running   0          68s   10.10.1.11   k8s-node-worker-1   <none>           <none>
+samplepod-7956c4498-xztf4   1/1     Running   0          68s   10.10.2.11   k8s-node-worker-2   <none>           <none>
+```
+
+```bash
+$ kubectl exec samplepod-7956c4498-65v6m -- ip addr
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+3: eth0@if18: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default
+    link/ether c2:ce:36:6b:ba:2d brd ff:ff:ff:ff:ff:ff link-netnsid 0
+    inet 10.10.2.10/24 brd 10.10.2.255 scope global eth0
+       valid_lft forever preferred_lft forever
+4: net1@if4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default
+    link/ether be:a0:35:f2:08:2d brd ff:ff:ff:ff:ff:ff link-netnsid 0
+    inet 192.168.78.205/24 brd 192.168.78.255 scope global net1
+       valid_lft forever preferred_lft forever
+```
+
+```bash
+$ kubectl exec samplepod-7956c4498-9dz98 -- ip addr
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+3: eth0@if20: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default
+    link/ether 92:8f:8a:1d:a0:f5 brd ff:ff:ff:ff:ff:ff link-netnsid 0
+    inet 10.10.1.12/24 brd 10.10.1.255 scope global eth0
+       valid_lft forever preferred_lft forever
+4: net1@if4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default
+    link/ether 22:6e:b1:0a:f3:ab brd ff:ff:ff:ff:ff:ff link-netnsid 0
+    inet 192.168.78.202/24 brd 192.168.78.255 scope global net1
+       valid_lft forever preferred_lft forever
+```
+
+```bash
+$ kubectl exec samplepod-7956c4498-9dz98 -- ping -c 3 192.168.78.205
+PING 192.168.78.205 (192.168.78.205) 56(84) bytes of data.
+64 bytes from 192.168.78.205: icmp_seq=1 ttl=64 time=0.846 ms
+64 bytes from 192.168.78.205: icmp_seq=2 ttl=64 time=0.410 ms
+64 bytes from 192.168.78.205: icmp_seq=3 ttl=64 time=0.507 ms
+
+--- 192.168.78.205 ping statistics ---
+3 packets transmitted, 3 received, 0% packet loss, time 2013ms
+rtt min/avg/max/mdev = 0.410/0.587/0.846/0.186 ms
+```
+
+### Overview of a test cluster Node
+
+The diagram below shows an overview of a K8s Node when using the [test cluster]
+and following all the steps above. For the sake of completeness, we show the
+DHCP server running on that Node, but as we use a Deployment with a single
+replica, the server may be running on any worker Node in the cluster.
+
+<img src="assets/testbed-multus-macvlan.svg" width="900" alt="Test cluster Node">
+
+## Using [whereabouts] for IPAM
+
+If you do not already have a DHCP server for the underlying parent network and
+you find that deploying one in-cluster is impractical, you may want to consider
+using [whereabouts] to assign IP addresses to the secondary interfaces. When
+using [whereabouts], follow steps 1 and 2 above, along with step 4 if you want
+the Nodes to be able to communicate with the Pods using the secondary
+network.
+
+The next step is to install the [whereabouts] plugin as follows:
+
+```bash
+git clone https://github.com/dougbtv/whereabouts && cd whereabouts
+kubectl apply -f ./doc/daemonset-install.yaml -f ./doc/whereabouts.cni.cncf.io_ippools.yaml
+```
+
+Then create a NetworkAttachmentDefinition like the one below, after ensuring
+that `"master"` matches the name of the parent interface on the Nodes, and that
+the `range` and `exclude` configuration parameters are correct for your cluster
+(in particular, make sure that you exclude IP addresses assigned to Nodes). If
+you are using our [test cluster], you can use the NetworkAttachmentDefinition
+below as is.
+
+```bash
+cat <<EOF | kubectl create -f -
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: macvlan-conf
+spec:
+  config: '{
+      "cniVersion": "0.3.0",
+      "type": "macvlan",
+      "master": "enp0s9",
+      "mode": "bridge",
+      "ipam": {
+        "type": "whereabouts",
+        "datastore": "kubernetes",
+        "kubernetes": { "kubeconfig": "/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig" },
+        "range": "192.168.78.0/24",
+        "exclude": [
+           "192.168.78.0/25",
+           "192.168.78.128/26",
+           "192.168.78.192/29",
+           "192.168.78.250/31",
+           "192.168.78.252/30"
+        ],
+        "log_file" : "/tmp/whereabouts.log",
+        "log_level" : "debug"
+      }
+    }'
+EOF
+```
+
+You can then validate that the configuration works by running the same
+[test](#testing) as above.
+
+[whereabouts]: https://github.com/dougbtv/whereabouts
+[test cluster]: #suggested-test-cluster
+[step-1]: #step-1-deploying-antrea
+[step-2]: #step-2-deploy-multus-as-a-daemonset
+[step-3]: #step-3-create-a-networkattachmentdefinition
+[step-4]: #step-4-optional-create-a-macvlan-subinterface-on-each-node
+[step-5]: #step-5-run-a-dhcp-server
+[step-6]: #step-6-run-the-dhcp-daemons

--- a/docs/cookbooks/multus/README.md
+++ b/docs/cookbooks/multus/README.md
@@ -39,7 +39,7 @@ example:
  * when using VMware Fusion, enable "promiscuous mode" in the guest (Node) for
    the appropriate interface (e.g. using `ifconfig`); this may prompt for your
    password on the host unless you uncheck `Require authentication to enter
-   promiscuous mode` in the Network Preferences
+   promiscuous mode` in `Preferences ... > Network`
 
 This needs to be done for every Node VM, so it's best if you can automate this
 when provisioning your VMs.
@@ -146,8 +146,9 @@ parent network interface.
 This manifest will create a DaemonSet that will run a bash script once on every
 Node. It will:
  * Enable promiscuous mode on the parent interface using `ifconfig`; if using a
-   virtual network for the Nodes, this does not replace enabling promiscuous
-   mode for the virtual adapters
+   virtual network for the Nodes, this needs to be done in addition to enabling
+   promiscuous mode in the hypervisor for the virtual adapters, as described in
+   the [Prerequisites](#prerequisites).
  * Create a macvlan subinterface for the Node
  * Move the IP address from the parent interface to the new subinterface
 

--- a/docs/cookbooks/multus/README.md
+++ b/docs/cookbooks/multus/README.md
@@ -13,6 +13,7 @@ e.g. [ipvlan](https://github.com/containernetworking/plugins/tree/master/plugins
 ## Prerequisites
 
 The only prerequisites are:
+
  * a K8s cluster (Linux Nodes) running a K8s version supported by Antrea. At the
    time of writing, we recommend version 1.16 or later. Typically the cluster
    needs to be running on a network infrastructure that you control. For
@@ -22,11 +23,16 @@ The only prerequisites are:
 All the required software will be deployed using YAML manifests, and the
 corresponding container images will be downloaded from public registries.
 
-macvlan requires the network to be able to handle "promiscuous mode", as the
-same physical interface / virtual adapter ends up being assigned multiple MAC
-addresses. When using a virtual network for the Nodes, some configuration
+For the sake of this guide, we will use macvlan in "bridge" mode, which supports
+the creation of multiple subinterfaces on one parent interface, and connects
+them all using a bridge. For more information on the different macvlan modes,
+you can refer to this [blog post](https://hicu.be/bridge-vs-macvlan). Macvlan in
+"bridge" mode requires the network to be able to handle "promiscuous mode", as
+the same physical interface / virtual adapter ends up being assigned multiple
+MAC addresses. When using a virtual network for the Nodes, some configuration
 changes are usually required, which depend on the virtualization technology. For
 example:
+
  * when using VirtualBox and [Internal
    Networking](https://www.virtualbox.org/manual/ch06.html#network_internal),
    set the `Promiscuous Mode` to `Allow All`
@@ -72,11 +78,16 @@ use as an example in this guide.
 
 ### Step 1: Deploying Antrea
 
+For detailed information on the Antrea requirements and instructions on how to
+deploy Antrea, please refer to
+[getting-started.md](/docs/getting-started.md). To deploy the latest version of
+Antrea, use:
+
 ```bash
-kubectl apply -f https://github.com/vmware-tanzu/antrea/releases/download/v0.9.2/antrea.yml
+kubectl apply -f https://raw.githubusercontent.com/vmware-tanzu/antrea/master/build/yamls/antrea.yml
 ```
 
-You may also choose a different [Antrea
+You may also choose a [released Antrea
 version](https://github.com/vmware-tanzu/antrea/releases).
 
 ### Step 2: Deploy Multus as a DaemonSet
@@ -171,7 +182,7 @@ include the IP addresses assigned to the parent interfaces.
 
 When using the [dhcp
 plugin](https://github.com/containernetworking/plugins/tree/master/plugins/ipam/dhcp)
-to assign IP addresses to Pod interfaces, a separate daemon needs to runone ach
+to assign IP addresses to Pod interfaces, a separate daemon needs to run on each
 Node, which will notably ensure that local DHCP leases are renewed
 periodically. To deploy the DHCP daemon (as a DaemonSet), you can use the
 following command:

--- a/docs/cookbooks/multus/assets/testbed-multus-macvlan.svg
+++ b/docs/cookbooks/multus/assets/testbed-multus-macvlan.svg
@@ -1,0 +1,1931 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="297mm"
+   height="210mm"
+   viewBox="0 0 297 210"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="macvlan.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.7"
+     inkscape:cx="423.74255"
+     inkscape:cy="388.57143"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer6"
+     showgrid="true"
+     inkscape:window-width="1613"
+     inkscape:window-height="995"
+     inkscape:window-x="67"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-87)"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.79374999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect1569"
+       width="291.04166"
+       height="201.08333"
+       x="2.1166666"
+       y="92.212509" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Node"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.39687496;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect819"
+       width="280.45834"
+       height="132.29166"
+       x="5.291676"
+       y="8.9166927" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Shapes"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.39687499;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect821"
+       width="31.749994"
+       height="15.875005"
+       x="15.875014"
+       y="130.62506" />
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.39687502;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect821-7"
+       width="79.375"
+       height="15.875022"
+       x="63.500011"
+       y="130.62506" />
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.39687496;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect821-7-5"
+       width="116.41666"
+       height="15.875005"
+       x="158.75002"
+       y="130.62506" />
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.39687499;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect853"
+       width="79.374992"
+       height="21.166662"
+       x="63.500011"
+       y="88.291679" />
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.39687499;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect855"
+       width="31.75"
+       height="47.625"
+       x="63.500011"
+       y="19.500008" />
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.39687502;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect855-3"
+       width="84.666664"
+       height="47.625"
+       x="111.12501"
+       y="19.500006" />
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.39687499;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect872"
+       width="21.166662"
+       height="79.375008"
+       x="164.04169"
+       y="56.541679" />
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.39687499;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect878"
+       width="58.208347"
+       height="15.875"
+       x="211.66669"
+       y="120.04169" />
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.39687499;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect876-8-8"
+       width="21.166666"
+       height="10.583333"
+       x="68.791679"
+       y="104.16669" />
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.39687499;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect876-8-8-3"
+       width="21.166666"
+       height="10.583333"
+       x="116.41666"
+       y="104.16669" />
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.39687496;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect955"
+       width="37.041672"
+       height="31.749985"
+       x="201.08334"
+       y="72.416679" />
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.39687499;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect955-9"
+       width="37.041664"
+       height="31.749987"
+       x="243.41669"
+       y="72.416695" />
+    <path
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.39687502;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 40.57424,162.84181 a 11.479244,7.5051486 0 0 0 -8.82423,2.70816 9.0194063,6.7010258 0 0 0 -5.442772,-1.368 9.0194063,6.7010258 0 0 0 -8.087485,3.75367 11.807223,6.4329852 0 0 0 -11.7550181,6.43178 11.807223,6.4329852 0 0 0 11.8070321,6.43325 11.807223,6.4329852 0 0 0 3.30656,-0.26129 18.366791,5.6288616 0 0 0 14.404213,2.13758 18.366791,5.6288616 0 0 0 17.20721,-3.68075 6.8875467,5.6288616 0 0 0 5.09525,-5.43281 6.8875467,5.6288616 0 0 0 -6.85481,-5.62739 11.479244,7.5051486 0 0 0 -10.85595,-5.0942 z"
+       id="path1047"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.39687502;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 113.86206,156.07532 a 15.53559,17.458313 0 0 0 -11.9424,6.29966 12.206536,15.587781 0 0 0 -7.366011,-3.18222 12.206536,15.587781 0 0 0 -10.945306,8.73171 15.979465,14.964269 0 0 0 -15.908814,14.96147 15.979465,14.964269 0 0 0 15.979208,14.96488 15.979465,14.964269 0 0 0 4.474978,-0.6078 24.856945,13.093736 0 0 0 19.494105,4.97239 24.856945,13.093736 0 0 0 23.28761,-8.56208 9.3213546,13.093736 0 0 0 6.89572,-12.63769 9.3213546,13.093736 0 0 0 -9.27705,-13.0903 15.53559,17.458313 0 0 0 -14.69204,-11.85002 z"
+       id="path1047-0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.39687502;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 225.9542,162.90415 a 11.479244,7.5051486 0 0 0 -8.82423,2.70816 9.0194064,6.7010259 0 0 0 -5.44277,-1.368 9.0194064,6.7010259 0 0 0 -8.08748,3.75367 11.807223,6.4329852 0 0 0 -11.75502,6.43178 11.807223,6.4329852 0 0 0 11.80703,6.43325 11.807223,6.4329852 0 0 0 3.30656,-0.26129 18.366791,5.6288617 0 0 0 14.40421,2.13758 18.366791,5.6288617 0 0 0 17.20722,-3.68075 6.8875468,5.6288617 0 0 0 5.09524,-5.43281 6.8875468,5.6288617 0 0 0 -6.85481,-5.62739 11.479244,7.5051486 0 0 0 -10.85595,-5.0942 z"
+       id="path1047-4"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.79374999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 103.10494,146.50008 -0.15198,14.60996"
+       id="path1082"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect821-7"
+       inkscape:connection-end="#path1047-0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.79374999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 217.14288,146.50007 0.4366,18.77924"
+       id="path1084"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect821-7-5"
+       inkscape:connection-end="#path1047-4" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.79374999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 31.895048,146.50007 0.341531,18.69114"
+       id="path1094"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect821"
+       inkscape:connection-end="#path1047" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="Veths"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.39687499;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect874-8"
+       width="21.166666"
+       height="15.875"
+       x="68.791672"
+       y="56.541679" />
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.39687499;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect876-8"
+       width="21.166666"
+       height="10.583333"
+       x="68.791672"
+       y="83.000008" />
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.39687499;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect874"
+       width="21.166666"
+       height="15.875"
+       x="116.41666"
+       y="56.541679" />
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.39687499;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect876"
+       width="21.166666"
+       height="10.583333"
+       x="116.41668"
+       y="83.000008" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.79374999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 79.375007,72.416679 V 83.000008"
+       id="path1005"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect874-8"
+       inkscape:connection-end="#rect876-8" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.79374999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 127,72.416679 1e-5,10.583329"
+       id="path1007"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#rect874"
+       inkscape:connection-end="#rect876" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer5"
+     inkscape:label="Text"
+     style="display:none"
+     sodipodi:insensitive="true">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="15.87501"
+       y="24.791676"
+       id="text1101"><tspan
+         sodipodi:role="line"
+         id="tspan1099"
+         x="15.87501"
+         y="24.791676"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:8.46666622px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">K8s Node</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="22.678579"
+       y="140.83043"
+       id="text1113"><tspan
+         sodipodi:role="line"
+         id="tspan1111"
+         x="22.678579"
+         y="140.83043"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">enp0s3</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="93.738098"
+       y="140.45245"
+       id="text1113-9"><tspan
+         sodipodi:role="line"
+         id="tspan1111-3"
+         x="93.738098"
+         y="140.45245"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">enp0s8</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="187.4762"
+       y="143.09828"
+       id="text1113-9-2"><tspan
+         sodipodi:role="line"
+         id="tspan1111-3-1"
+         x="187.4762"
+         y="143.09828"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">enp0s9 (macvlan parent)</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="169.71132"
+       y="66.066681"
+       id="text1153"><tspan
+         sodipodi:role="line"
+         id="tspan1151"
+         x="169.71132"
+         y="66.066681"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">net1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="122.31309"
+       y="65.991081"
+       id="text1153-3"><tspan
+         sodipodi:role="line"
+         id="tspan1151-6"
+         x="122.31309"
+         y="65.991081"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">eth0</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="73.327377"
+       y="65.991081"
+       id="text1153-3-3"><tspan
+         sodipodi:role="line"
+         id="tspan1151-6-1"
+         x="73.327377"
+         y="65.991081"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">eth0</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="73.327377"
+       y="90.559532"
+       id="text1153-3-3-7"><tspan
+         sodipodi:role="line"
+         id="tspan1151-6-1-3"
+         x="73.327377"
+         y="90.559532"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">vethA</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="119.81845"
+       y="90.937508"
+       id="text1153-3-3-7-0"><tspan
+         sodipodi:role="line"
+         id="tspan1151-6-1-3-0"
+         x="119.81845"
+         y="90.937508"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">vethB</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="74.385712"
+       y="111.7262"
+       id="text1153-3-3-7-6"><tspan
+         sodipodi:role="line"
+         id="tspan1151-6-1-3-07"
+         x="74.385712"
+         y="111.7262"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">gw0</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="120.95238"
+       y="111.7262"
+       id="text1153-3-3-7-6-6"><tspan
+         sodipodi:role="line"
+         id="tspan1151-6-1-3-07-9"
+         x="120.95238"
+         y="111.7262"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">tun0</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="67.657745"
+       y="30.083344"
+       id="text1265"><tspan
+         sodipodi:role="line"
+         id="tspan1263"
+         x="67.657745"
+         y="30.083344"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">Pod A</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="116.41668"
+       y="30.083344"
+       id="text1265-9"><tspan
+         sodipodi:role="line"
+         id="tspan1263-6"
+         x="116.41668"
+         y="30.083344"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">Pod B</tspan><tspan
+         sodipodi:role="line"
+         x="116.41668"
+         y="38.902786"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan1285">(with secondary interface)</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="205.61905"
+       y="90.257149"
+       id="text1265-4"><tspan
+         sodipodi:role="line"
+         id="tspan1263-8"
+         x="205.61905"
+         y="90.257149"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">DHCP server</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="246.89342"
+       y="90.635124"
+       id="text1265-4-9"><tspan
+         sodipodi:role="line"
+         id="tspan1263-8-4"
+         x="246.89342"
+         y="90.635124"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">DHCP daemon</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="234.34526"
+       y="130.24709"
+       id="text1113-9-2-9"><tspan
+         sodipodi:role="line"
+         id="tspan1111-3-1-9"
+         x="234.34526"
+         y="130.24709"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">mac0</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="17.008936"
+       y="128.20599"
+       id="text1343"><tspan
+         sodipodi:role="line"
+         id="tspan1341"
+         x="17.008936"
+         y="128.20599"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">10.0.2.15/24</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="66.523811"
+       y="121.55358"
+       id="text1343-1"><tspan
+         sodipodi:role="line"
+         id="tspan1341-2"
+         x="66.523811"
+         y="121.55358"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">10.10.1.1/24</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="81.718445"
+       y="129.11316"
+       id="text1343-1-4"><tspan
+         sodipodi:role="line"
+         id="tspan1341-2-3"
+         x="81.718445"
+         y="129.11316"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">192.168.77.101/24</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="218.99939"
+       y="118.15181"
+       id="text1343-1-4-1"><tspan
+         sodipodi:role="line"
+         id="tspan1341-2-3-3"
+         x="218.99939"
+         y="118.15181"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">192.168.78.101/24</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="65.389885"
+       y="54.273811"
+       id="text1343-1-7"><tspan
+         sodipodi:role="line"
+         id="tspan1341-2-4"
+         x="65.389885"
+         y="54.273811"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">10.10.1.9/24</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="111.88095"
+       y="54.349407"
+       id="text1343-1-7-3"><tspan
+         sodipodi:role="line"
+         id="tspan1341-2-4-2"
+         x="111.88095"
+         y="54.349407"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">10.10.1.12/24</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="150.73685"
+       y="54.802971"
+       id="text1343-1-4-1-1"><tspan
+         sodipodi:role="line"
+         id="tspan1341-2-3-3-9"
+         x="150.73685"
+         y="54.802971"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">192.168.78.202/24</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="10.583344"
+       y="175.60423"
+       id="text1509"><tspan
+         sodipodi:role="line"
+         id="tspan1507"
+         x="10.583344"
+         y="175.60423"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">Public network (NAT)</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="84.817863"
+       y="174.84833"
+       id="text1509-2"><tspan
+         sodipodi:role="line"
+         id="tspan1507-1"
+         x="84.817863"
+         y="174.84833"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">Node network:</tspan><tspan
+         sodipodi:role="line"
+         x="84.817863"
+         y="182.78583"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan1529">K8s control plane +</tspan><tspan
+         sodipodi:role="line"
+         x="84.817863"
+         y="190.72333"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan1531">Pod network underlay</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="197.30359"
+       y="175.98221"
+       id="text1509-0"><tspan
+         sodipodi:role="line"
+         id="tspan1507-0"
+         x="197.30359"
+         y="175.98221"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">Secondary network</tspan></text>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer6"
+     inkscape:label="TextPath">
+    <g
+       aria-label="K8s Node"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1574">
+      <path
+         d="m 16.467676,24.791676 v -6.858 h 0.651933 v 3.623733 l 1.8288,-3.623733 h 0.618067 l -1.413933,2.9464 1.718733,3.9116 h -0.635 l -1.507067,-3.429 -0.6096,1.1176 v 2.3114 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:8.46666622px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1737" />
+      <path
+         d="m 21.844671,24.876342 q -0.592667,0 -0.948267,-0.237066 -0.347133,-0.237067 -0.508,-0.668867 -0.160866,-0.440267 -0.160866,-1.016 0,-0.448733 0.08467,-0.745067 0.09313,-0.3048 0.237067,-0.499533 0.143933,-0.194733 0.321733,-0.313267 0.1778,-0.118533 0.347133,-0.2032 -0.414866,-0.169333 -0.668866,-0.5588 -0.254,-0.397933 -0.254,-1.049866 0,-0.499533 0.1524,-0.889 0.1524,-0.389467 0.491066,-0.6096 0.347134,-0.220133 0.905934,-0.220133 0.5588,0 0.889,0.2286 0.338666,0.220133 0.491066,0.6096 0.1524,0.389466 0.1524,0.897466 0,0.651933 -0.254,1.032933 -0.245533,0.381 -0.6604,0.5588 0.169334,0.08467 0.338667,0.2032 0.1778,0.118534 0.321733,0.313267 0.143934,0.194733 0.237067,0.499533 0.09313,0.296334 0.09313,0.745067 0,0.575733 -0.160866,1.016 -0.160867,0.4318 -0.516467,0.668867 -0.347133,0.237066 -0.931333,0.237066 z m 0,-0.491066 q 0.338666,0 0.5588,-0.1524 0.220133,-0.160867 0.3302,-0.474134 0.110066,-0.321733 0.110066,-0.804333 0,-0.423333 -0.1016,-0.7366 -0.09313,-0.321733 -0.313266,-0.516467 -0.211667,-0.194733 -0.5842,-0.220133 -0.372534,0.0254 -0.601134,0.220133 -0.220133,0.194734 -0.321733,0.516467 -0.09313,0.313267 -0.09313,0.7366 0,0.4826 0.110066,0.804333 0.118534,0.313267 0.338667,0.474134 0.2286,0.1524 0.567267,0.1524 z m 0,-3.471334 q 0.3556,-0.01693 0.550333,-0.194733 0.2032,-0.1778 0.287867,-0.474133 0.08467,-0.296334 0.08467,-0.668867 0,-0.592666 -0.220133,-0.897466 -0.220133,-0.313267 -0.702733,-0.313267 -0.491067,0 -0.719667,0.313267 -0.220133,0.3048 -0.220133,0.897466 0,0.372533 0.08467,0.668867 0.08467,0.296333 0.287867,0.474133 0.211667,0.1778 0.567267,0.194733 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:8.46666622px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1739" />
+      <path
+         d="m 25.536535,24.867876 q -0.5842,0 -0.931334,-0.372534 -0.347133,-0.381 -0.397933,-1.016 l 0.516467,-0.1524 q 0.0508,0.5588 0.262466,0.821267 0.211667,0.254 0.592667,0.254 0.321733,0 0.491067,-0.1778 0.1778,-0.186267 0.1778,-0.516467 0,-0.237066 -0.143934,-0.474133 -0.143933,-0.245533 -0.4572,-0.508 l -0.6604,-0.575733 q -0.3302,-0.2794 -0.499533,-0.5588 -0.169333,-0.2794 -0.169333,-0.668867 0,-0.3556 0.143933,-0.592667 0.1524,-0.245533 0.4064,-0.372533 0.262467,-0.135467 0.618067,-0.135467 0.5588,0 0.846666,0.364067 0.287867,0.3556 0.313267,0.922867 l -0.440267,0.143933 q -0.01693,-0.3302 -0.1016,-0.541867 -0.08467,-0.220133 -0.237066,-0.321733 -0.143934,-0.1016 -0.3556,-0.1016 -0.2794,0 -0.4572,0.160867 -0.169334,0.1524 -0.169334,0.4318 0,0.220133 0.08467,0.389466 0.08467,0.169334 0.313267,0.381 l 0.694266,0.618067 q 0.2032,0.1778 0.389467,0.381 0.186267,0.2032 0.3048,0.4572 0.118533,0.245533 0.118533,0.5842 0,0.381 -0.160866,0.643467 -0.1524,0.254 -0.4318,0.397933 -0.2794,0.135467 -0.6604,0.135467 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:8.46666622px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1741" />
+      <path
+         d="m 29.341507,24.791676 v -6.858 h 0.465667 l 2.184399,5.325533 v -5.325533 h 0.5588 v 6.858 h -0.4572 l -2.201333,-5.3848 v 5.3848 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:8.46666622px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1743" />
+      <path
+         d="m 34.823939,24.867876 q -0.499533,0 -0.7874,-0.211667 -0.287867,-0.220133 -0.4064,-0.626533 -0.110067,-0.414867 -0.110067,-1.007534 v -1.354666 q 0,-0.592667 0.110067,-0.999067 0.118533,-0.414867 0.4064,-0.626533 0.287867,-0.220134 0.7874,-0.220134 0.508,0 0.7874,0.220134 0.287867,0.211666 0.397933,0.626533 0.118534,0.4064 0.118534,0.999067 v 1.354666 q 0,0.592667 -0.118534,1.007534 -0.110066,0.4064 -0.397933,0.626533 -0.2794,0.211667 -0.7874,0.211667 z m 0,-0.465667 q 0.321733,0 0.465667,-0.169333 0.1524,-0.169334 0.186266,-0.474134 0.03387,-0.3048 0.03387,-0.702733 v -1.4224 q 0,-0.397933 -0.03387,-0.694267 -0.03387,-0.3048 -0.186266,-0.474133 -0.143934,-0.1778 -0.465667,-0.1778 -0.321733,0 -0.465667,0.1778 -0.143933,0.169333 -0.186266,0.474133 -0.03387,0.296334 -0.03387,0.694267 v 1.4224 q 0,0.397933 0.03387,0.702733 0.04233,0.3048 0.186266,0.474134 0.143934,0.169333 0.465667,0.169333 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:8.46666622px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1745" />
+      <path
+         d="m 38.070375,24.867876 q -0.626533,0 -0.905933,-0.474134 -0.270934,-0.474133 -0.270934,-1.5748 v -0.905933 q 0,-0.643467 0.09313,-1.109133 0.09313,-0.465667 0.338666,-0.719667 0.254,-0.262467 0.719667,-0.262467 0.287867,0 0.499533,0.135467 0.220134,0.127 0.364067,0.287867 v -2.3114 h 0.618067 v 6.858 h -0.618067 v -0.347134 q -0.143933,0.160867 -0.3556,0.296334 -0.2032,0.127 -0.4826,0.127 z m 0.127,-0.4826 q 0.194733,0 0.381,-0.09313 0.186267,-0.1016 0.3302,-0.237066 v -3.4036 q -0.127,-0.118534 -0.313267,-0.2286 -0.186266,-0.118534 -0.414866,-0.118534 -0.4064,0 -0.541867,0.364067 -0.127,0.3556 -0.127,1.049867 v 1.151466 q 0,0.491067 0.0508,0.829734 0.05927,0.338666 0.2032,0.516466 0.1524,0.169334 0.4318,0.169334 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:8.46666622px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1747" />
+      <path
+         d="m 41.703501,24.867876 q -0.4572,0 -0.753533,-0.1778 -0.287867,-0.186267 -0.4318,-0.6096 -0.135467,-0.423334 -0.135467,-1.126067 v -1.236133 q 0,-0.728134 0.143934,-1.134534 0.143933,-0.414866 0.440266,-0.5842 0.296334,-0.1778 0.7366,-0.1778 0.524934,0 0.795867,0.220134 0.270933,0.220133 0.372533,0.668866 0.110067,0.440267 0.110067,1.134534 v 0.440266 h -1.9812 v 0.855134 q 0,0.474133 0.06773,0.753533 0.0762,0.270933 0.2286,0.389467 0.160867,0.118533 0.4064,0.118533 0.186267,0 0.338667,-0.06773 0.1524,-0.0762 0.237067,-0.2794 0.09313,-0.211667 0.09313,-0.592667 v -0.338667 h 0.601133 v 0.270934 q 0,0.668866 -0.2794,1.075266 -0.2794,0.397934 -0.9906,0.397934 z m -0.702733,-2.937934 h 1.3716 v -0.4064 q 0,-0.389466 -0.04233,-0.6604 -0.04233,-0.2794 -0.186267,-0.423333 -0.135467,-0.1524 -0.440267,-0.1524 -0.254,0 -0.414866,0.110067 -0.1524,0.110066 -0.220134,0.397933 -0.06773,0.2794 -0.06773,0.804333 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:8.46666622px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1749" />
+    </g>
+    <g
+       aria-label="enp0s3"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1578">
+      <path
+         d="m 23.954929,140.88758 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.08255,0.3302 0.08255,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.05715,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0571 0.1778,-0.20955 0.06985,-0.15875 0.06985,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.03175,-0.4953 -0.03175,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0826 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1752" />
+      <path
+         d="m 25.539453,140.83043 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.06985,0.17145 0.06985,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1754" />
+      <path
+         d="m 28.131543,142.03693 v -4.8768 h 0.46355 v 0.3048 q 0.1143,-0.13335 0.28575,-0.24765 0.17145,-0.1143 0.4191,-0.1143 0.2667,0 0.42545,0.127 0.1651,0.12065 0.254,0.3302 0.0889,0.20955 0.12065,0.4699 0.03175,0.26035 0.03175,0.53975 v 0.76835 q 0,0.4699 -0.08255,0.81915 -0.0762,0.34925 -0.2667,0.53975 -0.1905,0.1905 -0.5334,0.1905 -0.22225,0 -0.38735,-0.1143 -0.15875,-0.1143 -0.2667,-0.23495 v 1.4986 z m 1.0414,-1.5113 q 0.20955,0 0.3175,-0.13335 0.10795,-0.1397 0.1397,-0.40005 0.0381,-0.2667 0.0381,-0.64135 v -0.78105 q 0,-0.36195 -0.0381,-0.60325 -0.03175,-0.24765 -0.1397,-0.37465 -0.10795,-0.127 -0.32385,-0.127 -0.1778,0 -0.3302,0.0952 -0.14605,0.0952 -0.2413,0.1905 v 2.5019 q 0.1016,0.10795 0.24765,0.1905 0.1524,0.0825 0.3302,0.0825 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1756" />
+      <path
+         d="m 32.068344,140.89393 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.06985,-0.254 0.06985,-0.56515 v -2.30505 q 0,-0.31115 -0.06985,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.06985,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1758" />
+      <path
+         d="m 34.910465,140.88758 q -0.43815,0 -0.6985,-0.2794 -0.26035,-0.28575 -0.29845,-0.762 l 0.38735,-0.1143 q 0.0381,0.4191 0.19685,0.61595 0.15875,0.1905 0.4445,0.1905 0.2413,0 0.3683,-0.13335 0.13335,-0.1397 0.13335,-0.38735 0,-0.1778 -0.10795,-0.3556 -0.10795,-0.18415 -0.3429,-0.381 l -0.4953,-0.4318 q -0.24765,-0.20955 -0.37465,-0.4191 -0.127,-0.20955 -0.127,-0.50165 0,-0.2667 0.10795,-0.4445 0.1143,-0.18415 0.3048,-0.2794 0.19685,-0.1016 0.46355,-0.1016 0.4191,0 0.635,0.27305 0.2159,0.2667 0.23495,0.69215 l -0.3302,0.10795 q -0.0127,-0.24765 -0.0762,-0.4064 -0.0635,-0.1651 -0.1778,-0.2413 -0.10795,-0.0762 -0.2667,-0.0762 -0.20955,0 -0.3429,0.12065 -0.127,0.1143 -0.127,0.32385 0,0.1651 0.0635,0.2921 0.0635,0.127 0.23495,0.28575 l 0.5207,0.46355 q 0.1524,0.13335 0.2921,0.28575 0.1397,0.1524 0.2286,0.3429 0.0889,0.18415 0.0889,0.43815 0,0.28575 -0.12065,0.4826 -0.1143,0.1905 -0.32385,0.29845 -0.20955,0.1016 -0.4953,0.1016 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1760" />
+      <path
+         d="m 37.534801,140.89393 q -0.40005,0 -0.65405,-0.1524 -0.254,-0.1524 -0.37465,-0.4318 -0.1143,-0.28575 -0.1143,-0.66675 v -0.127 h 0.4445 q 0,0.019 0,0.0571 0,0.0318 0,0.0508 0.0063,0.27305 0.06985,0.47625 0.06985,0.19685 0.22225,0.3048 0.1524,0.10795 0.4064,0.10795 0.2413,0 0.4064,-0.1016 0.17145,-0.10795 0.254,-0.34925 0.0889,-0.2413 0.0889,-0.62865 0,-0.47625 -0.17145,-0.7747 -0.17145,-0.3048 -0.5969,-0.3175 -0.0127,0 -0.0635,0 -0.0508,0 -0.0635,0 v -0.4445 q 0.0127,0 0.0635,0 0.0508,0 0.0635,0 0.41275,0 0.59055,-0.2286 0.1778,-0.23495 0.1778,-0.7493 0,-0.40005 -0.1524,-0.65405 -0.14605,-0.254 -0.5461,-0.254 -0.38735,0 -0.56515,0.22225 -0.17145,0.2159 -0.18415,0.6731 0,0.0127 0,0.0445 0,0.0254 0,0.0445 h -0.4445 v -0.12065 q 0,-0.381 0.1143,-0.65405 0.12065,-0.2794 0.38735,-0.4318 0.2667,-0.1524 0.6858,-0.1524 0.4064,0 0.66675,0.1651 0.26035,0.1651 0.381,0.4572 0.127,0.28575 0.127,0.6604 0,0.53975 -0.2032,0.8382 -0.2032,0.2921 -0.52705,0.3683 0.1905,0.0508 0.3556,0.2032 0.1651,0.1524 0.2667,0.42545 0.10795,0.2667 0.10795,0.6731 0,0.4318 -0.12065,0.76835 -0.12065,0.3302 -0.3937,0.51435 -0.2667,0.18415 -0.70485,0.18415 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1762" />
+    </g>
+    <g
+       aria-label="enp0s8"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1582">
+      <path
+         d="m 95.014448,140.5096 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.08255,0.3302 0.08255,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.05715,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0572 0.1778,-0.20955 0.06985,-0.15875 0.06985,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.03175,-0.4953 -0.03175,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1765" />
+      <path
+         d="m 96.598971,140.45245 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.06985,0.17145 0.06985,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1767" />
+      <path
+         d="m 99.191062,141.65895 v -4.8768 h 0.46355 v 0.3048 q 0.1143,-0.13335 0.28575,-0.24765 0.171448,-0.1143 0.419098,-0.1143 0.2667,0 0.42545,0.127 0.1651,0.12065 0.254,0.3302 0.0889,0.20955 0.12065,0.4699 0.0318,0.26035 0.0318,0.53975 v 0.76835 q 0,0.4699 -0.0825,0.81915 -0.0762,0.34925 -0.2667,0.53975 -0.1905,0.1905 -0.5334,0.1905 -0.22225,0 -0.387348,-0.1143 -0.15875,-0.1143 -0.2667,-0.23495 v 1.4986 z m 1.041398,-1.5113 q 0.20955,0 0.3175,-0.13335 0.10795,-0.1397 0.1397,-0.40005 0.0381,-0.2667 0.0381,-0.64135 v -0.78105 q 0,-0.36195 -0.0381,-0.60325 -0.0318,-0.24765 -0.1397,-0.37465 -0.10795,-0.127 -0.32385,-0.127 -0.1778,0 -0.330198,0.0952 -0.14605,0.0952 -0.2413,0.1905 v 2.5019 q 0.1016,0.10795 0.24765,0.1905 0.152398,0.0825 0.330198,0.0825 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1769" />
+      <path
+         d="m 103.12786,140.51595 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0699,-0.254 0.0699,-0.56515 v -2.30505 q 0,-0.31115 -0.0699,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0699,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1771" />
+      <path
+         d="m 105.96998,140.5096 q -0.43815,0 -0.6985,-0.2794 -0.26035,-0.28575 -0.29845,-0.762 l 0.38735,-0.1143 q 0.0381,0.4191 0.19685,0.61595 0.15875,0.1905 0.4445,0.1905 0.2413,0 0.3683,-0.13335 0.13335,-0.1397 0.13335,-0.38735 0,-0.1778 -0.10795,-0.3556 -0.10795,-0.18415 -0.3429,-0.381 l -0.4953,-0.4318 q -0.24765,-0.20955 -0.37465,-0.4191 -0.127,-0.20955 -0.127,-0.50165 0,-0.2667 0.10795,-0.4445 0.1143,-0.18415 0.3048,-0.2794 0.19685,-0.1016 0.46355,-0.1016 0.4191,0 0.635,0.27305 0.2159,0.2667 0.23495,0.69215 l -0.3302,0.10795 q -0.0127,-0.24765 -0.0762,-0.4064 -0.0635,-0.1651 -0.1778,-0.2413 -0.10795,-0.0762 -0.2667,-0.0762 -0.20955,0 -0.3429,0.12065 -0.127,0.1143 -0.127,0.32385 0,0.1651 0.0635,0.2921 0.0635,0.127 0.23495,0.28575 l 0.5207,0.46355 q 0.1524,0.13335 0.2921,0.28575 0.1397,0.1524 0.2286,0.3429 0.0889,0.18415 0.0889,0.43815 0,0.28575 -0.12065,0.4826 -0.1143,0.1905 -0.32385,0.29845 -0.20955,0.1016 -0.4953,0.1016 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1773" />
+      <path
+         d="m 108.67052,140.51595 q -0.4445,0 -0.7112,-0.1778 -0.26035,-0.1778 -0.381,-0.50165 -0.12065,-0.3302 -0.12065,-0.762 0,-0.33655 0.0635,-0.5588 0.0699,-0.2286 0.1778,-0.37465 0.10795,-0.14605 0.2413,-0.23495 0.13335,-0.0889 0.26035,-0.1524 -0.31115,-0.127 -0.50165,-0.4191 -0.1905,-0.29845 -0.1905,-0.7874 0,-0.37465 0.1143,-0.66675 0.1143,-0.2921 0.3683,-0.4572 0.26035,-0.1651 0.67945,-0.1651 0.4191,0 0.66675,0.17145 0.254,0.1651 0.3683,0.4572 0.1143,0.2921 0.1143,0.6731 0,0.48895 -0.1905,0.7747 -0.18415,0.28575 -0.4953,0.4191 0.127,0.0635 0.254,0.1524 0.13335,0.0889 0.2413,0.23495 0.10795,0.14605 0.1778,0.37465 0.0699,0.22225 0.0699,0.5588 0,0.4318 -0.12065,0.762 -0.12065,0.32385 -0.38735,0.50165 -0.26035,0.1778 -0.6985,0.1778 z m 0,-0.3683 q 0.254,0 0.4191,-0.1143 0.1651,-0.12065 0.24765,-0.3556 0.0825,-0.2413 0.0825,-0.60325 0,-0.3175 -0.0762,-0.55245 -0.0699,-0.2413 -0.23495,-0.38735 -0.15875,-0.14605 -0.43815,-0.1651 -0.2794,0.019 -0.45085,0.1651 -0.1651,0.14605 -0.2413,0.38735 -0.0699,0.23495 -0.0699,0.55245 0,0.36195 0.0825,0.60325 0.0889,0.23495 0.254,0.3556 0.17145,0.1143 0.42545,0.1143 z m 0,-2.6035 q 0.2667,-0.0127 0.41275,-0.14605 0.1524,-0.13335 0.2159,-0.3556 0.0635,-0.22225 0.0635,-0.50165 0,-0.4445 -0.1651,-0.6731 -0.1651,-0.23495 -0.52705,-0.23495 -0.3683,0 -0.53975,0.23495 -0.1651,0.2286 -0.1651,0.6731 0,0.2794 0.0635,0.50165 0.0635,0.22225 0.2159,0.3556 0.15875,0.13335 0.42545,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1775" />
+    </g>
+    <g
+       aria-label="enp0s9 (macvlan parent)"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1586">
+      <path
+         d="m 188.75255,143.15543 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0572,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0572 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0317,-0.4953 -0.0318,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1778" />
+      <path
+         d="m 190.33707,143.09828 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0953 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1780" />
+      <path
+         d="m 192.92916,144.30478 v -4.8768 h 0.46355 v 0.3048 q 0.1143,-0.13335 0.28575,-0.24765 0.17145,-0.1143 0.4191,-0.1143 0.2667,0 0.42545,0.127 0.1651,0.12065 0.254,0.3302 0.0889,0.20955 0.12065,0.4699 0.0317,0.26035 0.0317,0.53975 v 0.76835 q 0,0.4699 -0.0825,0.81915 -0.0762,0.34925 -0.2667,0.53975 -0.1905,0.1905 -0.5334,0.1905 -0.22225,0 -0.38735,-0.1143 -0.15875,-0.1143 -0.2667,-0.23495 v 1.4986 z m 1.0414,-1.5113 q 0.20955,0 0.3175,-0.13335 0.10795,-0.1397 0.1397,-0.40005 0.0381,-0.2667 0.0381,-0.64135 v -0.78105 q 0,-0.36195 -0.0381,-0.60325 -0.0318,-0.24765 -0.1397,-0.37465 -0.10795,-0.127 -0.32385,-0.127 -0.1778,0 -0.3302,0.0953 -0.14605,0.0952 -0.2413,0.1905 v 2.5019 q 0.1016,0.10795 0.24765,0.1905 0.1524,0.0825 0.3302,0.0825 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1782" />
+      <path
+         d="m 196.86596,143.16178 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0699,-0.254 0.0699,-0.56515 v -2.30505 q 0,-0.31115 -0.0699,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0699,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1784" />
+      <path
+         d="m 199.70808,143.15543 q -0.43815,0 -0.6985,-0.2794 -0.26035,-0.28575 -0.29845,-0.762 l 0.38735,-0.1143 q 0.0381,0.4191 0.19685,0.61595 0.15875,0.1905 0.4445,0.1905 0.2413,0 0.3683,-0.13335 0.13335,-0.1397 0.13335,-0.38735 0,-0.1778 -0.10795,-0.3556 -0.10795,-0.18415 -0.3429,-0.381 l -0.4953,-0.4318 q -0.24765,-0.20955 -0.37465,-0.4191 -0.127,-0.20955 -0.127,-0.50165 0,-0.2667 0.10795,-0.4445 0.1143,-0.18415 0.3048,-0.2794 0.19685,-0.1016 0.46355,-0.1016 0.4191,0 0.635,0.27305 0.2159,0.2667 0.23495,0.69215 l -0.3302,0.10795 q -0.0127,-0.24765 -0.0762,-0.4064 -0.0635,-0.1651 -0.1778,-0.2413 -0.10795,-0.0762 -0.2667,-0.0762 -0.20955,0 -0.3429,0.12065 -0.127,0.1143 -0.127,0.32385 0,0.1651 0.0635,0.2921 0.0635,0.127 0.23495,0.28575 l 0.5207,0.46355 q 0.1524,0.13335 0.2921,0.28575 0.1397,0.1524 0.2286,0.3429 0.0889,0.18415 0.0889,0.43815 0,0.28575 -0.12065,0.4826 -0.1143,0.1905 -0.32385,0.29845 -0.20955,0.1016 -0.4953,0.1016 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1786" />
+      <path
+         d="m 202.42132,143.16178 q -0.38735,0 -0.6477,-0.13335 -0.26035,-0.13335 -0.3937,-0.40005 -0.127,-0.27305 -0.13335,-0.66675 0,-0.0127 0,-0.0508 0,-0.0381 0,-0.0445 h 0.4572 q 0,0.48895 0.1524,0.6985 0.15875,0.20955 0.5715,0.20955 0.2159,0 0.3683,-0.1016 0.15875,-0.1016 0.2413,-0.3429 0.0825,-0.24765 0.0825,-0.6604 v -0.97155 q -0.0952,0.1143 -0.3048,0.20955 -0.2032,0.0952 -0.5207,0.0952 -0.42545,0 -0.66675,-0.15875 -0.2413,-0.1651 -0.3429,-0.50165 -0.1016,-0.3429 -0.1016,-0.8763 0,-0.47625 0.12065,-0.8255 0.127,-0.34925 0.3937,-0.53975 0.27305,-0.19685 0.7112,-0.19685 0.4191,0 0.67945,0.19685 0.26035,0.1905 0.381,0.55245 0.12065,0.3556 0.12065,0.85725 v 2.05105 q 0,0.4699 -0.1143,0.83185 -0.1143,0.36195 -0.3683,0.56515 -0.24765,0.2032 -0.6858,0.2032 z m -0.0191,-2.52095 q 0.27305,0 0.45085,-0.0952 0.1778,-0.1016 0.2667,-0.2032 v -0.88265 q 0,-0.4191 -0.0762,-0.6731 -0.0699,-0.26035 -0.2286,-0.37465 -0.15875,-0.12065 -0.4064,-0.12065 -0.24765,0 -0.4191,0.12065 -0.1651,0.1143 -0.24765,0.3556 -0.0825,0.2413 -0.0825,0.6096 0,0.42545 0.0444,0.70485 0.0508,0.2794 0.20955,0.4191 0.15875,0.1397 0.48895,0.1397 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1788" />
+      <path
+         d="m 206.86681,144.14603 q -0.31115,-0.019 -0.51435,-0.1905 -0.2032,-0.17145 -0.3175,-0.46355 -0.10795,-0.28575 -0.1651,-0.66675 -0.0508,-0.38735 -0.0635,-0.8382 -0.006,-0.4572 -0.006,-0.9525 0,-0.4953 0.006,-0.9525 0.0127,-0.46355 0.0635,-0.8509 0.0572,-0.38735 0.1651,-0.67945 0.1143,-0.2921 0.3175,-0.4572 0.2032,-0.1651 0.51435,-0.1778 v 0.3302 q -0.23495,0.019 -0.36195,0.254 -0.127,0.2286 -0.18415,0.61595 -0.0508,0.38735 -0.0635,0.88265 -0.006,0.48895 -0.006,1.03505 0,0.5461 0.006,1.0414 0.0127,0.4953 0.0635,0.88265 0.0572,0.381 0.18415,0.6096 0.127,0.23495 0.36195,0.254 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1790" />
+      <path
+         d="m 207.4151,143.09828 v -3.6703 h 0.4318 v 0.37465 q 0.18415,-0.2159 0.4064,-0.32385 0.22225,-0.1143 0.4572,-0.1143 0.1905,0 0.34925,0.1016 0.1651,0.1016 0.23495,0.381 0.18415,-0.2413 0.41275,-0.36195 0.23495,-0.12065 0.48895,-0.12065 0.15875,0 0.29845,0.0762 0.14605,0.0762 0.23495,0.26035 0.0889,0.18415 0.0889,0.50165 v 2.8956 h -0.43815 v -2.8829 q 0,-0.32385 -0.1016,-0.42545 -0.1016,-0.10795 -0.26035,-0.10795 -0.1778,0 -0.3556,0.1016 -0.1778,0.1016 -0.33655,0.2794 0.006,0.0317 0.006,0.0699 0,0.0317 0,0.0698 v 2.8956 h -0.4318 v -2.8829 q 0,-0.32385 -0.10795,-0.42545 -0.1016,-0.10795 -0.26035,-0.10795 -0.17145,0 -0.34925,0.1016 -0.1778,0.1016 -0.33655,0.27305 v 3.04165 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1792" />
+      <path
+         d="m 212.13652,143.15543 q -0.2159,0 -0.381,-0.10795 -0.1651,-0.1143 -0.26035,-0.29845 -0.0952,-0.18415 -0.0952,-0.41275 0,-0.2794 0.0825,-0.47625 0.0825,-0.19685 0.254,-0.34925 0.1778,-0.15875 0.4572,-0.3048 0.28575,-0.1524 0.69215,-0.33655 v -0.26035 q 0,-0.33655 -0.0444,-0.52705 -0.0381,-0.19685 -0.1397,-0.2794 -0.0952,-0.0825 -0.27305,-0.0825 -0.14605,0 -0.26035,0.0572 -0.1143,0.0572 -0.18415,0.19685 -0.0699,0.13335 -0.0699,0.37465 v 0.127 l -0.4572,-0.006 q 0.006,-0.5588 0.23495,-0.8255 0.23495,-0.27305 0.762,-0.27305 0.48895,0 0.69215,0.29845 0.2032,0.2921 0.2032,0.9144 v 1.78435 q 0,0.0952 0,0.24765 0.006,0.14605 0.0127,0.2794 0.0127,0.13335 0.0191,0.2032 h -0.41275 q -0.019,-0.12065 -0.0444,-0.2667 -0.0191,-0.1524 -0.0254,-0.2413 -0.0762,0.22225 -0.27305,0.3937 -0.1905,0.17145 -0.48895,0.17145 z m 0.1524,-0.3937 q 0.1397,0 0.24765,-0.0635 0.1143,-0.0699 0.2032,-0.17145 0.0952,-0.1016 0.14605,-0.2032 v -1.143 q -0.27305,0.14605 -0.4699,0.26035 -0.1905,0.10795 -0.31115,0.2159 -0.12065,0.10795 -0.1778,0.24765 -0.0572,0.13335 -0.0572,0.3175 0,0.2921 0.12065,0.4191 0.127,0.12065 0.29845,0.12065 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1794" />
+      <path
+         d="m 214.9336,143.15543 q -0.42545,0 -0.635,-0.1905 -0.20955,-0.1905 -0.2794,-0.51435 -0.0635,-0.3302 -0.0635,-0.74295 v -0.85725 q 0,-0.508 0.0825,-0.83185 0.0825,-0.3302 0.2921,-0.48895 0.2159,-0.15875 0.60325,-0.15875 0.3937,0 0.5969,0.14605 0.2032,0.14605 0.27305,0.41275 0.0699,0.2667 0.0699,0.6223 v 0.17145 h -0.4318 v -0.1778 q 0,-0.32385 -0.0508,-0.50165 -0.0445,-0.1778 -0.15875,-0.24765 -0.10795,-0.0762 -0.2921,-0.0762 -0.2159,0 -0.3302,0.1016 -0.1143,0.1016 -0.1524,0.33655 -0.0381,0.2286 -0.0381,0.61595 v 1.0287 q 0,0.55245 0.10795,0.78105 0.10795,0.22225 0.4191,0.22225 0.2159,0 0.32385,-0.0953 0.10795,-0.1016 0.1397,-0.29845 0.0317,-0.19685 0.0317,-0.48895 v -0.2032 h 0.4318 v 0.1778 q 0,0.3683 -0.0699,0.65405 -0.0699,0.2794 -0.27305,0.4445 -0.19685,0.15875 -0.5969,0.15875 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1796" />
+      <path
+         d="m 217.04606,143.09828 -0.79375,-3.6703 h 0.4699 l 0.5969,3.1369 0.59055,-3.1369 h 0.45085 l -0.76835,3.6703 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1798" />
+      <path
+         d="m 218.88875,143.09828 v -5.1435 h 0.46355 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1800" />
+      <path
+         d="m 220.73134,143.15543 q -0.2159,0 -0.381,-0.10795 -0.1651,-0.1143 -0.26035,-0.29845 -0.0952,-0.18415 -0.0952,-0.41275 0,-0.2794 0.0825,-0.47625 0.0825,-0.19685 0.254,-0.34925 0.1778,-0.15875 0.4572,-0.3048 0.28575,-0.1524 0.69215,-0.33655 v -0.26035 q 0,-0.33655 -0.0444,-0.52705 -0.0381,-0.19685 -0.1397,-0.2794 -0.0952,-0.0825 -0.27305,-0.0825 -0.14605,0 -0.26035,0.0572 -0.1143,0.0572 -0.18415,0.19685 -0.0699,0.13335 -0.0699,0.37465 v 0.127 l -0.4572,-0.006 q 0.006,-0.5588 0.23495,-0.8255 0.23495,-0.27305 0.762,-0.27305 0.48895,0 0.69215,0.29845 0.2032,0.2921 0.2032,0.9144 v 1.78435 q 0,0.0952 0,0.24765 0.006,0.14605 0.0127,0.2794 0.0127,0.13335 0.0191,0.2032 h -0.41275 q -0.019,-0.12065 -0.0444,-0.2667 -0.0191,-0.1524 -0.0254,-0.2413 -0.0762,0.22225 -0.27305,0.3937 -0.1905,0.17145 -0.48895,0.17145 z m 0.1524,-0.3937 q 0.1397,0 0.24765,-0.0635 0.1143,-0.0699 0.2032,-0.17145 0.0953,-0.1016 0.14605,-0.2032 v -1.143 q -0.27305,0.14605 -0.4699,0.26035 -0.1905,0.10795 -0.31115,0.2159 -0.12065,0.10795 -0.1778,0.24765 -0.0572,0.13335 -0.0572,0.3175 0,0.2921 0.12065,0.4191 0.127,0.12065 0.29845,0.12065 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1802" />
+      <path
+         d="m 222.62037,143.09828 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0953 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1804" />
+      <path
+         d="m 226.5023,144.30478 v -4.8768 h 0.46355 v 0.3048 q 0.1143,-0.13335 0.28575,-0.24765 0.17145,-0.1143 0.4191,-0.1143 0.2667,0 0.42545,0.127 0.1651,0.12065 0.254,0.3302 0.0889,0.20955 0.12065,0.4699 0.0318,0.26035 0.0318,0.53975 v 0.76835 q 0,0.4699 -0.0826,0.81915 -0.0762,0.34925 -0.2667,0.53975 -0.1905,0.1905 -0.5334,0.1905 -0.22225,0 -0.38735,-0.1143 -0.15875,-0.1143 -0.2667,-0.23495 v 1.4986 z m 1.0414,-1.5113 q 0.20955,0 0.3175,-0.13335 0.10795,-0.1397 0.1397,-0.40005 0.0381,-0.2667 0.0381,-0.64135 v -0.78105 q 0,-0.36195 -0.0381,-0.60325 -0.0317,-0.24765 -0.1397,-0.37465 -0.10795,-0.127 -0.32385,-0.127 -0.1778,0 -0.3302,0.0953 -0.14605,0.0952 -0.2413,0.1905 v 2.5019 q 0.1016,0.10795 0.24765,0.1905 0.1524,0.0825 0.3302,0.0825 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1806" />
+      <path
+         d="m 229.78505,143.15543 q -0.2159,0 -0.381,-0.10795 -0.1651,-0.1143 -0.26035,-0.29845 -0.0952,-0.18415 -0.0952,-0.41275 0,-0.2794 0.0825,-0.47625 0.0825,-0.19685 0.254,-0.34925 0.1778,-0.15875 0.4572,-0.3048 0.28575,-0.1524 0.69215,-0.33655 v -0.26035 q 0,-0.33655 -0.0444,-0.52705 -0.0381,-0.19685 -0.1397,-0.2794 -0.0952,-0.0825 -0.27305,-0.0825 -0.14605,0 -0.26035,0.0572 -0.1143,0.0572 -0.18415,0.19685 -0.0699,0.13335 -0.0699,0.37465 v 0.127 l -0.4572,-0.006 q 0.006,-0.5588 0.23495,-0.8255 0.23495,-0.27305 0.762,-0.27305 0.48895,0 0.69215,0.29845 0.2032,0.2921 0.2032,0.9144 v 1.78435 q 0,0.0952 0,0.24765 0.006,0.14605 0.0127,0.2794 0.0127,0.13335 0.019,0.2032 h -0.41275 q -0.019,-0.12065 -0.0444,-0.2667 -0.019,-0.1524 -0.0254,-0.2413 -0.0762,0.22225 -0.27305,0.3937 -0.1905,0.17145 -0.48895,0.17145 z m 0.1524,-0.3937 q 0.1397,0 0.24765,-0.0635 0.1143,-0.0699 0.2032,-0.17145 0.0953,-0.1016 0.14605,-0.2032 v -1.143 q -0.27305,0.14605 -0.4699,0.26035 -0.1905,0.10795 -0.31115,0.2159 -0.12065,0.10795 -0.1778,0.24765 -0.0572,0.13335 -0.0572,0.3175 0,0.2921 0.12065,0.4191 0.127,0.12065 0.29845,0.12065 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1808" />
+      <path
+         d="m 231.70583,143.09828 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.019,0 0.0381,0 0.019,0 0.0445,0.006 v 0.4953 q -0.0445,-0.019 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1810" />
+      <path
+         d="m 234.45518,143.15543 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0572,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0572 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0317,-0.4953 -0.0318,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1812" />
+      <path
+         d="m 236.0397,143.09828 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0953 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1814" />
+      <path
+         d="m 239.50175,143.14273 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0572,0.381 0.0635,0.10795 0.2667,0.10795 0.0572,0 0.127,-0.006 0.0699,-0.0127 0.13335,-0.019 v 0.34925 q -0.0953,0.0191 -0.19685,0.0254 -0.0952,0.0127 -0.1905,0.0127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1816" />
+      <path
+         d="m 240.24023,144.14603 v -0.32385 q 0.2413,-0.0254 0.3683,-0.26035 0.127,-0.2286 0.1778,-0.61595 0.0572,-0.38735 0.0635,-0.8763 0.0127,-0.4953 0.0127,-1.0414 0,-0.5461 -0.0127,-1.0414 -0.006,-0.4953 -0.0635,-0.8763 -0.0508,-0.381 -0.1778,-0.6096 -0.127,-0.23495 -0.3683,-0.26035 v -0.32385 q 0.3175,0.0127 0.5207,0.1778 0.2032,0.15875 0.3175,0.45085 0.1143,0.2921 0.1651,0.67945 0.0572,0.38735 0.0635,0.84455 0.0127,0.4572 0.0127,0.95885 0,0.4953 -0.0127,0.9525 -0.006,0.45085 -0.0635,0.8382 -0.0508,0.38735 -0.1651,0.6731 -0.1143,0.2921 -0.3175,0.46355 -0.2032,0.17145 -0.5207,0.1905 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1818" />
+    </g>
+    <g
+       aria-label="net1"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1590">
+      <path
+         d="m 170.06692,66.066681 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.09525 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.09525 -0.1651,0.09525 -0.31115,0.24765 v 3.0226 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1821" />
+      <path
+         d="m 173.57976,66.123831 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0572,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.05715 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0318,-0.4953 -0.0317,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.08255 -0.1143,0.08255 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1823" />
+      <path
+         d="m 176.03423,66.111131 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0572,0.381 0.0635,0.10795 0.2667,0.10795 0.0572,0 0.127,-0.0063 0.0699,-0.0127 0.13335,-0.01905 v 0.34925 q -0.0952,0.01905 -0.19685,0.0254 -0.0952,0.0127 -0.1905,0.0127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1825" />
+      <path
+         d="m 177.64902,66.066681 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1827" />
+    </g>
+    <g
+       aria-label="eth0"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1594">
+      <path
+         d="m 123.58944,66.048231 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0571,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.05715 0.1778,-0.20955 0.0698,-0.15875 0.0698,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0317,-0.4953 -0.0318,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.08255 -0.1143,0.08255 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1830" />
+      <path
+         d="m 126.04391,66.035531 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0572,0.381 0.0635,0.10795 0.2667,0.10795 0.0571,0 0.127,-0.0063 0.0699,-0.0127 0.13335,-0.01905 v 0.34925 q -0.0952,0.01905 -0.19685,0.0254 -0.0952,0.0127 -0.1905,0.0127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1832" />
+      <path
+         d="m 126.95385,65.991081 v -5.1435 h 0.46355 v 1.86055 q 0.18415,-0.19685 0.4064,-0.3175 0.22225,-0.127 0.48895,-0.127 0.18415,0 0.3048,0.09525 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.4699 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0825,-0.12065 -0.26035,-0.12065 -0.15875,0 -0.3302,0.1016 -0.1651,0.09525 -0.31115,0.24765 v 3.01625 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1834" />
+      <path
+         d="m 130.84709,66.054581 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0699,-0.254 0.0699,-0.56515 v -2.30505 q 0,-0.31115 -0.0699,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0699,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1836" />
+    </g>
+    <g
+       aria-label="eth0"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1598">
+      <path
+         d="m 74.603727,66.048231 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.08255,0.3302 0.08255,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.05715,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.05715 0.1778,-0.20955 0.06985,-0.15875 0.06985,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.03175,-0.4953 -0.03175,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.08255 -0.1143,0.08255 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1839" />
+      <path
+         d="m 77.058201,66.035531 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.05715,0.381 0.0635,0.10795 0.2667,0.10795 0.05715,0 0.127,-0.0063 0.06985,-0.0127 0.13335,-0.01905 v 0.34925 q -0.09525,0.01905 -0.19685,0.0254 -0.09525,0.0127 -0.1905,0.0127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1841" />
+      <path
+         d="m 77.968136,65.991081 v -5.1435 h 0.46355 v 1.86055 q 0.18415,-0.19685 0.4064,-0.3175 0.22225,-0.127 0.48895,-0.127 0.18415,0 0.3048,0.09525 0.127,0.0889 0.1905,0.2667 0.06985,0.17145 0.06985,0.4191 v 2.9464 h -0.4699 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.08255,-0.12065 -0.26035,-0.12065 -0.15875,0 -0.3302,0.1016 -0.1651,0.09525 -0.31115,0.24765 v 3.01625 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1843" />
+      <path
+         d="m 81.86138,66.054581 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.06985,-0.254 0.06985,-0.56515 v -2.30505 q 0,-0.31115 -0.06985,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.06985,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1845" />
+    </g>
+    <g
+       aria-label="vethA"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1602">
+      <path
+         d="m 74.235427,90.559532 -0.79375,-3.6703 h 0.4699 l 0.5969,3.1369 0.59055,-3.1369 h 0.45085 l -0.76835,3.6703 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1848" />
+      <path
+         d="m 76.935368,90.616682 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.08255,0.3302 0.08255,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.05715,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.05715 0.1778,-0.20955 0.06985,-0.15875 0.06985,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.03175,-0.4953 -0.03175,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.08255 -0.1143,0.08255 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1850" />
+      <path
+         d="m 79.389841,90.603982 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.05715,0.381 0.0635,0.10795 0.2667,0.10795 0.05715,0 0.127,-0.0063 0.06985,-0.0127 0.13335,-0.01905 v 0.34925 q -0.09525,0.01905 -0.19685,0.0254 -0.09525,0.0127 -0.1905,0.0127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1852" />
+      <path
+         d="m 80.299776,90.559532 v -5.1435 h 0.46355 v 1.86055 q 0.18415,-0.19685 0.4064,-0.3175 0.22225,-0.127 0.48895,-0.127 0.18415,0 0.3048,0.09525 0.127,0.0889 0.1905,0.2667 0.06985,0.17145 0.06985,0.4191 v 2.9464 h -0.4699 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.08255,-0.12065 -0.26035,-0.12065 -0.15875,0 -0.3302,0.1016 -0.1651,0.09525 -0.31115,0.24765 v 3.01625 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1854" />
+      <path
+         d="m 82.726171,90.559532 1.08585,-5.1435 h 0.508 l 1.0922,5.1435 h -0.47625 l -0.254,-1.37795 h -1.22555 l -0.26035,1.37795 z m 0.8001,-1.7272 h 1.0922 l -0.55245,-2.77495 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1856" />
+    </g>
+    <g
+       aria-label="vethB"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1606">
+      <path
+         d="m 120.7265,90.937508 -0.79375,-3.6703 h 0.4699 l 0.5969,3.1369 0.59055,-3.1369 h 0.45085 l -0.76835,3.6703 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1859" />
+      <path
+         d="m 123.42644,90.994658 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0571,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.05715 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0318,-0.4953 -0.0317,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.08255 -0.1143,0.08255 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1861" />
+      <path
+         d="m 125.88091,90.981958 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0571,0.381 0.0635,0.10795 0.2667,0.10795 0.0572,0 0.127,-0.0063 0.0698,-0.0127 0.13335,-0.01905 v 0.34925 q -0.0952,0.01905 -0.19685,0.0254 -0.0953,0.0127 -0.1905,0.0127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1863" />
+      <path
+         d="m 126.79085,90.937508 v -5.1435 h 0.46355 v 1.86055 q 0.18415,-0.19685 0.4064,-0.3175 0.22225,-0.127 0.48895,-0.127 0.18415,0 0.3048,0.09525 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.4699 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0825,-0.12065 -0.26035,-0.12065 -0.15875,0 -0.3302,0.1016 -0.1651,0.09525 -0.31115,0.24765 v 3.01625 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1865" />
+      <path
+         d="m 129.49664,90.937508 v -5.1435 h 1.1049 q 0.34925,0 0.59055,0.0889 0.2413,0.0889 0.38735,0.26035 0.14605,0.17145 0.20955,0.41275 0.0635,0.23495 0.0635,0.5207 0,0.24765 -0.0571,0.4826 -0.0572,0.2286 -0.19685,0.3937 -0.1397,0.15875 -0.3937,0.20955 0.29845,0.08255 0.46355,0.28575 0.17145,0.19685 0.2413,0.46355 0.0699,0.26035 0.0699,0.53975 0,0.3048 -0.0572,0.57785 -0.0508,0.2667 -0.1905,0.4699 -0.13335,0.2032 -0.3683,0.32385 -0.23495,0.1143 -0.5969,0.1143 z m 0.4826,-0.36195 h 0.69215 q 0.50165,0 0.66675,-0.27305 0.17145,-0.27305 0.17145,-0.8509 0,-0.31115 -0.0762,-0.55245 -0.0762,-0.2413 -0.26035,-0.37465 -0.1778,-0.1397 -0.48895,-0.1397 h -0.70485 z m 0,-2.5654 h 0.6985 q 0.29845,0 0.4572,-0.1143 0.15875,-0.12065 0.22225,-0.32385 0.0635,-0.20955 0.0635,-0.4953 0,-0.31115 -0.0889,-0.51435 -0.0826,-0.2032 -0.2921,-0.29845 -0.20955,-0.09525 -0.60325,-0.09525 h -0.4572 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1867" />
+    </g>
+    <g
+       aria-label="gw0"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1610">
+      <path
+         d="m 75.674762,112.9327 q -0.36195,0 -0.62865,-0.0699 -0.2667,-0.0698 -0.41275,-0.22225 -0.1397,-0.14605 -0.1397,-0.37465 0,-0.18415 0.0889,-0.33655 0.0889,-0.1524 0.2286,-0.2667 0.1397,-0.12065 0.28575,-0.19685 -0.20955,-0.0572 -0.31115,-0.1524 -0.09525,-0.1016 -0.09525,-0.24765 0,-0.1905 0.1143,-0.3429 0.12065,-0.1524 0.32385,-0.32385 -0.254,-0.1778 -0.36195,-0.4572 -0.1016,-0.2794 -0.1016,-0.6604 0,-0.34925 0.10795,-0.635 0.10795,-0.2921 0.33655,-0.4699 0.2286,-0.1778 0.5842,-0.1778 0.32385,0 0.508,0.13335 0.18415,0.13335 0.2794,0.3302 0.05715,-0.0952 0.19685,-0.22225 0.1397,-0.13335 0.29845,-0.1905 l 0.09525,-0.0381 0.127,0.32385 q -0.1016,0.019 -0.2286,0.0762 -0.12065,0.0508 -0.22225,0.1143 -0.1016,0.0635 -0.1524,0.127 0.04445,0.1143 0.0762,0.31115 0.0381,0.19685 0.0381,0.3302 0,0.36195 -0.1016,0.65405 -0.09525,0.2921 -0.3175,0.46355 -0.22225,0.1651 -0.59055,0.1651 -0.09525,0 -0.2032,-0.019 -0.1016,-0.0191 -0.17145,-0.0381 -0.09525,0.0952 -0.17145,0.20955 -0.0762,0.10795 -0.0762,0.20955 0,0.0889 0.06985,0.1397 0.0762,0.0444 0.23495,0.0698 l 0.5842,0.0826 q 0.4445,0.0698 0.67945,0.27305 0.2413,0.19685 0.2413,0.57785 0,0.28575 -0.15875,0.47625 -0.1524,0.1905 -0.42545,0.2794 -0.27305,0.0952 -0.62865,0.0952 z m 0.01905,-0.37465 q 0.3683,0 0.5969,-0.1143 0.2286,-0.10795 0.2286,-0.3556 0,-0.12065 -0.05715,-0.22225 -0.0508,-0.0952 -0.2032,-0.15875 -0.14605,-0.0699 -0.43815,-0.1143 l -0.46355,-0.0635 q -0.09525,0.0635 -0.2032,0.15875 -0.10795,0.0889 -0.1905,0.2032 -0.0762,0.1143 -0.0762,0.26035 0,0.20955 0.19685,0.3048 0.19685,0.1016 0.6096,0.1016 z m 0.0064,-2.31775 q 0.2032,0 0.3175,-0.0826 0.12065,-0.0889 0.1778,-0.2286 0.0635,-0.1397 0.08255,-0.31115 0.0254,-0.17145 0.0254,-0.33655 0,-0.1651 -0.0254,-0.3302 -0.0254,-0.1651 -0.0889,-0.3048 -0.0635,-0.14605 -0.18415,-0.2286 -0.1143,-0.0889 -0.3048,-0.0889 -0.1905,0 -0.3175,0.0889 -0.12065,0.0889 -0.1905,0.23495 -0.0635,0.1397 -0.0889,0.31115 -0.0254,0.1651 -0.0254,0.3175 0,0.1524 0.01905,0.32385 0.0254,0.17145 0.0889,0.3175 0.06985,0.1397 0.1905,0.2286 0.127,0.0889 0.32385,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1870" />
+      <path
+         d="m 77.92038,111.7262 -0.5969,-3.6703 h 0.3937 l 0.46355,3.06705 0.57785,-3.06705 h 0.40005 l 0.5842,3.05435 0.43815,-3.05435 h 0.40005 l -0.5969,3.6703 h -0.4318 l -0.59055,-2.9845 -0.5715,2.9845 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1872" />
+      <path
+         d="m 82.411219,111.7897 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.06985,-0.254 0.06985,-0.56515 v -2.30505 q 0,-0.31115 -0.06985,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.06985,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1874" />
+    </g>
+    <g
+       aria-label="tun0"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1614">
+      <path
+         d="m 122.17793,111.77065 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0571,0.381 0.0635,0.10795 0.2667,0.10795 0.0572,0 0.127,-0.006 0.0699,-0.0127 0.13335,-0.019 v 0.34925 q -0.0953,0.019 -0.19685,0.0254 -0.0953,0.0127 -0.1905,0.0127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1877" />
+      <path
+         d="m 123.62126,111.78335 q -0.18415,0 -0.31115,-0.0889 -0.127,-0.0953 -0.19685,-0.2667 -0.0635,-0.1778 -0.0635,-0.42545 v -2.9464 h 0.46355 v 2.8448 q 0,0.28575 0.0889,0.4064 0.0889,0.1143 0.2667,0.1143 0.1651,0 0.3302,-0.1016 0.17145,-0.10795 0.3175,-0.2667 v -2.9972 h 0.46355 v 3.6703 h -0.46355 v -0.4064 q -0.1778,0.2032 -0.4064,0.33655 -0.2286,0.127 -0.48895,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1879" />
+      <path
+         d="m 125.69841,111.7262 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.0698,0.17145 0.0698,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0953 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1881" />
+      <path
+         d="m 129.5732,111.7897 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0699,-0.254 0.0699,-0.56515 v -2.30505 q 0,-0.31115 -0.0699,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0698,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1883" />
+    </g>
+    <g
+       aria-label="Pod A"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1618">
+      <path
+         d="m 68.15869,30.083344 v -5.715 h 1.368778 q 0.515055,0 0.804333,0.1905 0.296333,0.1905 0.423333,0.529166 0.127,0.338667 0.127,0.797278 0,0.402167 -0.134055,0.747889 -0.127,0.338667 -0.430389,0.543278 -0.296334,0.204611 -0.783167,0.204611 h -0.839611 v 2.702278 z m 0.536222,-3.104445 h 0.684389 q 0.345722,0 0.557389,-0.09878 0.218722,-0.105833 0.3175,-0.345722 0.09878,-0.239889 0.09878,-0.649111 0,-0.437444 -0.08467,-0.677333 -0.08467,-0.246945 -0.296333,-0.338667 -0.204612,-0.09878 -0.585612,-0.09878 h -0.691444 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1886" />
+      <path
+         d="m 72.437994,30.146844 q -0.416277,0 -0.656166,-0.176389 -0.239889,-0.183445 -0.338667,-0.522111 -0.09172,-0.345723 -0.09172,-0.839612 v -1.128888 q 0,-0.493889 0.09172,-0.832556 0.09878,-0.345722 0.338667,-0.522111 0.239889,-0.183444 0.656166,-0.183444 0.423334,0 0.656167,0.183444 0.239889,0.176389 0.331611,0.522111 0.09878,0.338667 0.09878,0.832556 v 1.128888 q 0,0.493889 -0.09878,0.839612 -0.09172,0.338666 -0.331611,0.522111 -0.232833,0.176389 -0.656167,0.176389 z m 0,-0.388056 q 0.268112,0 0.388056,-0.141111 0.127,-0.141111 0.155222,-0.395111 0.02822,-0.254 0.02822,-0.585611 v -1.185334 q 0,-0.331611 -0.02822,-0.578555 -0.02822,-0.254 -0.155222,-0.395111 -0.119944,-0.148167 -0.388056,-0.148167 -0.268111,0 -0.388055,0.148167 -0.119945,0.141111 -0.155222,0.395111 -0.02822,0.246944 -0.02822,0.578555 v 1.185334 q 0,0.331611 0.02822,0.585611 0.03528,0.254 0.155222,0.395111 0.119944,0.141111 0.388055,0.141111 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1888" />
+      <path
+         d="m 75.143359,30.146844 q -0.522111,0 -0.754945,-0.395112 -0.225777,-0.395111 -0.225777,-1.312333 v -0.754944 q 0,-0.536223 0.07761,-0.924278 0.07761,-0.388056 0.282222,-0.599722 0.211667,-0.218722 0.599722,-0.218722 0.239889,0 0.416278,0.112888 0.183444,0.105834 0.303389,0.239889 v -1.926166 h 0.515055 v 5.715 h -0.515055 v -0.289278 q -0.119945,0.134055 -0.296334,0.246944 -0.169333,0.105834 -0.402166,0.105834 z m 0.105833,-0.402167 q 0.162278,0 0.3175,-0.07761 0.155222,-0.08467 0.275167,-0.197556 v -2.836333 q -0.105834,-0.09878 -0.261056,-0.1905 -0.155222,-0.09878 -0.345722,-0.09878 -0.338667,0 -0.451555,0.303389 -0.105834,0.296333 -0.105834,0.874889 v 0.959555 q 0,0.409223 0.04233,0.691445 0.04939,0.282222 0.169333,0.430389 0.127,0.141111 0.359833,0.141111 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1890" />
+      <path
+         d="m 78.376457,30.083344 1.2065,-5.715 h 0.564444 l 1.213556,5.715 H 80.83179 l -0.282222,-1.531056 h -1.361722 l -0.289278,1.531056 z m 0.889,-1.919112 h 1.213555 l -0.613833,-3.083277 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1892" />
+    </g>
+    <g
+       aria-label="Pod B
+(with secondary interface)"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1624">
+      <path
+         d="m 116.91762,30.083344 v -5.715 h 1.36878 q 0.51506,0 0.80433,0.1905 0.29634,0.1905 0.42334,0.529166 0.127,0.338667 0.127,0.797278 0,0.402167 -0.13406,0.747889 -0.127,0.338667 -0.43039,0.543278 -0.29633,0.204611 -0.78316,0.204611 h -0.83961 v 2.702278 z m 0.53623,-3.104445 h 0.68438 q 0.34573,0 0.55739,-0.09878 0.21873,-0.105833 0.3175,-0.345722 0.0988,-0.239889 0.0988,-0.649111 0,-0.437444 -0.0847,-0.677333 -0.0847,-0.246945 -0.29633,-0.338667 -0.20461,-0.09878 -0.58561,-0.09878 h -0.69144 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1895" />
+      <path
+         d="m 121.19693,30.146844 q -0.41628,0 -0.65617,-0.176389 -0.23989,-0.183445 -0.33866,-0.522111 -0.0917,-0.345723 -0.0917,-0.839612 v -1.128888 q 0,-0.493889 0.0917,-0.832556 0.0988,-0.345722 0.33866,-0.522111 0.23989,-0.183444 0.65617,-0.183444 0.42333,0 0.65617,0.183444 0.23988,0.176389 0.33161,0.522111 0.0988,0.338667 0.0988,0.832556 v 1.128888 q 0,0.493889 -0.0988,0.839612 -0.0917,0.338666 -0.33161,0.522111 -0.23284,0.176389 -0.65617,0.176389 z m 0,-0.388056 q 0.26811,0 0.38805,-0.141111 0.127,-0.141111 0.15523,-0.395111 0.0282,-0.254 0.0282,-0.585611 v -1.185334 q 0,-0.331611 -0.0282,-0.578555 -0.0282,-0.254 -0.15523,-0.395111 -0.11994,-0.148167 -0.38805,-0.148167 -0.26811,0 -0.38806,0.148167 -0.11994,0.141111 -0.15522,0.395111 -0.0282,0.246944 -0.0282,0.578555 v 1.185334 q 0,0.331611 0.0282,0.585611 0.0353,0.254 0.15522,0.395111 0.11995,0.141111 0.38806,0.141111 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1897" />
+      <path
+         d="m 123.90229,30.146844 q -0.52211,0 -0.75494,-0.395112 -0.22578,-0.395111 -0.22578,-1.312333 v -0.754944 q 0,-0.536223 0.0776,-0.924278 0.0776,-0.388056 0.28222,-0.599722 0.21167,-0.218722 0.59973,-0.218722 0.23989,0 0.41627,0.112888 0.18345,0.105834 0.30339,0.239889 v -1.926166 h 0.51506 v 5.715 h -0.51506 v -0.289278 q -0.11994,0.134055 -0.29633,0.246944 -0.16933,0.105834 -0.40217,0.105834 z m 0.10584,-0.402167 q 0.16227,0 0.3175,-0.07761 0.15522,-0.08467 0.27516,-0.197556 v -2.836333 q -0.10583,-0.09878 -0.26105,-0.1905 -0.15522,-0.09878 -0.34572,-0.09878 -0.33867,0 -0.45156,0.303389 -0.10583,0.296333 -0.10583,0.874889 v 0.959555 q 0,0.409223 0.0423,0.691445 0.0494,0.282222 0.16933,0.430389 0.127,0.141111 0.35984,0.141111 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1899" />
+      <path
+         d="m 127.44584,30.083344 v -5.715 h 1.22766 q 0.38806,0 0.65617,0.09878 0.26811,0.09878 0.43039,0.289278 0.16228,0.1905 0.23283,0.458611 0.0706,0.261056 0.0706,0.578556 0,0.275167 -0.0635,0.536222 -0.0635,0.254 -0.21873,0.437444 -0.15522,0.176389 -0.43744,0.232834 0.33161,0.09172 0.51506,0.3175 0.1905,0.218722 0.26811,0.515055 0.0776,0.289278 0.0776,0.599723 0,0.338666 -0.0635,0.642055 -0.0565,0.296333 -0.21167,0.522111 -0.14817,0.225778 -0.40922,0.359834 -0.26106,0.127 -0.66322,0.127 z m 0.53622,-0.402167 h 0.76905 q 0.55739,0 0.74084,-0.303389 0.1905,-0.303389 0.1905,-0.945444 0,-0.345723 -0.0847,-0.613834 -0.0847,-0.268111 -0.28928,-0.416278 -0.19755,-0.155222 -0.54328,-0.155222 h -0.78316 z m 0,-2.850445 h 0.77611 q 0.33161,0 0.508,-0.127 0.17639,-0.134055 0.24694,-0.359833 0.0706,-0.232833 0.0706,-0.550333 0,-0.345722 -0.0988,-0.5715 -0.0917,-0.225778 -0.32455,-0.331611 -0.23284,-0.105834 -0.67028,-0.105834 h -0.508 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1901" />
+      <path
+         d="m 118.1594,40.066954 q -0.34572,-0.02117 -0.5715,-0.211666 -0.22578,-0.1905 -0.35278,-0.515056 -0.11994,-0.3175 -0.18344,-0.740833 -0.0564,-0.430389 -0.0706,-0.931333 -0.007,-0.508 -0.007,-1.058334 0,-0.550333 0.007,-1.058333 0.0141,-0.515056 0.0706,-0.945445 0.0635,-0.430388 0.18344,-0.754944 0.127,-0.324555 0.35278,-0.508 0.22578,-0.183444 0.5715,-0.197555 v 0.366888 q -0.26105,0.02117 -0.40217,0.282223 -0.14111,0.254 -0.20461,0.684388 -0.0564,0.430389 -0.0706,0.980723 -0.007,0.543277 -0.007,1.150055 0,0.606778 0.007,1.157111 0.0141,0.550334 0.0706,0.980722 0.0635,0.423334 0.20461,0.677334 0.14112,0.261055 0.40217,0.282222 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1903" />
+      <path
+         d="m 119.25544,38.902788 -0.66322,-4.078111 h 0.43744 l 0.51506,3.407833 0.64205,-3.407833 h 0.4445 l 0.64911,3.393722 0.48684,-3.393722 h 0.4445 l -0.66323,4.078111 h -0.47977 l -0.65617,-3.316111 -0.635,3.316111 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1905" />
+      <path
+         d="m 122.87648,38.902788 v -4.078111 h 0.51506 v 4.078111 z m 0,-4.642556 v -0.6985 h 0.51506 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1907" />
+      <path
+         d="m 125.21981,38.952177 q -0.29634,0 -0.45861,-0.112889 -0.16228,-0.119945 -0.21873,-0.3175 -0.0564,-0.204611 -0.0564,-0.465667 v -2.892778 h -0.50094 v -0.338666 h 0.50094 v -1.262945 h 0.51506 v 1.262945 h 0.67733 v 0.338666 h -0.67733 v 2.843389 q 0,0.296333 0.0635,0.423333 0.0706,0.119945 0.29633,0.119945 0.0635,0 0.14111,-0.0071 0.0776,-0.01411 0.14817,-0.02117 v 0.388055 q -0.10584,0.02117 -0.21873,0.02822 -0.10583,0.01411 -0.21166,0.01411 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1909" />
+      <path
+         d="m 126.23085,38.902788 v -5.715 h 0.51505 v 2.067278 q 0.20461,-0.218723 0.45156,-0.352778 0.24694,-0.141111 0.54328,-0.141111 0.20461,0 0.33866,0.105833 0.14111,0.09878 0.21167,0.296333 0.0776,0.1905 0.0776,0.465667 v 3.273778 h -0.52211 v -3.160889 q 0,-0.3175 -0.0988,-0.4445 -0.0917,-0.134056 -0.28928,-0.134056 -0.17639,0 -0.36689,0.112889 -0.18344,0.105834 -0.34572,0.275167 v 3.351389 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1911" />
+      <path
+         d="m 131.49594,38.966288 q -0.48683,0 -0.77611,-0.310445 -0.28927,-0.3175 -0.33161,-0.846666 l 0.43039,-0.127 q 0.0423,0.465666 0.21872,0.684388 0.17639,0.211667 0.49389,0.211667 0.26811,0 0.40922,-0.148167 0.14817,-0.155222 0.14817,-0.430388 0,-0.197556 -0.11994,-0.395111 -0.11995,-0.204612 -0.381,-0.423334 l -0.55034,-0.479778 q -0.27516,-0.232833 -0.41627,-0.465666 -0.14112,-0.232834 -0.14112,-0.557389 0,-0.296333 0.11995,-0.493889 0.127,-0.204611 0.33867,-0.310444 0.21872,-0.112889 0.51505,-0.112889 0.46567,0 0.70556,0.303389 0.23989,0.296333 0.26105,0.769055 l -0.36689,0.119945 q -0.0141,-0.275167 -0.0847,-0.451556 -0.0706,-0.183444 -0.19756,-0.268111 -0.11994,-0.08467 -0.29633,-0.08467 -0.23284,0 -0.381,0.134056 -0.14111,0.127 -0.14111,0.359833 0,0.183445 0.0705,0.324556 0.0706,0.141111 0.26106,0.3175 l 0.57855,0.515055 q 0.16934,0.148167 0.32456,0.3175 0.15522,0.169334 0.254,0.381 0.0988,0.204611 0.0988,0.486833 0,0.3175 -0.13406,0.536223 -0.127,0.211666 -0.35983,0.331611 -0.23284,0.112889 -0.55034,0.112889 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1913" />
+      <path
+         d="m 134.15082,38.966288 q -0.381,0 -0.62795,-0.148167 -0.23989,-0.155222 -0.35983,-0.508 -0.11289,-0.352778 -0.11289,-0.938389 v -1.030111 q 0,-0.606778 0.11995,-0.945444 0.11994,-0.345723 0.36688,-0.486834 0.24695,-0.148166 0.61384,-0.148166 0.43744,0 0.66322,0.183444 0.22578,0.183445 0.31044,0.557389 0.0917,0.366889 0.0917,0.945444 v 0.366889 h -1.651 v 0.712611 q 0,0.395111 0.0564,0.627945 0.0635,0.225778 0.1905,0.324555 0.13406,0.09878 0.33867,0.09878 0.15522,0 0.28222,-0.05644 0.127,-0.0635 0.19756,-0.232834 0.0776,-0.176389 0.0776,-0.493889 v -0.282222 h 0.50094 v 0.225778 q 0,0.557389 -0.23283,0.896056 -0.23284,0.331611 -0.8255,0.331611 z m -0.58561,-2.448278 h 1.143 v -0.338667 q 0,-0.324555 -0.0353,-0.550333 -0.0353,-0.232833 -0.15522,-0.352778 -0.11289,-0.127 -0.36689,-0.127 -0.21167,0 -0.34572,0.09172 -0.127,0.09172 -0.18345,0.331612 -0.0564,0.232833 -0.0564,0.670277 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1915" />
+      <path
+         d="m 136.92034,38.966288 q -0.47272,0 -0.70555,-0.211667 -0.23283,-0.211667 -0.31045,-0.5715 -0.0705,-0.366889 -0.0705,-0.8255 v -0.9525 q 0,-0.564444 0.0917,-0.924278 0.0917,-0.366889 0.32456,-0.543277 0.23989,-0.176389 0.67027,-0.176389 0.43745,0 0.66323,0.162277 0.22577,0.162278 0.30339,0.458612 0.0776,0.296333 0.0776,0.691444 v 0.1905 h -0.47978 v -0.197556 q 0,-0.359833 -0.0565,-0.557388 -0.0494,-0.197556 -0.17638,-0.275167 -0.11995,-0.08467 -0.32456,-0.08467 -0.23989,0 -0.36689,0.112889 -0.127,0.112889 -0.16933,0.373945 -0.0423,0.254 -0.0423,0.684388 v 1.143 q 0,0.613834 0.11995,0.867834 0.11994,0.246944 0.46567,0.246944 0.23988,0 0.35983,-0.105833 0.11994,-0.112889 0.15522,-0.331611 0.0353,-0.218723 0.0353,-0.543278 v -0.225778 h 0.47978 v 0.197556 q 0,0.409222 -0.0776,0.726722 -0.0776,0.310444 -0.30339,0.493889 -0.21873,0.176389 -0.66323,0.176389 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1917" />
+      <path
+         d="m 139.66264,38.966288 q -0.41628,0 -0.65617,-0.176389 -0.23989,-0.183445 -0.33866,-0.522111 -0.0917,-0.345723 -0.0917,-0.839611 v -1.128889 q 0,-0.493889 0.0917,-0.832556 0.0988,-0.345722 0.33866,-0.522111 0.23989,-0.183444 0.65617,-0.183444 0.42333,0 0.65617,0.183444 0.23988,0.176389 0.33161,0.522111 0.0988,0.338667 0.0988,0.832556 v 1.128889 q 0,0.493888 -0.0988,0.839611 -0.0917,0.338666 -0.33161,0.522111 -0.23284,0.176389 -0.65617,0.176389 z m 0,-0.388056 q 0.26811,0 0.38805,-0.141111 0.127,-0.141111 0.15523,-0.395111 0.0282,-0.254 0.0282,-0.585611 v -1.185333 q 0,-0.331612 -0.0282,-0.578556 -0.0282,-0.254 -0.15523,-0.395111 -0.11994,-0.148167 -0.38805,-0.148167 -0.26811,0 -0.38806,0.148167 -0.11994,0.141111 -0.15522,0.395111 -0.0282,0.246944 -0.0282,0.578556 v 1.185333 q 0,0.331611 0.0282,0.585611 0.0353,0.254 0.15522,0.395111 0.11995,0.141111 0.38806,0.141111 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1919" />
+      <path
+         d="m 141.46489,38.902788 v -4.078111 h 0.51506 v 0.423333 q 0.19755,-0.211667 0.4445,-0.345722 0.24694,-0.141111 0.53622,-0.141111 0.20461,0 0.33867,0.105833 0.14111,0.09878 0.21166,0.296333 0.0776,0.1905 0.0776,0.465667 v 3.273778 h -0.51506 v -3.160889 q 0,-0.3175 -0.0988,-0.4445 -0.0988,-0.134056 -0.29633,-0.134056 -0.16933,0 -0.35278,0.105834 -0.18344,0.105833 -0.34572,0.275166 v 3.358445 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1921" />
+      <path
+         d="m 145.2481,38.966288 q -0.52211,0 -0.75494,-0.395111 -0.22578,-0.395112 -0.22578,-1.312334 v -0.754944 q 0,-0.536222 0.0776,-0.924278 0.0776,-0.388055 0.28223,-0.599722 0.21166,-0.218722 0.59972,-0.218722 0.23989,0 0.41628,0.112889 0.18344,0.105833 0.30338,0.239888 v -1.926166 h 0.51506 v 5.715 H 145.9466 V 38.61351 q -0.11994,0.134055 -0.29633,0.246944 -0.16933,0.105834 -0.40217,0.105834 z m 0.10584,-0.402167 q 0.16228,0 0.3175,-0.07761 0.15522,-0.08467 0.27516,-0.197556 v -2.836333 q -0.10583,-0.09878 -0.26105,-0.1905 -0.15522,-0.09878 -0.34572,-0.09878 -0.33867,0 -0.45156,0.303389 -0.10583,0.296334 -0.10583,0.874889 v 0.959556 q 0,0.409222 0.0423,0.691444 0.0494,0.282222 0.16933,0.430389 0.127,0.141111 0.35984,0.141111 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1923" />
+      <path
+         d="m 147.95115,38.966288 q -0.23989,0 -0.42333,-0.119945 -0.18344,-0.127 -0.28928,-0.331611 -0.10583,-0.204611 -0.10583,-0.458611 0,-0.310444 0.0917,-0.529167 0.0917,-0.218722 0.28222,-0.388055 0.19756,-0.176389 0.508,-0.338667 0.3175,-0.169333 0.76906,-0.373944 V 36.13701 q 0,-0.373944 -0.0494,-0.585611 -0.0423,-0.218722 -0.15522,-0.310445 -0.10584,-0.09172 -0.30339,-0.09172 -0.16228,0 -0.28928,0.0635 -0.127,0.0635 -0.20461,0.218722 -0.0776,0.148167 -0.0776,0.416278 v 0.141111 l -0.508,-0.0071 q 0.007,-0.620889 0.26105,-0.917222 0.26106,-0.303389 0.84667,-0.303389 0.54328,0 0.76906,0.331611 0.22577,0.324555 0.22577,1.016 v 1.982611 q 0,0.105833 0,0.275166 0.007,0.162278 0.0141,0.310445 0.0141,0.148167 0.0212,0.225778 h -0.45861 q -0.0212,-0.134056 -0.0494,-0.296334 -0.0212,-0.169333 -0.0282,-0.268111 -0.0847,0.246945 -0.30339,0.437445 -0.21167,0.1905 -0.54328,0.1905 z m 0.16934,-0.437445 q 0.15522,0 0.27516,-0.07055 0.127,-0.07761 0.22578,-0.1905 0.10583,-0.112889 0.16228,-0.225778 v -1.27 q -0.30339,0.162278 -0.52211,0.289278 -0.21167,0.119944 -0.34572,0.239889 -0.13406,0.119944 -0.19756,0.275166 -0.0635,0.148167 -0.0635,0.352778 0,0.324556 0.13406,0.465667 0.14111,0.134055 0.33161,0.134055 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1925" />
+      <path
+         d="m 150.08535,38.902788 v -4.078111 h 0.52211 v 0.557389 q 0.19756,-0.324556 0.45156,-0.458612 0.254,-0.141111 0.48683,-0.141111 0.0212,0 0.0423,0 0.0212,0 0.0494,0.0071 v 0.550333 q -0.0494,-0.02117 -0.11994,-0.02822 -0.0706,-0.01411 -0.13406,-0.01411 -0.23989,0 -0.43744,0.112889 -0.1905,0.112889 -0.33867,0.359833 v 3.132667 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1927" />
+      <path
+         d="m 152.0318,39.918788 v -0.402167 q 0.35278,0 0.52917,-0.05644 0.18344,-0.04939 0.23988,-0.148167 0.0635,-0.09172 0.0635,-0.218722 0,-0.112889 -0.0423,-0.296334 -0.0423,-0.183444 -0.0917,-0.381 l -0.83961,-3.591277 h 0.508 l 0.71261,3.471333 0.68439,-3.471333 h 0.51505 l -0.98072,4.367388 q -0.0564,0.261056 -0.20461,0.416278 -0.14111,0.162278 -0.381,0.232834 -0.23283,0.07761 -0.57856,0.07761 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1929" />
+      <path
+         d="m 156.32147,38.902788 v -4.078111 h 0.51505 v 4.078111 z m 0,-4.642556 v -0.6985 h 0.51505 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1931" />
+      <path
+         d="m 157.69818,38.902788 v -4.078111 h 0.51506 v 0.423333 q 0.19755,-0.211667 0.4445,-0.345722 0.24694,-0.141111 0.53622,-0.141111 0.20461,0 0.33867,0.105833 0.14111,0.09878 0.21166,0.296333 0.0776,0.1905 0.0776,0.465667 v 3.273778 h -0.51505 v -3.160889 q 0,-0.3175 -0.0988,-0.4445 -0.0988,-0.134056 -0.29633,-0.134056 -0.16934,0 -0.35278,0.105834 -0.18345,0.105833 -0.34572,0.275166 v 3.358445 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1933" />
+      <path
+         d="m 161.54489,38.952177 q -0.29633,0 -0.45861,-0.112889 -0.16228,-0.119945 -0.21872,-0.3175 -0.0564,-0.204611 -0.0564,-0.465667 v -2.892778 h -0.50094 v -0.338666 h 0.50094 v -1.262945 h 0.51506 v 1.262945 h 0.67733 v 0.338666 h -0.67733 v 2.843389 q 0,0.296333 0.0635,0.423333 0.0706,0.119945 0.29633,0.119945 0.0635,0 0.14111,-0.0071 0.0776,-0.01411 0.14817,-0.02117 v 0.388055 q -0.10583,0.02117 -0.21872,0.02822 -0.10583,0.01411 -0.21167,0.01411 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1935" />
+      <path
+         d="m 163.57193,38.966288 q -0.381,0 -0.62794,-0.148167 -0.23989,-0.155222 -0.35983,-0.508 -0.11289,-0.352778 -0.11289,-0.938389 v -1.030111 q 0,-0.606778 0.11994,-0.945444 0.11995,-0.345723 0.36689,-0.486834 0.24694,-0.148166 0.61383,-0.148166 0.43745,0 0.66323,0.183444 0.22577,0.183445 0.31044,0.557389 0.0917,0.366889 0.0917,0.945444 v 0.366889 h -1.651 v 0.712611 q 0,0.395111 0.0564,0.627945 0.0635,0.225778 0.1905,0.324555 0.13405,0.09878 0.33866,0.09878 0.15523,0 0.28223,-0.05644 0.127,-0.0635 0.19755,-0.232834 0.0776,-0.176389 0.0776,-0.493889 v -0.282222 h 0.50095 v 0.225778 q 0,0.557389 -0.23284,0.896056 -0.23283,0.331611 -0.8255,0.331611 z m -0.58561,-2.448278 h 1.143 v -0.338667 q 0,-0.324555 -0.0353,-0.550333 -0.0353,-0.232833 -0.15522,-0.352778 -0.11289,-0.127 -0.36689,-0.127 -0.21166,0 -0.34572,0.09172 -0.127,0.09172 -0.18344,0.331612 -0.0564,0.232833 -0.0564,0.670277 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1937" />
+      <path
+         d="m 165.36779,38.902788 v -4.078111 h 0.52211 v 0.557389 q 0.19756,-0.324556 0.45156,-0.458612 0.254,-0.141111 0.48683,-0.141111 0.0212,0 0.0423,0 0.0212,0 0.0494,0.0071 v 0.550333 q -0.0494,-0.02117 -0.11994,-0.02822 -0.0706,-0.01411 -0.13406,-0.01411 -0.23989,0 -0.43744,0.112889 -0.1905,0.112889 -0.33867,0.359833 v 3.132667 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1939" />
+      <path
+         d="m 167.68113,38.902788 v -3.704167 h -0.52211 v -0.373944 h 0.52211 v -0.423334 q 0,-0.303389 0.0494,-0.536222 0.0494,-0.232833 0.20461,-0.366889 0.16228,-0.134055 0.49389,-0.134055 0.11289,0 0.21167,0.01411 0.10583,0.0071 0.20461,0.03528 v 0.381 q -0.0635,-0.01411 -0.14817,-0.02117 -0.0776,-0.01411 -0.14111,-0.01411 -0.23283,0 -0.29633,0.148167 -0.0565,0.141111 -0.0565,0.444499 v 0.472723 h 0.65617 v 0.373944 h -0.65617 v 3.704167 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1941" />
+      <path
+         d="m 170.01354,38.966288 q -0.23988,0 -0.42333,-0.119945 -0.18344,-0.127 -0.28928,-0.331611 -0.10583,-0.204611 -0.10583,-0.458611 0,-0.310444 0.0917,-0.529167 0.0917,-0.218722 0.28222,-0.388055 0.19756,-0.176389 0.508,-0.338667 0.3175,-0.169333 0.76906,-0.373944 V 36.13701 q 0,-0.373944 -0.0494,-0.585611 -0.0423,-0.218722 -0.15522,-0.310445 -0.10583,-0.09172 -0.30339,-0.09172 -0.16228,0 -0.28928,0.0635 -0.127,0.0635 -0.20461,0.218722 -0.0776,0.148167 -0.0776,0.416278 v 0.141111 l -0.508,-0.0071 q 0.007,-0.620889 0.26106,-0.917222 0.26105,-0.303389 0.84666,-0.303389 0.54328,0 0.76906,0.331611 0.22578,0.324555 0.22578,1.016 v 1.982611 q 0,0.105833 0,0.275166 0.007,0.162278 0.0141,0.310445 0.0141,0.148167 0.0212,0.225778 h -0.45861 q -0.0212,-0.134056 -0.0494,-0.296334 -0.0212,-0.169333 -0.0282,-0.268111 -0.0847,0.246945 -0.30339,0.437445 -0.21166,0.1905 -0.54328,0.1905 z m 0.16934,-0.437445 q 0.15522,0 0.27516,-0.07055 0.127,-0.07761 0.22578,-0.1905 0.10584,-0.112889 0.16228,-0.225778 v -1.27 q -0.30339,0.162278 -0.52211,0.289278 -0.21167,0.119944 -0.34572,0.239889 -0.13406,0.119944 -0.19756,0.275166 -0.0635,0.148167 -0.0635,0.352778 0,0.324556 0.13406,0.465667 0.14111,0.134055 0.33161,0.134055 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1943" />
+      <path
+         d="m 173.12141,38.966288 q -0.47273,0 -0.70556,-0.211667 -0.23283,-0.211667 -0.31044,-0.5715 -0.0706,-0.366889 -0.0706,-0.8255 v -0.9525 q 0,-0.564444 0.0917,-0.924278 0.0917,-0.366889 0.32456,-0.543277 0.23989,-0.176389 0.67028,-0.176389 0.43744,0 0.66322,0.162277 0.22578,0.162278 0.30339,0.458612 0.0776,0.296333 0.0776,0.691444 v 0.1905 h -0.47978 v -0.197556 q 0,-0.359833 -0.0564,-0.557388 -0.0494,-0.197556 -0.17639,-0.275167 -0.11995,-0.08467 -0.32456,-0.08467 -0.23989,0 -0.36689,0.112889 -0.127,0.112889 -0.16933,0.373945 -0.0423,0.254 -0.0423,0.684388 v 1.143 q 0,0.613834 0.11994,0.867834 0.11994,0.246944 0.46567,0.246944 0.23989,0 0.35983,-0.105833 0.11994,-0.112889 0.15522,-0.331611 0.0353,-0.218723 0.0353,-0.543278 v -0.225778 h 0.47978 v 0.197556 q 0,0.409222 -0.0776,0.726722 -0.0776,0.310444 -0.30339,0.493889 -0.21872,0.176389 -0.66322,0.176389 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1945" />
+      <path
+         d="m 175.87781,38.966288 q -0.381,0 -0.62794,-0.148167 -0.23989,-0.155222 -0.35983,-0.508 -0.11289,-0.352778 -0.11289,-0.938389 v -1.030111 q 0,-0.606778 0.11994,-0.945444 0.11995,-0.345723 0.36689,-0.486834 0.24695,-0.148166 0.61383,-0.148166 0.43745,0 0.66323,0.183444 0.22577,0.183445 0.31044,0.557389 0.0917,0.366889 0.0917,0.945444 v 0.366889 h -1.651 v 0.712611 q 0,0.395111 0.0564,0.627945 0.0635,0.225778 0.1905,0.324555 0.13405,0.09878 0.33866,0.09878 0.15523,0 0.28223,-0.05644 0.127,-0.0635 0.19755,-0.232834 0.0776,-0.176389 0.0776,-0.493889 v -0.282222 h 0.50095 v 0.225778 q 0,0.557389 -0.23284,0.896056 -0.23283,0.331611 -0.8255,0.331611 z M 175.2922,36.51801 h 1.143 v -0.338667 q 0,-0.324555 -0.0353,-0.550333 -0.0353,-0.232833 -0.15523,-0.352778 -0.11289,-0.127 -0.36689,-0.127 -0.21166,0 -0.34572,0.09172 -0.127,0.09172 -0.18344,0.331612 -0.0564,0.232833 -0.0564,0.670277 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1947" />
+      <path
+         d="m 177.45495,40.066954 v -0.359833 q 0.26811,-0.02822 0.40922,-0.289278 0.14111,-0.254 0.19756,-0.684389 0.0635,-0.430389 0.0705,-0.973666 0.0141,-0.550334 0.0141,-1.157111 0,-0.606778 -0.0141,-1.157111 -0.007,-0.550334 -0.0705,-0.973667 -0.0565,-0.423333 -0.19756,-0.677333 -0.14111,-0.261056 -0.40922,-0.289278 v -0.359833 q 0.35278,0.01411 0.57855,0.197555 0.22578,0.176389 0.35278,0.500945 0.127,0.324555 0.18345,0.754944 0.0635,0.430389 0.0705,0.938389 0.0141,0.508 0.0141,1.065389 0,0.550333 -0.0141,1.058333 -0.007,0.500944 -0.0705,0.931333 -0.0564,0.430389 -0.18345,0.747889 -0.127,0.324556 -0.35278,0.515056 -0.22577,0.1905 -0.57855,0.211666 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1949" />
+    </g>
+    <g
+       aria-label="DHCP server"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1628">
+      <path
+         d="m 206.0699,90.257149 v -5.1435 h 1.1176 q 0.53975,0 0.8382,0.1905 0.3048,0.18415 0.42545,0.52705 0.127,0.3429 0.127,0.79375 v 2.0447 q 0,0.47625 -0.127,0.8382 -0.12065,0.3556 -0.41275,0.55245 -0.2921,0.19685 -0.80645,0.19685 z m 0.4826,-0.36195 h 0.6477 q 0.4064,0 0.5969,-0.1651 0.1905,-0.17145 0.2413,-0.46355 0.0508,-0.29845 0.0508,-0.6731 v -1.9177 q 0,-0.38735 -0.0699,-0.6477 -0.0635,-0.2667 -0.26035,-0.40005 -0.1905,-0.1397 -0.57785,-0.1397 h -0.62865 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1952" />
+      <path
+         d="m 209.37497,90.257149 v -5.1435 h 0.48895 v 2.27965 h 1.61925 v -2.27965 h 0.4826 v 5.1435 h -0.4826 v -2.5019 h -1.61925 v 2.5019 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1954" />
+      <path
+         d="m 214.06018,90.320649 q -0.5207,0 -0.80645,-0.2159 -0.2794,-0.2159 -0.38735,-0.57785 -0.10795,-0.3683 -0.10795,-0.8128 v -2.0447 q 0,-0.47625 0.10795,-0.8382 0.1143,-0.36195 0.40005,-0.56515 0.28575,-0.2032 0.79375,-0.2032 0.46355,0 0.7239,0.1778 0.2667,0.1778 0.381,0.508 0.1143,0.32385 0.1143,0.7747 v 0.31115 h -0.4572 v -0.29845 q 0,-0.33655 -0.0572,-0.57785 -0.0508,-0.2413 -0.2159,-0.37465 -0.1651,-0.13335 -0.48895,-0.13335 -0.3429,0 -0.5207,0.14605 -0.17145,0.1397 -0.23495,0.40005 -0.0572,0.26035 -0.0572,0.60325 v 2.19075 q 0,0.381 0.0699,0.635 0.0762,0.254 0.254,0.381 0.1778,0.127 0.48895,0.127 0.32385,0 0.48895,-0.1397 0.1651,-0.1397 0.2159,-0.38735 0.0572,-0.254 0.0572,-0.59055 v -0.33655 h 0.4572 v 0.3048 q 0,0.45085 -0.10795,0.8001 -0.1016,0.34925 -0.3683,0.5461 -0.26035,0.1905 -0.74295,0.1905 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1956" />
+      <path
+         d="m 216.02898,90.257149 v -5.1435 h 1.2319 q 0.46355,0 0.7239,0.17145 0.2667,0.17145 0.381,0.47625 0.1143,0.3048 0.1143,0.71755 0,0.36195 -0.12065,0.6731 -0.1143,0.3048 -0.38735,0.48895 -0.2667,0.18415 -0.70485,0.18415 h -0.75565 v 2.43205 z m 0.4826,-2.794 h 0.61595 q 0.31115,0 0.50165,-0.0889 0.19685,-0.09525 0.28575,-0.31115 0.0889,-0.2159 0.0889,-0.5842 0,-0.3937 -0.0762,-0.6096 -0.0762,-0.22225 -0.2667,-0.3048 -0.18415,-0.0889 -0.52705,-0.0889 h -0.6223 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1958" />
+      <path
+         d="m 221.07554,90.314299 q -0.43815,0 -0.6985,-0.2794 -0.26035,-0.28575 -0.29845,-0.762 l 0.38735,-0.1143 q 0.0381,0.4191 0.19685,0.61595 0.15875,0.1905 0.4445,0.1905 0.2413,0 0.3683,-0.13335 0.13335,-0.1397 0.13335,-0.38735 0,-0.1778 -0.10795,-0.3556 -0.10795,-0.18415 -0.3429,-0.381 l -0.4953,-0.4318 q -0.24765,-0.20955 -0.37465,-0.4191 -0.127,-0.20955 -0.127,-0.50165 0,-0.2667 0.10795,-0.4445 0.1143,-0.18415 0.3048,-0.2794 0.19685,-0.1016 0.46355,-0.1016 0.4191,0 0.635,0.27305 0.2159,0.2667 0.23495,0.69215 l -0.3302,0.10795 q -0.0127,-0.24765 -0.0762,-0.4064 -0.0635,-0.1651 -0.1778,-0.2413 -0.10795,-0.0762 -0.2667,-0.0762 -0.20955,0 -0.3429,0.12065 -0.127,0.1143 -0.127,0.32385 0,0.1651 0.0635,0.2921 0.0635,0.127 0.23495,0.28575 l 0.5207,0.46355 q 0.1524,0.13335 0.2921,0.28575 0.1397,0.1524 0.2286,0.3429 0.0889,0.18415 0.0889,0.43815 0,0.28575 -0.12065,0.4826 -0.1143,0.1905 -0.32385,0.29845 -0.20955,0.1016 -0.4953,0.1016 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1960" />
+      <path
+         d="m 223.46493,90.314299 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0572,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.05715 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0317,-0.4953 -0.0318,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.08255 -0.1143,0.08255 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1962" />
+      <path
+         d="m 225.0812,90.257149 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.0191,0 0.0381,0 0.019,0 0.0444,0.0063 v 0.4953 q -0.0444,-0.01905 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1964" />
+      <path
+         d="m 227.48706,90.257149 -0.79375,-3.6703 h 0.4699 l 0.5969,3.1369 0.59055,-3.1369 h 0.45085 l -0.76835,3.6703 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1966" />
+      <path
+         d="m 230.187,90.314299 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0572,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.05715 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0317,-0.4953 -0.0318,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.08255 -0.1143,0.08255 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1968" />
+      <path
+         d="m 231.80327,90.257149 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.0191,0 0.0381,0 0.019,0 0.0444,0.0063 v 0.4953 q -0.0444,-0.01905 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1970" />
+    </g>
+    <g
+       aria-label="DHCP daemon"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1632">
+      <path
+         d="m 247.34427,90.635124 v -5.1435 h 1.1176 q 0.53975,0 0.8382,0.1905 0.3048,0.18415 0.42545,0.52705 0.127,0.3429 0.127,0.79375 v 2.0447 q 0,0.47625 -0.127,0.8382 -0.12065,0.3556 -0.41275,0.55245 -0.2921,0.19685 -0.80645,0.19685 z m 0.4826,-0.36195 h 0.6477 q 0.4064,0 0.5969,-0.1651 0.1905,-0.17145 0.2413,-0.46355 0.0508,-0.29845 0.0508,-0.6731 v -1.9177 q 0,-0.38735 -0.0699,-0.6477 -0.0635,-0.2667 -0.26035,-0.40005 -0.1905,-0.1397 -0.57785,-0.1397 h -0.62865 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1973" />
+      <path
+         d="m 250.64934,90.635124 v -5.1435 h 0.48895 v 2.27965 h 1.61925 v -2.27965 h 0.4826 v 5.1435 h -0.4826 v -2.5019 h -1.61925 v 2.5019 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1975" />
+      <path
+         d="m 255.33455,90.698624 q -0.5207,0 -0.80645,-0.2159 -0.2794,-0.2159 -0.38735,-0.57785 -0.10795,-0.3683 -0.10795,-0.8128 v -2.0447 q 0,-0.47625 0.10795,-0.8382 0.1143,-0.36195 0.40005,-0.56515 0.28575,-0.2032 0.79375,-0.2032 0.46355,0 0.7239,0.1778 0.2667,0.1778 0.381,0.508 0.1143,0.32385 0.1143,0.7747 v 0.31115 h -0.4572 v -0.29845 q 0,-0.33655 -0.0571,-0.57785 -0.0508,-0.2413 -0.2159,-0.37465 -0.1651,-0.13335 -0.48895,-0.13335 -0.3429,0 -0.5207,0.14605 -0.17145,0.1397 -0.23495,0.40005 -0.0572,0.26035 -0.0572,0.60325 v 2.19075 q 0,0.381 0.0699,0.635 0.0762,0.254 0.254,0.381 0.1778,0.127 0.48895,0.127 0.32385,0 0.48895,-0.1397 0.1651,-0.1397 0.2159,-0.38735 0.0571,-0.254 0.0571,-0.59055 v -0.33655 h 0.4572 v 0.3048 q 0,0.45085 -0.10795,0.8001 -0.1016,0.34925 -0.3683,0.5461 -0.26035,0.1905 -0.74295,0.1905 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1977" />
+      <path
+         d="m 257.30335,90.635124 v -5.1435 h 1.2319 q 0.46355,0 0.7239,0.17145 0.2667,0.17145 0.381,0.47625 0.1143,0.3048 0.1143,0.71755 0,0.36195 -0.12065,0.6731 -0.1143,0.3048 -0.38735,0.48895 -0.2667,0.18415 -0.70485,0.18415 h -0.75565 v 2.43205 z m 0.4826,-2.794 h 0.61595 q 0.31115,0 0.50165,-0.0889 0.19685,-0.09525 0.28575,-0.31115 0.0889,-0.2159 0.0889,-0.5842 0,-0.3937 -0.0762,-0.6096 -0.0762,-0.22225 -0.2667,-0.3048 -0.18415,-0.0889 -0.52705,-0.0889 h -0.6223 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1979" />
+      <path
+         d="m 262.32451,90.692274 q -0.4699,0 -0.67945,-0.3556 -0.2032,-0.3556 -0.2032,-1.1811 v -0.67945 q 0,-0.4826 0.0698,-0.83185 0.0699,-0.34925 0.254,-0.53975 0.1905,-0.19685 0.53975,-0.19685 0.2159,0 0.37465,0.1016 0.1651,0.09525 0.27305,0.2159 v -1.73355 h 0.46355 v 5.1435 h -0.46355 v -0.26035 q -0.10795,0.12065 -0.2667,0.22225 -0.1524,0.09525 -0.36195,0.09525 z m 0.0953,-0.36195 q 0.14605,0 0.28575,-0.06985 0.1397,-0.0762 0.24765,-0.1778 v -2.5527 q -0.0953,-0.0889 -0.23495,-0.17145 -0.1397,-0.0889 -0.31115,-0.0889 -0.3048,0 -0.4064,0.27305 -0.0952,0.2667 -0.0952,0.7874 v 0.8636 q 0,0.3683 0.0381,0.6223 0.0444,0.254 0.1524,0.38735 0.1143,0.127 0.32385,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1981" />
+      <path
+         d="m 264.75726,90.692274 q -0.2159,0 -0.381,-0.10795 -0.1651,-0.1143 -0.26035,-0.29845 -0.0952,-0.18415 -0.0952,-0.41275 0,-0.2794 0.0825,-0.47625 0.0826,-0.19685 0.254,-0.34925 0.1778,-0.15875 0.4572,-0.3048 0.28575,-0.1524 0.69215,-0.33655 v -0.26035 q 0,-0.33655 -0.0444,-0.52705 -0.0381,-0.19685 -0.1397,-0.2794 -0.0952,-0.08255 -0.27305,-0.08255 -0.14605,0 -0.26035,0.05715 -0.1143,0.05715 -0.18415,0.19685 -0.0698,0.13335 -0.0698,0.37465 v 0.127 l -0.4572,-0.0063 q 0.006,-0.5588 0.23495,-0.8255 0.23495,-0.27305 0.762,-0.27305 0.48895,0 0.69215,0.29845 0.2032,0.2921 0.2032,0.9144 v 1.78435 q 0,0.09525 0,0.24765 0.006,0.14605 0.0127,0.2794 0.0127,0.13335 0.0191,0.2032 h -0.41275 q -0.019,-0.12065 -0.0444,-0.2667 -0.0191,-0.1524 -0.0254,-0.2413 -0.0762,0.22225 -0.27305,0.3937 -0.1905,0.17145 -0.48895,0.17145 z m 0.1524,-0.3937 q 0.1397,0 0.24765,-0.0635 0.1143,-0.06985 0.2032,-0.17145 0.0953,-0.1016 0.14605,-0.2032 v -1.143 q -0.27305,0.14605 -0.4699,0.26035 -0.1905,0.10795 -0.31115,0.2159 -0.12065,0.10795 -0.1778,0.24765 -0.0571,0.13335 -0.0571,0.3175 0,0.2921 0.12065,0.4191 0.127,0.12065 0.29845,0.12065 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1983" />
+      <path
+         d="m 267.56703,90.692274 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0571,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.05715 0.1778,-0.20955 0.0698,-0.15875 0.0698,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0317,-0.4953 -0.0317,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.08255 -0.1143,0.08255 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1985" />
+      <path
+         d="m 269.15156,90.635124 v -3.6703 h 0.4318 v 0.37465 q 0.18415,-0.2159 0.4064,-0.32385 0.22225,-0.1143 0.4572,-0.1143 0.1905,0 0.34925,0.1016 0.1651,0.1016 0.23495,0.381 0.18415,-0.2413 0.41275,-0.36195 0.23495,-0.12065 0.48895,-0.12065 0.15875,0 0.29845,0.0762 0.14605,0.0762 0.23495,0.26035 0.0889,0.18415 0.0889,0.50165 v 2.8956 h -0.43815 v -2.8829 q 0,-0.32385 -0.1016,-0.42545 -0.1016,-0.10795 -0.26035,-0.10795 -0.1778,0 -0.3556,0.1016 -0.1778,0.1016 -0.33655,0.2794 0.006,0.03175 0.006,0.06985 0,0.03175 0,0.06985 v 2.8956 h -0.4318 v -2.8829 q 0,-0.32385 -0.10795,-0.42545 -0.1016,-0.10795 -0.26035,-0.10795 -0.17145,0 -0.34925,0.1016 -0.1778,0.1016 -0.33655,0.27305 v 3.04165 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1987" />
+      <path
+         d="m 274.15238,90.692274 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.0825,-0.31115 -0.0825,-0.75565 v -1.016 q 0,-0.4445 0.0825,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.0826,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.0317,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1989" />
+      <path
+         d="m 275.77441,90.635124 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.09525 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.09525 -0.1651,0.09525 -0.31115,0.24765 v 3.0226 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1991" />
+    </g>
+    <g
+       aria-label="mac0"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1636">
+      <path
+         d="m 234.70086,130.24709 v -3.6703 h 0.4318 v 0.37465 q 0.18415,-0.2159 0.4064,-0.32385 0.22225,-0.1143 0.4572,-0.1143 0.1905,0 0.34925,0.1016 0.1651,0.1016 0.23495,0.381 0.18415,-0.2413 0.41275,-0.36195 0.23495,-0.12065 0.48895,-0.12065 0.15875,0 0.29845,0.0762 0.14605,0.0762 0.23495,0.26035 0.0889,0.18415 0.0889,0.50165 v 2.8956 h -0.43815 v -2.8829 q 0,-0.32385 -0.1016,-0.42545 -0.1016,-0.10795 -0.26035,-0.10795 -0.1778,0 -0.3556,0.1016 -0.1778,0.1016 -0.33655,0.2794 0.006,0.0318 0.006,0.0699 0,0.0318 0,0.0699 v 2.8956 h -0.4318 v -2.8829 q 0,-0.32385 -0.10795,-0.42545 -0.1016,-0.10795 -0.26035,-0.10795 -0.17145,0 -0.34925,0.1016 -0.1778,0.1016 -0.33655,0.27305 v 3.04165 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1994" />
+      <path
+         d="m 239.42228,130.30424 q -0.2159,0 -0.381,-0.10795 -0.1651,-0.1143 -0.26035,-0.29845 -0.0953,-0.18415 -0.0953,-0.41275 0,-0.2794 0.0825,-0.47625 0.0825,-0.19685 0.254,-0.34925 0.1778,-0.15875 0.4572,-0.3048 0.28575,-0.1524 0.69215,-0.33655 v -0.26035 q 0,-0.33655 -0.0445,-0.52705 -0.0381,-0.19685 -0.1397,-0.2794 -0.0952,-0.0826 -0.27305,-0.0826 -0.14605,0 -0.26035,0.0572 -0.1143,0.0571 -0.18415,0.19685 -0.0699,0.13335 -0.0699,0.37465 v 0.127 l -0.4572,-0.006 q 0.006,-0.5588 0.23495,-0.8255 0.23495,-0.27305 0.762,-0.27305 0.48895,0 0.69215,0.29845 0.2032,0.2921 0.2032,0.9144 v 1.78435 q 0,0.0952 0,0.24765 0.006,0.14605 0.0127,0.2794 0.0127,0.13335 0.019,0.2032 h -0.41275 q -0.019,-0.12065 -0.0445,-0.2667 -0.019,-0.1524 -0.0254,-0.2413 -0.0762,0.22225 -0.27305,0.3937 -0.1905,0.17145 -0.48895,0.17145 z m 0.1524,-0.3937 q 0.1397,0 0.24765,-0.0635 0.1143,-0.0699 0.2032,-0.17145 0.0952,-0.1016 0.14605,-0.2032 v -1.143 q -0.27305,0.14605 -0.4699,0.26035 -0.1905,0.10795 -0.31115,0.2159 -0.12065,0.10795 -0.1778,0.24765 -0.0572,0.13335 -0.0572,0.3175 0,0.2921 0.12065,0.4191 0.127,0.12065 0.29845,0.12065 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1996" />
+      <path
+         d="m 242.21936,130.30424 q -0.42545,0 -0.635,-0.1905 -0.20955,-0.1905 -0.2794,-0.51435 -0.0635,-0.3302 -0.0635,-0.74295 v -0.85725 q 0,-0.508 0.0825,-0.83185 0.0826,-0.3302 0.2921,-0.48895 0.2159,-0.15875 0.60325,-0.15875 0.3937,0 0.5969,0.14605 0.2032,0.14605 0.27305,0.41275 0.0699,0.2667 0.0699,0.6223 v 0.17145 h -0.4318 v -0.1778 q 0,-0.32385 -0.0508,-0.50165 -0.0444,-0.1778 -0.15875,-0.24765 -0.10795,-0.0762 -0.2921,-0.0762 -0.2159,0 -0.3302,0.1016 -0.1143,0.1016 -0.1524,0.33655 -0.0381,0.2286 -0.0381,0.61595 v 1.0287 q 0,0.55245 0.10795,0.78105 0.10795,0.22225 0.4191,0.22225 0.2159,0 0.32385,-0.0953 0.10795,-0.1016 0.1397,-0.29845 0.0318,-0.19685 0.0318,-0.48895 v -0.2032 h 0.4318 v 0.1778 q 0,0.3683 -0.0699,0.65405 -0.0699,0.2794 -0.27305,0.4445 -0.19685,0.15875 -0.5969,0.15875 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path1998" />
+      <path
+         d="m 245.06208,130.31059 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0699,-0.254 0.0699,-0.56515 v -2.30505 q 0,-0.31115 -0.0699,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0699,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2000" />
+    </g>
+    <g
+       aria-label="10.0.2.15/24"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1640">
+      <path
+         d="m 18.075736,128.20599 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0444 -0.24765,0.0825 -0.10795,0.0318 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0953 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2003" />
+      <path
+         d="m 20.978876,128.26949 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.06985,-0.254 0.06985,-0.56515 v -2.30505 q 0,-0.31115 -0.06985,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.06985,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2005" />
+      <path
+         d="m 23.008197,128.20599 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2007" />
+      <path
+         d="m 25.418915,128.26949 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.06985,-0.254 0.06985,-0.56515 v -2.30505 q 0,-0.31115 -0.06985,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.06985,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2009" />
+      <path
+         d="m 27.448237,128.20599 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2011" />
+      <path
+         d="m 28.531804,128.20599 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2013" />
+      <path
+         d="m 31.677435,128.20599 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2015" />
+      <path
+         d="m 33.516654,128.20599 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0444 -0.24765,0.0825 -0.10795,0.0318 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0953 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2017" />
+      <path
+         d="m 36.311844,128.26314 q -0.41275,0 -0.66675,-0.15875 -0.24765,-0.15875 -0.36195,-0.4699 -0.1143,-0.31115 -0.1143,-0.75565 h 0.46355 q 0,0.31115 0.05715,0.53975 0.0635,0.2286 0.2159,0.3556 0.15875,0.12065 0.42545,0.12065 0.2921,0 0.4445,-0.1524 0.1524,-0.1524 0.20955,-0.4445 0.05715,-0.2921 0.05715,-0.71755 0,-0.4699 -0.06985,-0.7493 -0.0635,-0.2794 -0.22225,-0.40005 -0.1524,-0.127 -0.41275,-0.127 -0.19685,0 -0.3683,0.10795 -0.17145,0.10795 -0.29845,0.3175 h -0.38735 v -2.667 h 2.00025 l -0.0064,0.43815 h -1.58115 l -0.0254,1.78435 q 0.1143,-0.1397 0.3048,-0.2413 0.19685,-0.1016 0.4826,-0.1016 0.381,0 0.6096,0.1905 0.23495,0.1905 0.33655,0.5461 0.1016,0.34925 0.1016,0.84455 0,0.4191 -0.0635,0.74295 -0.0635,0.32385 -0.20955,0.5461 -0.1397,0.22225 -0.3683,0.33655 -0.22225,0.1143 -0.55245,0.1143 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2019" />
+      <path
+         d="m 37.960067,128.20599 1.46685,-5.1435 h 0.4064 l -1.46685,5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2021" />
+      <path
+         d="m 40.301629,128.20599 v -0.33655 l 1.384299,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.165099,0.1397 -0.234949,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.273049,-0.1651 0.711199,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.289049,1.9431 h 1.790699 v 0.3937 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2023" />
+      <path
+         d="m 44.833941,128.20599 v -1.50495 h -1.5494 v -0.4699 l 1.4605,-3.16865 h 0.5461 v 3.21945 h 0.59055 v 0.4191 h -0.59055 v 1.50495 z m -1.0795,-1.92405 h 1.0795 v -2.6035 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2025" />
+    </g>
+    <g
+       aria-label="10.10.1.1/24"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1644">
+      <path
+         d="m 67.590611,121.55358 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0445 -0.24765,0.0826 -0.10795,0.0317 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2028" />
+      <path
+         d="m 70.493752,121.61708 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.06985,-0.254 0.06985,-0.56515 v -2.30505 q 0,-0.31115 -0.06985,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.06985,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2030" />
+      <path
+         d="m 72.523073,121.55358 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2032" />
+      <path
+         d="m 74.362291,121.55358 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0445 -0.24765,0.0826 -0.10795,0.0317 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2034" />
+      <path
+         d="m 77.265431,121.61708 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.06985,-0.254 0.06985,-0.56515 v -2.30505 q 0,-0.31115 -0.06985,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.06985,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2036" />
+      <path
+         d="m 79.294753,121.55358 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2038" />
+      <path
+         d="m 81.13397,121.55358 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0445 -0.24765,0.0826 -0.10795,0.0317 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2040" />
+      <path
+         d="m 82.779811,121.55358 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2042" />
+      <path
+         d="m 84.619029,121.55358 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0445 -0.24765,0.0826 -0.10795,0.0317 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2044" />
+      <path
+         d="m 86.036269,121.55358 1.46685,-5.1435 h 0.4064 l -1.46685,5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2046" />
+      <path
+         d="m 88.377831,121.55358 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2048" />
+      <path
+         d="m 92.910143,121.55358 v -1.50495 h -1.5494 v -0.4699 l 1.4605,-3.16865 h 0.5461 v 3.21945 h 0.59055 v 0.4191 h -0.59055 v 1.50495 z m -1.0795,-1.92405 h 1.0795 v -2.6035 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2050" />
+    </g>
+    <g
+       aria-label="192.168.77.101/24"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1648">
+      <path
+         d="m 82.785245,129.11316 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0444 -0.24765,0.0825 -0.10795,0.0318 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2053" />
+      <path
+         d="m 85.650285,129.17666 q -0.38735,0 -0.6477,-0.13335 -0.26035,-0.13335 -0.3937,-0.40005 -0.127,-0.27305 -0.13335,-0.66675 0,-0.0127 0,-0.0508 0,-0.0381 0,-0.0444 h 0.4572 q 0,0.48895 0.1524,0.6985 0.15875,0.20955 0.5715,0.20955 0.2159,0 0.3683,-0.1016 0.15875,-0.1016 0.2413,-0.3429 0.08255,-0.24765 0.08255,-0.6604 v -0.97155 q -0.09525,0.1143 -0.3048,0.20955 -0.2032,0.0953 -0.5207,0.0953 -0.42545,0 -0.66675,-0.15875 -0.2413,-0.1651 -0.3429,-0.50165 -0.1016,-0.3429 -0.1016,-0.8763 0,-0.47625 0.12065,-0.8255 0.127,-0.34925 0.3937,-0.53975 0.27305,-0.19685 0.7112,-0.19685 0.4191,0 0.67945,0.19685 0.26035,0.1905 0.381,0.55245 0.12065,0.3556 0.12065,0.85725 v 2.05105 q 0,0.4699 -0.1143,0.83185 -0.1143,0.36195 -0.3683,0.56515 -0.24765,0.2032 -0.6858,0.2032 z m -0.01905,-2.52095 q 0.27305,0 0.45085,-0.0952 0.1778,-0.1016 0.2667,-0.2032 v -0.88265 q 0,-0.4191 -0.0762,-0.6731 -0.06985,-0.26035 -0.2286,-0.37465 -0.15875,-0.12065 -0.4064,-0.12065 -0.24765,0 -0.4191,0.12065 -0.1651,0.1143 -0.24765,0.3556 -0.08255,0.2413 -0.08255,0.6096 0,0.42545 0.04445,0.70485 0.0508,0.2794 0.20955,0.4191 0.15875,0.1397 0.48895,0.1397 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2055" />
+      <path
+         d="m 87.548638,129.11316 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2057" />
+      <path
+         d="m 90.694269,129.11316 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2059" />
+      <path
+         d="m 92.533486,129.11316 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0444 -0.24765,0.0825 -0.10795,0.0318 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2061" />
+      <path
+         d="m 95.404877,129.17666 q -0.42545,0 -0.6858,-0.1905 -0.26035,-0.19685 -0.381,-0.5588 -0.12065,-0.36195 -0.12065,-0.8636 v -2.05105 q 0,-0.47625 0.1143,-0.83185 0.1143,-0.36195 0.37465,-0.5588 0.26035,-0.2032 0.69215,-0.2032 0.38735,0 0.64135,0.13335 0.254,0.13335 0.381,0.40005 0.13335,0.26035 0.13335,0.65405 0,0.0127 0,0.0572 0.0063,0.0381 0.0063,0.0508 h -0.46355 q 0,-0.4953 -0.15875,-0.70485 -0.1524,-0.20955 -0.52705,-0.20955 -0.20955,0 -0.381,0.10795 -0.1651,0.1016 -0.26035,0.3429 -0.0889,0.2413 -0.0889,0.65405 v 0.9779 q 0.1143,-0.1143 0.3302,-0.20955 0.22225,-0.0952 0.4953,-0.0952 0.42545,0 0.66675,0.15875 0.2413,0.15875 0.3429,0.4953 0.1016,0.33655 0.1016,0.8763 0,0.4699 -0.12065,0.8255 -0.12065,0.3556 -0.38735,0.55245 -0.2667,0.1905 -0.70485,0.1905 z m 0,-0.38735 q 0.254,0 0.41275,-0.10795 0.1651,-0.1143 0.24765,-0.3556 0.08255,-0.2413 0.08255,-0.62865 0,-0.4191 -0.0508,-0.6985 -0.04445,-0.2794 -0.2032,-0.4191 -0.1524,-0.1397 -0.48895,-0.1397 -0.1524,0 -0.2921,0.0508 -0.1397,0.0444 -0.254,0.1143 -0.1143,0.0635 -0.1778,0.127 v 0.889 q 0,0.41275 0.0762,0.6731 0.0762,0.26035 0.23495,0.381 0.1651,0.1143 0.41275,0.1143 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2063" />
+      <path
+         d="m 98.548425,129.17666 q -0.4445,0 -0.7112,-0.1778 -0.26035,-0.1778 -0.381,-0.50165 -0.12065,-0.3302 -0.12065,-0.762 0,-0.33655 0.0635,-0.5588 0.06985,-0.2286 0.1778,-0.37465 0.10795,-0.14605 0.2413,-0.23495 0.13335,-0.0889 0.26035,-0.1524 -0.31115,-0.127 -0.50165,-0.4191 -0.1905,-0.29845 -0.1905,-0.7874 0,-0.37465 0.1143,-0.66675 0.1143,-0.2921 0.3683,-0.4572 0.26035,-0.1651 0.67945,-0.1651 0.4191,0 0.66675,0.17145 0.254,0.1651 0.3683,0.4572 0.1143,0.2921 0.1143,0.6731 0,0.48895 -0.1905,0.7747 -0.18415,0.28575 -0.4953,0.4191 0.127,0.0635 0.254,0.1524 0.13335,0.0889 0.2413,0.23495 0.10795,0.14605 0.1778,0.37465 0.06985,0.22225 0.06985,0.5588 0,0.4318 -0.12065,0.762 -0.12065,0.32385 -0.38735,0.50165 -0.26035,0.1778 -0.6985,0.1778 z m 0,-0.3683 q 0.254,0 0.4191,-0.1143 0.1651,-0.12065 0.24765,-0.3556 0.08255,-0.2413 0.08255,-0.60325 0,-0.3175 -0.0762,-0.55245 -0.06985,-0.2413 -0.23495,-0.38735 -0.15875,-0.14605 -0.43815,-0.1651 -0.2794,0.0191 -0.45085,0.1651 -0.1651,0.14605 -0.2413,0.38735 -0.06985,0.23495 -0.06985,0.55245 0,0.36195 0.08255,0.60325 0.0889,0.23495 0.254,0.3556 0.17145,0.1143 0.42545,0.1143 z m 0,-2.6035 q 0.2667,-0.0127 0.41275,-0.14605 0.1524,-0.13335 0.2159,-0.3556 0.0635,-0.22225 0.0635,-0.50165 0,-0.4445 -0.1651,-0.6731 -0.1651,-0.23495 -0.52705,-0.23495 -0.3683,0 -0.53975,0.23495 -0.1651,0.2286 -0.1651,0.6731 0,0.2794 0.0635,0.50165 0.0635,0.22225 0.2159,0.3556 0.15875,0.13335 0.42545,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2065" />
+      <path
+         d="m 100.50452,129.11316 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2067" />
+      <path
+         d="m 102.01989,129.11316 1.0033,-4.76885 h -1.55575 v -0.37465 h 2.032 v 0.2286 l -1.0287,4.9149 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2069" />
+      <path
+         d="m 104.57477,129.11316 1.0033,-4.76885 h -1.55575 v -0.37465 h 2.032 v 0.2286 l -1.0287,4.9149 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2071" />
+      <path
+         d="m 106.76771,129.11316 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2073" />
+      <path
+         d="m 108.60692,129.11316 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0444 -0.24765,0.0825 -0.10795,0.0318 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2075" />
+      <path
+         d="m 111.51007,129.17666 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0699,-0.254 0.0699,-0.56515 v -2.30505 q 0,-0.31115 -0.0699,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0699,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2077" />
+      <path
+         d="m 114.22519,129.11316 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0444 -0.24765,0.0825 -0.10795,0.0318 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2079" />
+      <path
+         d="m 115.64242,129.11316 1.46685,-5.1435 h 0.4064 l -1.46685,5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2081" />
+      <path
+         d="m 117.98399,129.11316 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2083" />
+      <path
+         d="m 122.5163,129.11316 v -1.50495 h -1.5494 v -0.4699 l 1.4605,-3.16865 h 0.5461 v 3.21945 h 0.59055 v 0.4191 h -0.59055 v 1.50495 z m -1.0795,-1.92405 h 1.0795 v -2.6035 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2085" />
+    </g>
+    <g
+       aria-label="192.168.78.101/24"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1652">
+      <path
+         d="m 220.06619,118.15181 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0445 -0.24765,0.0826 -0.10795,0.0317 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2088" />
+      <path
+         d="m 222.93123,118.21531 q -0.38735,0 -0.6477,-0.13335 -0.26035,-0.13335 -0.3937,-0.40005 -0.127,-0.27305 -0.13335,-0.66675 0,-0.0127 0,-0.0508 0,-0.0381 0,-0.0444 h 0.4572 q 0,0.48895 0.1524,0.6985 0.15875,0.20955 0.5715,0.20955 0.2159,0 0.3683,-0.1016 0.15875,-0.1016 0.2413,-0.3429 0.0825,-0.24765 0.0825,-0.6604 v -0.97155 q -0.0952,0.1143 -0.3048,0.20955 -0.2032,0.0952 -0.5207,0.0952 -0.42545,0 -0.66675,-0.15875 -0.2413,-0.1651 -0.3429,-0.50165 -0.1016,-0.3429 -0.1016,-0.8763 0,-0.47625 0.12065,-0.8255 0.127,-0.34925 0.3937,-0.53975 0.27305,-0.19685 0.7112,-0.19685 0.4191,0 0.67945,0.19685 0.26035,0.1905 0.381,0.55245 0.12065,0.3556 0.12065,0.85725 v 2.05105 q 0,0.4699 -0.1143,0.83185 -0.1143,0.36195 -0.3683,0.56515 -0.24765,0.2032 -0.6858,0.2032 z m -0.019,-2.52095 q 0.27305,0 0.45085,-0.0953 0.1778,-0.1016 0.2667,-0.2032 v -0.88265 q 0,-0.4191 -0.0762,-0.6731 -0.0699,-0.26035 -0.2286,-0.37465 -0.15875,-0.12065 -0.4064,-0.12065 -0.24765,0 -0.4191,0.12065 -0.1651,0.1143 -0.24765,0.3556 -0.0825,0.2413 -0.0825,0.6096 0,0.42545 0.0445,0.70485 0.0508,0.2794 0.20955,0.4191 0.15875,0.1397 0.48895,0.1397 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2090" />
+      <path
+         d="m 224.82958,118.15181 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2092" />
+      <path
+         d="m 227.97521,118.15181 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2094" />
+      <path
+         d="m 229.81443,118.15181 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0445 -0.24765,0.0826 -0.10795,0.0317 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2096" />
+      <path
+         d="m 232.68582,118.21531 q -0.42545,0 -0.6858,-0.1905 -0.26035,-0.19685 -0.381,-0.5588 -0.12065,-0.36195 -0.12065,-0.8636 v -2.05105 q 0,-0.47625 0.1143,-0.83185 0.1143,-0.36195 0.37465,-0.5588 0.26035,-0.2032 0.69215,-0.2032 0.38735,0 0.64135,0.13335 0.254,0.13335 0.381,0.40005 0.13335,0.26035 0.13335,0.65405 0,0.0127 0,0.0572 0.006,0.0381 0.006,0.0508 h -0.46355 q 0,-0.4953 -0.15875,-0.70485 -0.1524,-0.20955 -0.52705,-0.20955 -0.20955,0 -0.381,0.10795 -0.1651,0.1016 -0.26035,0.3429 -0.0889,0.2413 -0.0889,0.65405 v 0.9779 q 0.1143,-0.1143 0.3302,-0.20955 0.22225,-0.0952 0.4953,-0.0952 0.42545,0 0.66675,0.15875 0.2413,0.15875 0.3429,0.4953 0.1016,0.33655 0.1016,0.8763 0,0.4699 -0.12065,0.8255 -0.12065,0.3556 -0.38735,0.55245 -0.2667,0.1905 -0.70485,0.1905 z m 0,-0.38735 q 0.254,0 0.41275,-0.10795 0.1651,-0.1143 0.24765,-0.3556 0.0825,-0.2413 0.0825,-0.62865 0,-0.4191 -0.0508,-0.6985 -0.0445,-0.2794 -0.2032,-0.4191 -0.1524,-0.1397 -0.48895,-0.1397 -0.1524,0 -0.2921,0.0508 -0.1397,0.0445 -0.254,0.1143 -0.1143,0.0635 -0.1778,0.127 v 0.889 q 0,0.41275 0.0762,0.6731 0.0762,0.26035 0.23495,0.381 0.1651,0.1143 0.41275,0.1143 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2098" />
+      <path
+         d="m 235.82937,118.21531 q -0.4445,0 -0.7112,-0.1778 -0.26035,-0.1778 -0.381,-0.50165 -0.12065,-0.3302 -0.12065,-0.762 0,-0.33655 0.0635,-0.5588 0.0698,-0.2286 0.1778,-0.37465 0.10795,-0.14605 0.2413,-0.23495 0.13335,-0.0889 0.26035,-0.1524 -0.31115,-0.127 -0.50165,-0.4191 -0.1905,-0.29845 -0.1905,-0.7874 0,-0.37465 0.1143,-0.66675 0.1143,-0.2921 0.3683,-0.4572 0.26035,-0.1651 0.67945,-0.1651 0.4191,0 0.66675,0.17145 0.254,0.1651 0.3683,0.4572 0.1143,0.2921 0.1143,0.6731 0,0.48895 -0.1905,0.7747 -0.18415,0.28575 -0.4953,0.4191 0.127,0.0635 0.254,0.1524 0.13335,0.0889 0.2413,0.23495 0.10795,0.14605 0.1778,0.37465 0.0699,0.22225 0.0699,0.5588 0,0.4318 -0.12065,0.762 -0.12065,0.32385 -0.38735,0.50165 -0.26035,0.1778 -0.6985,0.1778 z m 0,-0.3683 q 0.254,0 0.4191,-0.1143 0.1651,-0.12065 0.24765,-0.3556 0.0825,-0.2413 0.0825,-0.60325 0,-0.3175 -0.0762,-0.55245 -0.0699,-0.2413 -0.23495,-0.38735 -0.15875,-0.14605 -0.43815,-0.1651 -0.2794,0.0191 -0.45085,0.1651 -0.1651,0.14605 -0.2413,0.38735 -0.0699,0.23495 -0.0699,0.55245 0,0.36195 0.0825,0.60325 0.0889,0.23495 0.254,0.3556 0.17145,0.1143 0.42545,0.1143 z m 0,-2.6035 q 0.2667,-0.0127 0.41275,-0.14605 0.1524,-0.13335 0.2159,-0.3556 0.0635,-0.22225 0.0635,-0.50165 0,-0.4445 -0.1651,-0.6731 -0.1651,-0.23495 -0.52705,-0.23495 -0.3683,0 -0.53975,0.23495 -0.1651,0.2286 -0.1651,0.6731 0,0.2794 0.0635,0.50165 0.0635,0.22225 0.2159,0.3556 0.15875,0.13335 0.42545,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2100" />
+      <path
+         d="m 237.78547,118.15181 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2102" />
+      <path
+         d="m 239.30083,118.15181 1.0033,-4.76885 h -1.55575 v -0.37465 h 2.032 v 0.2286 l -1.0287,4.9149 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2104" />
+      <path
+         d="m 242.70027,118.21531 q -0.4445,0 -0.7112,-0.1778 -0.26035,-0.1778 -0.381,-0.50165 -0.12065,-0.3302 -0.12065,-0.762 0,-0.33655 0.0635,-0.5588 0.0699,-0.2286 0.1778,-0.37465 0.10795,-0.14605 0.2413,-0.23495 0.13335,-0.0889 0.26035,-0.1524 -0.31115,-0.127 -0.50165,-0.4191 -0.1905,-0.29845 -0.1905,-0.7874 0,-0.37465 0.1143,-0.66675 0.1143,-0.2921 0.3683,-0.4572 0.26035,-0.1651 0.67945,-0.1651 0.4191,0 0.66675,0.17145 0.254,0.1651 0.3683,0.4572 0.1143,0.2921 0.1143,0.6731 0,0.48895 -0.1905,0.7747 -0.18415,0.28575 -0.4953,0.4191 0.127,0.0635 0.254,0.1524 0.13335,0.0889 0.2413,0.23495 0.10795,0.14605 0.1778,0.37465 0.0699,0.22225 0.0699,0.5588 0,0.4318 -0.12065,0.762 -0.12065,0.32385 -0.38735,0.50165 -0.26035,0.1778 -0.6985,0.1778 z m 0,-0.3683 q 0.254,0 0.4191,-0.1143 0.1651,-0.12065 0.24765,-0.3556 0.0825,-0.2413 0.0825,-0.60325 0,-0.3175 -0.0762,-0.55245 -0.0699,-0.2413 -0.23495,-0.38735 -0.15875,-0.14605 -0.43815,-0.1651 -0.2794,0.0191 -0.45085,0.1651 -0.1651,0.14605 -0.2413,0.38735 -0.0699,0.23495 -0.0699,0.55245 0,0.36195 0.0825,0.60325 0.0889,0.23495 0.254,0.3556 0.17145,0.1143 0.42545,0.1143 z m 0,-2.6035 q 0.2667,-0.0127 0.41275,-0.14605 0.1524,-0.13335 0.2159,-0.3556 0.0635,-0.22225 0.0635,-0.50165 0,-0.4445 -0.1651,-0.6731 -0.1651,-0.23495 -0.52705,-0.23495 -0.3683,0 -0.53975,0.23495 -0.1651,0.2286 -0.1651,0.6731 0,0.2794 0.0635,0.50165 0.0635,0.22225 0.2159,0.3556 0.15875,0.13335 0.42545,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2106" />
+      <path
+         d="m 244.65637,118.15181 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2108" />
+      <path
+         d="m 246.49558,118.15181 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0445 -0.24765,0.0826 -0.10795,0.0317 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2110" />
+      <path
+         d="m 249.39872,118.21531 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0699,-0.254 0.0699,-0.56515 v -2.30505 q 0,-0.31115 -0.0699,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0699,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2112" />
+      <path
+         d="m 252.11385,118.15181 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0445 -0.24765,0.0826 -0.10795,0.0317 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2114" />
+      <path
+         d="m 253.53108,118.15181 1.46685,-5.1435 h 0.4064 l -1.46685,5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2116" />
+      <path
+         d="m 255.87265,118.15181 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2118" />
+      <path
+         d="m 260.40496,118.15181 v -1.50495 h -1.5494 v -0.4699 l 1.4605,-3.16865 h 0.5461 v 3.21945 h 0.59055 v 0.4191 h -0.59055 v 1.50495 z m -1.0795,-1.92405 h 1.0795 v -2.6035 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2120" />
+    </g>
+    <g
+       aria-label="10.10.1.9/24"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1656">
+      <path
+         d="m 66.456685,54.273811 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2123" />
+      <path
+         d="m 69.359825,54.337311 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.06985,-0.254 0.06985,-0.56515 v -2.30505 q 0,-0.31115 -0.06985,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.06985,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2125" />
+      <path
+         d="m 71.389146,54.273811 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2127" />
+      <path
+         d="m 73.228364,54.273811 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2129" />
+      <path
+         d="m 76.131505,54.337311 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.06985,-0.254 0.06985,-0.56515 v -2.30505 q 0,-0.31115 -0.06985,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.06985,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2131" />
+      <path
+         d="m 78.160826,54.273811 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2133" />
+      <path
+         d="m 80.000044,54.273811 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2135" />
+      <path
+         d="m 81.645885,54.273811 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2137" />
+      <path
+         d="m 84.018503,54.337311 q -0.38735,0 -0.6477,-0.13335 -0.26035,-0.13335 -0.3937,-0.40005 -0.127,-0.27305 -0.13335,-0.66675 0,-0.0127 0,-0.0508 0,-0.0381 0,-0.04445 h 0.4572 q 0,0.48895 0.1524,0.6985 0.15875,0.20955 0.5715,0.20955 0.2159,0 0.3683,-0.1016 0.15875,-0.1016 0.2413,-0.3429 0.08255,-0.24765 0.08255,-0.6604 v -0.97155 q -0.09525,0.1143 -0.3048,0.20955 -0.2032,0.09525 -0.5207,0.09525 -0.42545,0 -0.66675,-0.15875 -0.2413,-0.1651 -0.3429,-0.50165 -0.1016,-0.3429 -0.1016,-0.8763 0,-0.47625 0.12065,-0.8255 0.127,-0.34925 0.3937,-0.53975 0.27305,-0.19685 0.7112,-0.19685 0.4191,0 0.67945,0.19685 0.260349,0.1905 0.380999,0.55245 0.12065,0.3556 0.12065,0.85725 v 2.05105 q 0,0.4699 -0.1143,0.83185 -0.1143,0.36195 -0.368299,0.56515 -0.24765,0.2032 -0.6858,0.2032 z m -0.01905,-2.52095 q 0.27305,0 0.45085,-0.09525 0.1778,-0.1016 0.2667,-0.2032 v -0.88265 q 0,-0.4191 -0.0762,-0.6731 -0.06985,-0.26035 -0.2286,-0.37465 -0.15875,-0.12065 -0.4064,-0.12065 -0.24765,0 -0.4191,0.12065 -0.1651,0.1143 -0.24765,0.3556 -0.08255,0.2413 -0.08255,0.6096 0,0.42545 0.04445,0.70485 0.0508,0.2794 0.20955,0.4191 0.15875,0.1397 0.48895,0.1397 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2139" />
+      <path
+         d="m 85.758105,54.273811 1.46685,-5.1435 h 0.4064 l -1.46685,5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2141" />
+      <path
+         d="m 88.099667,54.273811 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2143" />
+      <path
+         d="m 92.631979,54.273811 v -1.50495 h -1.5494 v -0.4699 l 1.4605,-3.16865 h 0.5461 v 3.21945 h 0.59055 v 0.4191 h -0.59055 v 1.50495 z m -1.0795,-1.92405 h 1.0795 v -2.6035 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2145" />
+    </g>
+    <g
+       aria-label="10.10.1.12/24"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1660">
+      <path
+         d="m 112.94775,54.349407 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2148" />
+      <path
+         d="m 115.85089,54.412907 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0699,-0.254 0.0699,-0.56515 v -2.30505 q 0,-0.31115 -0.0699,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0698,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2150" />
+      <path
+         d="m 117.88021,54.349407 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2152" />
+      <path
+         d="m 119.71943,54.349407 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2154" />
+      <path
+         d="m 122.62257,54.412907 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0699,-0.254 0.0699,-0.56515 v -2.30505 q 0,-0.31115 -0.0699,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0699,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2156" />
+      <path
+         d="m 124.65189,54.349407 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2158" />
+      <path
+         d="m 126.49111,54.349407 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2160" />
+      <path
+         d="m 128.13695,54.349407 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2162" />
+      <path
+         d="m 129.97617,54.349407 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2164" />
+      <path
+         d="m 131.55216,54.349407 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2166" />
+      <path
+         d="m 134.46919,54.349407 1.46685,-5.1435 h 0.4064 l -1.46685,5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2168" />
+      <path
+         d="m 136.81075,54.349407 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2170" />
+      <path
+         d="m 141.34307,54.349407 v -1.50495 h -1.5494 v -0.4699 l 1.4605,-3.16865 h 0.5461 v 3.21945 h 0.59055 v 0.4191 h -0.59055 v 1.50495 z m -1.0795,-1.92405 h 1.0795 v -2.6035 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2172" />
+    </g>
+    <g
+       aria-label="192.168.78.202/24"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1664">
+      <path
+         d="m 151.80365,54.802971 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2175" />
+      <path
+         d="m 154.66869,54.866471 q -0.38735,0 -0.6477,-0.13335 -0.26035,-0.13335 -0.3937,-0.40005 -0.127,-0.27305 -0.13335,-0.66675 0,-0.0127 0,-0.0508 0,-0.0381 0,-0.04445 h 0.4572 q 0,0.48895 0.1524,0.6985 0.15875,0.20955 0.5715,0.20955 0.2159,0 0.3683,-0.1016 0.15875,-0.1016 0.2413,-0.3429 0.0825,-0.24765 0.0825,-0.6604 v -0.97155 q -0.0952,0.1143 -0.3048,0.20955 -0.2032,0.09525 -0.5207,0.09525 -0.42545,0 -0.66675,-0.15875 -0.2413,-0.1651 -0.3429,-0.50165 -0.1016,-0.3429 -0.1016,-0.8763 0,-0.47625 0.12065,-0.8255 0.127,-0.34925 0.3937,-0.53975 0.27305,-0.19685 0.7112,-0.19685 0.4191,0 0.67945,0.19685 0.26035,0.1905 0.381,0.55245 0.12065,0.3556 0.12065,0.85725 v 2.05105 q 0,0.4699 -0.1143,0.83185 -0.1143,0.36195 -0.3683,0.56515 -0.24765,0.2032 -0.6858,0.2032 z m -0.019,-2.52095 q 0.27305,0 0.45085,-0.09525 0.1778,-0.1016 0.2667,-0.2032 v -0.88265 q 0,-0.4191 -0.0762,-0.6731 -0.0699,-0.26035 -0.2286,-0.37465 -0.15875,-0.12065 -0.4064,-0.12065 -0.24765,0 -0.4191,0.12065 -0.1651,0.1143 -0.24765,0.3556 -0.0825,0.2413 -0.0825,0.6096 0,0.42545 0.0445,0.70485 0.0508,0.2794 0.20955,0.4191 0.15875,0.1397 0.48895,0.1397 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2177" />
+      <path
+         d="m 156.56704,54.802971 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2179" />
+      <path
+         d="m 159.71267,54.802971 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2181" />
+      <path
+         d="m 161.55189,54.802971 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2183" />
+      <path
+         d="m 164.42328,54.866471 q -0.42545,0 -0.6858,-0.1905 -0.26035,-0.19685 -0.381,-0.5588 -0.12065,-0.36195 -0.12065,-0.8636 v -2.05105 q 0,-0.47625 0.1143,-0.83185 0.1143,-0.36195 0.37465,-0.5588 0.26035,-0.2032 0.69215,-0.2032 0.38735,0 0.64135,0.13335 0.254,0.13335 0.381,0.40005 0.13335,0.26035 0.13335,0.65405 0,0.0127 0,0.05715 0.006,0.0381 0.006,0.0508 h -0.46355 q 0,-0.4953 -0.15875,-0.70485 -0.1524,-0.20955 -0.52705,-0.20955 -0.20955,0 -0.381,0.10795 -0.1651,0.1016 -0.26035,0.3429 -0.0889,0.2413 -0.0889,0.65405 v 0.9779 q 0.1143,-0.1143 0.3302,-0.20955 0.22225,-0.09525 0.4953,-0.09525 0.42545,0 0.66675,0.15875 0.2413,0.15875 0.3429,0.4953 0.1016,0.33655 0.1016,0.8763 0,0.4699 -0.12065,0.8255 -0.12065,0.3556 -0.38735,0.55245 -0.2667,0.1905 -0.70485,0.1905 z m 0,-0.38735 q 0.254,0 0.41275,-0.10795 0.1651,-0.1143 0.24765,-0.3556 0.0826,-0.2413 0.0826,-0.62865 0,-0.4191 -0.0508,-0.6985 -0.0445,-0.2794 -0.2032,-0.4191 -0.1524,-0.1397 -0.48895,-0.1397 -0.1524,0 -0.2921,0.0508 -0.1397,0.04445 -0.254,0.1143 -0.1143,0.0635 -0.1778,0.127 v 0.889 q 0,0.41275 0.0762,0.6731 0.0762,0.26035 0.23495,0.381 0.1651,0.1143 0.41275,0.1143 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2185" />
+      <path
+         d="m 167.56683,54.866471 q -0.4445,0 -0.7112,-0.1778 -0.26035,-0.1778 -0.381,-0.50165 -0.12065,-0.3302 -0.12065,-0.762 0,-0.33655 0.0635,-0.5588 0.0698,-0.2286 0.1778,-0.37465 0.10795,-0.14605 0.2413,-0.23495 0.13335,-0.0889 0.26035,-0.1524 -0.31115,-0.127 -0.50165,-0.4191 -0.1905,-0.29845 -0.1905,-0.7874 0,-0.37465 0.1143,-0.66675 0.1143,-0.2921 0.3683,-0.4572 0.26035,-0.1651 0.67945,-0.1651 0.4191,0 0.66675,0.17145 0.254,0.1651 0.3683,0.4572 0.1143,0.2921 0.1143,0.6731 0,0.48895 -0.1905,0.7747 -0.18415,0.28575 -0.4953,0.4191 0.127,0.0635 0.254,0.1524 0.13335,0.0889 0.2413,0.23495 0.10795,0.14605 0.1778,0.37465 0.0698,0.22225 0.0698,0.5588 0,0.4318 -0.12065,0.762 -0.12065,0.32385 -0.38735,0.50165 -0.26035,0.1778 -0.6985,0.1778 z m 0,-0.3683 q 0.254,0 0.4191,-0.1143 0.1651,-0.12065 0.24765,-0.3556 0.0825,-0.2413 0.0825,-0.60325 0,-0.3175 -0.0762,-0.55245 -0.0698,-0.2413 -0.23495,-0.38735 -0.15875,-0.14605 -0.43815,-0.1651 -0.2794,0.01905 -0.45085,0.1651 -0.1651,0.14605 -0.2413,0.38735 -0.0699,0.23495 -0.0699,0.55245 0,0.36195 0.0825,0.60325 0.0889,0.23495 0.254,0.3556 0.17145,0.1143 0.42545,0.1143 z m 0,-2.6035 q 0.2667,-0.0127 0.41275,-0.14605 0.1524,-0.13335 0.2159,-0.3556 0.0635,-0.22225 0.0635,-0.50165 0,-0.4445 -0.1651,-0.6731 -0.1651,-0.23495 -0.52705,-0.23495 -0.3683,0 -0.53975,0.23495 -0.1651,0.2286 -0.1651,0.6731 0,0.2794 0.0635,0.50165 0.0635,0.22225 0.2159,0.3556 0.15875,0.13335 0.42545,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2187" />
+      <path
+         d="m 169.52292,54.802971 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2189" />
+      <path
+         d="m 171.03829,54.802971 1.0033,-4.76885 h -1.55575 v -0.37465 h 2.032 v 0.2286 l -1.0287,4.9149 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2191" />
+      <path
+         d="m 174.43773,54.866471 q -0.4445,0 -0.7112,-0.1778 -0.26035,-0.1778 -0.381,-0.50165 -0.12065,-0.3302 -0.12065,-0.762 0,-0.33655 0.0635,-0.5588 0.0699,-0.2286 0.1778,-0.37465 0.10795,-0.14605 0.2413,-0.23495 0.13335,-0.0889 0.26035,-0.1524 -0.31115,-0.127 -0.50165,-0.4191 -0.1905,-0.29845 -0.1905,-0.7874 0,-0.37465 0.1143,-0.66675 0.1143,-0.2921 0.3683,-0.4572 0.26035,-0.1651 0.67945,-0.1651 0.4191,0 0.66675,0.17145 0.254,0.1651 0.3683,0.4572 0.1143,0.2921 0.1143,0.6731 0,0.48895 -0.1905,0.7747 -0.18415,0.28575 -0.4953,0.4191 0.127,0.0635 0.254,0.1524 0.13335,0.0889 0.2413,0.23495 0.10795,0.14605 0.1778,0.37465 0.0699,0.22225 0.0699,0.5588 0,0.4318 -0.12065,0.762 -0.12065,0.32385 -0.38735,0.50165 -0.26035,0.1778 -0.6985,0.1778 z m 0,-0.3683 q 0.254,0 0.4191,-0.1143 0.1651,-0.12065 0.24765,-0.3556 0.0825,-0.2413 0.0825,-0.60325 0,-0.3175 -0.0762,-0.55245 -0.0699,-0.2413 -0.23495,-0.38735 -0.15875,-0.14605 -0.43815,-0.1651 -0.2794,0.01905 -0.45085,0.1651 -0.1651,0.14605 -0.2413,0.38735 -0.0699,0.23495 -0.0699,0.55245 0,0.36195 0.0826,0.60325 0.0889,0.23495 0.254,0.3556 0.17145,0.1143 0.42545,0.1143 z m 0,-2.6035 q 0.2667,-0.0127 0.41275,-0.14605 0.1524,-0.13335 0.2159,-0.3556 0.0635,-0.22225 0.0635,-0.50165 0,-0.4445 -0.1651,-0.6731 -0.1651,-0.23495 -0.52705,-0.23495 -0.3683,0 -0.53975,0.23495 -0.1651,0.2286 -0.1651,0.6731 0,0.2794 0.0635,0.50165 0.0635,0.22225 0.2159,0.3556 0.15875,0.13335 0.42545,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2193" />
+      <path
+         d="m 176.39382,54.802971 v -0.6985 h 0.48895 v 0.6985 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2195" />
+      <path
+         d="m 177.47739,54.802971 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2197" />
+      <path
+         d="m 181.88032,54.866471 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0698,-0.254 0.0698,-0.56515 v -2.30505 q 0,-0.31115 -0.0698,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0699,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2199" />
+      <path
+         d="m 183.83979,54.802971 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2201" />
+      <path
+         d="m 186.75682,54.802971 1.46685,-5.1435 h 0.4064 l -1.46685,5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2203" />
+      <path
+         d="m 189.09839,54.802971 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2205" />
+      <path
+         d="m 193.6307,54.802971 v -1.50495 h -1.5494 v -0.4699 l 1.4605,-3.16865 h 0.5461 v 3.21945 h 0.59055 v 0.4191 h -0.59055 v 1.50495 z m -1.0795,-1.92405 h 1.0795 v -2.6035 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2207" />
+    </g>
+    <g
+       aria-label="Public network (NAT)"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1668">
+      <path
+         d="m 11.034194,175.60423 v -5.1435 h 1.2319 q 0.46355,0 0.7239,0.17145 0.2667,0.17145 0.381,0.47625 0.1143,0.3048 0.1143,0.71755 0,0.36195 -0.12065,0.6731 -0.1143,0.3048 -0.38735,0.48895 -0.2667,0.18415 -0.70485,0.18415 h -0.75565 v 2.43205 z m 0.4826,-2.794 h 0.61595 q 0.31115,0 0.50165,-0.0889 0.19685,-0.0952 0.28575,-0.31115 0.0889,-0.2159 0.0889,-0.5842 0,-0.3937 -0.0762,-0.6096 -0.0762,-0.22225 -0.2667,-0.3048 -0.18415,-0.0889 -0.52705,-0.0889 h -0.6223 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2210" />
+      <path
+         d="m 14.542073,175.66138 q -0.18415,0 -0.31115,-0.0889 -0.127,-0.0953 -0.19685,-0.2667 -0.0635,-0.1778 -0.0635,-0.42545 v -2.9464 h 0.46355 v 2.8448 q 0,0.28575 0.0889,0.4064 0.0889,0.1143 0.2667,0.1143 0.1651,0 0.3302,-0.1016 0.17145,-0.10795 0.3175,-0.2667 v -2.9972 h 0.46355 v 3.6703 h -0.46355 v -0.4064 q -0.1778,0.2032 -0.4064,0.33655 -0.2286,0.127 -0.48895,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2212" />
+      <path
+         d="m 17.743167,175.66138 q -0.22225,0 -0.38735,-0.1143 -0.158749,-0.1143 -0.266699,-0.23495 v 0.2921 h -0.46355 v -5.1435 h 0.46355 v 1.778 q 0.10795,-0.13335 0.279399,-0.24765 0.17145,-0.1143 0.4191,-0.1143 0.2667,0 0.4318,0.127 0.1651,0.12065 0.254,0.3302 0.0889,0.20955 0.1143,0.4699 0.03175,0.26035 0.03175,0.53975 v 0.76835 q 0,0.4699 -0.0762,0.81915 -0.0762,0.34925 -0.2667,0.53975 -0.1905,0.1905 -0.5334,0.1905 z m -0.08255,-0.36195 q 0.2159,0 0.3175,-0.13335 0.10795,-0.1397 0.1397,-0.40005 0.0381,-0.2667 0.0381,-0.64135 v -0.78105 q 0,-0.36195 -0.0381,-0.60325 -0.0381,-0.24765 -0.1397,-0.37465 -0.1016,-0.127 -0.32385,-0.127 -0.1778,0 -0.32385,0.0952 -0.146049,0.0952 -0.241299,0.1905 v 2.5019 q 0.1016,0.10795 0.247649,0.1905 0.14605,0.0825 0.32385,0.0825 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2214" />
+      <path
+         d="m 19.324416,175.60423 v -5.1435 h 0.46355 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2216" />
+      <path
+         d="m 20.589158,175.60423 v -3.6703 h 0.46355 v 3.6703 z m 0,-4.1783 v -0.62865 h 0.46355 v 0.62865 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2218" />
+      <path
+         d="m 22.736252,175.66138 q -0.42545,0 -0.635,-0.1905 -0.20955,-0.1905 -0.2794,-0.51435 -0.0635,-0.3302 -0.0635,-0.74295 v -0.85725 q 0,-0.508 0.08255,-0.83185 0.08255,-0.3302 0.2921,-0.48895 0.2159,-0.15875 0.60325,-0.15875 0.3937,0 0.5969,0.14605 0.2032,0.14605 0.27305,0.41275 0.06985,0.2667 0.06985,0.6223 v 0.17145 h -0.4318 v -0.1778 q 0,-0.32385 -0.0508,-0.50165 -0.04445,-0.1778 -0.15875,-0.24765 -0.10795,-0.0762 -0.2921,-0.0762 -0.2159,0 -0.3302,0.1016 -0.1143,0.1016 -0.1524,0.33655 -0.0381,0.2286 -0.0381,0.61595 v 1.0287 q 0,0.55245 0.10795,0.78105 0.10795,0.22225 0.4191,0.22225 0.2159,0 0.32385,-0.0952 0.10795,-0.1016 0.1397,-0.29845 0.03175,-0.19685 0.03175,-0.48895 v -0.2032 h 0.4318 v 0.1778 q 0,0.3683 -0.06985,0.65405 -0.06985,0.2794 -0.27305,0.4445 -0.19685,0.15875 -0.5969,0.15875 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2220" />
+      <path
+         d="m 25.586112,175.60423 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.06985,0.17145 0.06985,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2222" />
+      <path
+         d="m 29.098952,175.66138 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.08255,0.3302 0.08255,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.05715,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0571 0.1778,-0.20955 0.06985,-0.15875 0.06985,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.03175,-0.4953 -0.03175,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2224" />
+      <path
+         d="m 31.553426,175.64868 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.05715,0.381 0.0635,0.10795 0.2667,0.10795 0.05715,0 0.127,-0.006 0.06985,-0.0127 0.13335,-0.0191 v 0.34925 q -0.09525,0.019 -0.19685,0.0254 -0.09525,0.0127 -0.1905,0.0127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2226" />
+      <path
+         d="m 32.895161,175.60423 -0.5969,-3.6703 h 0.3937 l 0.46355,3.06705 0.57785,-3.06705 h 0.40005 l 0.5842,3.05435 0.43815,-3.05435 h 0.40005 l -0.5969,3.6703 h -0.4318 l -0.59055,-2.9845 -0.5715,2.9845 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2228" />
+      <path
+         d="m 37.011349,175.66138 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.08255,-0.31115 -0.08255,-0.75565 v -1.016 q 0,-0.4445 0.08255,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.08255,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.03175,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2230" />
+      <path
+         d="m 38.665128,175.60423 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.01905,0 0.0381,0 0.01905,0 0.04445,0.006 v 0.4953 q -0.04445,-0.019 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2232" />
+      <path
+         d="m 40.524884,175.60423 v -5.1435 h 0.46355 v 3.27025 l 1.22555,-1.79705 h 0.48895 l -0.9271,1.41605 0.889,2.25425 h -0.4699 l -0.7747,-1.9939 -0.4318,0.60325 v 1.39065 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2234" />
+      <path
+         d="m 45.563709,176.65198 q -0.31115,-0.0191 -0.51435,-0.1905 -0.2032,-0.17145 -0.3175,-0.46355 -0.10795,-0.28575 -0.1651,-0.66675 -0.0508,-0.38735 -0.0635,-0.8382 -0.0063,-0.4572 -0.0063,-0.9525 0,-0.4953 0.0063,-0.9525 0.0127,-0.46355 0.0635,-0.8509 0.05715,-0.38735 0.1651,-0.67945 0.1143,-0.2921 0.3175,-0.4572 0.2032,-0.1651 0.51435,-0.1778 v 0.3302 q -0.23495,0.0191 -0.36195,0.254 -0.127,0.2286 -0.18415,0.61595 -0.0508,0.38735 -0.0635,0.88265 -0.0064,0.48895 -0.0064,1.03505 0,0.5461 0.0064,1.0414 0.0127,0.4953 0.0635,0.88265 0.05715,0.381 0.18415,0.6096 0.127,0.23495 0.36195,0.254 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2236" />
+      <path
+         d="m 46.207241,175.60423 v -5.1435 h 0.34925 l 1.6383,3.99415 v -3.99415 h 0.4191 v 5.1435 h -0.3429 l -1.651,-4.0386 v 4.0386 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2238" />
+      <path
+         d="m 49.226863,175.60423 1.08585,-5.1435 h 0.508 l 1.0922,5.1435 h -0.47625 l -0.254,-1.37795 h -1.22555 l -0.26035,1.37795 z m 0.8001,-1.7272 h 1.0922 l -0.55245,-2.77495 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2240" />
+      <path
+         d="m 52.857377,175.60423 v -4.76885 h -0.97155 v -0.37465 h 2.39395 v 0.37465 h -0.9398 v 4.76885 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2242" />
+      <path
+         d="m 54.591323,176.65198 v -0.32385 q 0.2413,-0.0254 0.3683,-0.26035 0.127,-0.2286 0.1778,-0.61595 0.05715,-0.38735 0.0635,-0.8763 0.0127,-0.4953 0.0127,-1.0414 0,-0.5461 -0.0127,-1.0414 -0.0064,-0.4953 -0.0635,-0.8763 -0.0508,-0.381 -0.1778,-0.6096 -0.127,-0.23495 -0.3683,-0.26035 v -0.32385 q 0.3175,0.0127 0.5207,0.1778 0.2032,0.15875 0.3175,0.45085 0.1143,0.2921 0.1651,0.67945 0.05715,0.38735 0.0635,0.84455 0.0127,0.4572 0.0127,0.95885 0,0.4953 -0.0127,0.9525 -0.0064,0.45085 -0.0635,0.8382 -0.0508,0.38735 -0.1651,0.6731 -0.1143,0.2921 -0.3175,0.46355 -0.2032,0.17145 -0.5207,0.1905 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2244" />
+    </g>
+    <g
+       aria-label="Node network:
+K8s control plane +
+Pod network underlay"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1676">
+      <path
+         d="m 85.268713,174.84833 v -5.1435 h 0.34925 l 1.6383,3.99415 v -3.99415 h 0.4191 v 5.1435 h -0.3429 l -1.651,-4.0386 v 4.0386 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2247" />
+      <path
+         d="m 89.380537,174.90548 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.08255,-0.31115 -0.08255,-0.75565 v -1.016 q 0,-0.4445 0.08255,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.08255,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.03175,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2249" />
+      <path
+         d="m 91.815365,174.90548 q -0.4699,0 -0.67945,-0.3556 -0.2032,-0.3556 -0.2032,-1.1811 v -0.67945 q 0,-0.4826 0.06985,-0.83185 0.06985,-0.34925 0.254,-0.53975 0.1905,-0.19685 0.53975,-0.19685 0.2159,0 0.37465,0.1016 0.1651,0.0953 0.27305,0.2159 v -1.73355 h 0.46355 v 5.1435 h -0.46355 v -0.26035 q -0.10795,0.12065 -0.2667,0.22225 -0.1524,0.0953 -0.36195,0.0953 z m 0.09525,-0.36195 q 0.14605,0 0.28575,-0.0699 0.1397,-0.0762 0.24765,-0.1778 v -2.5527 q -0.09525,-0.0889 -0.23495,-0.17145 -0.1397,-0.0889 -0.31115,-0.0889 -0.3048,0 -0.4064,0.27305 -0.09525,0.2667 -0.09525,0.7874 v 0.8636 q 0,0.3683 0.0381,0.6223 0.04445,0.254 0.1524,0.38735 0.1143,0.127 0.32385,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2251" />
+      <path
+         d="m 94.54021,174.90548 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.08255,0.3302 0.08255,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.05715,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0571 0.1778,-0.20955 0.06985,-0.15875 0.06985,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.03175,-0.4953 -0.03175,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2253" />
+      <path
+         d="m 97.414576,174.84833 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.06985,0.17145 0.06985,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2255" />
+      <path
+         d="m 100.92742,174.90548 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.101603,-0.3175 -0.101603,-0.84455 v -0.9271 q 0,-0.5461 0.107953,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0571,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0571 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0318,-0.4953 -0.0317,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2257" />
+      <path
+         d="m 103.38189,174.89278 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0571,0.381 0.0635,0.10795 0.2667,0.10795 0.0572,0 0.127,-0.006 0.0699,-0.0127 0.13335,-0.0191 v 0.34925 q -0.0952,0.019 -0.19685,0.0254 -0.0952,0.0127 -0.1905,0.0127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2259" />
+      <path
+         d="m 104.72362,174.84833 -0.5969,-3.6703 h 0.3937 l 0.46355,3.06705 0.57785,-3.06705 h 0.40005 l 0.5842,3.05435 0.43815,-3.05435 h 0.40005 l -0.5969,3.6703 h -0.4318 l -0.59055,-2.9845 -0.5715,2.9845 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2261" />
+      <path
+         d="m 108.83981,174.90548 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.0826,-0.31115 -0.0826,-0.75565 v -1.016 q 0,-0.4445 0.0826,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.0825,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.0318,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2263" />
+      <path
+         d="m 110.49359,174.84833 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.019,0 0.0381,0 0.019,0 0.0444,0.006 v 0.4953 q -0.0444,-0.019 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2265" />
+      <path
+         d="m 112.35335,174.84833 v -5.1435 h 0.46355 v 3.27025 l 1.22555,-1.79705 h 0.48895 l -0.9271,1.41605 0.889,2.25425 h -0.4699 l -0.7747,-1.9939 -0.4318,0.60325 v 1.39065 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2267" />
+      <path
+         d="m 114.97203,172.16228 v -0.67945 h 0.4953 v 0.67945 z m 0,2.159 v -0.67945 h 0.4953 v 0.67945 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2269" />
+      <path
+         d="m 85.262363,182.78583 v -5.1435 h 0.48895 v 2.7178 l 1.3716,-2.7178 h 0.46355 l -1.06045,2.2098 1.28905,2.9337 h -0.47625 l -1.1303,-2.57175 -0.4572,0.8382 v 1.73355 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2271" />
+      <path
+         d="m 89.295109,182.84933 q -0.4445,0 -0.7112,-0.1778 -0.26035,-0.1778 -0.381,-0.50165 -0.12065,-0.3302 -0.12065,-0.762 0,-0.33655 0.0635,-0.5588 0.06985,-0.2286 0.1778,-0.37465 0.10795,-0.14605 0.2413,-0.23495 0.13335,-0.0889 0.26035,-0.1524 -0.31115,-0.127 -0.50165,-0.4191 -0.1905,-0.29845 -0.1905,-0.7874 0,-0.37465 0.1143,-0.66675 0.1143,-0.2921 0.3683,-0.4572 0.26035,-0.1651 0.67945,-0.1651 0.4191,0 0.66675,0.17145 0.254,0.1651 0.3683,0.4572 0.1143,0.2921 0.1143,0.6731 0,0.48895 -0.1905,0.7747 -0.18415,0.28575 -0.4953,0.4191 0.127,0.0635 0.254,0.1524 0.13335,0.0889 0.2413,0.23495 0.10795,0.14605 0.1778,0.37465 0.06985,0.22225 0.06985,0.5588 0,0.4318 -0.12065,0.762 -0.12065,0.32385 -0.38735,0.50165 -0.26035,0.1778 -0.6985,0.1778 z m 0,-0.3683 q 0.254,0 0.4191,-0.1143 0.1651,-0.12065 0.24765,-0.3556 0.08255,-0.2413 0.08255,-0.60325 0,-0.3175 -0.0762,-0.55245 -0.06985,-0.2413 -0.23495,-0.38735 -0.15875,-0.14605 -0.43815,-0.1651 -0.2794,0.0191 -0.45085,0.1651 -0.1651,0.14605 -0.2413,0.38735 -0.06985,0.23495 -0.06985,0.55245 0,0.36195 0.08255,0.60325 0.0889,0.23495 0.254,0.3556 0.17145,0.1143 0.42545,0.1143 z m 0,-2.6035 q 0.2667,-0.0127 0.41275,-0.14605 0.1524,-0.13335 0.2159,-0.3556 0.0635,-0.22225 0.0635,-0.50165 0,-0.4445 -0.1651,-0.6731 -0.1651,-0.23495 -0.52705,-0.23495 -0.3683,0 -0.53975,0.23495 -0.1651,0.2286 -0.1651,0.6731 0,0.2794 0.0635,0.50165 0.0635,0.22225 0.2159,0.3556 0.15875,0.13335 0.42545,0.14605 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2273" />
+      <path
+         d="m 92.064007,182.84298 q -0.43815,0 -0.6985,-0.2794 -0.26035,-0.28575 -0.29845,-0.762 l 0.38735,-0.1143 q 0.0381,0.4191 0.19685,0.61595 0.15875,0.1905 0.4445,0.1905 0.2413,0 0.3683,-0.13335 0.13335,-0.1397 0.13335,-0.38735 0,-0.1778 -0.10795,-0.3556 -0.10795,-0.18415 -0.3429,-0.381 l -0.4953,-0.4318 q -0.24765,-0.20955 -0.37465,-0.4191 -0.127,-0.20955 -0.127,-0.50165 0,-0.2667 0.10795,-0.4445 0.1143,-0.18415 0.3048,-0.2794 0.19685,-0.1016 0.46355,-0.1016 0.4191,0 0.635,0.27305 0.2159,0.2667 0.23495,0.69215 l -0.3302,0.10795 q -0.0127,-0.24765 -0.0762,-0.4064 -0.0635,-0.1651 -0.1778,-0.2413 -0.10795,-0.0762 -0.2667,-0.0762 -0.20955,0 -0.3429,0.12065 -0.127,0.1143 -0.127,0.32385 0,0.1651 0.0635,0.2921 0.0635,0.127 0.23495,0.28575 l 0.5207,0.46355 q 0.1524,0.13335 0.2921,0.28575 0.1397,0.1524 0.2286,0.3429 0.0889,0.18415 0.0889,0.43815 0,0.28575 -0.12065,0.4826 -0.1143,0.1905 -0.32385,0.29845 -0.20955,0.1016 -0.4953,0.1016 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2275" />
+      <path
+         d="m 95.730537,182.84298 q -0.42545,0 -0.635,-0.1905 -0.20955,-0.1905 -0.2794,-0.51435 -0.0635,-0.3302 -0.0635,-0.74295 v -0.85725 q 0,-0.508 0.08255,-0.83185 0.08255,-0.3302 0.2921,-0.48895 0.2159,-0.15875 0.60325,-0.15875 0.393699,0 0.596899,0.14605 0.2032,0.14605 0.27305,0.41275 0.06985,0.2667 0.06985,0.6223 v 0.17145 h -0.4318 v -0.1778 q 0,-0.32385 -0.0508,-0.50165 -0.04445,-0.1778 -0.15875,-0.24765 -0.10795,-0.0762 -0.292099,-0.0762 -0.2159,0 -0.3302,0.1016 -0.1143,0.1016 -0.1524,0.33655 -0.0381,0.2286 -0.0381,0.61595 v 1.0287 q 0,0.55245 0.10795,0.78105 0.10795,0.22225 0.4191,0.22225 0.215899,0 0.323849,-0.0952 0.10795,-0.1016 0.1397,-0.29845 0.03175,-0.19685 0.03175,-0.48895 v -0.2032 h 0.4318 v 0.1778 q 0,0.3683 -0.06985,0.65405 -0.06985,0.2794 -0.27305,0.4445 -0.19685,0.15875 -0.596899,0.15875 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2277" />
+      <path
+         d="m 98.198603,182.84298 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.08255,-0.31115 -0.08255,-0.75565 v -1.016 q 0,-0.4445 0.08255,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.08255,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.03175,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2279" />
+      <path
+         d="m 99.820632,182.78583 v -3.6703 h 0.463548 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.0698,0.17145 0.0698,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2281" />
+      <path
+         d="m 103.28267,182.83028 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0572,0.381 0.0635,0.10795 0.2667,0.10795 0.0571,0 0.127,-0.006 0.0699,-0.0127 0.13335,-0.0191 v 0.34925 q -0.0952,0.019 -0.19685,0.0254 -0.0952,0.0127 -0.1905,0.0127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2283" />
+      <path
+         d="m 104.21801,182.78583 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.019,0 0.0381,0 0.019,0 0.0444,0.006 v 0.4953 q -0.0444,-0.019 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2285" />
+      <path
+         d="m 106.95466,182.84298 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.0825,-0.31115 -0.0825,-0.75565 v -1.016 q 0,-0.4445 0.0825,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.0825,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.0318,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2287" />
+      <path
+         d="m 108.64019,182.78583 v -5.1435 h 0.46355 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2289" />
+      <path
+         d="m 111.14397,183.99233 v -4.8768 h 0.46355 v 0.3048 q 0.1143,-0.13335 0.28575,-0.24765 0.17145,-0.1143 0.4191,-0.1143 0.2667,0 0.42545,0.127 0.1651,0.12065 0.254,0.3302 0.0889,0.20955 0.12065,0.4699 0.0318,0.26035 0.0318,0.53975 v 0.76835 q 0,0.4699 -0.0825,0.81915 -0.0762,0.34925 -0.2667,0.53975 -0.1905,0.1905 -0.5334,0.1905 -0.22225,0 -0.38735,-0.1143 -0.15875,-0.1143 -0.2667,-0.23495 v 1.4986 z m 1.0414,-1.5113 q 0.20955,0 0.3175,-0.13335 0.10795,-0.1397 0.1397,-0.40005 0.0381,-0.2667 0.0381,-0.64135 v -0.78105 q 0,-0.36195 -0.0381,-0.60325 -0.0318,-0.24765 -0.1397,-0.37465 -0.10795,-0.127 -0.32385,-0.127 -0.1778,0 -0.3302,0.0952 -0.14605,0.0952 -0.2413,0.1905 v 2.5019 q 0.1016,0.10795 0.24765,0.1905 0.1524,0.0825 0.3302,0.0825 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2291" />
+      <path
+         d="m 113.86157,182.78583 v -5.1435 h 0.46355 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2293" />
+      <path
+         d="m 115.70416,182.84298 q -0.2159,0 -0.381,-0.10795 -0.1651,-0.1143 -0.26035,-0.29845 -0.0952,-0.18415 -0.0952,-0.41275 0,-0.2794 0.0825,-0.47625 0.0825,-0.19685 0.254,-0.34925 0.1778,-0.15875 0.4572,-0.3048 0.28575,-0.1524 0.69215,-0.33655 v -0.26035 q 0,-0.33655 -0.0445,-0.52705 -0.0381,-0.19685 -0.1397,-0.2794 -0.0953,-0.0825 -0.27305,-0.0825 -0.14605,0 -0.26035,0.0571 -0.1143,0.0572 -0.18415,0.19685 -0.0699,0.13335 -0.0699,0.37465 v 0.127 l -0.4572,-0.006 q 0.006,-0.5588 0.23495,-0.8255 0.23495,-0.27305 0.762,-0.27305 0.48895,0 0.69215,0.29845 0.2032,0.2921 0.2032,0.9144 v 1.78435 q 0,0.0953 0,0.24765 0.006,0.14605 0.0127,0.2794 0.0127,0.13335 0.019,0.2032 h -0.41275 q -0.0191,-0.12065 -0.0444,-0.2667 -0.0191,-0.1524 -0.0254,-0.2413 -0.0762,0.22225 -0.27305,0.3937 -0.1905,0.17145 -0.48895,0.17145 z m 0.1524,-0.3937 q 0.1397,0 0.24765,-0.0635 0.1143,-0.0699 0.2032,-0.17145 0.0952,-0.1016 0.14605,-0.2032 v -1.143 q -0.27305,0.14605 -0.4699,0.26035 -0.1905,0.10795 -0.31115,0.2159 -0.12065,0.10795 -0.1778,0.24765 -0.0571,0.13335 -0.0571,0.3175 0,0.2921 0.12065,0.4191 0.127,0.12065 0.29845,0.12065 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2295" />
+      <path
+         d="m 117.59319,182.78583 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2297" />
+      <path
+         d="m 121.10603,182.84298 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0572,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0571 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0318,-0.4953 -0.0318,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2299" />
+      <path
+         d="m 124.6535,181.32533 v -1.0033 h -0.88265 v -0.34925 h 0.88265 v -0.99695 h 0.3556 v 0.99695 h 0.89535 v 0.34925 h -0.89535 v 1.0033 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2301" />
+      <path
+         d="m 85.268713,190.72333 v -5.1435 h 1.2319 q 0.46355,0 0.7239,0.17145 0.2667,0.17145 0.381,0.47625 0.1143,0.3048 0.1143,0.71755 0,0.36195 -0.12065,0.6731 -0.1143,0.3048 -0.38735,0.48895 -0.2667,0.18415 -0.70485,0.18415 h -0.75565 v 2.43205 z m 0.4826,-2.794 h 0.61595 q 0.31115,0 0.50165,-0.0889 0.19685,-0.0952 0.28575,-0.31115 0.0889,-0.2159 0.0889,-0.5842 0,-0.3937 -0.0762,-0.6096 -0.0762,-0.22225 -0.2667,-0.3048 -0.18415,-0.0889 -0.52705,-0.0889 h -0.6223 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2303" />
+      <path
+         d="m 89.120088,190.78048 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.08255,-0.31115 -0.08255,-0.75565 v -1.016 q 0,-0.4445 0.08255,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.08255,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.03175,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2305" />
+      <path
+         d="m 91.554916,190.78048 q -0.4699,0 -0.67945,-0.3556 -0.2032,-0.3556 -0.2032,-1.1811 v -0.67945 q 0,-0.4826 0.06985,-0.83185 0.06985,-0.34925 0.254,-0.53975 0.1905,-0.19685 0.53975,-0.19685 0.2159,0 0.37465,0.1016 0.1651,0.0953 0.27305,0.2159 v -1.73355 h 0.46355 v 5.1435 h -0.46355 v -0.26035 q -0.10795,0.12065 -0.2667,0.22225 -0.1524,0.0953 -0.36195,0.0953 z m 0.09525,-0.36195 q 0.14605,0 0.28575,-0.0699 0.1397,-0.0762 0.24765,-0.1778 v -2.5527 q -0.09525,-0.0889 -0.23495,-0.17145 -0.1397,-0.0889 -0.31115,-0.0889 -0.3048,0 -0.4064,0.27305 -0.09525,0.2667 -0.09525,0.7874 v 0.8636 q 0,0.3683 0.0381,0.6223 0.04445,0.254 0.1524,0.38735 0.1143,0.127 0.32385,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2307" />
+      <path
+         d="m 94.648854,190.72333 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.06985,0.17145 0.06985,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2309" />
+      <path
+         d="m 98.161694,190.78048 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.08255,0.3302 0.08255,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.05715,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0571 0.1778,-0.20955 0.06985,-0.15875 0.06985,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.03175,-0.4953 -0.03175,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2311" />
+      <path
+         d="m 100.61617,190.76778 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.463553 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0572,0.381 0.0635,0.10795 0.2667,0.10795 0.0571,0 0.127,-0.006 0.0699,-0.0127 0.13335,-0.0191 v 0.34925 q -0.0952,0.019 -0.19685,0.0254 -0.0952,0.0127 -0.1905,0.0127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2313" />
+      <path
+         d="m 101.9579,190.72333 -0.5969,-3.6703 h 0.3937 l 0.46355,3.06705 0.57785,-3.06705 h 0.40005 l 0.5842,3.05435 0.43815,-3.05435 h 0.40005 l -0.5969,3.6703 h -0.4318 l -0.59055,-2.9845 -0.5715,2.9845 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2315" />
+      <path
+         d="m 106.07409,190.78048 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.0825,-0.31115 -0.0825,-0.75565 v -1.016 q 0,-0.4445 0.0825,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.0825,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.0318,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2317" />
+      <path
+         d="m 107.72787,190.72333 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.019,0 0.0381,0 0.019,0 0.0444,0.006 v 0.4953 q -0.0444,-0.019 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2319" />
+      <path
+         d="m 109.58763,190.72333 v -5.1435 h 0.46355 v 3.27025 l 1.22555,-1.79705 h 0.48895 l -0.9271,1.41605 0.889,2.25425 h -0.4699 l -0.7747,-1.9939 -0.4318,0.60325 v 1.39065 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2321" />
+      <path
+         d="m 113.95335,190.78048 q -0.18415,0 -0.31115,-0.0889 -0.127,-0.0952 -0.19685,-0.2667 -0.0635,-0.1778 -0.0635,-0.42545 v -2.9464 h 0.46355 v 2.8448 q 0,0.28575 0.0889,0.4064 0.0889,0.1143 0.2667,0.1143 0.1651,0 0.3302,-0.1016 0.17145,-0.10795 0.3175,-0.2667 v -2.9972 h 0.46355 v 3.6703 h -0.46355 v -0.4064 q -0.1778,0.2032 -0.4064,0.33655 -0.2286,0.127 -0.48895,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2323" />
+      <path
+         d="m 116.03049,190.72333 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2325" />
+      <path
+         d="m 119.43538,190.78048 q -0.4699,0 -0.67945,-0.3556 -0.2032,-0.3556 -0.2032,-1.1811 v -0.67945 q 0,-0.4826 0.0699,-0.83185 0.0699,-0.34925 0.254,-0.53975 0.1905,-0.19685 0.53975,-0.19685 0.2159,0 0.37465,0.1016 0.1651,0.0953 0.27305,0.2159 v -1.73355 h 0.46355 v 5.1435 h -0.46355 v -0.26035 q -0.10795,0.12065 -0.2667,0.22225 -0.1524,0.0953 -0.36195,0.0953 z m 0.0953,-0.36195 q 0.14605,0 0.28575,-0.0699 0.1397,-0.0762 0.24765,-0.1778 v -2.5527 q -0.0953,-0.0889 -0.23495,-0.17145 -0.1397,-0.0889 -0.31115,-0.0889 -0.3048,0 -0.4064,0.27305 -0.0953,0.2667 -0.0953,0.7874 v 0.8636 q 0,0.3683 0.0381,0.6223 0.0445,0.254 0.1524,0.38735 0.1143,0.127 0.32385,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2327" />
+      <path
+         d="m 122.16023,190.78048 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0571,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0571 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0318,-0.4953 -0.0317,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2329" />
+      <path
+         d="m 123.7765,190.72333 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.019,0 0.0381,0 0.019,0 0.0444,0.006 v 0.4953 q -0.0444,-0.019 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2331" />
+      <path
+         d="m 125.69341,190.72333 v -5.1435 h 0.46355 v 5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2333" />
+      <path
+         d="m 127.536,190.78048 q -0.2159,0 -0.381,-0.10795 -0.1651,-0.1143 -0.26035,-0.29845 -0.0952,-0.18415 -0.0952,-0.41275 0,-0.2794 0.0825,-0.47625 0.0825,-0.19685 0.254,-0.34925 0.1778,-0.15875 0.4572,-0.3048 0.28575,-0.1524 0.69215,-0.33655 v -0.26035 q 0,-0.33655 -0.0445,-0.52705 -0.0381,-0.19685 -0.1397,-0.2794 -0.0952,-0.0825 -0.27305,-0.0825 -0.14605,0 -0.26035,0.0571 -0.1143,0.0572 -0.18415,0.19685 -0.0699,0.13335 -0.0699,0.37465 v 0.127 l -0.4572,-0.006 q 0.006,-0.5588 0.23495,-0.8255 0.23495,-0.27305 0.762,-0.27305 0.48895,0 0.69215,0.29845 0.2032,0.2921 0.2032,0.9144 v 1.78435 q 0,0.0953 0,0.24765 0.006,0.14605 0.0127,0.2794 0.0127,0.13335 0.019,0.2032 h -0.41275 q -0.019,-0.12065 -0.0445,-0.2667 -0.019,-0.1524 -0.0254,-0.2413 -0.0762,0.22225 -0.27305,0.3937 -0.1905,0.17145 -0.48895,0.17145 z m 0.1524,-0.3937 q 0.1397,0 0.24765,-0.0635 0.1143,-0.0699 0.2032,-0.17145 0.0952,-0.1016 0.14605,-0.2032 v -1.143 q -0.27305,0.14605 -0.4699,0.26035 -0.1905,0.10795 -0.31115,0.2159 -0.12065,0.10795 -0.1778,0.24765 -0.0571,0.13335 -0.0571,0.3175 0,0.2921 0.12065,0.4191 0.127,0.12065 0.29845,0.12065 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2335" />
+      <path
+         d="m 129.32343,191.63773 v -0.36195 q 0.3175,0 0.47625,-0.0508 0.1651,-0.0444 0.2159,-0.13335 0.0572,-0.0825 0.0572,-0.19685 0,-0.1016 -0.0381,-0.2667 -0.0381,-0.1651 -0.0825,-0.3429 l -0.75565,-3.23215 h 0.4572 l 0.64135,3.1242 0.61595,-3.1242 h 0.46355 l -0.88265,3.93065 q -0.0508,0.23495 -0.18415,0.37465 -0.127,0.14605 -0.3429,0.20955 -0.20955,0.0699 -0.5207,0.0699 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2337" />
+    </g>
+    <g
+       aria-label="Secondary network"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1680">
+      <path
+         d="m 198.84664,176.04571 q -0.4191,0 -0.6985,-0.17145 -0.27305,-0.1778 -0.41275,-0.48895 -0.1397,-0.3175 -0.17145,-0.7366 l 0.42545,-0.127 q 0.0318,0.3175 0.1143,0.57785 0.0825,0.254 0.26035,0.4064 0.1778,0.14605 0.48895,0.14605 0.3429,0 0.5334,-0.1778 0.1905,-0.1778 0.1905,-0.56515 0,-0.33655 -0.17145,-0.5842 -0.1651,-0.254 -0.4572,-0.52705 l -0.90805,-0.86995 q -0.2413,-0.23495 -0.3556,-0.4826 -0.1143,-0.254 -0.1143,-0.55245 0,-0.5334 0.3175,-0.81915 0.3175,-0.28575 0.84455,-0.28575 0.27305,0 0.48895,0.0699 0.22225,0.0698 0.37465,0.2286 0.15875,0.1524 0.24765,0.40005 0.0889,0.24765 0.12065,0.60325 l -0.41275,0.10795 q -0.0254,-0.32385 -0.10795,-0.55245 -0.0762,-0.23495 -0.24765,-0.3556 -0.1651,-0.12065 -0.46355,-0.12065 -0.3175,0 -0.5207,0.1651 -0.2032,0.1651 -0.2032,0.51435 0,0.20955 0.0762,0.381 0.0825,0.17145 0.28575,0.3683 l 0.90805,0.85725 q 0.3048,0.28575 0.52705,0.635 0.22225,0.34925 0.22225,0.7874 0,0.38735 -0.1524,0.6477 -0.14605,0.26035 -0.41275,0.3937 -0.2667,0.127 -0.61595,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2340" />
+      <path
+         d="m 201.50689,176.03936 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0572,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0572 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0318,-0.4953 -0.0317,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0826 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2342" />
+      <path
+         d="m 203.99947,176.03936 q -0.42545,0 -0.635,-0.1905 -0.20955,-0.1905 -0.2794,-0.51435 -0.0635,-0.3302 -0.0635,-0.74295 v -0.85725 q 0,-0.508 0.0825,-0.83185 0.0825,-0.3302 0.2921,-0.48895 0.2159,-0.15875 0.60325,-0.15875 0.3937,0 0.5969,0.14605 0.2032,0.14605 0.27305,0.41275 0.0699,0.2667 0.0699,0.6223 v 0.17145 h -0.4318 v -0.1778 q 0,-0.32385 -0.0508,-0.50165 -0.0445,-0.1778 -0.15875,-0.24765 -0.10795,-0.0762 -0.2921,-0.0762 -0.2159,0 -0.3302,0.1016 -0.1143,0.1016 -0.1524,0.33655 -0.0381,0.2286 -0.0381,0.61595 v 1.0287 q 0,0.55245 0.10795,0.78105 0.10795,0.22225 0.4191,0.22225 0.2159,0 0.32385,-0.0952 0.10795,-0.1016 0.1397,-0.29845 0.0318,-0.19685 0.0318,-0.48895 v -0.2032 h 0.4318 v 0.1778 q 0,0.3683 -0.0699,0.65405 -0.0699,0.2794 -0.27305,0.4445 -0.19685,0.15875 -0.5969,0.15875 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2344" />
+      <path
+         d="m 206.46753,176.03936 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.0825,-0.31115 -0.0825,-0.75565 v -1.016 q 0,-0.4445 0.0825,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.0825,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.0318,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2346" />
+      <path
+         d="m 208.08956,175.98221 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2348" />
+      <path
+         d="m 211.49445,176.03936 q -0.4699,0 -0.67945,-0.3556 -0.2032,-0.3556 -0.2032,-1.1811 v -0.67945 q 0,-0.4826 0.0699,-0.83185 0.0699,-0.34925 0.254,-0.53975 0.1905,-0.19685 0.53975,-0.19685 0.2159,0 0.37465,0.1016 0.1651,0.0952 0.27305,0.2159 v -1.73355 h 0.46355 v 5.1435 h -0.46355 v -0.26035 q -0.10795,0.12065 -0.2667,0.22225 -0.1524,0.0952 -0.36195,0.0952 z m 0.0952,-0.36195 q 0.14605,0 0.28575,-0.0699 0.1397,-0.0762 0.24765,-0.1778 v -2.5527 q -0.0952,-0.0889 -0.23495,-0.17145 -0.1397,-0.0889 -0.31115,-0.0889 -0.3048,0 -0.4064,0.27305 -0.0953,0.2667 -0.0953,0.7874 v 0.8636 q 0,0.3683 0.0381,0.6223 0.0445,0.254 0.1524,0.38735 0.1143,0.127 0.32385,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2350" />
+      <path
+         d="m 213.92719,176.03936 q -0.2159,0 -0.381,-0.10795 -0.1651,-0.1143 -0.26035,-0.29845 -0.0953,-0.18415 -0.0953,-0.41275 0,-0.2794 0.0826,-0.47625 0.0825,-0.19685 0.254,-0.34925 0.1778,-0.15875 0.4572,-0.3048 0.28575,-0.1524 0.69215,-0.33655 v -0.26035 q 0,-0.33655 -0.0445,-0.52705 -0.0381,-0.19685 -0.1397,-0.2794 -0.0953,-0.0825 -0.27305,-0.0825 -0.14605,0 -0.26035,0.0572 -0.1143,0.0572 -0.18415,0.19685 -0.0699,0.13335 -0.0699,0.37465 v 0.127 l -0.4572,-0.006 q 0.006,-0.5588 0.23495,-0.8255 0.23495,-0.27305 0.762,-0.27305 0.48895,0 0.69215,0.29845 0.2032,0.2921 0.2032,0.9144 v 1.78435 q 0,0.0952 0,0.24765 0.006,0.14605 0.0127,0.2794 0.0127,0.13335 0.019,0.2032 h -0.41275 q -0.019,-0.12065 -0.0445,-0.2667 -0.019,-0.1524 -0.0254,-0.2413 -0.0762,0.22225 -0.27305,0.3937 -0.1905,0.17145 -0.48895,0.17145 z m 0.1524,-0.3937 q 0.1397,0 0.24765,-0.0635 0.1143,-0.0698 0.2032,-0.17145 0.0952,-0.1016 0.14605,-0.2032 v -1.143 q -0.27305,0.14605 -0.4699,0.26035 -0.1905,0.10795 -0.31115,0.2159 -0.12065,0.10795 -0.1778,0.24765 -0.0571,0.13335 -0.0571,0.3175 0,0.2921 0.12065,0.4191 0.127,0.12065 0.29845,0.12065 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2352" />
+      <path
+         d="m 215.84797,175.98221 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.019,0 0.0381,0 0.019,0 0.0444,0.006 v 0.4953 q -0.0444,-0.0191 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2354" />
+      <path
+         d="m 217.59978,176.89661 v -0.36195 q 0.3175,0 0.47625,-0.0508 0.1651,-0.0444 0.2159,-0.13335 0.0571,-0.0826 0.0571,-0.19685 0,-0.1016 -0.0381,-0.2667 -0.0381,-0.1651 -0.0825,-0.3429 l -0.75565,-3.23215 h 0.4572 l 0.64135,3.1242 0.61595,-3.1242 h 0.46355 l -0.88265,3.93065 q -0.0508,0.23495 -0.18415,0.37465 -0.127,0.14605 -0.3429,0.20955 -0.20955,0.0699 -0.5207,0.0699 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2356" />
+      <path
+         d="m 221.40968,175.98221 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2358" />
+      <path
+         d="m 224.92252,176.03936 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0572,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0572 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0318,-0.4953 -0.0317,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0826 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2360" />
+      <path
+         d="m 227.37699,176.02666 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0572,0.381 0.0635,0.10795 0.2667,0.10795 0.0572,0 0.127,-0.006 0.0699,-0.0127 0.13335,-0.019 v 0.34925 q -0.0952,0.019 -0.19685,0.0254 -0.0952,0.0127 -0.1905,0.0127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2362" />
+      <path
+         d="m 228.71872,175.98221 -0.5969,-3.6703 h 0.3937 l 0.46355,3.06705 0.57785,-3.06705 h 0.40005 l 0.5842,3.05435 0.43815,-3.05435 h 0.40005 l -0.5969,3.6703 h -0.4318 l -0.59055,-2.9845 -0.5715,2.9845 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2364" />
+      <path
+         d="m 232.83492,176.03936 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.0825,-0.31115 -0.0825,-0.75565 v -1.016 q 0,-0.4445 0.0825,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.0825,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.0318,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2366" />
+      <path
+         d="m 234.48869,175.98221 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.019,0 0.0381,0 0.019,0 0.0445,0.006 v 0.4953 q -0.0445,-0.0191 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2368" />
+      <path
+         d="m 236.34845,175.98221 v -5.1435 h 0.46355 v 3.27025 l 1.22555,-1.79705 h 0.48895 l -0.9271,1.41605 0.889,2.25425 h -0.4699 l -0.7747,-1.9939 -0.4318,0.60325 v 1.39065 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2370" />
+    </g>
+  </g>
+</svg>

--- a/docs/cookbooks/multus/assets/testbed-multus-macvlan.svg
+++ b/docs/cookbooks/multus/assets/testbed-multus-macvlan.svg
@@ -48,7 +48,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -247,7 +247,7 @@
        y="83.000008" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.79374999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 79.375007,72.416679 V 83.000008"
+       d="M 79.375005,72.416679 V 83.000008"
        id="path1005"
        inkscape:connector-type="polyline"
        inkscape:connector-curvature="0"
@@ -569,1363 +569,1771 @@
          x="197.30359"
          y="175.98221"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">Secondary network</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="83.154762"
+       y="100.76487"
+       id="text1240"><tspan
+         sodipodi:role="line"
+         id="tspan1238"
+         x="83.154762"
+         y="100.76487"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">OVS bridge (br-int)</tspan></text>
   </g>
   <g
      inkscape:groupmode="layer"
      id="layer6"
-     inkscape:label="TextPath">
+     inkscape:label="TextPath"
+     style="display:inline"
+     sodipodi:insensitive="true">
     <g
        aria-label="K8s Node"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1574">
+       id="text1244">
       <path
          d="m 16.467676,24.791676 v -6.858 h 0.651933 v 3.623733 l 1.8288,-3.623733 h 0.618067 l -1.413933,2.9464 1.718733,3.9116 h -0.635 l -1.507067,-3.429 -0.6096,1.1176 v 2.3114 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:8.46666622px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1737" />
+         id="path1413"
+         inkscape:connector-curvature="0" />
       <path
-         d="m 21.844671,24.876342 q -0.592667,0 -0.948267,-0.237066 -0.347133,-0.237067 -0.508,-0.668867 -0.160866,-0.440267 -0.160866,-1.016 0,-0.448733 0.08467,-0.745067 0.09313,-0.3048 0.237067,-0.499533 0.143933,-0.194733 0.321733,-0.313267 0.1778,-0.118533 0.347133,-0.2032 -0.414866,-0.169333 -0.668866,-0.5588 -0.254,-0.397933 -0.254,-1.049866 0,-0.499533 0.1524,-0.889 0.1524,-0.389467 0.491066,-0.6096 0.347134,-0.220133 0.905934,-0.220133 0.5588,0 0.889,0.2286 0.338666,0.220133 0.491066,0.6096 0.1524,0.389466 0.1524,0.897466 0,0.651933 -0.254,1.032933 -0.245533,0.381 -0.6604,0.5588 0.169334,0.08467 0.338667,0.2032 0.1778,0.118534 0.321733,0.313267 0.143934,0.194733 0.237067,0.499533 0.09313,0.296334 0.09313,0.745067 0,0.575733 -0.160866,1.016 -0.160867,0.4318 -0.516467,0.668867 -0.347133,0.237066 -0.931333,0.237066 z m 0,-0.491066 q 0.338666,0 0.5588,-0.1524 0.220133,-0.160867 0.3302,-0.474134 0.110066,-0.321733 0.110066,-0.804333 0,-0.423333 -0.1016,-0.7366 -0.09313,-0.321733 -0.313266,-0.516467 -0.211667,-0.194733 -0.5842,-0.220133 -0.372534,0.0254 -0.601134,0.220133 -0.220133,0.194734 -0.321733,0.516467 -0.09313,0.313267 -0.09313,0.7366 0,0.4826 0.110066,0.804333 0.118534,0.313267 0.338667,0.474134 0.2286,0.1524 0.567267,0.1524 z m 0,-3.471334 q 0.3556,-0.01693 0.550333,-0.194733 0.2032,-0.1778 0.287867,-0.474133 0.08467,-0.296334 0.08467,-0.668867 0,-0.592666 -0.220133,-0.897466 -0.220133,-0.313267 -0.702733,-0.313267 -0.491067,0 -0.719667,0.313267 -0.220133,0.3048 -0.220133,0.897466 0,0.372533 0.08467,0.668867 0.08467,0.296333 0.287867,0.474133 0.211667,0.1778 0.567267,0.194733 z"
+         d="m 21.844671,24.876342 q -0.592667,0 -0.948267,-0.237066 -0.347133,-0.237067 -0.508,-0.668867 -0.160866,-0.440267 -0.160866,-1.016 0,-0.448733 0.08467,-0.745067 0.09313,-0.3048 0.237067,-0.499533 0.143933,-0.194733 0.321733,-0.313267 0.1778,-0.118533 0.347133,-0.2032 -0.414866,-0.169333 -0.668866,-0.5588 -0.254,-0.397933 -0.254,-1.049866 0,-0.499533 0.1524,-0.889 0.1524,-0.389467 0.491066,-0.6096 0.347134,-0.220133 0.905934,-0.220133 0.5588,0 0.889,0.2286 0.338666,0.220133 0.491066,0.6096 0.1524,0.389466 0.1524,0.897466 0,0.651933 -0.254,1.032933 -0.245533,0.381 -0.6604,0.5588 0.169334,0.08467 0.338667,0.2032 0.1778,0.118534 0.321733,0.313267 0.143934,0.194733 0.237067,0.499533 0.09313,0.296334 0.09313,0.745067 0,0.575733 -0.160866,1.016 -0.160867,0.4318 -0.516467,0.668867 -0.347133,0.237066 -0.931334,0.237066 z m 0,-0.491066 q 0.338666,0 0.5588,-0.1524 0.220133,-0.160867 0.3302,-0.474134 0.110066,-0.321733 0.110066,-0.804333 0,-0.423333 -0.1016,-0.7366 -0.09313,-0.321733 -0.313266,-0.516467 -0.211667,-0.194733 -0.5842,-0.220133 -0.372534,0.0254 -0.601134,0.220133 -0.220133,0.194734 -0.321733,0.516467 -0.09313,0.313267 -0.09313,0.7366 0,0.4826 0.110066,0.804333 0.118534,0.313267 0.338667,0.474134 0.2286,0.1524 0.567267,0.1524 z m 0,-3.471334 q 0.3556,-0.01693 0.550333,-0.194733 0.2032,-0.1778 0.287867,-0.474133 0.08467,-0.296334 0.08467,-0.668867 0,-0.592666 -0.220133,-0.897466 -0.220133,-0.313267 -0.702733,-0.313267 -0.491067,0 -0.719667,0.313267 -0.220133,0.3048 -0.220133,0.897466 0,0.372533 0.08467,0.668867 0.08467,0.296333 0.287867,0.474133 0.211667,0.1778 0.567267,0.194733 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:8.46666622px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1739" />
+         id="path1415"
+         inkscape:connector-curvature="0" />
       <path
          d="m 25.536535,24.867876 q -0.5842,0 -0.931334,-0.372534 -0.347133,-0.381 -0.397933,-1.016 l 0.516467,-0.1524 q 0.0508,0.5588 0.262466,0.821267 0.211667,0.254 0.592667,0.254 0.321733,0 0.491067,-0.1778 0.1778,-0.186267 0.1778,-0.516467 0,-0.237066 -0.143934,-0.474133 -0.143933,-0.245533 -0.4572,-0.508 l -0.6604,-0.575733 q -0.3302,-0.2794 -0.499533,-0.5588 -0.169333,-0.2794 -0.169333,-0.668867 0,-0.3556 0.143933,-0.592667 0.1524,-0.245533 0.4064,-0.372533 0.262467,-0.135467 0.618067,-0.135467 0.5588,0 0.846666,0.364067 0.287867,0.3556 0.313267,0.922867 l -0.440267,0.143933 q -0.01693,-0.3302 -0.1016,-0.541867 -0.08467,-0.220133 -0.237066,-0.321733 -0.143934,-0.1016 -0.3556,-0.1016 -0.2794,0 -0.4572,0.160867 -0.169334,0.1524 -0.169334,0.4318 0,0.220133 0.08467,0.389466 0.08467,0.169334 0.313267,0.381 l 0.694266,0.618067 q 0.2032,0.1778 0.389467,0.381 0.186267,0.2032 0.3048,0.4572 0.118533,0.245533 0.118533,0.5842 0,0.381 -0.160866,0.643467 -0.1524,0.254 -0.4318,0.397933 -0.2794,0.135467 -0.6604,0.135467 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:8.46666622px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1741" />
+         id="path1417"
+         inkscape:connector-curvature="0" />
       <path
          d="m 29.341507,24.791676 v -6.858 h 0.465667 l 2.184399,5.325533 v -5.325533 h 0.5588 v 6.858 h -0.4572 l -2.201333,-5.3848 v 5.3848 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:8.46666622px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1743" />
+         id="path1419"
+         inkscape:connector-curvature="0" />
       <path
          d="m 34.823939,24.867876 q -0.499533,0 -0.7874,-0.211667 -0.287867,-0.220133 -0.4064,-0.626533 -0.110067,-0.414867 -0.110067,-1.007534 v -1.354666 q 0,-0.592667 0.110067,-0.999067 0.118533,-0.414867 0.4064,-0.626533 0.287867,-0.220134 0.7874,-0.220134 0.508,0 0.7874,0.220134 0.287867,0.211666 0.397933,0.626533 0.118534,0.4064 0.118534,0.999067 v 1.354666 q 0,0.592667 -0.118534,1.007534 -0.110066,0.4064 -0.397933,0.626533 -0.2794,0.211667 -0.7874,0.211667 z m 0,-0.465667 q 0.321733,0 0.465667,-0.169333 0.1524,-0.169334 0.186266,-0.474134 0.03387,-0.3048 0.03387,-0.702733 v -1.4224 q 0,-0.397933 -0.03387,-0.694267 -0.03387,-0.3048 -0.186266,-0.474133 -0.143934,-0.1778 -0.465667,-0.1778 -0.321733,0 -0.465667,0.1778 -0.143933,0.169333 -0.186266,0.474133 -0.03387,0.296334 -0.03387,0.694267 v 1.4224 q 0,0.397933 0.03387,0.702733 0.04233,0.3048 0.186266,0.474134 0.143934,0.169333 0.465667,0.169333 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:8.46666622px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1745" />
+         id="path1421"
+         inkscape:connector-curvature="0" />
       <path
          d="m 38.070375,24.867876 q -0.626533,0 -0.905933,-0.474134 -0.270934,-0.474133 -0.270934,-1.5748 v -0.905933 q 0,-0.643467 0.09313,-1.109133 0.09313,-0.465667 0.338666,-0.719667 0.254,-0.262467 0.719667,-0.262467 0.287867,0 0.499533,0.135467 0.220134,0.127 0.364067,0.287867 v -2.3114 h 0.618067 v 6.858 h -0.618067 v -0.347134 q -0.143933,0.160867 -0.3556,0.296334 -0.2032,0.127 -0.4826,0.127 z m 0.127,-0.4826 q 0.194733,0 0.381,-0.09313 0.186267,-0.1016 0.3302,-0.237066 v -3.4036 q -0.127,-0.118534 -0.313267,-0.2286 -0.186266,-0.118534 -0.414866,-0.118534 -0.4064,0 -0.541867,0.364067 -0.127,0.3556 -0.127,1.049867 v 1.151466 q 0,0.491067 0.0508,0.829734 0.05927,0.338666 0.2032,0.516466 0.1524,0.169334 0.4318,0.169334 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:8.46666622px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1747" />
+         id="path1423"
+         inkscape:connector-curvature="0" />
       <path
          d="m 41.703501,24.867876 q -0.4572,0 -0.753533,-0.1778 -0.287867,-0.186267 -0.4318,-0.6096 -0.135467,-0.423334 -0.135467,-1.126067 v -1.236133 q 0,-0.728134 0.143934,-1.134534 0.143933,-0.414866 0.440266,-0.5842 0.296334,-0.1778 0.7366,-0.1778 0.524934,0 0.795867,0.220134 0.270933,0.220133 0.372533,0.668866 0.110067,0.440267 0.110067,1.134534 v 0.440266 h -1.9812 v 0.855134 q 0,0.474133 0.06773,0.753533 0.0762,0.270933 0.2286,0.389467 0.160867,0.118533 0.4064,0.118533 0.186267,0 0.338667,-0.06773 0.1524,-0.0762 0.237067,-0.2794 0.09313,-0.211667 0.09313,-0.592667 v -0.338667 h 0.601133 v 0.270934 q 0,0.668866 -0.2794,1.075266 -0.2794,0.397934 -0.9906,0.397934 z m -0.702733,-2.937934 h 1.3716 v -0.4064 q 0,-0.389466 -0.04233,-0.6604 -0.04233,-0.2794 -0.186267,-0.423333 -0.135467,-0.1524 -0.440267,-0.1524 -0.254,0 -0.414866,0.110067 -0.1524,0.110066 -0.220134,0.397933 -0.06773,0.2794 -0.06773,0.804333 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:8.46666622px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1749" />
+         id="path1425"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="enp0s3"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1578">
+       id="text1248">
       <path
          d="m 23.954929,140.88758 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.08255,0.3302 0.08255,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.05715,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0571 0.1778,-0.20955 0.06985,-0.15875 0.06985,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.03175,-0.4953 -0.03175,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0826 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1752" />
+         id="path1428"
+         inkscape:connector-curvature="0" />
       <path
          d="m 25.539453,140.83043 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.06985,0.17145 0.06985,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1754" />
+         id="path1430"
+         inkscape:connector-curvature="0" />
       <path
          d="m 28.131543,142.03693 v -4.8768 h 0.46355 v 0.3048 q 0.1143,-0.13335 0.28575,-0.24765 0.17145,-0.1143 0.4191,-0.1143 0.2667,0 0.42545,0.127 0.1651,0.12065 0.254,0.3302 0.0889,0.20955 0.12065,0.4699 0.03175,0.26035 0.03175,0.53975 v 0.76835 q 0,0.4699 -0.08255,0.81915 -0.0762,0.34925 -0.2667,0.53975 -0.1905,0.1905 -0.5334,0.1905 -0.22225,0 -0.38735,-0.1143 -0.15875,-0.1143 -0.2667,-0.23495 v 1.4986 z m 1.0414,-1.5113 q 0.20955,0 0.3175,-0.13335 0.10795,-0.1397 0.1397,-0.40005 0.0381,-0.2667 0.0381,-0.64135 v -0.78105 q 0,-0.36195 -0.0381,-0.60325 -0.03175,-0.24765 -0.1397,-0.37465 -0.10795,-0.127 -0.32385,-0.127 -0.1778,0 -0.3302,0.0952 -0.14605,0.0952 -0.2413,0.1905 v 2.5019 q 0.1016,0.10795 0.24765,0.1905 0.1524,0.0825 0.3302,0.0825 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1756" />
+         id="path1432"
+         inkscape:connector-curvature="0" />
       <path
          d="m 32.068344,140.89393 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.06985,-0.254 0.06985,-0.56515 v -2.30505 q 0,-0.31115 -0.06985,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.06985,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1758" />
+         id="path1434"
+         inkscape:connector-curvature="0" />
       <path
          d="m 34.910465,140.88758 q -0.43815,0 -0.6985,-0.2794 -0.26035,-0.28575 -0.29845,-0.762 l 0.38735,-0.1143 q 0.0381,0.4191 0.19685,0.61595 0.15875,0.1905 0.4445,0.1905 0.2413,0 0.3683,-0.13335 0.13335,-0.1397 0.13335,-0.38735 0,-0.1778 -0.10795,-0.3556 -0.10795,-0.18415 -0.3429,-0.381 l -0.4953,-0.4318 q -0.24765,-0.20955 -0.37465,-0.4191 -0.127,-0.20955 -0.127,-0.50165 0,-0.2667 0.10795,-0.4445 0.1143,-0.18415 0.3048,-0.2794 0.19685,-0.1016 0.46355,-0.1016 0.4191,0 0.635,0.27305 0.2159,0.2667 0.23495,0.69215 l -0.3302,0.10795 q -0.0127,-0.24765 -0.0762,-0.4064 -0.0635,-0.1651 -0.1778,-0.2413 -0.10795,-0.0762 -0.2667,-0.0762 -0.20955,0 -0.3429,0.12065 -0.127,0.1143 -0.127,0.32385 0,0.1651 0.0635,0.2921 0.0635,0.127 0.23495,0.28575 l 0.5207,0.46355 q 0.1524,0.13335 0.2921,0.28575 0.1397,0.1524 0.2286,0.3429 0.0889,0.18415 0.0889,0.43815 0,0.28575 -0.12065,0.4826 -0.1143,0.1905 -0.32385,0.29845 -0.20955,0.1016 -0.4953,0.1016 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1760" />
+         id="path1436"
+         inkscape:connector-curvature="0" />
       <path
          d="m 37.534801,140.89393 q -0.40005,0 -0.65405,-0.1524 -0.254,-0.1524 -0.37465,-0.4318 -0.1143,-0.28575 -0.1143,-0.66675 v -0.127 h 0.4445 q 0,0.019 0,0.0571 0,0.0318 0,0.0508 0.0063,0.27305 0.06985,0.47625 0.06985,0.19685 0.22225,0.3048 0.1524,0.10795 0.4064,0.10795 0.2413,0 0.4064,-0.1016 0.17145,-0.10795 0.254,-0.34925 0.0889,-0.2413 0.0889,-0.62865 0,-0.47625 -0.17145,-0.7747 -0.17145,-0.3048 -0.5969,-0.3175 -0.0127,0 -0.0635,0 -0.0508,0 -0.0635,0 v -0.4445 q 0.0127,0 0.0635,0 0.0508,0 0.0635,0 0.41275,0 0.59055,-0.2286 0.1778,-0.23495 0.1778,-0.7493 0,-0.40005 -0.1524,-0.65405 -0.14605,-0.254 -0.5461,-0.254 -0.38735,0 -0.56515,0.22225 -0.17145,0.2159 -0.18415,0.6731 0,0.0127 0,0.0445 0,0.0254 0,0.0445 h -0.4445 v -0.12065 q 0,-0.381 0.1143,-0.65405 0.12065,-0.2794 0.38735,-0.4318 0.2667,-0.1524 0.6858,-0.1524 0.4064,0 0.66675,0.1651 0.26035,0.1651 0.381,0.4572 0.127,0.28575 0.127,0.6604 0,0.53975 -0.2032,0.8382 -0.2032,0.2921 -0.52705,0.3683 0.1905,0.0508 0.3556,0.2032 0.1651,0.1524 0.2667,0.42545 0.10795,0.2667 0.10795,0.6731 0,0.4318 -0.12065,0.76835 -0.12065,0.3302 -0.3937,0.51435 -0.2667,0.18415 -0.70485,0.18415 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1762" />
+         id="path1438"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="enp0s8"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1582">
+       id="text1252">
       <path
          d="m 95.014448,140.5096 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.08255,0.3302 0.08255,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.05715,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0572 0.1778,-0.20955 0.06985,-0.15875 0.06985,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.03175,-0.4953 -0.03175,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1765" />
+         id="path1441"
+         inkscape:connector-curvature="0" />
       <path
          d="m 96.598971,140.45245 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.06985,0.17145 0.06985,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1767" />
+         id="path1443"
+         inkscape:connector-curvature="0" />
       <path
          d="m 99.191062,141.65895 v -4.8768 h 0.46355 v 0.3048 q 0.1143,-0.13335 0.28575,-0.24765 0.171448,-0.1143 0.419098,-0.1143 0.2667,0 0.42545,0.127 0.1651,0.12065 0.254,0.3302 0.0889,0.20955 0.12065,0.4699 0.0318,0.26035 0.0318,0.53975 v 0.76835 q 0,0.4699 -0.0825,0.81915 -0.0762,0.34925 -0.2667,0.53975 -0.1905,0.1905 -0.5334,0.1905 -0.22225,0 -0.387348,-0.1143 -0.15875,-0.1143 -0.2667,-0.23495 v 1.4986 z m 1.041398,-1.5113 q 0.20955,0 0.3175,-0.13335 0.10795,-0.1397 0.1397,-0.40005 0.0381,-0.2667 0.0381,-0.64135 v -0.78105 q 0,-0.36195 -0.0381,-0.60325 -0.0318,-0.24765 -0.1397,-0.37465 -0.10795,-0.127 -0.32385,-0.127 -0.1778,0 -0.330198,0.0952 -0.14605,0.0952 -0.2413,0.1905 v 2.5019 q 0.1016,0.10795 0.24765,0.1905 0.152398,0.0825 0.330198,0.0825 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1769" />
+         id="path1445"
+         inkscape:connector-curvature="0" />
       <path
          d="m 103.12786,140.51595 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0699,-0.254 0.0699,-0.56515 v -2.30505 q 0,-0.31115 -0.0699,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0699,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1771" />
+         id="path1447"
+         inkscape:connector-curvature="0" />
       <path
          d="m 105.96998,140.5096 q -0.43815,0 -0.6985,-0.2794 -0.26035,-0.28575 -0.29845,-0.762 l 0.38735,-0.1143 q 0.0381,0.4191 0.19685,0.61595 0.15875,0.1905 0.4445,0.1905 0.2413,0 0.3683,-0.13335 0.13335,-0.1397 0.13335,-0.38735 0,-0.1778 -0.10795,-0.3556 -0.10795,-0.18415 -0.3429,-0.381 l -0.4953,-0.4318 q -0.24765,-0.20955 -0.37465,-0.4191 -0.127,-0.20955 -0.127,-0.50165 0,-0.2667 0.10795,-0.4445 0.1143,-0.18415 0.3048,-0.2794 0.19685,-0.1016 0.46355,-0.1016 0.4191,0 0.635,0.27305 0.2159,0.2667 0.23495,0.69215 l -0.3302,0.10795 q -0.0127,-0.24765 -0.0762,-0.4064 -0.0635,-0.1651 -0.1778,-0.2413 -0.10795,-0.0762 -0.2667,-0.0762 -0.20955,0 -0.3429,0.12065 -0.127,0.1143 -0.127,0.32385 0,0.1651 0.0635,0.2921 0.0635,0.127 0.23495,0.28575 l 0.5207,0.46355 q 0.1524,0.13335 0.2921,0.28575 0.1397,0.1524 0.2286,0.3429 0.0889,0.18415 0.0889,0.43815 0,0.28575 -0.12065,0.4826 -0.1143,0.1905 -0.32385,0.29845 -0.20955,0.1016 -0.4953,0.1016 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1773" />
+         id="path1449"
+         inkscape:connector-curvature="0" />
       <path
          d="m 108.67052,140.51595 q -0.4445,0 -0.7112,-0.1778 -0.26035,-0.1778 -0.381,-0.50165 -0.12065,-0.3302 -0.12065,-0.762 0,-0.33655 0.0635,-0.5588 0.0699,-0.2286 0.1778,-0.37465 0.10795,-0.14605 0.2413,-0.23495 0.13335,-0.0889 0.26035,-0.1524 -0.31115,-0.127 -0.50165,-0.4191 -0.1905,-0.29845 -0.1905,-0.7874 0,-0.37465 0.1143,-0.66675 0.1143,-0.2921 0.3683,-0.4572 0.26035,-0.1651 0.67945,-0.1651 0.4191,0 0.66675,0.17145 0.254,0.1651 0.3683,0.4572 0.1143,0.2921 0.1143,0.6731 0,0.48895 -0.1905,0.7747 -0.18415,0.28575 -0.4953,0.4191 0.127,0.0635 0.254,0.1524 0.13335,0.0889 0.2413,0.23495 0.10795,0.14605 0.1778,0.37465 0.0699,0.22225 0.0699,0.5588 0,0.4318 -0.12065,0.762 -0.12065,0.32385 -0.38735,0.50165 -0.26035,0.1778 -0.6985,0.1778 z m 0,-0.3683 q 0.254,0 0.4191,-0.1143 0.1651,-0.12065 0.24765,-0.3556 0.0825,-0.2413 0.0825,-0.60325 0,-0.3175 -0.0762,-0.55245 -0.0699,-0.2413 -0.23495,-0.38735 -0.15875,-0.14605 -0.43815,-0.1651 -0.2794,0.019 -0.45085,0.1651 -0.1651,0.14605 -0.2413,0.38735 -0.0699,0.23495 -0.0699,0.55245 0,0.36195 0.0825,0.60325 0.0889,0.23495 0.254,0.3556 0.17145,0.1143 0.42545,0.1143 z m 0,-2.6035 q 0.2667,-0.0127 0.41275,-0.14605 0.1524,-0.13335 0.2159,-0.3556 0.0635,-0.22225 0.0635,-0.50165 0,-0.4445 -0.1651,-0.6731 -0.1651,-0.23495 -0.52705,-0.23495 -0.3683,0 -0.53975,0.23495 -0.1651,0.2286 -0.1651,0.6731 0,0.2794 0.0635,0.50165 0.0635,0.22225 0.2159,0.3556 0.15875,0.13335 0.42545,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1775" />
+         id="path1451"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="enp0s9 (macvlan parent)"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1586">
+       id="text1256">
       <path
          d="m 188.75255,143.15543 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0572,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0572 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0317,-0.4953 -0.0318,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1778" />
+         id="path1454"
+         inkscape:connector-curvature="0" />
       <path
          d="m 190.33707,143.09828 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0953 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1780" />
+         id="path1456"
+         inkscape:connector-curvature="0" />
       <path
          d="m 192.92916,144.30478 v -4.8768 h 0.46355 v 0.3048 q 0.1143,-0.13335 0.28575,-0.24765 0.17145,-0.1143 0.4191,-0.1143 0.2667,0 0.42545,0.127 0.1651,0.12065 0.254,0.3302 0.0889,0.20955 0.12065,0.4699 0.0317,0.26035 0.0317,0.53975 v 0.76835 q 0,0.4699 -0.0825,0.81915 -0.0762,0.34925 -0.2667,0.53975 -0.1905,0.1905 -0.5334,0.1905 -0.22225,0 -0.38735,-0.1143 -0.15875,-0.1143 -0.2667,-0.23495 v 1.4986 z m 1.0414,-1.5113 q 0.20955,0 0.3175,-0.13335 0.10795,-0.1397 0.1397,-0.40005 0.0381,-0.2667 0.0381,-0.64135 v -0.78105 q 0,-0.36195 -0.0381,-0.60325 -0.0318,-0.24765 -0.1397,-0.37465 -0.10795,-0.127 -0.32385,-0.127 -0.1778,0 -0.3302,0.0953 -0.14605,0.0952 -0.2413,0.1905 v 2.5019 q 0.1016,0.10795 0.24765,0.1905 0.1524,0.0825 0.3302,0.0825 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1782" />
+         id="path1458"
+         inkscape:connector-curvature="0" />
       <path
          d="m 196.86596,143.16178 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0699,-0.254 0.0699,-0.56515 v -2.30505 q 0,-0.31115 -0.0699,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0699,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1784" />
+         id="path1460"
+         inkscape:connector-curvature="0" />
       <path
          d="m 199.70808,143.15543 q -0.43815,0 -0.6985,-0.2794 -0.26035,-0.28575 -0.29845,-0.762 l 0.38735,-0.1143 q 0.0381,0.4191 0.19685,0.61595 0.15875,0.1905 0.4445,0.1905 0.2413,0 0.3683,-0.13335 0.13335,-0.1397 0.13335,-0.38735 0,-0.1778 -0.10795,-0.3556 -0.10795,-0.18415 -0.3429,-0.381 l -0.4953,-0.4318 q -0.24765,-0.20955 -0.37465,-0.4191 -0.127,-0.20955 -0.127,-0.50165 0,-0.2667 0.10795,-0.4445 0.1143,-0.18415 0.3048,-0.2794 0.19685,-0.1016 0.46355,-0.1016 0.4191,0 0.635,0.27305 0.2159,0.2667 0.23495,0.69215 l -0.3302,0.10795 q -0.0127,-0.24765 -0.0762,-0.4064 -0.0635,-0.1651 -0.1778,-0.2413 -0.10795,-0.0762 -0.2667,-0.0762 -0.20955,0 -0.3429,0.12065 -0.127,0.1143 -0.127,0.32385 0,0.1651 0.0635,0.2921 0.0635,0.127 0.23495,0.28575 l 0.5207,0.46355 q 0.1524,0.13335 0.2921,0.28575 0.1397,0.1524 0.2286,0.3429 0.0889,0.18415 0.0889,0.43815 0,0.28575 -0.12065,0.4826 -0.1143,0.1905 -0.32385,0.29845 -0.20955,0.1016 -0.4953,0.1016 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1786" />
+         id="path1462"
+         inkscape:connector-curvature="0" />
       <path
          d="m 202.42132,143.16178 q -0.38735,0 -0.6477,-0.13335 -0.26035,-0.13335 -0.3937,-0.40005 -0.127,-0.27305 -0.13335,-0.66675 0,-0.0127 0,-0.0508 0,-0.0381 0,-0.0445 h 0.4572 q 0,0.48895 0.1524,0.6985 0.15875,0.20955 0.5715,0.20955 0.2159,0 0.3683,-0.1016 0.15875,-0.1016 0.2413,-0.3429 0.0825,-0.24765 0.0825,-0.6604 v -0.97155 q -0.0952,0.1143 -0.3048,0.20955 -0.2032,0.0952 -0.5207,0.0952 -0.42545,0 -0.66675,-0.15875 -0.2413,-0.1651 -0.3429,-0.50165 -0.1016,-0.3429 -0.1016,-0.8763 0,-0.47625 0.12065,-0.8255 0.127,-0.34925 0.3937,-0.53975 0.27305,-0.19685 0.7112,-0.19685 0.4191,0 0.67945,0.19685 0.26035,0.1905 0.381,0.55245 0.12065,0.3556 0.12065,0.85725 v 2.05105 q 0,0.4699 -0.1143,0.83185 -0.1143,0.36195 -0.3683,0.56515 -0.24765,0.2032 -0.6858,0.2032 z m -0.0191,-2.52095 q 0.27305,0 0.45085,-0.0952 0.1778,-0.1016 0.2667,-0.2032 v -0.88265 q 0,-0.4191 -0.0762,-0.6731 -0.0699,-0.26035 -0.2286,-0.37465 -0.15875,-0.12065 -0.4064,-0.12065 -0.24765,0 -0.4191,0.12065 -0.1651,0.1143 -0.24765,0.3556 -0.0825,0.2413 -0.0825,0.6096 0,0.42545 0.0444,0.70485 0.0508,0.2794 0.20955,0.4191 0.15875,0.1397 0.48895,0.1397 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1788" />
+         id="path1464"
+         inkscape:connector-curvature="0" />
       <path
          d="m 206.86681,144.14603 q -0.31115,-0.019 -0.51435,-0.1905 -0.2032,-0.17145 -0.3175,-0.46355 -0.10795,-0.28575 -0.1651,-0.66675 -0.0508,-0.38735 -0.0635,-0.8382 -0.006,-0.4572 -0.006,-0.9525 0,-0.4953 0.006,-0.9525 0.0127,-0.46355 0.0635,-0.8509 0.0572,-0.38735 0.1651,-0.67945 0.1143,-0.2921 0.3175,-0.4572 0.2032,-0.1651 0.51435,-0.1778 v 0.3302 q -0.23495,0.019 -0.36195,0.254 -0.127,0.2286 -0.18415,0.61595 -0.0508,0.38735 -0.0635,0.88265 -0.006,0.48895 -0.006,1.03505 0,0.5461 0.006,1.0414 0.0127,0.4953 0.0635,0.88265 0.0572,0.381 0.18415,0.6096 0.127,0.23495 0.36195,0.254 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1790" />
+         id="path1466"
+         inkscape:connector-curvature="0" />
       <path
          d="m 207.4151,143.09828 v -3.6703 h 0.4318 v 0.37465 q 0.18415,-0.2159 0.4064,-0.32385 0.22225,-0.1143 0.4572,-0.1143 0.1905,0 0.34925,0.1016 0.1651,0.1016 0.23495,0.381 0.18415,-0.2413 0.41275,-0.36195 0.23495,-0.12065 0.48895,-0.12065 0.15875,0 0.29845,0.0762 0.14605,0.0762 0.23495,0.26035 0.0889,0.18415 0.0889,0.50165 v 2.8956 h -0.43815 v -2.8829 q 0,-0.32385 -0.1016,-0.42545 -0.1016,-0.10795 -0.26035,-0.10795 -0.1778,0 -0.3556,0.1016 -0.1778,0.1016 -0.33655,0.2794 0.006,0.0317 0.006,0.0699 0,0.0317 0,0.0698 v 2.8956 h -0.4318 v -2.8829 q 0,-0.32385 -0.10795,-0.42545 -0.1016,-0.10795 -0.26035,-0.10795 -0.17145,0 -0.34925,0.1016 -0.1778,0.1016 -0.33655,0.27305 v 3.04165 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1792" />
+         id="path1468"
+         inkscape:connector-curvature="0" />
       <path
          d="m 212.13652,143.15543 q -0.2159,0 -0.381,-0.10795 -0.1651,-0.1143 -0.26035,-0.29845 -0.0952,-0.18415 -0.0952,-0.41275 0,-0.2794 0.0825,-0.47625 0.0825,-0.19685 0.254,-0.34925 0.1778,-0.15875 0.4572,-0.3048 0.28575,-0.1524 0.69215,-0.33655 v -0.26035 q 0,-0.33655 -0.0444,-0.52705 -0.0381,-0.19685 -0.1397,-0.2794 -0.0952,-0.0825 -0.27305,-0.0825 -0.14605,0 -0.26035,0.0572 -0.1143,0.0572 -0.18415,0.19685 -0.0699,0.13335 -0.0699,0.37465 v 0.127 l -0.4572,-0.006 q 0.006,-0.5588 0.23495,-0.8255 0.23495,-0.27305 0.762,-0.27305 0.48895,0 0.69215,0.29845 0.2032,0.2921 0.2032,0.9144 v 1.78435 q 0,0.0952 0,0.24765 0.006,0.14605 0.0127,0.2794 0.0127,0.13335 0.0191,0.2032 h -0.41275 q -0.019,-0.12065 -0.0444,-0.2667 -0.0191,-0.1524 -0.0254,-0.2413 -0.0762,0.22225 -0.27305,0.3937 -0.1905,0.17145 -0.48895,0.17145 z m 0.1524,-0.3937 q 0.1397,0 0.24765,-0.0635 0.1143,-0.0699 0.2032,-0.17145 0.0952,-0.1016 0.14605,-0.2032 v -1.143 q -0.27305,0.14605 -0.4699,0.26035 -0.1905,0.10795 -0.31115,0.2159 -0.12065,0.10795 -0.1778,0.24765 -0.0572,0.13335 -0.0572,0.3175 0,0.2921 0.12065,0.4191 0.127,0.12065 0.29845,0.12065 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1794" />
+         id="path1470"
+         inkscape:connector-curvature="0" />
       <path
          d="m 214.9336,143.15543 q -0.42545,0 -0.635,-0.1905 -0.20955,-0.1905 -0.2794,-0.51435 -0.0635,-0.3302 -0.0635,-0.74295 v -0.85725 q 0,-0.508 0.0825,-0.83185 0.0825,-0.3302 0.2921,-0.48895 0.2159,-0.15875 0.60325,-0.15875 0.3937,0 0.5969,0.14605 0.2032,0.14605 0.27305,0.41275 0.0699,0.2667 0.0699,0.6223 v 0.17145 h -0.4318 v -0.1778 q 0,-0.32385 -0.0508,-0.50165 -0.0445,-0.1778 -0.15875,-0.24765 -0.10795,-0.0762 -0.2921,-0.0762 -0.2159,0 -0.3302,0.1016 -0.1143,0.1016 -0.1524,0.33655 -0.0381,0.2286 -0.0381,0.61595 v 1.0287 q 0,0.55245 0.10795,0.78105 0.10795,0.22225 0.4191,0.22225 0.2159,0 0.32385,-0.0953 0.10795,-0.1016 0.1397,-0.29845 0.0317,-0.19685 0.0317,-0.48895 v -0.2032 h 0.4318 v 0.1778 q 0,0.3683 -0.0699,0.65405 -0.0699,0.2794 -0.27305,0.4445 -0.19685,0.15875 -0.5969,0.15875 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1796" />
+         id="path1472"
+         inkscape:connector-curvature="0" />
       <path
          d="m 217.04606,143.09828 -0.79375,-3.6703 h 0.4699 l 0.5969,3.1369 0.59055,-3.1369 h 0.45085 l -0.76835,3.6703 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1798" />
+         id="path1474"
+         inkscape:connector-curvature="0" />
       <path
          d="m 218.88875,143.09828 v -5.1435 h 0.46355 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1800" />
+         id="path1476"
+         inkscape:connector-curvature="0" />
       <path
          d="m 220.73134,143.15543 q -0.2159,0 -0.381,-0.10795 -0.1651,-0.1143 -0.26035,-0.29845 -0.0952,-0.18415 -0.0952,-0.41275 0,-0.2794 0.0825,-0.47625 0.0825,-0.19685 0.254,-0.34925 0.1778,-0.15875 0.4572,-0.3048 0.28575,-0.1524 0.69215,-0.33655 v -0.26035 q 0,-0.33655 -0.0444,-0.52705 -0.0381,-0.19685 -0.1397,-0.2794 -0.0952,-0.0825 -0.27305,-0.0825 -0.14605,0 -0.26035,0.0572 -0.1143,0.0572 -0.18415,0.19685 -0.0699,0.13335 -0.0699,0.37465 v 0.127 l -0.4572,-0.006 q 0.006,-0.5588 0.23495,-0.8255 0.23495,-0.27305 0.762,-0.27305 0.48895,0 0.69215,0.29845 0.2032,0.2921 0.2032,0.9144 v 1.78435 q 0,0.0952 0,0.24765 0.006,0.14605 0.0127,0.2794 0.0127,0.13335 0.0191,0.2032 h -0.41275 q -0.019,-0.12065 -0.0444,-0.2667 -0.0191,-0.1524 -0.0254,-0.2413 -0.0762,0.22225 -0.27305,0.3937 -0.1905,0.17145 -0.48895,0.17145 z m 0.1524,-0.3937 q 0.1397,0 0.24765,-0.0635 0.1143,-0.0699 0.2032,-0.17145 0.0953,-0.1016 0.14605,-0.2032 v -1.143 q -0.27305,0.14605 -0.4699,0.26035 -0.1905,0.10795 -0.31115,0.2159 -0.12065,0.10795 -0.1778,0.24765 -0.0572,0.13335 -0.0572,0.3175 0,0.2921 0.12065,0.4191 0.127,0.12065 0.29845,0.12065 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1802" />
+         id="path1478"
+         inkscape:connector-curvature="0" />
       <path
          d="m 222.62037,143.09828 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0953 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1804" />
+         id="path1480"
+         inkscape:connector-curvature="0" />
       <path
          d="m 226.5023,144.30478 v -4.8768 h 0.46355 v 0.3048 q 0.1143,-0.13335 0.28575,-0.24765 0.17145,-0.1143 0.4191,-0.1143 0.2667,0 0.42545,0.127 0.1651,0.12065 0.254,0.3302 0.0889,0.20955 0.12065,0.4699 0.0318,0.26035 0.0318,0.53975 v 0.76835 q 0,0.4699 -0.0826,0.81915 -0.0762,0.34925 -0.2667,0.53975 -0.1905,0.1905 -0.5334,0.1905 -0.22225,0 -0.38735,-0.1143 -0.15875,-0.1143 -0.2667,-0.23495 v 1.4986 z m 1.0414,-1.5113 q 0.20955,0 0.3175,-0.13335 0.10795,-0.1397 0.1397,-0.40005 0.0381,-0.2667 0.0381,-0.64135 v -0.78105 q 0,-0.36195 -0.0381,-0.60325 -0.0317,-0.24765 -0.1397,-0.37465 -0.10795,-0.127 -0.32385,-0.127 -0.1778,0 -0.3302,0.0953 -0.14605,0.0952 -0.2413,0.1905 v 2.5019 q 0.1016,0.10795 0.24765,0.1905 0.1524,0.0825 0.3302,0.0825 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1806" />
+         id="path1482"
+         inkscape:connector-curvature="0" />
       <path
          d="m 229.78505,143.15543 q -0.2159,0 -0.381,-0.10795 -0.1651,-0.1143 -0.26035,-0.29845 -0.0952,-0.18415 -0.0952,-0.41275 0,-0.2794 0.0825,-0.47625 0.0825,-0.19685 0.254,-0.34925 0.1778,-0.15875 0.4572,-0.3048 0.28575,-0.1524 0.69215,-0.33655 v -0.26035 q 0,-0.33655 -0.0444,-0.52705 -0.0381,-0.19685 -0.1397,-0.2794 -0.0952,-0.0825 -0.27305,-0.0825 -0.14605,0 -0.26035,0.0572 -0.1143,0.0572 -0.18415,0.19685 -0.0699,0.13335 -0.0699,0.37465 v 0.127 l -0.4572,-0.006 q 0.006,-0.5588 0.23495,-0.8255 0.23495,-0.27305 0.762,-0.27305 0.48895,0 0.69215,0.29845 0.2032,0.2921 0.2032,0.9144 v 1.78435 q 0,0.0952 0,0.24765 0.006,0.14605 0.0127,0.2794 0.0127,0.13335 0.019,0.2032 h -0.41275 q -0.019,-0.12065 -0.0444,-0.2667 -0.019,-0.1524 -0.0254,-0.2413 -0.0762,0.22225 -0.27305,0.3937 -0.1905,0.17145 -0.48895,0.17145 z m 0.1524,-0.3937 q 0.1397,0 0.24765,-0.0635 0.1143,-0.0699 0.2032,-0.17145 0.0953,-0.1016 0.14605,-0.2032 v -1.143 q -0.27305,0.14605 -0.4699,0.26035 -0.1905,0.10795 -0.31115,0.2159 -0.12065,0.10795 -0.1778,0.24765 -0.0572,0.13335 -0.0572,0.3175 0,0.2921 0.12065,0.4191 0.127,0.12065 0.29845,0.12065 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1808" />
+         id="path1484"
+         inkscape:connector-curvature="0" />
       <path
          d="m 231.70583,143.09828 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.019,0 0.0381,0 0.019,0 0.0445,0.006 v 0.4953 q -0.0445,-0.019 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1810" />
+         id="path1486"
+         inkscape:connector-curvature="0" />
       <path
          d="m 234.45518,143.15543 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0572,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0572 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0317,-0.4953 -0.0318,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1812" />
+         id="path1488"
+         inkscape:connector-curvature="0" />
       <path
          d="m 236.0397,143.09828 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0953 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1814" />
+         id="path1490"
+         inkscape:connector-curvature="0" />
       <path
          d="m 239.50175,143.14273 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0572,0.381 0.0635,0.10795 0.2667,0.10795 0.0572,0 0.127,-0.006 0.0699,-0.0127 0.13335,-0.019 v 0.34925 q -0.0953,0.0191 -0.19685,0.0254 -0.0952,0.0127 -0.1905,0.0127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1816" />
+         id="path1492"
+         inkscape:connector-curvature="0" />
       <path
          d="m 240.24023,144.14603 v -0.32385 q 0.2413,-0.0254 0.3683,-0.26035 0.127,-0.2286 0.1778,-0.61595 0.0572,-0.38735 0.0635,-0.8763 0.0127,-0.4953 0.0127,-1.0414 0,-0.5461 -0.0127,-1.0414 -0.006,-0.4953 -0.0635,-0.8763 -0.0508,-0.381 -0.1778,-0.6096 -0.127,-0.23495 -0.3683,-0.26035 v -0.32385 q 0.3175,0.0127 0.5207,0.1778 0.2032,0.15875 0.3175,0.45085 0.1143,0.2921 0.1651,0.67945 0.0572,0.38735 0.0635,0.84455 0.0127,0.4572 0.0127,0.95885 0,0.4953 -0.0127,0.9525 -0.006,0.45085 -0.0635,0.8382 -0.0508,0.38735 -0.1651,0.6731 -0.1143,0.2921 -0.3175,0.46355 -0.2032,0.17145 -0.5207,0.1905 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1818" />
+         id="path1494"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="net1"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1590">
+       id="text1260">
       <path
          d="m 170.06692,66.066681 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.09525 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.09525 -0.1651,0.09525 -0.31115,0.24765 v 3.0226 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1821" />
+         id="path1497"
+         inkscape:connector-curvature="0" />
       <path
          d="m 173.57976,66.123831 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0572,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.05715 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0318,-0.4953 -0.0317,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.08255 -0.1143,0.08255 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1823" />
+         id="path1499"
+         inkscape:connector-curvature="0" />
       <path
          d="m 176.03423,66.111131 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0572,0.381 0.0635,0.10795 0.2667,0.10795 0.0572,0 0.127,-0.0063 0.0699,-0.0127 0.13335,-0.01905 v 0.34925 q -0.0952,0.01905 -0.19685,0.0254 -0.0952,0.0127 -0.1905,0.0127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1825" />
+         id="path1501"
+         inkscape:connector-curvature="0" />
       <path
          d="m 177.64902,66.066681 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1827" />
+         id="path1503"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="eth0"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1594">
+       id="text1264">
       <path
          d="m 123.58944,66.048231 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0571,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.05715 0.1778,-0.20955 0.0698,-0.15875 0.0698,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0317,-0.4953 -0.0318,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.08255 -0.1143,0.08255 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1830" />
+         id="path1506"
+         inkscape:connector-curvature="0" />
       <path
          d="m 126.04391,66.035531 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0572,0.381 0.0635,0.10795 0.2667,0.10795 0.0571,0 0.127,-0.0063 0.0699,-0.0127 0.13335,-0.01905 v 0.34925 q -0.0952,0.01905 -0.19685,0.0254 -0.0952,0.0127 -0.1905,0.0127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1832" />
+         id="path1508"
+         inkscape:connector-curvature="0" />
       <path
          d="m 126.95385,65.991081 v -5.1435 h 0.46355 v 1.86055 q 0.18415,-0.19685 0.4064,-0.3175 0.22225,-0.127 0.48895,-0.127 0.18415,0 0.3048,0.09525 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.4699 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0825,-0.12065 -0.26035,-0.12065 -0.15875,0 -0.3302,0.1016 -0.1651,0.09525 -0.31115,0.24765 v 3.01625 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1834" />
+         id="path1510"
+         inkscape:connector-curvature="0" />
       <path
          d="m 130.84709,66.054581 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0699,-0.254 0.0699,-0.56515 v -2.30505 q 0,-0.31115 -0.0699,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0699,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1836" />
+         id="path1512"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="eth0"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1598">
+       id="text1268">
       <path
          d="m 74.603727,66.048231 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.08255,0.3302 0.08255,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.05715,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.05715 0.1778,-0.20955 0.06985,-0.15875 0.06985,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.03175,-0.4953 -0.03175,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.08255 -0.1143,0.08255 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1839" />
+         id="path1515"
+         inkscape:connector-curvature="0" />
       <path
          d="m 77.058201,66.035531 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.05715,0.381 0.0635,0.10795 0.2667,0.10795 0.05715,0 0.127,-0.0063 0.06985,-0.0127 0.13335,-0.01905 v 0.34925 q -0.09525,0.01905 -0.19685,0.0254 -0.09525,0.0127 -0.1905,0.0127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1841" />
+         id="path1517"
+         inkscape:connector-curvature="0" />
       <path
          d="m 77.968136,65.991081 v -5.1435 h 0.46355 v 1.86055 q 0.18415,-0.19685 0.4064,-0.3175 0.22225,-0.127 0.48895,-0.127 0.18415,0 0.3048,0.09525 0.127,0.0889 0.1905,0.2667 0.06985,0.17145 0.06985,0.4191 v 2.9464 h -0.4699 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.08255,-0.12065 -0.26035,-0.12065 -0.15875,0 -0.3302,0.1016 -0.1651,0.09525 -0.31115,0.24765 v 3.01625 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1843" />
+         id="path1519"
+         inkscape:connector-curvature="0" />
       <path
          d="m 81.86138,66.054581 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.06985,-0.254 0.06985,-0.56515 v -2.30505 q 0,-0.31115 -0.06985,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.06985,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1845" />
+         id="path1521"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="vethA"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1602">
+       id="text1272">
       <path
          d="m 74.235427,90.559532 -0.79375,-3.6703 h 0.4699 l 0.5969,3.1369 0.59055,-3.1369 h 0.45085 l -0.76835,3.6703 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1848" />
+         id="path1524"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.935368,90.616682 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.08255,0.3302 0.08255,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.05715,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.05715 0.1778,-0.20955 0.06985,-0.15875 0.06985,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.03175,-0.4953 -0.03175,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.08255 -0.1143,0.08255 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1850" />
+         id="path1526"
+         inkscape:connector-curvature="0" />
       <path
          d="m 79.389841,90.603982 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.05715,0.381 0.0635,0.10795 0.2667,0.10795 0.05715,0 0.127,-0.0063 0.06985,-0.0127 0.13335,-0.01905 v 0.34925 q -0.09525,0.01905 -0.19685,0.0254 -0.09525,0.0127 -0.1905,0.0127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1852" />
+         id="path1528"
+         inkscape:connector-curvature="0" />
       <path
          d="m 80.299776,90.559532 v -5.1435 h 0.46355 v 1.86055 q 0.18415,-0.19685 0.4064,-0.3175 0.22225,-0.127 0.48895,-0.127 0.18415,0 0.3048,0.09525 0.127,0.0889 0.1905,0.2667 0.06985,0.17145 0.06985,0.4191 v 2.9464 h -0.4699 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.08255,-0.12065 -0.26035,-0.12065 -0.15875,0 -0.3302,0.1016 -0.1651,0.09525 -0.31115,0.24765 v 3.01625 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1854" />
+         id="path1530"
+         inkscape:connector-curvature="0" />
       <path
          d="m 82.726171,90.559532 1.08585,-5.1435 h 0.508 l 1.0922,5.1435 h -0.47625 l -0.254,-1.37795 h -1.22555 l -0.26035,1.37795 z m 0.8001,-1.7272 h 1.0922 l -0.55245,-2.77495 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1856" />
+         id="path1532"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="vethB"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1606">
+       id="text1276">
       <path
          d="m 120.7265,90.937508 -0.79375,-3.6703 h 0.4699 l 0.5969,3.1369 0.59055,-3.1369 h 0.45085 l -0.76835,3.6703 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1859" />
+         id="path1535"
+         inkscape:connector-curvature="0" />
       <path
          d="m 123.42644,90.994658 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0571,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.05715 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0318,-0.4953 -0.0317,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.08255 -0.1143,0.08255 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1861" />
+         id="path1537"
+         inkscape:connector-curvature="0" />
       <path
          d="m 125.88091,90.981958 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0571,0.381 0.0635,0.10795 0.2667,0.10795 0.0572,0 0.127,-0.0063 0.0698,-0.0127 0.13335,-0.01905 v 0.34925 q -0.0952,0.01905 -0.19685,0.0254 -0.0953,0.0127 -0.1905,0.0127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1863" />
+         id="path1539"
+         inkscape:connector-curvature="0" />
       <path
          d="m 126.79085,90.937508 v -5.1435 h 0.46355 v 1.86055 q 0.18415,-0.19685 0.4064,-0.3175 0.22225,-0.127 0.48895,-0.127 0.18415,0 0.3048,0.09525 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.4699 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0825,-0.12065 -0.26035,-0.12065 -0.15875,0 -0.3302,0.1016 -0.1651,0.09525 -0.31115,0.24765 v 3.01625 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1865" />
+         id="path1541"
+         inkscape:connector-curvature="0" />
       <path
          d="m 129.49664,90.937508 v -5.1435 h 1.1049 q 0.34925,0 0.59055,0.0889 0.2413,0.0889 0.38735,0.26035 0.14605,0.17145 0.20955,0.41275 0.0635,0.23495 0.0635,0.5207 0,0.24765 -0.0571,0.4826 -0.0572,0.2286 -0.19685,0.3937 -0.1397,0.15875 -0.3937,0.20955 0.29845,0.08255 0.46355,0.28575 0.17145,0.19685 0.2413,0.46355 0.0699,0.26035 0.0699,0.53975 0,0.3048 -0.0572,0.57785 -0.0508,0.2667 -0.1905,0.4699 -0.13335,0.2032 -0.3683,0.32385 -0.23495,0.1143 -0.5969,0.1143 z m 0.4826,-0.36195 h 0.69215 q 0.50165,0 0.66675,-0.27305 0.17145,-0.27305 0.17145,-0.8509 0,-0.31115 -0.0762,-0.55245 -0.0762,-0.2413 -0.26035,-0.37465 -0.1778,-0.1397 -0.48895,-0.1397 h -0.70485 z m 0,-2.5654 h 0.6985 q 0.29845,0 0.4572,-0.1143 0.15875,-0.12065 0.22225,-0.32385 0.0635,-0.20955 0.0635,-0.4953 0,-0.31115 -0.0889,-0.51435 -0.0826,-0.2032 -0.2921,-0.29845 -0.20955,-0.09525 -0.60325,-0.09525 h -0.4572 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1867" />
+         id="path1543"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="gw0"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1610">
+       id="text1280">
       <path
          d="m 75.674762,112.9327 q -0.36195,0 -0.62865,-0.0699 -0.2667,-0.0698 -0.41275,-0.22225 -0.1397,-0.14605 -0.1397,-0.37465 0,-0.18415 0.0889,-0.33655 0.0889,-0.1524 0.2286,-0.2667 0.1397,-0.12065 0.28575,-0.19685 -0.20955,-0.0572 -0.31115,-0.1524 -0.09525,-0.1016 -0.09525,-0.24765 0,-0.1905 0.1143,-0.3429 0.12065,-0.1524 0.32385,-0.32385 -0.254,-0.1778 -0.36195,-0.4572 -0.1016,-0.2794 -0.1016,-0.6604 0,-0.34925 0.10795,-0.635 0.10795,-0.2921 0.33655,-0.4699 0.2286,-0.1778 0.5842,-0.1778 0.32385,0 0.508,0.13335 0.18415,0.13335 0.2794,0.3302 0.05715,-0.0952 0.19685,-0.22225 0.1397,-0.13335 0.29845,-0.1905 l 0.09525,-0.0381 0.127,0.32385 q -0.1016,0.019 -0.2286,0.0762 -0.12065,0.0508 -0.22225,0.1143 -0.1016,0.0635 -0.1524,0.127 0.04445,0.1143 0.0762,0.31115 0.0381,0.19685 0.0381,0.3302 0,0.36195 -0.1016,0.65405 -0.09525,0.2921 -0.3175,0.46355 -0.22225,0.1651 -0.59055,0.1651 -0.09525,0 -0.2032,-0.019 -0.1016,-0.0191 -0.17145,-0.0381 -0.09525,0.0952 -0.17145,0.20955 -0.0762,0.10795 -0.0762,0.20955 0,0.0889 0.06985,0.1397 0.0762,0.0444 0.23495,0.0698 l 0.5842,0.0826 q 0.4445,0.0698 0.67945,0.27305 0.2413,0.19685 0.2413,0.57785 0,0.28575 -0.15875,0.47625 -0.1524,0.1905 -0.42545,0.2794 -0.27305,0.0952 -0.62865,0.0952 z m 0.01905,-0.37465 q 0.3683,0 0.5969,-0.1143 0.2286,-0.10795 0.2286,-0.3556 0,-0.12065 -0.05715,-0.22225 -0.0508,-0.0952 -0.2032,-0.15875 -0.14605,-0.0699 -0.43815,-0.1143 l -0.46355,-0.0635 q -0.09525,0.0635 -0.2032,0.15875 -0.10795,0.0889 -0.1905,0.2032 -0.0762,0.1143 -0.0762,0.26035 0,0.20955 0.19685,0.3048 0.19685,0.1016 0.6096,0.1016 z m 0.0064,-2.31775 q 0.2032,0 0.3175,-0.0826 0.12065,-0.0889 0.1778,-0.2286 0.0635,-0.1397 0.08255,-0.31115 0.0254,-0.17145 0.0254,-0.33655 0,-0.1651 -0.0254,-0.3302 -0.0254,-0.1651 -0.0889,-0.3048 -0.0635,-0.14605 -0.18415,-0.2286 -0.1143,-0.0889 -0.3048,-0.0889 -0.1905,0 -0.3175,0.0889 -0.12065,0.0889 -0.1905,0.23495 -0.0635,0.1397 -0.0889,0.31115 -0.0254,0.1651 -0.0254,0.3175 0,0.1524 0.01905,0.32385 0.0254,0.17145 0.0889,0.3175 0.06985,0.1397 0.1905,0.2286 0.127,0.0889 0.32385,0.0889 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1870" />
+         id="path1546"
+         inkscape:connector-curvature="0" />
       <path
          d="m 77.92038,111.7262 -0.5969,-3.6703 h 0.3937 l 0.46355,3.06705 0.57785,-3.06705 h 0.40005 l 0.5842,3.05435 0.43815,-3.05435 h 0.40005 l -0.5969,3.6703 h -0.4318 l -0.59055,-2.9845 -0.5715,2.9845 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1872" />
+         id="path1548"
+         inkscape:connector-curvature="0" />
       <path
          d="m 82.411219,111.7897 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.06985,-0.254 0.06985,-0.56515 v -2.30505 q 0,-0.31115 -0.06985,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.06985,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1874" />
+         id="path1550"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="tun0"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1614">
+       id="text1284">
       <path
          d="m 122.17793,111.77065 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0571,0.381 0.0635,0.10795 0.2667,0.10795 0.0572,0 0.127,-0.006 0.0699,-0.0127 0.13335,-0.019 v 0.34925 q -0.0953,0.019 -0.19685,0.0254 -0.0953,0.0127 -0.1905,0.0127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1877" />
+         id="path1553"
+         inkscape:connector-curvature="0" />
       <path
          d="m 123.62126,111.78335 q -0.18415,0 -0.31115,-0.0889 -0.127,-0.0953 -0.19685,-0.2667 -0.0635,-0.1778 -0.0635,-0.42545 v -2.9464 h 0.46355 v 2.8448 q 0,0.28575 0.0889,0.4064 0.0889,0.1143 0.2667,0.1143 0.1651,0 0.3302,-0.1016 0.17145,-0.10795 0.3175,-0.2667 v -2.9972 h 0.46355 v 3.6703 h -0.46355 v -0.4064 q -0.1778,0.2032 -0.4064,0.33655 -0.2286,0.127 -0.48895,0.127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1879" />
+         id="path1555"
+         inkscape:connector-curvature="0" />
       <path
          d="m 125.69841,111.7262 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.0698,0.17145 0.0698,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0953 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1881" />
+         id="path1557"
+         inkscape:connector-curvature="0" />
       <path
          d="m 129.5732,111.7897 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0699,-0.254 0.0699,-0.56515 v -2.30505 q 0,-0.31115 -0.0699,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0698,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1883" />
+         id="path1559"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="Pod A"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1618">
+       id="text1288">
       <path
          d="m 68.15869,30.083344 v -5.715 h 1.368778 q 0.515055,0 0.804333,0.1905 0.296333,0.1905 0.423333,0.529166 0.127,0.338667 0.127,0.797278 0,0.402167 -0.134055,0.747889 -0.127,0.338667 -0.430389,0.543278 -0.296334,0.204611 -0.783167,0.204611 h -0.839611 v 2.702278 z m 0.536222,-3.104445 h 0.684389 q 0.345722,0 0.557389,-0.09878 0.218722,-0.105833 0.3175,-0.345722 0.09878,-0.239889 0.09878,-0.649111 0,-0.437444 -0.08467,-0.677333 -0.08467,-0.246945 -0.296333,-0.338667 -0.204612,-0.09878 -0.585612,-0.09878 h -0.691444 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1886" />
+         id="path1562"
+         inkscape:connector-curvature="0" />
       <path
          d="m 72.437994,30.146844 q -0.416277,0 -0.656166,-0.176389 -0.239889,-0.183445 -0.338667,-0.522111 -0.09172,-0.345723 -0.09172,-0.839612 v -1.128888 q 0,-0.493889 0.09172,-0.832556 0.09878,-0.345722 0.338667,-0.522111 0.239889,-0.183444 0.656166,-0.183444 0.423334,0 0.656167,0.183444 0.239889,0.176389 0.331611,0.522111 0.09878,0.338667 0.09878,0.832556 v 1.128888 q 0,0.493889 -0.09878,0.839612 -0.09172,0.338666 -0.331611,0.522111 -0.232833,0.176389 -0.656167,0.176389 z m 0,-0.388056 q 0.268112,0 0.388056,-0.141111 0.127,-0.141111 0.155222,-0.395111 0.02822,-0.254 0.02822,-0.585611 v -1.185334 q 0,-0.331611 -0.02822,-0.578555 -0.02822,-0.254 -0.155222,-0.395111 -0.119944,-0.148167 -0.388056,-0.148167 -0.268111,0 -0.388055,0.148167 -0.119945,0.141111 -0.155222,0.395111 -0.02822,0.246944 -0.02822,0.578555 v 1.185334 q 0,0.331611 0.02822,0.585611 0.03528,0.254 0.155222,0.395111 0.119944,0.141111 0.388055,0.141111 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1888" />
+         id="path1564"
+         inkscape:connector-curvature="0" />
       <path
-         d="m 75.143359,30.146844 q -0.522111,0 -0.754945,-0.395112 -0.225777,-0.395111 -0.225777,-1.312333 v -0.754944 q 0,-0.536223 0.07761,-0.924278 0.07761,-0.388056 0.282222,-0.599722 0.211667,-0.218722 0.599722,-0.218722 0.239889,0 0.416278,0.112888 0.183444,0.105834 0.303389,0.239889 v -1.926166 h 0.515055 v 5.715 h -0.515055 v -0.289278 q -0.119945,0.134055 -0.296334,0.246944 -0.169333,0.105834 -0.402166,0.105834 z m 0.105833,-0.402167 q 0.162278,0 0.3175,-0.07761 0.155222,-0.08467 0.275167,-0.197556 v -2.836333 q -0.105834,-0.09878 -0.261056,-0.1905 -0.155222,-0.09878 -0.345722,-0.09878 -0.338667,0 -0.451555,0.303389 -0.105834,0.296333 -0.105834,0.874889 v 0.959555 q 0,0.409223 0.04233,0.691445 0.04939,0.282222 0.169333,0.430389 0.127,0.141111 0.359833,0.141111 z"
+         d="m 75.143359,30.146844 q -0.522111,0 -0.754945,-0.395112 -0.225777,-0.395111 -0.225777,-1.312333 v -0.754944 q 0,-0.536223 0.07761,-0.924278 0.07761,-0.388056 0.282222,-0.599722 0.211667,-0.218722 0.599722,-0.218722 0.239889,0 0.416278,0.112888 0.183444,0.105834 0.303389,0.239889 v -1.926166 h 0.515055 v 5.715 h -0.515055 v -0.289278 q -0.119945,0.134055 -0.296334,0.246944 -0.169333,0.105834 -0.402165,0.105834 z m 0.105833,-0.402167 q 0.162278,0 0.3175,-0.07761 0.155222,-0.08467 0.275167,-0.197556 v -2.836333 q -0.105834,-0.09878 -0.261056,-0.1905 -0.155222,-0.09878 -0.345722,-0.09878 -0.338667,0 -0.451555,0.303389 -0.105834,0.296333 -0.105834,0.874889 v 0.959555 q 0,0.409223 0.04233,0.691445 0.04939,0.282222 0.169333,0.430389 0.127,0.141111 0.359833,0.141111 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1890" />
+         id="path1566"
+         inkscape:connector-curvature="0" />
       <path
          d="m 78.376457,30.083344 1.2065,-5.715 h 0.564444 l 1.213556,5.715 H 80.83179 l -0.282222,-1.531056 h -1.361722 l -0.289278,1.531056 z m 0.889,-1.919112 h 1.213555 l -0.613833,-3.083277 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1892" />
+         id="path1568"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="Pod B
 (with secondary interface)"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1624">
+       id="text1294">
       <path
          d="m 116.91762,30.083344 v -5.715 h 1.36878 q 0.51506,0 0.80433,0.1905 0.29634,0.1905 0.42334,0.529166 0.127,0.338667 0.127,0.797278 0,0.402167 -0.13406,0.747889 -0.127,0.338667 -0.43039,0.543278 -0.29633,0.204611 -0.78316,0.204611 h -0.83961 v 2.702278 z m 0.53623,-3.104445 h 0.68438 q 0.34573,0 0.55739,-0.09878 0.21873,-0.105833 0.3175,-0.345722 0.0988,-0.239889 0.0988,-0.649111 0,-0.437444 -0.0847,-0.677333 -0.0847,-0.246945 -0.29633,-0.338667 -0.20461,-0.09878 -0.58561,-0.09878 h -0.69144 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1895" />
+         id="path1571"
+         inkscape:connector-curvature="0" />
       <path
          d="m 121.19693,30.146844 q -0.41628,0 -0.65617,-0.176389 -0.23989,-0.183445 -0.33866,-0.522111 -0.0917,-0.345723 -0.0917,-0.839612 v -1.128888 q 0,-0.493889 0.0917,-0.832556 0.0988,-0.345722 0.33866,-0.522111 0.23989,-0.183444 0.65617,-0.183444 0.42333,0 0.65617,0.183444 0.23988,0.176389 0.33161,0.522111 0.0988,0.338667 0.0988,0.832556 v 1.128888 q 0,0.493889 -0.0988,0.839612 -0.0917,0.338666 -0.33161,0.522111 -0.23284,0.176389 -0.65617,0.176389 z m 0,-0.388056 q 0.26811,0 0.38805,-0.141111 0.127,-0.141111 0.15523,-0.395111 0.0282,-0.254 0.0282,-0.585611 v -1.185334 q 0,-0.331611 -0.0282,-0.578555 -0.0282,-0.254 -0.15523,-0.395111 -0.11994,-0.148167 -0.38805,-0.148167 -0.26811,0 -0.38806,0.148167 -0.11994,0.141111 -0.15522,0.395111 -0.0282,0.246944 -0.0282,0.578555 v 1.185334 q 0,0.331611 0.0282,0.585611 0.0353,0.254 0.15522,0.395111 0.11995,0.141111 0.38806,0.141111 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1897" />
+         id="path1573"
+         inkscape:connector-curvature="0" />
       <path
          d="m 123.90229,30.146844 q -0.52211,0 -0.75494,-0.395112 -0.22578,-0.395111 -0.22578,-1.312333 v -0.754944 q 0,-0.536223 0.0776,-0.924278 0.0776,-0.388056 0.28222,-0.599722 0.21167,-0.218722 0.59973,-0.218722 0.23989,0 0.41627,0.112888 0.18345,0.105834 0.30339,0.239889 v -1.926166 h 0.51506 v 5.715 h -0.51506 v -0.289278 q -0.11994,0.134055 -0.29633,0.246944 -0.16933,0.105834 -0.40217,0.105834 z m 0.10584,-0.402167 q 0.16227,0 0.3175,-0.07761 0.15522,-0.08467 0.27516,-0.197556 v -2.836333 q -0.10583,-0.09878 -0.26105,-0.1905 -0.15522,-0.09878 -0.34572,-0.09878 -0.33867,0 -0.45156,0.303389 -0.10583,0.296333 -0.10583,0.874889 v 0.959555 q 0,0.409223 0.0423,0.691445 0.0494,0.282222 0.16933,0.430389 0.127,0.141111 0.35984,0.141111 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1899" />
+         id="path1575"
+         inkscape:connector-curvature="0" />
       <path
          d="m 127.44584,30.083344 v -5.715 h 1.22766 q 0.38806,0 0.65617,0.09878 0.26811,0.09878 0.43039,0.289278 0.16228,0.1905 0.23283,0.458611 0.0706,0.261056 0.0706,0.578556 0,0.275167 -0.0635,0.536222 -0.0635,0.254 -0.21873,0.437444 -0.15522,0.176389 -0.43744,0.232834 0.33161,0.09172 0.51506,0.3175 0.1905,0.218722 0.26811,0.515055 0.0776,0.289278 0.0776,0.599723 0,0.338666 -0.0635,0.642055 -0.0565,0.296333 -0.21167,0.522111 -0.14817,0.225778 -0.40922,0.359834 -0.26106,0.127 -0.66322,0.127 z m 0.53622,-0.402167 h 0.76905 q 0.55739,0 0.74084,-0.303389 0.1905,-0.303389 0.1905,-0.945444 0,-0.345723 -0.0847,-0.613834 -0.0847,-0.268111 -0.28928,-0.416278 -0.19755,-0.155222 -0.54328,-0.155222 h -0.78316 z m 0,-2.850445 h 0.77611 q 0.33161,0 0.508,-0.127 0.17639,-0.134055 0.24694,-0.359833 0.0706,-0.232833 0.0706,-0.550333 0,-0.345722 -0.0988,-0.5715 -0.0917,-0.225778 -0.32455,-0.331611 -0.23284,-0.105834 -0.67028,-0.105834 h -0.508 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1901" />
+         id="path1577"
+         inkscape:connector-curvature="0" />
       <path
          d="m 118.1594,40.066954 q -0.34572,-0.02117 -0.5715,-0.211666 -0.22578,-0.1905 -0.35278,-0.515056 -0.11994,-0.3175 -0.18344,-0.740833 -0.0564,-0.430389 -0.0706,-0.931333 -0.007,-0.508 -0.007,-1.058334 0,-0.550333 0.007,-1.058333 0.0141,-0.515056 0.0706,-0.945445 0.0635,-0.430388 0.18344,-0.754944 0.127,-0.324555 0.35278,-0.508 0.22578,-0.183444 0.5715,-0.197555 v 0.366888 q -0.26105,0.02117 -0.40217,0.282223 -0.14111,0.254 -0.20461,0.684388 -0.0564,0.430389 -0.0706,0.980723 -0.007,0.543277 -0.007,1.150055 0,0.606778 0.007,1.157111 0.0141,0.550334 0.0706,0.980722 0.0635,0.423334 0.20461,0.677334 0.14112,0.261055 0.40217,0.282222 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1903" />
+         id="path1579"
+         inkscape:connector-curvature="0" />
       <path
          d="m 119.25544,38.902788 -0.66322,-4.078111 h 0.43744 l 0.51506,3.407833 0.64205,-3.407833 h 0.4445 l 0.64911,3.393722 0.48684,-3.393722 h 0.4445 l -0.66323,4.078111 h -0.47977 l -0.65617,-3.316111 -0.635,3.316111 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1905" />
+         id="path1581"
+         inkscape:connector-curvature="0" />
       <path
          d="m 122.87648,38.902788 v -4.078111 h 0.51506 v 4.078111 z m 0,-4.642556 v -0.6985 h 0.51506 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1907" />
+         id="path1583"
+         inkscape:connector-curvature="0" />
       <path
          d="m 125.21981,38.952177 q -0.29634,0 -0.45861,-0.112889 -0.16228,-0.119945 -0.21873,-0.3175 -0.0564,-0.204611 -0.0564,-0.465667 v -2.892778 h -0.50094 v -0.338666 h 0.50094 v -1.262945 h 0.51506 v 1.262945 h 0.67733 v 0.338666 h -0.67733 v 2.843389 q 0,0.296333 0.0635,0.423333 0.0706,0.119945 0.29633,0.119945 0.0635,0 0.14111,-0.0071 0.0776,-0.01411 0.14817,-0.02117 v 0.388055 q -0.10584,0.02117 -0.21873,0.02822 -0.10583,0.01411 -0.21166,0.01411 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1909" />
+         id="path1585"
+         inkscape:connector-curvature="0" />
       <path
          d="m 126.23085,38.902788 v -5.715 h 0.51505 v 2.067278 q 0.20461,-0.218723 0.45156,-0.352778 0.24694,-0.141111 0.54328,-0.141111 0.20461,0 0.33866,0.105833 0.14111,0.09878 0.21167,0.296333 0.0776,0.1905 0.0776,0.465667 v 3.273778 h -0.52211 v -3.160889 q 0,-0.3175 -0.0988,-0.4445 -0.0917,-0.134056 -0.28928,-0.134056 -0.17639,0 -0.36689,0.112889 -0.18344,0.105834 -0.34572,0.275167 v 3.351389 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1911" />
+         id="path1587"
+         inkscape:connector-curvature="0" />
       <path
          d="m 131.49594,38.966288 q -0.48683,0 -0.77611,-0.310445 -0.28927,-0.3175 -0.33161,-0.846666 l 0.43039,-0.127 q 0.0423,0.465666 0.21872,0.684388 0.17639,0.211667 0.49389,0.211667 0.26811,0 0.40922,-0.148167 0.14817,-0.155222 0.14817,-0.430388 0,-0.197556 -0.11994,-0.395111 -0.11995,-0.204612 -0.381,-0.423334 l -0.55034,-0.479778 q -0.27516,-0.232833 -0.41627,-0.465666 -0.14112,-0.232834 -0.14112,-0.557389 0,-0.296333 0.11995,-0.493889 0.127,-0.204611 0.33867,-0.310444 0.21872,-0.112889 0.51505,-0.112889 0.46567,0 0.70556,0.303389 0.23989,0.296333 0.26105,0.769055 l -0.36689,0.119945 q -0.0141,-0.275167 -0.0847,-0.451556 -0.0706,-0.183444 -0.19756,-0.268111 -0.11994,-0.08467 -0.29633,-0.08467 -0.23284,0 -0.381,0.134056 -0.14111,0.127 -0.14111,0.359833 0,0.183445 0.0705,0.324556 0.0706,0.141111 0.26106,0.3175 l 0.57855,0.515055 q 0.16934,0.148167 0.32456,0.3175 0.15522,0.169334 0.254,0.381 0.0988,0.204611 0.0988,0.486833 0,0.3175 -0.13406,0.536223 -0.127,0.211666 -0.35983,0.331611 -0.23284,0.112889 -0.55034,0.112889 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1913" />
+         id="path1589"
+         inkscape:connector-curvature="0" />
       <path
          d="m 134.15082,38.966288 q -0.381,0 -0.62795,-0.148167 -0.23989,-0.155222 -0.35983,-0.508 -0.11289,-0.352778 -0.11289,-0.938389 v -1.030111 q 0,-0.606778 0.11995,-0.945444 0.11994,-0.345723 0.36688,-0.486834 0.24695,-0.148166 0.61384,-0.148166 0.43744,0 0.66322,0.183444 0.22578,0.183445 0.31044,0.557389 0.0917,0.366889 0.0917,0.945444 v 0.366889 h -1.651 v 0.712611 q 0,0.395111 0.0564,0.627945 0.0635,0.225778 0.1905,0.324555 0.13406,0.09878 0.33867,0.09878 0.15522,0 0.28222,-0.05644 0.127,-0.0635 0.19756,-0.232834 0.0776,-0.176389 0.0776,-0.493889 v -0.282222 h 0.50094 v 0.225778 q 0,0.557389 -0.23283,0.896056 -0.23284,0.331611 -0.8255,0.331611 z m -0.58561,-2.448278 h 1.143 v -0.338667 q 0,-0.324555 -0.0353,-0.550333 -0.0353,-0.232833 -0.15522,-0.352778 -0.11289,-0.127 -0.36689,-0.127 -0.21167,0 -0.34572,0.09172 -0.127,0.09172 -0.18345,0.331612 -0.0564,0.232833 -0.0564,0.670277 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1915" />
+         id="path1591"
+         inkscape:connector-curvature="0" />
       <path
          d="m 136.92034,38.966288 q -0.47272,0 -0.70555,-0.211667 -0.23283,-0.211667 -0.31045,-0.5715 -0.0705,-0.366889 -0.0705,-0.8255 v -0.9525 q 0,-0.564444 0.0917,-0.924278 0.0917,-0.366889 0.32456,-0.543277 0.23989,-0.176389 0.67027,-0.176389 0.43745,0 0.66323,0.162277 0.22577,0.162278 0.30339,0.458612 0.0776,0.296333 0.0776,0.691444 v 0.1905 h -0.47978 v -0.197556 q 0,-0.359833 -0.0565,-0.557388 -0.0494,-0.197556 -0.17638,-0.275167 -0.11995,-0.08467 -0.32456,-0.08467 -0.23989,0 -0.36689,0.112889 -0.127,0.112889 -0.16933,0.373945 -0.0423,0.254 -0.0423,0.684388 v 1.143 q 0,0.613834 0.11995,0.867834 0.11994,0.246944 0.46567,0.246944 0.23988,0 0.35983,-0.105833 0.11994,-0.112889 0.15522,-0.331611 0.0353,-0.218723 0.0353,-0.543278 v -0.225778 h 0.47978 v 0.197556 q 0,0.409222 -0.0776,0.726722 -0.0776,0.310444 -0.30339,0.493889 -0.21873,0.176389 -0.66323,0.176389 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1917" />
+         id="path1593"
+         inkscape:connector-curvature="0" />
       <path
          d="m 139.66264,38.966288 q -0.41628,0 -0.65617,-0.176389 -0.23989,-0.183445 -0.33866,-0.522111 -0.0917,-0.345723 -0.0917,-0.839611 v -1.128889 q 0,-0.493889 0.0917,-0.832556 0.0988,-0.345722 0.33866,-0.522111 0.23989,-0.183444 0.65617,-0.183444 0.42333,0 0.65617,0.183444 0.23988,0.176389 0.33161,0.522111 0.0988,0.338667 0.0988,0.832556 v 1.128889 q 0,0.493888 -0.0988,0.839611 -0.0917,0.338666 -0.33161,0.522111 -0.23284,0.176389 -0.65617,0.176389 z m 0,-0.388056 q 0.26811,0 0.38805,-0.141111 0.127,-0.141111 0.15523,-0.395111 0.0282,-0.254 0.0282,-0.585611 v -1.185333 q 0,-0.331612 -0.0282,-0.578556 -0.0282,-0.254 -0.15523,-0.395111 -0.11994,-0.148167 -0.38805,-0.148167 -0.26811,0 -0.38806,0.148167 -0.11994,0.141111 -0.15522,0.395111 -0.0282,0.246944 -0.0282,0.578556 v 1.185333 q 0,0.331611 0.0282,0.585611 0.0353,0.254 0.15522,0.395111 0.11995,0.141111 0.38806,0.141111 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1919" />
+         id="path1595"
+         inkscape:connector-curvature="0" />
       <path
          d="m 141.46489,38.902788 v -4.078111 h 0.51506 v 0.423333 q 0.19755,-0.211667 0.4445,-0.345722 0.24694,-0.141111 0.53622,-0.141111 0.20461,0 0.33867,0.105833 0.14111,0.09878 0.21166,0.296333 0.0776,0.1905 0.0776,0.465667 v 3.273778 h -0.51506 v -3.160889 q 0,-0.3175 -0.0988,-0.4445 -0.0988,-0.134056 -0.29633,-0.134056 -0.16933,0 -0.35278,0.105834 -0.18344,0.105833 -0.34572,0.275166 v 3.358445 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1921" />
+         id="path1597"
+         inkscape:connector-curvature="0" />
       <path
          d="m 145.2481,38.966288 q -0.52211,0 -0.75494,-0.395111 -0.22578,-0.395112 -0.22578,-1.312334 v -0.754944 q 0,-0.536222 0.0776,-0.924278 0.0776,-0.388055 0.28223,-0.599722 0.21166,-0.218722 0.59972,-0.218722 0.23989,0 0.41628,0.112889 0.18344,0.105833 0.30338,0.239888 v -1.926166 h 0.51506 v 5.715 H 145.9466 V 38.61351 q -0.11994,0.134055 -0.29633,0.246944 -0.16933,0.105834 -0.40217,0.105834 z m 0.10584,-0.402167 q 0.16228,0 0.3175,-0.07761 0.15522,-0.08467 0.27516,-0.197556 v -2.836333 q -0.10583,-0.09878 -0.26105,-0.1905 -0.15522,-0.09878 -0.34572,-0.09878 -0.33867,0 -0.45156,0.303389 -0.10583,0.296334 -0.10583,0.874889 v 0.959556 q 0,0.409222 0.0423,0.691444 0.0494,0.282222 0.16933,0.430389 0.127,0.141111 0.35984,0.141111 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1923" />
+         id="path1599"
+         inkscape:connector-curvature="0" />
       <path
          d="m 147.95115,38.966288 q -0.23989,0 -0.42333,-0.119945 -0.18344,-0.127 -0.28928,-0.331611 -0.10583,-0.204611 -0.10583,-0.458611 0,-0.310444 0.0917,-0.529167 0.0917,-0.218722 0.28222,-0.388055 0.19756,-0.176389 0.508,-0.338667 0.3175,-0.169333 0.76906,-0.373944 V 36.13701 q 0,-0.373944 -0.0494,-0.585611 -0.0423,-0.218722 -0.15522,-0.310445 -0.10584,-0.09172 -0.30339,-0.09172 -0.16228,0 -0.28928,0.0635 -0.127,0.0635 -0.20461,0.218722 -0.0776,0.148167 -0.0776,0.416278 v 0.141111 l -0.508,-0.0071 q 0.007,-0.620889 0.26105,-0.917222 0.26106,-0.303389 0.84667,-0.303389 0.54328,0 0.76906,0.331611 0.22577,0.324555 0.22577,1.016 v 1.982611 q 0,0.105833 0,0.275166 0.007,0.162278 0.0141,0.310445 0.0141,0.148167 0.0212,0.225778 h -0.45861 q -0.0212,-0.134056 -0.0494,-0.296334 -0.0212,-0.169333 -0.0282,-0.268111 -0.0847,0.246945 -0.30339,0.437445 -0.21167,0.1905 -0.54328,0.1905 z m 0.16934,-0.437445 q 0.15522,0 0.27516,-0.07055 0.127,-0.07761 0.22578,-0.1905 0.10583,-0.112889 0.16228,-0.225778 v -1.27 q -0.30339,0.162278 -0.52211,0.289278 -0.21167,0.119944 -0.34572,0.239889 -0.13406,0.119944 -0.19756,0.275166 -0.0635,0.148167 -0.0635,0.352778 0,0.324556 0.13406,0.465667 0.14111,0.134055 0.33161,0.134055 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1925" />
+         id="path1601"
+         inkscape:connector-curvature="0" />
       <path
          d="m 150.08535,38.902788 v -4.078111 h 0.52211 v 0.557389 q 0.19756,-0.324556 0.45156,-0.458612 0.254,-0.141111 0.48683,-0.141111 0.0212,0 0.0423,0 0.0212,0 0.0494,0.0071 v 0.550333 q -0.0494,-0.02117 -0.11994,-0.02822 -0.0706,-0.01411 -0.13406,-0.01411 -0.23989,0 -0.43744,0.112889 -0.1905,0.112889 -0.33867,0.359833 v 3.132667 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1927" />
+         id="path1603"
+         inkscape:connector-curvature="0" />
       <path
          d="m 152.0318,39.918788 v -0.402167 q 0.35278,0 0.52917,-0.05644 0.18344,-0.04939 0.23988,-0.148167 0.0635,-0.09172 0.0635,-0.218722 0,-0.112889 -0.0423,-0.296334 -0.0423,-0.183444 -0.0917,-0.381 l -0.83961,-3.591277 h 0.508 l 0.71261,3.471333 0.68439,-3.471333 h 0.51505 l -0.98072,4.367388 q -0.0564,0.261056 -0.20461,0.416278 -0.14111,0.162278 -0.381,0.232834 -0.23283,0.07761 -0.57856,0.07761 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1929" />
+         id="path1605"
+         inkscape:connector-curvature="0" />
       <path
          d="m 156.32147,38.902788 v -4.078111 h 0.51505 v 4.078111 z m 0,-4.642556 v -0.6985 h 0.51505 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1931" />
+         id="path1607"
+         inkscape:connector-curvature="0" />
       <path
          d="m 157.69818,38.902788 v -4.078111 h 0.51506 v 0.423333 q 0.19755,-0.211667 0.4445,-0.345722 0.24694,-0.141111 0.53622,-0.141111 0.20461,0 0.33867,0.105833 0.14111,0.09878 0.21166,0.296333 0.0776,0.1905 0.0776,0.465667 v 3.273778 h -0.51505 v -3.160889 q 0,-0.3175 -0.0988,-0.4445 -0.0988,-0.134056 -0.29633,-0.134056 -0.16934,0 -0.35278,0.105834 -0.18345,0.105833 -0.34572,0.275166 v 3.358445 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1933" />
+         id="path1609"
+         inkscape:connector-curvature="0" />
       <path
          d="m 161.54489,38.952177 q -0.29633,0 -0.45861,-0.112889 -0.16228,-0.119945 -0.21872,-0.3175 -0.0564,-0.204611 -0.0564,-0.465667 v -2.892778 h -0.50094 v -0.338666 h 0.50094 v -1.262945 h 0.51506 v 1.262945 h 0.67733 v 0.338666 h -0.67733 v 2.843389 q 0,0.296333 0.0635,0.423333 0.0706,0.119945 0.29633,0.119945 0.0635,0 0.14111,-0.0071 0.0776,-0.01411 0.14817,-0.02117 v 0.388055 q -0.10583,0.02117 -0.21872,0.02822 -0.10583,0.01411 -0.21167,0.01411 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1935" />
+         id="path1611"
+         inkscape:connector-curvature="0" />
       <path
          d="m 163.57193,38.966288 q -0.381,0 -0.62794,-0.148167 -0.23989,-0.155222 -0.35983,-0.508 -0.11289,-0.352778 -0.11289,-0.938389 v -1.030111 q 0,-0.606778 0.11994,-0.945444 0.11995,-0.345723 0.36689,-0.486834 0.24694,-0.148166 0.61383,-0.148166 0.43745,0 0.66323,0.183444 0.22577,0.183445 0.31044,0.557389 0.0917,0.366889 0.0917,0.945444 v 0.366889 h -1.651 v 0.712611 q 0,0.395111 0.0564,0.627945 0.0635,0.225778 0.1905,0.324555 0.13405,0.09878 0.33866,0.09878 0.15523,0 0.28223,-0.05644 0.127,-0.0635 0.19755,-0.232834 0.0776,-0.176389 0.0776,-0.493889 v -0.282222 h 0.50095 v 0.225778 q 0,0.557389 -0.23284,0.896056 -0.23283,0.331611 -0.8255,0.331611 z m -0.58561,-2.448278 h 1.143 v -0.338667 q 0,-0.324555 -0.0353,-0.550333 -0.0353,-0.232833 -0.15522,-0.352778 -0.11289,-0.127 -0.36689,-0.127 -0.21166,0 -0.34572,0.09172 -0.127,0.09172 -0.18344,0.331612 -0.0564,0.232833 -0.0564,0.670277 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1937" />
+         id="path1613"
+         inkscape:connector-curvature="0" />
       <path
          d="m 165.36779,38.902788 v -4.078111 h 0.52211 v 0.557389 q 0.19756,-0.324556 0.45156,-0.458612 0.254,-0.141111 0.48683,-0.141111 0.0212,0 0.0423,0 0.0212,0 0.0494,0.0071 v 0.550333 q -0.0494,-0.02117 -0.11994,-0.02822 -0.0706,-0.01411 -0.13406,-0.01411 -0.23989,0 -0.43744,0.112889 -0.1905,0.112889 -0.33867,0.359833 v 3.132667 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1939" />
+         id="path1615"
+         inkscape:connector-curvature="0" />
       <path
          d="m 167.68113,38.902788 v -3.704167 h -0.52211 v -0.373944 h 0.52211 v -0.423334 q 0,-0.303389 0.0494,-0.536222 0.0494,-0.232833 0.20461,-0.366889 0.16228,-0.134055 0.49389,-0.134055 0.11289,0 0.21167,0.01411 0.10583,0.0071 0.20461,0.03528 v 0.381 q -0.0635,-0.01411 -0.14817,-0.02117 -0.0776,-0.01411 -0.14111,-0.01411 -0.23283,0 -0.29633,0.148167 -0.0565,0.141111 -0.0565,0.444499 v 0.472723 h 0.65617 v 0.373944 h -0.65617 v 3.704167 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1941" />
+         id="path1617"
+         inkscape:connector-curvature="0" />
       <path
          d="m 170.01354,38.966288 q -0.23988,0 -0.42333,-0.119945 -0.18344,-0.127 -0.28928,-0.331611 -0.10583,-0.204611 -0.10583,-0.458611 0,-0.310444 0.0917,-0.529167 0.0917,-0.218722 0.28222,-0.388055 0.19756,-0.176389 0.508,-0.338667 0.3175,-0.169333 0.76906,-0.373944 V 36.13701 q 0,-0.373944 -0.0494,-0.585611 -0.0423,-0.218722 -0.15522,-0.310445 -0.10583,-0.09172 -0.30339,-0.09172 -0.16228,0 -0.28928,0.0635 -0.127,0.0635 -0.20461,0.218722 -0.0776,0.148167 -0.0776,0.416278 v 0.141111 l -0.508,-0.0071 q 0.007,-0.620889 0.26106,-0.917222 0.26105,-0.303389 0.84666,-0.303389 0.54328,0 0.76906,0.331611 0.22578,0.324555 0.22578,1.016 v 1.982611 q 0,0.105833 0,0.275166 0.007,0.162278 0.0141,0.310445 0.0141,0.148167 0.0212,0.225778 h -0.45861 q -0.0212,-0.134056 -0.0494,-0.296334 -0.0212,-0.169333 -0.0282,-0.268111 -0.0847,0.246945 -0.30339,0.437445 -0.21166,0.1905 -0.54328,0.1905 z m 0.16934,-0.437445 q 0.15522,0 0.27516,-0.07055 0.127,-0.07761 0.22578,-0.1905 0.10584,-0.112889 0.16228,-0.225778 v -1.27 q -0.30339,0.162278 -0.52211,0.289278 -0.21167,0.119944 -0.34572,0.239889 -0.13406,0.119944 -0.19756,0.275166 -0.0635,0.148167 -0.0635,0.352778 0,0.324556 0.13406,0.465667 0.14111,0.134055 0.33161,0.134055 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1943" />
+         id="path1619"
+         inkscape:connector-curvature="0" />
       <path
          d="m 173.12141,38.966288 q -0.47273,0 -0.70556,-0.211667 -0.23283,-0.211667 -0.31044,-0.5715 -0.0706,-0.366889 -0.0706,-0.8255 v -0.9525 q 0,-0.564444 0.0917,-0.924278 0.0917,-0.366889 0.32456,-0.543277 0.23989,-0.176389 0.67028,-0.176389 0.43744,0 0.66322,0.162277 0.22578,0.162278 0.30339,0.458612 0.0776,0.296333 0.0776,0.691444 v 0.1905 h -0.47978 v -0.197556 q 0,-0.359833 -0.0564,-0.557388 -0.0494,-0.197556 -0.17639,-0.275167 -0.11995,-0.08467 -0.32456,-0.08467 -0.23989,0 -0.36689,0.112889 -0.127,0.112889 -0.16933,0.373945 -0.0423,0.254 -0.0423,0.684388 v 1.143 q 0,0.613834 0.11994,0.867834 0.11994,0.246944 0.46567,0.246944 0.23989,0 0.35983,-0.105833 0.11994,-0.112889 0.15522,-0.331611 0.0353,-0.218723 0.0353,-0.543278 v -0.225778 h 0.47978 v 0.197556 q 0,0.409222 -0.0776,0.726722 -0.0776,0.310444 -0.30339,0.493889 -0.21872,0.176389 -0.66322,0.176389 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1945" />
+         id="path1621"
+         inkscape:connector-curvature="0" />
       <path
          d="m 175.87781,38.966288 q -0.381,0 -0.62794,-0.148167 -0.23989,-0.155222 -0.35983,-0.508 -0.11289,-0.352778 -0.11289,-0.938389 v -1.030111 q 0,-0.606778 0.11994,-0.945444 0.11995,-0.345723 0.36689,-0.486834 0.24695,-0.148166 0.61383,-0.148166 0.43745,0 0.66323,0.183444 0.22577,0.183445 0.31044,0.557389 0.0917,0.366889 0.0917,0.945444 v 0.366889 h -1.651 v 0.712611 q 0,0.395111 0.0564,0.627945 0.0635,0.225778 0.1905,0.324555 0.13405,0.09878 0.33866,0.09878 0.15523,0 0.28223,-0.05644 0.127,-0.0635 0.19755,-0.232834 0.0776,-0.176389 0.0776,-0.493889 v -0.282222 h 0.50095 v 0.225778 q 0,0.557389 -0.23284,0.896056 -0.23283,0.331611 -0.8255,0.331611 z M 175.2922,36.51801 h 1.143 v -0.338667 q 0,-0.324555 -0.0353,-0.550333 -0.0353,-0.232833 -0.15523,-0.352778 -0.11289,-0.127 -0.36689,-0.127 -0.21166,0 -0.34572,0.09172 -0.127,0.09172 -0.18344,0.331612 -0.0564,0.232833 -0.0564,0.670277 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1947" />
+         id="path1623"
+         inkscape:connector-curvature="0" />
       <path
          d="m 177.45495,40.066954 v -0.359833 q 0.26811,-0.02822 0.40922,-0.289278 0.14111,-0.254 0.19756,-0.684389 0.0635,-0.430389 0.0705,-0.973666 0.0141,-0.550334 0.0141,-1.157111 0,-0.606778 -0.0141,-1.157111 -0.007,-0.550334 -0.0705,-0.973667 -0.0565,-0.423333 -0.19756,-0.677333 -0.14111,-0.261056 -0.40922,-0.289278 v -0.359833 q 0.35278,0.01411 0.57855,0.197555 0.22578,0.176389 0.35278,0.500945 0.127,0.324555 0.18345,0.754944 0.0635,0.430389 0.0705,0.938389 0.0141,0.508 0.0141,1.065389 0,0.550333 -0.0141,1.058333 -0.007,0.500944 -0.0705,0.931333 -0.0564,0.430389 -0.18345,0.747889 -0.127,0.324556 -0.35278,0.515056 -0.22577,0.1905 -0.57855,0.211666 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:7.05555534px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1949" />
+         id="path1625"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="DHCP server"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1628">
+       id="text1298">
       <path
          d="m 206.0699,90.257149 v -5.1435 h 1.1176 q 0.53975,0 0.8382,0.1905 0.3048,0.18415 0.42545,0.52705 0.127,0.3429 0.127,0.79375 v 2.0447 q 0,0.47625 -0.127,0.8382 -0.12065,0.3556 -0.41275,0.55245 -0.2921,0.19685 -0.80645,0.19685 z m 0.4826,-0.36195 h 0.6477 q 0.4064,0 0.5969,-0.1651 0.1905,-0.17145 0.2413,-0.46355 0.0508,-0.29845 0.0508,-0.6731 v -1.9177 q 0,-0.38735 -0.0699,-0.6477 -0.0635,-0.2667 -0.26035,-0.40005 -0.1905,-0.1397 -0.57785,-0.1397 h -0.62865 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1952" />
+         id="path1628"
+         inkscape:connector-curvature="0" />
       <path
          d="m 209.37497,90.257149 v -5.1435 h 0.48895 v 2.27965 h 1.61925 v -2.27965 h 0.4826 v 5.1435 h -0.4826 v -2.5019 h -1.61925 v 2.5019 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1954" />
+         id="path1630"
+         inkscape:connector-curvature="0" />
       <path
          d="m 214.06018,90.320649 q -0.5207,0 -0.80645,-0.2159 -0.2794,-0.2159 -0.38735,-0.57785 -0.10795,-0.3683 -0.10795,-0.8128 v -2.0447 q 0,-0.47625 0.10795,-0.8382 0.1143,-0.36195 0.40005,-0.56515 0.28575,-0.2032 0.79375,-0.2032 0.46355,0 0.7239,0.1778 0.2667,0.1778 0.381,0.508 0.1143,0.32385 0.1143,0.7747 v 0.31115 h -0.4572 v -0.29845 q 0,-0.33655 -0.0572,-0.57785 -0.0508,-0.2413 -0.2159,-0.37465 -0.1651,-0.13335 -0.48895,-0.13335 -0.3429,0 -0.5207,0.14605 -0.17145,0.1397 -0.23495,0.40005 -0.0572,0.26035 -0.0572,0.60325 v 2.19075 q 0,0.381 0.0699,0.635 0.0762,0.254 0.254,0.381 0.1778,0.127 0.48895,0.127 0.32385,0 0.48895,-0.1397 0.1651,-0.1397 0.2159,-0.38735 0.0572,-0.254 0.0572,-0.59055 v -0.33655 h 0.4572 v 0.3048 q 0,0.45085 -0.10795,0.8001 -0.1016,0.34925 -0.3683,0.5461 -0.26035,0.1905 -0.74295,0.1905 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1956" />
+         id="path1632"
+         inkscape:connector-curvature="0" />
       <path
          d="m 216.02898,90.257149 v -5.1435 h 1.2319 q 0.46355,0 0.7239,0.17145 0.2667,0.17145 0.381,0.47625 0.1143,0.3048 0.1143,0.71755 0,0.36195 -0.12065,0.6731 -0.1143,0.3048 -0.38735,0.48895 -0.2667,0.18415 -0.70485,0.18415 h -0.75565 v 2.43205 z m 0.4826,-2.794 h 0.61595 q 0.31115,0 0.50165,-0.0889 0.19685,-0.09525 0.28575,-0.31115 0.0889,-0.2159 0.0889,-0.5842 0,-0.3937 -0.0762,-0.6096 -0.0762,-0.22225 -0.2667,-0.3048 -0.18415,-0.0889 -0.52705,-0.0889 h -0.6223 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1958" />
+         id="path1634"
+         inkscape:connector-curvature="0" />
       <path
          d="m 221.07554,90.314299 q -0.43815,0 -0.6985,-0.2794 -0.26035,-0.28575 -0.29845,-0.762 l 0.38735,-0.1143 q 0.0381,0.4191 0.19685,0.61595 0.15875,0.1905 0.4445,0.1905 0.2413,0 0.3683,-0.13335 0.13335,-0.1397 0.13335,-0.38735 0,-0.1778 -0.10795,-0.3556 -0.10795,-0.18415 -0.3429,-0.381 l -0.4953,-0.4318 q -0.24765,-0.20955 -0.37465,-0.4191 -0.127,-0.20955 -0.127,-0.50165 0,-0.2667 0.10795,-0.4445 0.1143,-0.18415 0.3048,-0.2794 0.19685,-0.1016 0.46355,-0.1016 0.4191,0 0.635,0.27305 0.2159,0.2667 0.23495,0.69215 l -0.3302,0.10795 q -0.0127,-0.24765 -0.0762,-0.4064 -0.0635,-0.1651 -0.1778,-0.2413 -0.10795,-0.0762 -0.2667,-0.0762 -0.20955,0 -0.3429,0.12065 -0.127,0.1143 -0.127,0.32385 0,0.1651 0.0635,0.2921 0.0635,0.127 0.23495,0.28575 l 0.5207,0.46355 q 0.1524,0.13335 0.2921,0.28575 0.1397,0.1524 0.2286,0.3429 0.0889,0.18415 0.0889,0.43815 0,0.28575 -0.12065,0.4826 -0.1143,0.1905 -0.32385,0.29845 -0.20955,0.1016 -0.4953,0.1016 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1960" />
+         id="path1636"
+         inkscape:connector-curvature="0" />
       <path
          d="m 223.46493,90.314299 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0572,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.05715 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0317,-0.4953 -0.0318,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.08255 -0.1143,0.08255 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1962" />
+         id="path1638"
+         inkscape:connector-curvature="0" />
       <path
          d="m 225.0812,90.257149 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.0191,0 0.0381,0 0.019,0 0.0444,0.0063 v 0.4953 q -0.0444,-0.01905 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1964" />
+         id="path1640"
+         inkscape:connector-curvature="0" />
       <path
          d="m 227.48706,90.257149 -0.79375,-3.6703 h 0.4699 l 0.5969,3.1369 0.59055,-3.1369 h 0.45085 l -0.76835,3.6703 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1966" />
+         id="path1642"
+         inkscape:connector-curvature="0" />
       <path
          d="m 230.187,90.314299 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0572,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.05715 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0317,-0.4953 -0.0318,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.08255 -0.1143,0.08255 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1968" />
+         id="path1644"
+         inkscape:connector-curvature="0" />
       <path
          d="m 231.80327,90.257149 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.0191,0 0.0381,0 0.019,0 0.0444,0.0063 v 0.4953 q -0.0444,-0.01905 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1970" />
+         id="path1646"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="DHCP daemon"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1632">
+       id="text1302">
       <path
          d="m 247.34427,90.635124 v -5.1435 h 1.1176 q 0.53975,0 0.8382,0.1905 0.3048,0.18415 0.42545,0.52705 0.127,0.3429 0.127,0.79375 v 2.0447 q 0,0.47625 -0.127,0.8382 -0.12065,0.3556 -0.41275,0.55245 -0.2921,0.19685 -0.80645,0.19685 z m 0.4826,-0.36195 h 0.6477 q 0.4064,0 0.5969,-0.1651 0.1905,-0.17145 0.2413,-0.46355 0.0508,-0.29845 0.0508,-0.6731 v -1.9177 q 0,-0.38735 -0.0699,-0.6477 -0.0635,-0.2667 -0.26035,-0.40005 -0.1905,-0.1397 -0.57785,-0.1397 h -0.62865 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1973" />
+         id="path1649"
+         inkscape:connector-curvature="0" />
       <path
          d="m 250.64934,90.635124 v -5.1435 h 0.48895 v 2.27965 h 1.61925 v -2.27965 h 0.4826 v 5.1435 h -0.4826 v -2.5019 h -1.61925 v 2.5019 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1975" />
+         id="path1651"
+         inkscape:connector-curvature="0" />
       <path
          d="m 255.33455,90.698624 q -0.5207,0 -0.80645,-0.2159 -0.2794,-0.2159 -0.38735,-0.57785 -0.10795,-0.3683 -0.10795,-0.8128 v -2.0447 q 0,-0.47625 0.10795,-0.8382 0.1143,-0.36195 0.40005,-0.56515 0.28575,-0.2032 0.79375,-0.2032 0.46355,0 0.7239,0.1778 0.2667,0.1778 0.381,0.508 0.1143,0.32385 0.1143,0.7747 v 0.31115 h -0.4572 v -0.29845 q 0,-0.33655 -0.0571,-0.57785 -0.0508,-0.2413 -0.2159,-0.37465 -0.1651,-0.13335 -0.48895,-0.13335 -0.3429,0 -0.5207,0.14605 -0.17145,0.1397 -0.23495,0.40005 -0.0572,0.26035 -0.0572,0.60325 v 2.19075 q 0,0.381 0.0699,0.635 0.0762,0.254 0.254,0.381 0.1778,0.127 0.48895,0.127 0.32385,0 0.48895,-0.1397 0.1651,-0.1397 0.2159,-0.38735 0.0571,-0.254 0.0571,-0.59055 v -0.33655 h 0.4572 v 0.3048 q 0,0.45085 -0.10795,0.8001 -0.1016,0.34925 -0.3683,0.5461 -0.26035,0.1905 -0.74295,0.1905 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1977" />
+         id="path1653"
+         inkscape:connector-curvature="0" />
       <path
          d="m 257.30335,90.635124 v -5.1435 h 1.2319 q 0.46355,0 0.7239,0.17145 0.2667,0.17145 0.381,0.47625 0.1143,0.3048 0.1143,0.71755 0,0.36195 -0.12065,0.6731 -0.1143,0.3048 -0.38735,0.48895 -0.2667,0.18415 -0.70485,0.18415 h -0.75565 v 2.43205 z m 0.4826,-2.794 h 0.61595 q 0.31115,0 0.50165,-0.0889 0.19685,-0.09525 0.28575,-0.31115 0.0889,-0.2159 0.0889,-0.5842 0,-0.3937 -0.0762,-0.6096 -0.0762,-0.22225 -0.2667,-0.3048 -0.18415,-0.0889 -0.52705,-0.0889 h -0.6223 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1979" />
+         id="path1655"
+         inkscape:connector-curvature="0" />
       <path
          d="m 262.32451,90.692274 q -0.4699,0 -0.67945,-0.3556 -0.2032,-0.3556 -0.2032,-1.1811 v -0.67945 q 0,-0.4826 0.0698,-0.83185 0.0699,-0.34925 0.254,-0.53975 0.1905,-0.19685 0.53975,-0.19685 0.2159,0 0.37465,0.1016 0.1651,0.09525 0.27305,0.2159 v -1.73355 h 0.46355 v 5.1435 h -0.46355 v -0.26035 q -0.10795,0.12065 -0.2667,0.22225 -0.1524,0.09525 -0.36195,0.09525 z m 0.0953,-0.36195 q 0.14605,0 0.28575,-0.06985 0.1397,-0.0762 0.24765,-0.1778 v -2.5527 q -0.0953,-0.0889 -0.23495,-0.17145 -0.1397,-0.0889 -0.31115,-0.0889 -0.3048,0 -0.4064,0.27305 -0.0952,0.2667 -0.0952,0.7874 v 0.8636 q 0,0.3683 0.0381,0.6223 0.0444,0.254 0.1524,0.38735 0.1143,0.127 0.32385,0.127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1981" />
+         id="path1657"
+         inkscape:connector-curvature="0" />
       <path
          d="m 264.75726,90.692274 q -0.2159,0 -0.381,-0.10795 -0.1651,-0.1143 -0.26035,-0.29845 -0.0952,-0.18415 -0.0952,-0.41275 0,-0.2794 0.0825,-0.47625 0.0826,-0.19685 0.254,-0.34925 0.1778,-0.15875 0.4572,-0.3048 0.28575,-0.1524 0.69215,-0.33655 v -0.26035 q 0,-0.33655 -0.0444,-0.52705 -0.0381,-0.19685 -0.1397,-0.2794 -0.0952,-0.08255 -0.27305,-0.08255 -0.14605,0 -0.26035,0.05715 -0.1143,0.05715 -0.18415,0.19685 -0.0698,0.13335 -0.0698,0.37465 v 0.127 l -0.4572,-0.0063 q 0.006,-0.5588 0.23495,-0.8255 0.23495,-0.27305 0.762,-0.27305 0.48895,0 0.69215,0.29845 0.2032,0.2921 0.2032,0.9144 v 1.78435 q 0,0.09525 0,0.24765 0.006,0.14605 0.0127,0.2794 0.0127,0.13335 0.0191,0.2032 h -0.41275 q -0.019,-0.12065 -0.0444,-0.2667 -0.0191,-0.1524 -0.0254,-0.2413 -0.0762,0.22225 -0.27305,0.3937 -0.1905,0.17145 -0.48895,0.17145 z m 0.1524,-0.3937 q 0.1397,0 0.24765,-0.0635 0.1143,-0.06985 0.2032,-0.17145 0.0953,-0.1016 0.14605,-0.2032 v -1.143 q -0.27305,0.14605 -0.4699,0.26035 -0.1905,0.10795 -0.31115,0.2159 -0.12065,0.10795 -0.1778,0.24765 -0.0571,0.13335 -0.0571,0.3175 0,0.2921 0.12065,0.4191 0.127,0.12065 0.29845,0.12065 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1983" />
+         id="path1659"
+         inkscape:connector-curvature="0" />
       <path
          d="m 267.56703,90.692274 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0571,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.05715 0.1778,-0.20955 0.0698,-0.15875 0.0698,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0317,-0.4953 -0.0317,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.08255 -0.1143,0.08255 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1985" />
+         id="path1661"
+         inkscape:connector-curvature="0" />
       <path
          d="m 269.15156,90.635124 v -3.6703 h 0.4318 v 0.37465 q 0.18415,-0.2159 0.4064,-0.32385 0.22225,-0.1143 0.4572,-0.1143 0.1905,0 0.34925,0.1016 0.1651,0.1016 0.23495,0.381 0.18415,-0.2413 0.41275,-0.36195 0.23495,-0.12065 0.48895,-0.12065 0.15875,0 0.29845,0.0762 0.14605,0.0762 0.23495,0.26035 0.0889,0.18415 0.0889,0.50165 v 2.8956 h -0.43815 v -2.8829 q 0,-0.32385 -0.1016,-0.42545 -0.1016,-0.10795 -0.26035,-0.10795 -0.1778,0 -0.3556,0.1016 -0.1778,0.1016 -0.33655,0.2794 0.006,0.03175 0.006,0.06985 0,0.03175 0,0.06985 v 2.8956 h -0.4318 v -2.8829 q 0,-0.32385 -0.10795,-0.42545 -0.1016,-0.10795 -0.26035,-0.10795 -0.17145,0 -0.34925,0.1016 -0.1778,0.1016 -0.33655,0.27305 v 3.04165 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1987" />
+         id="path1663"
+         inkscape:connector-curvature="0" />
       <path
          d="m 274.15238,90.692274 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.0825,-0.31115 -0.0825,-0.75565 v -1.016 q 0,-0.4445 0.0825,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.0826,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.0317,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1989" />
+         id="path1665"
+         inkscape:connector-curvature="0" />
       <path
          d="m 275.77441,90.635124 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.09525 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.09525 -0.1651,0.09525 -0.31115,0.24765 v 3.0226 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1991" />
+         id="path1667"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="mac0"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1636">
+       id="text1306">
       <path
          d="m 234.70086,130.24709 v -3.6703 h 0.4318 v 0.37465 q 0.18415,-0.2159 0.4064,-0.32385 0.22225,-0.1143 0.4572,-0.1143 0.1905,0 0.34925,0.1016 0.1651,0.1016 0.23495,0.381 0.18415,-0.2413 0.41275,-0.36195 0.23495,-0.12065 0.48895,-0.12065 0.15875,0 0.29845,0.0762 0.14605,0.0762 0.23495,0.26035 0.0889,0.18415 0.0889,0.50165 v 2.8956 h -0.43815 v -2.8829 q 0,-0.32385 -0.1016,-0.42545 -0.1016,-0.10795 -0.26035,-0.10795 -0.1778,0 -0.3556,0.1016 -0.1778,0.1016 -0.33655,0.2794 0.006,0.0318 0.006,0.0699 0,0.0318 0,0.0699 v 2.8956 h -0.4318 v -2.8829 q 0,-0.32385 -0.10795,-0.42545 -0.1016,-0.10795 -0.26035,-0.10795 -0.17145,0 -0.34925,0.1016 -0.1778,0.1016 -0.33655,0.27305 v 3.04165 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1994" />
+         id="path1670"
+         inkscape:connector-curvature="0" />
       <path
          d="m 239.42228,130.30424 q -0.2159,0 -0.381,-0.10795 -0.1651,-0.1143 -0.26035,-0.29845 -0.0953,-0.18415 -0.0953,-0.41275 0,-0.2794 0.0825,-0.47625 0.0825,-0.19685 0.254,-0.34925 0.1778,-0.15875 0.4572,-0.3048 0.28575,-0.1524 0.69215,-0.33655 v -0.26035 q 0,-0.33655 -0.0445,-0.52705 -0.0381,-0.19685 -0.1397,-0.2794 -0.0952,-0.0826 -0.27305,-0.0826 -0.14605,0 -0.26035,0.0572 -0.1143,0.0571 -0.18415,0.19685 -0.0699,0.13335 -0.0699,0.37465 v 0.127 l -0.4572,-0.006 q 0.006,-0.5588 0.23495,-0.8255 0.23495,-0.27305 0.762,-0.27305 0.48895,0 0.69215,0.29845 0.2032,0.2921 0.2032,0.9144 v 1.78435 q 0,0.0952 0,0.24765 0.006,0.14605 0.0127,0.2794 0.0127,0.13335 0.019,0.2032 h -0.41275 q -0.019,-0.12065 -0.0445,-0.2667 -0.019,-0.1524 -0.0254,-0.2413 -0.0762,0.22225 -0.27305,0.3937 -0.1905,0.17145 -0.48895,0.17145 z m 0.1524,-0.3937 q 0.1397,0 0.24765,-0.0635 0.1143,-0.0699 0.2032,-0.17145 0.0952,-0.1016 0.14605,-0.2032 v -1.143 q -0.27305,0.14605 -0.4699,0.26035 -0.1905,0.10795 -0.31115,0.2159 -0.12065,0.10795 -0.1778,0.24765 -0.0572,0.13335 -0.0572,0.3175 0,0.2921 0.12065,0.4191 0.127,0.12065 0.29845,0.12065 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1996" />
+         id="path1672"
+         inkscape:connector-curvature="0" />
       <path
          d="m 242.21936,130.30424 q -0.42545,0 -0.635,-0.1905 -0.20955,-0.1905 -0.2794,-0.51435 -0.0635,-0.3302 -0.0635,-0.74295 v -0.85725 q 0,-0.508 0.0825,-0.83185 0.0826,-0.3302 0.2921,-0.48895 0.2159,-0.15875 0.60325,-0.15875 0.3937,0 0.5969,0.14605 0.2032,0.14605 0.27305,0.41275 0.0699,0.2667 0.0699,0.6223 v 0.17145 h -0.4318 v -0.1778 q 0,-0.32385 -0.0508,-0.50165 -0.0444,-0.1778 -0.15875,-0.24765 -0.10795,-0.0762 -0.2921,-0.0762 -0.2159,0 -0.3302,0.1016 -0.1143,0.1016 -0.1524,0.33655 -0.0381,0.2286 -0.0381,0.61595 v 1.0287 q 0,0.55245 0.10795,0.78105 0.10795,0.22225 0.4191,0.22225 0.2159,0 0.32385,-0.0953 0.10795,-0.1016 0.1397,-0.29845 0.0318,-0.19685 0.0318,-0.48895 v -0.2032 h 0.4318 v 0.1778 q 0,0.3683 -0.0699,0.65405 -0.0699,0.2794 -0.27305,0.4445 -0.19685,0.15875 -0.5969,0.15875 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path1998" />
+         id="path1674"
+         inkscape:connector-curvature="0" />
       <path
          d="m 245.06208,130.31059 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0699,-0.254 0.0699,-0.56515 v -2.30505 q 0,-0.31115 -0.0699,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0699,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2000" />
+         id="path1676"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="10.0.2.15/24"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1640">
+       id="text1310">
       <path
          d="m 18.075736,128.20599 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0444 -0.24765,0.0825 -0.10795,0.0318 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0953 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2003" />
+         id="path1679"
+         inkscape:connector-curvature="0" />
       <path
          d="m 20.978876,128.26949 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.06985,-0.254 0.06985,-0.56515 v -2.30505 q 0,-0.31115 -0.06985,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.06985,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2005" />
+         id="path1681"
+         inkscape:connector-curvature="0" />
       <path
          d="m 23.008197,128.20599 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2007" />
+         id="path1683"
+         inkscape:connector-curvature="0" />
       <path
          d="m 25.418915,128.26949 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.06985,-0.254 0.06985,-0.56515 v -2.30505 q 0,-0.31115 -0.06985,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.06985,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2009" />
+         id="path1685"
+         inkscape:connector-curvature="0" />
       <path
          d="m 27.448237,128.20599 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2011" />
+         id="path1687"
+         inkscape:connector-curvature="0" />
       <path
          d="m 28.531804,128.20599 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2013" />
+         id="path1689"
+         inkscape:connector-curvature="0" />
       <path
          d="m 31.677435,128.20599 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2015" />
+         id="path1691"
+         inkscape:connector-curvature="0" />
       <path
          d="m 33.516654,128.20599 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0444 -0.24765,0.0825 -0.10795,0.0318 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0953 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2017" />
+         id="path1693"
+         inkscape:connector-curvature="0" />
       <path
          d="m 36.311844,128.26314 q -0.41275,0 -0.66675,-0.15875 -0.24765,-0.15875 -0.36195,-0.4699 -0.1143,-0.31115 -0.1143,-0.75565 h 0.46355 q 0,0.31115 0.05715,0.53975 0.0635,0.2286 0.2159,0.3556 0.15875,0.12065 0.42545,0.12065 0.2921,0 0.4445,-0.1524 0.1524,-0.1524 0.20955,-0.4445 0.05715,-0.2921 0.05715,-0.71755 0,-0.4699 -0.06985,-0.7493 -0.0635,-0.2794 -0.22225,-0.40005 -0.1524,-0.127 -0.41275,-0.127 -0.19685,0 -0.3683,0.10795 -0.17145,0.10795 -0.29845,0.3175 h -0.38735 v -2.667 h 2.00025 l -0.0064,0.43815 h -1.58115 l -0.0254,1.78435 q 0.1143,-0.1397 0.3048,-0.2413 0.19685,-0.1016 0.4826,-0.1016 0.381,0 0.6096,0.1905 0.23495,0.1905 0.33655,0.5461 0.1016,0.34925 0.1016,0.84455 0,0.4191 -0.0635,0.74295 -0.0635,0.32385 -0.20955,0.5461 -0.1397,0.22225 -0.3683,0.33655 -0.22225,0.1143 -0.55245,0.1143 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2019" />
+         id="path1695"
+         inkscape:connector-curvature="0" />
       <path
          d="m 37.960067,128.20599 1.46685,-5.1435 h 0.4064 l -1.46685,5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2021" />
+         id="path1697"
+         inkscape:connector-curvature="0" />
       <path
          d="m 40.301629,128.20599 v -0.33655 l 1.384299,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.165099,0.1397 -0.234949,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.273049,-0.1651 0.711199,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.289049,1.9431 h 1.790699 v 0.3937 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2023" />
+         id="path1699"
+         inkscape:connector-curvature="0" />
       <path
          d="m 44.833941,128.20599 v -1.50495 h -1.5494 v -0.4699 l 1.4605,-3.16865 h 0.5461 v 3.21945 h 0.59055 v 0.4191 h -0.59055 v 1.50495 z m -1.0795,-1.92405 h 1.0795 v -2.6035 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2025" />
+         id="path1701"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="10.10.1.1/24"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1644">
+       id="text1314">
       <path
          d="m 67.590611,121.55358 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0445 -0.24765,0.0826 -0.10795,0.0317 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2028" />
+         id="path1704"
+         inkscape:connector-curvature="0" />
       <path
          d="m 70.493752,121.61708 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.06985,-0.254 0.06985,-0.56515 v -2.30505 q 0,-0.31115 -0.06985,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.06985,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2030" />
+         id="path1706"
+         inkscape:connector-curvature="0" />
       <path
          d="m 72.523073,121.55358 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2032" />
+         id="path1708"
+         inkscape:connector-curvature="0" />
       <path
          d="m 74.362291,121.55358 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0445 -0.24765,0.0826 -0.10795,0.0317 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2034" />
+         id="path1710"
+         inkscape:connector-curvature="0" />
       <path
          d="m 77.265431,121.61708 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.06985,-0.254 0.06985,-0.56515 v -2.30505 q 0,-0.31115 -0.06985,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.06985,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2036" />
+         id="path1712"
+         inkscape:connector-curvature="0" />
       <path
          d="m 79.294753,121.55358 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2038" />
+         id="path1714"
+         inkscape:connector-curvature="0" />
       <path
          d="m 81.13397,121.55358 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0445 -0.24765,0.0826 -0.10795,0.0317 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2040" />
+         id="path1716"
+         inkscape:connector-curvature="0" />
       <path
          d="m 82.779811,121.55358 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2042" />
+         id="path1718"
+         inkscape:connector-curvature="0" />
       <path
          d="m 84.619029,121.55358 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0445 -0.24765,0.0826 -0.10795,0.0317 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2044" />
+         id="path1720"
+         inkscape:connector-curvature="0" />
       <path
          d="m 86.036269,121.55358 1.46685,-5.1435 h 0.4064 l -1.46685,5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2046" />
+         id="path1722"
+         inkscape:connector-curvature="0" />
       <path
          d="m 88.377831,121.55358 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2048" />
+         id="path1724"
+         inkscape:connector-curvature="0" />
       <path
          d="m 92.910143,121.55358 v -1.50495 h -1.5494 v -0.4699 l 1.4605,-3.16865 h 0.5461 v 3.21945 h 0.59055 v 0.4191 h -0.59055 v 1.50495 z m -1.0795,-1.92405 h 1.0795 v -2.6035 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2050" />
+         id="path1726"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="192.168.77.101/24"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1648">
+       id="text1318">
       <path
          d="m 82.785245,129.11316 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0444 -0.24765,0.0825 -0.10795,0.0318 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2053" />
+         id="path1729"
+         inkscape:connector-curvature="0" />
       <path
          d="m 85.650285,129.17666 q -0.38735,0 -0.6477,-0.13335 -0.26035,-0.13335 -0.3937,-0.40005 -0.127,-0.27305 -0.13335,-0.66675 0,-0.0127 0,-0.0508 0,-0.0381 0,-0.0444 h 0.4572 q 0,0.48895 0.1524,0.6985 0.15875,0.20955 0.5715,0.20955 0.2159,0 0.3683,-0.1016 0.15875,-0.1016 0.2413,-0.3429 0.08255,-0.24765 0.08255,-0.6604 v -0.97155 q -0.09525,0.1143 -0.3048,0.20955 -0.2032,0.0953 -0.5207,0.0953 -0.42545,0 -0.66675,-0.15875 -0.2413,-0.1651 -0.3429,-0.50165 -0.1016,-0.3429 -0.1016,-0.8763 0,-0.47625 0.12065,-0.8255 0.127,-0.34925 0.3937,-0.53975 0.27305,-0.19685 0.7112,-0.19685 0.4191,0 0.67945,0.19685 0.26035,0.1905 0.381,0.55245 0.12065,0.3556 0.12065,0.85725 v 2.05105 q 0,0.4699 -0.1143,0.83185 -0.1143,0.36195 -0.3683,0.56515 -0.24765,0.2032 -0.6858,0.2032 z m -0.01905,-2.52095 q 0.27305,0 0.45085,-0.0952 0.1778,-0.1016 0.2667,-0.2032 v -0.88265 q 0,-0.4191 -0.0762,-0.6731 -0.06985,-0.26035 -0.2286,-0.37465 -0.15875,-0.12065 -0.4064,-0.12065 -0.24765,0 -0.4191,0.12065 -0.1651,0.1143 -0.24765,0.3556 -0.08255,0.2413 -0.08255,0.6096 0,0.42545 0.04445,0.70485 0.0508,0.2794 0.20955,0.4191 0.15875,0.1397 0.48895,0.1397 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2055" />
+         id="path1731"
+         inkscape:connector-curvature="0" />
       <path
          d="m 87.548638,129.11316 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2057" />
+         id="path1733"
+         inkscape:connector-curvature="0" />
       <path
          d="m 90.694269,129.11316 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2059" />
+         id="path1735"
+         inkscape:connector-curvature="0" />
       <path
          d="m 92.533486,129.11316 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0444 -0.24765,0.0825 -0.10795,0.0318 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2061" />
+         id="path1737"
+         inkscape:connector-curvature="0" />
       <path
          d="m 95.404877,129.17666 q -0.42545,0 -0.6858,-0.1905 -0.26035,-0.19685 -0.381,-0.5588 -0.12065,-0.36195 -0.12065,-0.8636 v -2.05105 q 0,-0.47625 0.1143,-0.83185 0.1143,-0.36195 0.37465,-0.5588 0.26035,-0.2032 0.69215,-0.2032 0.38735,0 0.64135,0.13335 0.254,0.13335 0.381,0.40005 0.13335,0.26035 0.13335,0.65405 0,0.0127 0,0.0572 0.0063,0.0381 0.0063,0.0508 h -0.46355 q 0,-0.4953 -0.15875,-0.70485 -0.1524,-0.20955 -0.52705,-0.20955 -0.20955,0 -0.381,0.10795 -0.1651,0.1016 -0.26035,0.3429 -0.0889,0.2413 -0.0889,0.65405 v 0.9779 q 0.1143,-0.1143 0.3302,-0.20955 0.22225,-0.0952 0.4953,-0.0952 0.42545,0 0.66675,0.15875 0.2413,0.15875 0.3429,0.4953 0.1016,0.33655 0.1016,0.8763 0,0.4699 -0.12065,0.8255 -0.12065,0.3556 -0.38735,0.55245 -0.2667,0.1905 -0.70485,0.1905 z m 0,-0.38735 q 0.254,0 0.41275,-0.10795 0.1651,-0.1143 0.24765,-0.3556 0.08255,-0.2413 0.08255,-0.62865 0,-0.4191 -0.0508,-0.6985 -0.04445,-0.2794 -0.2032,-0.4191 -0.1524,-0.1397 -0.48895,-0.1397 -0.1524,0 -0.2921,0.0508 -0.1397,0.0444 -0.254,0.1143 -0.1143,0.0635 -0.1778,0.127 v 0.889 q 0,0.41275 0.0762,0.6731 0.0762,0.26035 0.23495,0.381 0.1651,0.1143 0.41275,0.1143 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2063" />
+         id="path1739"
+         inkscape:connector-curvature="0" />
       <path
          d="m 98.548425,129.17666 q -0.4445,0 -0.7112,-0.1778 -0.26035,-0.1778 -0.381,-0.50165 -0.12065,-0.3302 -0.12065,-0.762 0,-0.33655 0.0635,-0.5588 0.06985,-0.2286 0.1778,-0.37465 0.10795,-0.14605 0.2413,-0.23495 0.13335,-0.0889 0.26035,-0.1524 -0.31115,-0.127 -0.50165,-0.4191 -0.1905,-0.29845 -0.1905,-0.7874 0,-0.37465 0.1143,-0.66675 0.1143,-0.2921 0.3683,-0.4572 0.26035,-0.1651 0.67945,-0.1651 0.4191,0 0.66675,0.17145 0.254,0.1651 0.3683,0.4572 0.1143,0.2921 0.1143,0.6731 0,0.48895 -0.1905,0.7747 -0.18415,0.28575 -0.4953,0.4191 0.127,0.0635 0.254,0.1524 0.13335,0.0889 0.2413,0.23495 0.10795,0.14605 0.1778,0.37465 0.06985,0.22225 0.06985,0.5588 0,0.4318 -0.12065,0.762 -0.12065,0.32385 -0.38735,0.50165 -0.26035,0.1778 -0.6985,0.1778 z m 0,-0.3683 q 0.254,0 0.4191,-0.1143 0.1651,-0.12065 0.24765,-0.3556 0.08255,-0.2413 0.08255,-0.60325 0,-0.3175 -0.0762,-0.55245 -0.06985,-0.2413 -0.23495,-0.38735 -0.15875,-0.14605 -0.43815,-0.1651 -0.2794,0.0191 -0.45085,0.1651 -0.1651,0.14605 -0.2413,0.38735 -0.06985,0.23495 -0.06985,0.55245 0,0.36195 0.08255,0.60325 0.0889,0.23495 0.254,0.3556 0.17145,0.1143 0.42545,0.1143 z m 0,-2.6035 q 0.2667,-0.0127 0.41275,-0.14605 0.1524,-0.13335 0.2159,-0.3556 0.0635,-0.22225 0.0635,-0.50165 0,-0.4445 -0.1651,-0.6731 -0.1651,-0.23495 -0.52705,-0.23495 -0.3683,0 -0.53975,0.23495 -0.1651,0.2286 -0.1651,0.6731 0,0.2794 0.0635,0.50165 0.0635,0.22225 0.2159,0.3556 0.15875,0.13335 0.42545,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2065" />
+         id="path1741"
+         inkscape:connector-curvature="0" />
       <path
          d="m 100.50452,129.11316 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2067" />
+         id="path1743"
+         inkscape:connector-curvature="0" />
       <path
          d="m 102.01989,129.11316 1.0033,-4.76885 h -1.55575 v -0.37465 h 2.032 v 0.2286 l -1.0287,4.9149 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2069" />
+         id="path1745"
+         inkscape:connector-curvature="0" />
       <path
          d="m 104.57477,129.11316 1.0033,-4.76885 h -1.55575 v -0.37465 h 2.032 v 0.2286 l -1.0287,4.9149 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2071" />
+         id="path1747"
+         inkscape:connector-curvature="0" />
       <path
          d="m 106.76771,129.11316 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2073" />
+         id="path1749"
+         inkscape:connector-curvature="0" />
       <path
          d="m 108.60692,129.11316 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0444 -0.24765,0.0825 -0.10795,0.0318 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2075" />
+         id="path1751"
+         inkscape:connector-curvature="0" />
       <path
          d="m 111.51007,129.17666 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0699,-0.254 0.0699,-0.56515 v -2.30505 q 0,-0.31115 -0.0699,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0699,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2077" />
+         id="path1753"
+         inkscape:connector-curvature="0" />
       <path
          d="m 114.22519,129.11316 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0444 -0.24765,0.0825 -0.10795,0.0318 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2079" />
+         id="path1755"
+         inkscape:connector-curvature="0" />
       <path
          d="m 115.64242,129.11316 1.46685,-5.1435 h 0.4064 l -1.46685,5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2081" />
+         id="path1757"
+         inkscape:connector-curvature="0" />
       <path
          d="m 117.98399,129.11316 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2083" />
+         id="path1759"
+         inkscape:connector-curvature="0" />
       <path
          d="m 122.5163,129.11316 v -1.50495 h -1.5494 v -0.4699 l 1.4605,-3.16865 h 0.5461 v 3.21945 h 0.59055 v 0.4191 h -0.59055 v 1.50495 z m -1.0795,-1.92405 h 1.0795 v -2.6035 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2085" />
+         id="path1761"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="192.168.78.101/24"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1652">
+       id="text1322">
       <path
          d="m 220.06619,118.15181 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0445 -0.24765,0.0826 -0.10795,0.0317 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2088" />
+         id="path1764"
+         inkscape:connector-curvature="0" />
       <path
          d="m 222.93123,118.21531 q -0.38735,0 -0.6477,-0.13335 -0.26035,-0.13335 -0.3937,-0.40005 -0.127,-0.27305 -0.13335,-0.66675 0,-0.0127 0,-0.0508 0,-0.0381 0,-0.0444 h 0.4572 q 0,0.48895 0.1524,0.6985 0.15875,0.20955 0.5715,0.20955 0.2159,0 0.3683,-0.1016 0.15875,-0.1016 0.2413,-0.3429 0.0825,-0.24765 0.0825,-0.6604 v -0.97155 q -0.0952,0.1143 -0.3048,0.20955 -0.2032,0.0952 -0.5207,0.0952 -0.42545,0 -0.66675,-0.15875 -0.2413,-0.1651 -0.3429,-0.50165 -0.1016,-0.3429 -0.1016,-0.8763 0,-0.47625 0.12065,-0.8255 0.127,-0.34925 0.3937,-0.53975 0.27305,-0.19685 0.7112,-0.19685 0.4191,0 0.67945,0.19685 0.26035,0.1905 0.381,0.55245 0.12065,0.3556 0.12065,0.85725 v 2.05105 q 0,0.4699 -0.1143,0.83185 -0.1143,0.36195 -0.3683,0.56515 -0.24765,0.2032 -0.6858,0.2032 z m -0.019,-2.52095 q 0.27305,0 0.45085,-0.0953 0.1778,-0.1016 0.2667,-0.2032 v -0.88265 q 0,-0.4191 -0.0762,-0.6731 -0.0699,-0.26035 -0.2286,-0.37465 -0.15875,-0.12065 -0.4064,-0.12065 -0.24765,0 -0.4191,0.12065 -0.1651,0.1143 -0.24765,0.3556 -0.0825,0.2413 -0.0825,0.6096 0,0.42545 0.0445,0.70485 0.0508,0.2794 0.20955,0.4191 0.15875,0.1397 0.48895,0.1397 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2090" />
+         id="path1766"
+         inkscape:connector-curvature="0" />
       <path
          d="m 224.82958,118.15181 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2092" />
+         id="path1768"
+         inkscape:connector-curvature="0" />
       <path
          d="m 227.97521,118.15181 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2094" />
+         id="path1770"
+         inkscape:connector-curvature="0" />
       <path
          d="m 229.81443,118.15181 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0445 -0.24765,0.0826 -0.10795,0.0317 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2096" />
+         id="path1772"
+         inkscape:connector-curvature="0" />
       <path
          d="m 232.68582,118.21531 q -0.42545,0 -0.6858,-0.1905 -0.26035,-0.19685 -0.381,-0.5588 -0.12065,-0.36195 -0.12065,-0.8636 v -2.05105 q 0,-0.47625 0.1143,-0.83185 0.1143,-0.36195 0.37465,-0.5588 0.26035,-0.2032 0.69215,-0.2032 0.38735,0 0.64135,0.13335 0.254,0.13335 0.381,0.40005 0.13335,0.26035 0.13335,0.65405 0,0.0127 0,0.0572 0.006,0.0381 0.006,0.0508 h -0.46355 q 0,-0.4953 -0.15875,-0.70485 -0.1524,-0.20955 -0.52705,-0.20955 -0.20955,0 -0.381,0.10795 -0.1651,0.1016 -0.26035,0.3429 -0.0889,0.2413 -0.0889,0.65405 v 0.9779 q 0.1143,-0.1143 0.3302,-0.20955 0.22225,-0.0952 0.4953,-0.0952 0.42545,0 0.66675,0.15875 0.2413,0.15875 0.3429,0.4953 0.1016,0.33655 0.1016,0.8763 0,0.4699 -0.12065,0.8255 -0.12065,0.3556 -0.38735,0.55245 -0.2667,0.1905 -0.70485,0.1905 z m 0,-0.38735 q 0.254,0 0.41275,-0.10795 0.1651,-0.1143 0.24765,-0.3556 0.0825,-0.2413 0.0825,-0.62865 0,-0.4191 -0.0508,-0.6985 -0.0445,-0.2794 -0.2032,-0.4191 -0.1524,-0.1397 -0.48895,-0.1397 -0.1524,0 -0.2921,0.0508 -0.1397,0.0445 -0.254,0.1143 -0.1143,0.0635 -0.1778,0.127 v 0.889 q 0,0.41275 0.0762,0.6731 0.0762,0.26035 0.23495,0.381 0.1651,0.1143 0.41275,0.1143 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2098" />
+         id="path1774"
+         inkscape:connector-curvature="0" />
       <path
          d="m 235.82937,118.21531 q -0.4445,0 -0.7112,-0.1778 -0.26035,-0.1778 -0.381,-0.50165 -0.12065,-0.3302 -0.12065,-0.762 0,-0.33655 0.0635,-0.5588 0.0698,-0.2286 0.1778,-0.37465 0.10795,-0.14605 0.2413,-0.23495 0.13335,-0.0889 0.26035,-0.1524 -0.31115,-0.127 -0.50165,-0.4191 -0.1905,-0.29845 -0.1905,-0.7874 0,-0.37465 0.1143,-0.66675 0.1143,-0.2921 0.3683,-0.4572 0.26035,-0.1651 0.67945,-0.1651 0.4191,0 0.66675,0.17145 0.254,0.1651 0.3683,0.4572 0.1143,0.2921 0.1143,0.6731 0,0.48895 -0.1905,0.7747 -0.18415,0.28575 -0.4953,0.4191 0.127,0.0635 0.254,0.1524 0.13335,0.0889 0.2413,0.23495 0.10795,0.14605 0.1778,0.37465 0.0699,0.22225 0.0699,0.5588 0,0.4318 -0.12065,0.762 -0.12065,0.32385 -0.38735,0.50165 -0.26035,0.1778 -0.6985,0.1778 z m 0,-0.3683 q 0.254,0 0.4191,-0.1143 0.1651,-0.12065 0.24765,-0.3556 0.0825,-0.2413 0.0825,-0.60325 0,-0.3175 -0.0762,-0.55245 -0.0699,-0.2413 -0.23495,-0.38735 -0.15875,-0.14605 -0.43815,-0.1651 -0.2794,0.0191 -0.45085,0.1651 -0.1651,0.14605 -0.2413,0.38735 -0.0699,0.23495 -0.0699,0.55245 0,0.36195 0.0825,0.60325 0.0889,0.23495 0.254,0.3556 0.17145,0.1143 0.42545,0.1143 z m 0,-2.6035 q 0.2667,-0.0127 0.41275,-0.14605 0.1524,-0.13335 0.2159,-0.3556 0.0635,-0.22225 0.0635,-0.50165 0,-0.4445 -0.1651,-0.6731 -0.1651,-0.23495 -0.52705,-0.23495 -0.3683,0 -0.53975,0.23495 -0.1651,0.2286 -0.1651,0.6731 0,0.2794 0.0635,0.50165 0.0635,0.22225 0.2159,0.3556 0.15875,0.13335 0.42545,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2100" />
+         id="path1776"
+         inkscape:connector-curvature="0" />
       <path
          d="m 237.78547,118.15181 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2102" />
+         id="path1778"
+         inkscape:connector-curvature="0" />
       <path
          d="m 239.30083,118.15181 1.0033,-4.76885 h -1.55575 v -0.37465 h 2.032 v 0.2286 l -1.0287,4.9149 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2104" />
+         id="path1780"
+         inkscape:connector-curvature="0" />
       <path
          d="m 242.70027,118.21531 q -0.4445,0 -0.7112,-0.1778 -0.26035,-0.1778 -0.381,-0.50165 -0.12065,-0.3302 -0.12065,-0.762 0,-0.33655 0.0635,-0.5588 0.0699,-0.2286 0.1778,-0.37465 0.10795,-0.14605 0.2413,-0.23495 0.13335,-0.0889 0.26035,-0.1524 -0.31115,-0.127 -0.50165,-0.4191 -0.1905,-0.29845 -0.1905,-0.7874 0,-0.37465 0.1143,-0.66675 0.1143,-0.2921 0.3683,-0.4572 0.26035,-0.1651 0.67945,-0.1651 0.4191,0 0.66675,0.17145 0.254,0.1651 0.3683,0.4572 0.1143,0.2921 0.1143,0.6731 0,0.48895 -0.1905,0.7747 -0.18415,0.28575 -0.4953,0.4191 0.127,0.0635 0.254,0.1524 0.13335,0.0889 0.2413,0.23495 0.10795,0.14605 0.1778,0.37465 0.0699,0.22225 0.0699,0.5588 0,0.4318 -0.12065,0.762 -0.12065,0.32385 -0.38735,0.50165 -0.26035,0.1778 -0.6985,0.1778 z m 0,-0.3683 q 0.254,0 0.4191,-0.1143 0.1651,-0.12065 0.24765,-0.3556 0.0825,-0.2413 0.0825,-0.60325 0,-0.3175 -0.0762,-0.55245 -0.0699,-0.2413 -0.23495,-0.38735 -0.15875,-0.14605 -0.43815,-0.1651 -0.2794,0.0191 -0.45085,0.1651 -0.1651,0.14605 -0.2413,0.38735 -0.0699,0.23495 -0.0699,0.55245 0,0.36195 0.0825,0.60325 0.0889,0.23495 0.254,0.3556 0.17145,0.1143 0.42545,0.1143 z m 0,-2.6035 q 0.2667,-0.0127 0.41275,-0.14605 0.1524,-0.13335 0.2159,-0.3556 0.0635,-0.22225 0.0635,-0.50165 0,-0.4445 -0.1651,-0.6731 -0.1651,-0.23495 -0.52705,-0.23495 -0.3683,0 -0.53975,0.23495 -0.1651,0.2286 -0.1651,0.6731 0,0.2794 0.0635,0.50165 0.0635,0.22225 0.2159,0.3556 0.15875,0.13335 0.42545,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2106" />
+         id="path1782"
+         inkscape:connector-curvature="0" />
       <path
          d="m 244.65637,118.15181 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2108" />
+         id="path1784"
+         inkscape:connector-curvature="0" />
       <path
          d="m 246.49558,118.15181 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0445 -0.24765,0.0826 -0.10795,0.0317 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2110" />
+         id="path1786"
+         inkscape:connector-curvature="0" />
       <path
          d="m 249.39872,118.21531 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0699,-0.254 0.0699,-0.56515 v -2.30505 q 0,-0.31115 -0.0699,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0699,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2112" />
+         id="path1788"
+         inkscape:connector-curvature="0" />
       <path
          d="m 252.11385,118.15181 v -4.5212 q -0.0381,0.0571 -0.1524,0.1143 -0.1143,0.0571 -0.254,0.1016 -0.13335,0.0445 -0.24765,0.0826 -0.10795,0.0317 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.0699 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.0952 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2114" />
+         id="path1790"
+         inkscape:connector-curvature="0" />
       <path
          d="m 253.53108,118.15181 1.46685,-5.1435 h 0.4064 l -1.46685,5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2116" />
+         id="path1792"
+         inkscape:connector-curvature="0" />
       <path
          d="m 255.87265,118.15181 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2118" />
+         id="path1794"
+         inkscape:connector-curvature="0" />
       <path
          d="m 260.40496,118.15181 v -1.50495 h -1.5494 v -0.4699 l 1.4605,-3.16865 h 0.5461 v 3.21945 h 0.59055 v 0.4191 h -0.59055 v 1.50495 z m -1.0795,-1.92405 h 1.0795 v -2.6035 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2120" />
+         id="path1796"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="10.10.1.9/24"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1656">
+       id="text1326">
       <path
          d="m 66.456685,54.273811 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2123" />
+         id="path1799"
+         inkscape:connector-curvature="0" />
       <path
          d="m 69.359825,54.337311 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.06985,-0.254 0.06985,-0.56515 v -2.30505 q 0,-0.31115 -0.06985,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.06985,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2125" />
+         id="path1801"
+         inkscape:connector-curvature="0" />
       <path
          d="m 71.389146,54.273811 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2127" />
+         id="path1803"
+         inkscape:connector-curvature="0" />
       <path
          d="m 73.228364,54.273811 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2129" />
+         id="path1805"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.131505,54.337311 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.06985,-0.254 0.06985,-0.56515 v -2.30505 q 0,-0.31115 -0.06985,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.06985,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2131" />
+         id="path1807"
+         inkscape:connector-curvature="0" />
       <path
          d="m 78.160826,54.273811 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2133" />
+         id="path1809"
+         inkscape:connector-curvature="0" />
       <path
          d="m 80.000044,54.273811 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2135" />
+         id="path1811"
+         inkscape:connector-curvature="0" />
       <path
          d="m 81.645885,54.273811 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2137" />
+         id="path1813"
+         inkscape:connector-curvature="0" />
       <path
          d="m 84.018503,54.337311 q -0.38735,0 -0.6477,-0.13335 -0.26035,-0.13335 -0.3937,-0.40005 -0.127,-0.27305 -0.13335,-0.66675 0,-0.0127 0,-0.0508 0,-0.0381 0,-0.04445 h 0.4572 q 0,0.48895 0.1524,0.6985 0.15875,0.20955 0.5715,0.20955 0.2159,0 0.3683,-0.1016 0.15875,-0.1016 0.2413,-0.3429 0.08255,-0.24765 0.08255,-0.6604 v -0.97155 q -0.09525,0.1143 -0.3048,0.20955 -0.2032,0.09525 -0.5207,0.09525 -0.42545,0 -0.66675,-0.15875 -0.2413,-0.1651 -0.3429,-0.50165 -0.1016,-0.3429 -0.1016,-0.8763 0,-0.47625 0.12065,-0.8255 0.127,-0.34925 0.3937,-0.53975 0.27305,-0.19685 0.7112,-0.19685 0.4191,0 0.67945,0.19685 0.260349,0.1905 0.380999,0.55245 0.12065,0.3556 0.12065,0.85725 v 2.05105 q 0,0.4699 -0.1143,0.83185 -0.1143,0.36195 -0.368299,0.56515 -0.24765,0.2032 -0.6858,0.2032 z m -0.01905,-2.52095 q 0.27305,0 0.45085,-0.09525 0.1778,-0.1016 0.2667,-0.2032 v -0.88265 q 0,-0.4191 -0.0762,-0.6731 -0.06985,-0.26035 -0.2286,-0.37465 -0.15875,-0.12065 -0.4064,-0.12065 -0.24765,0 -0.4191,0.12065 -0.1651,0.1143 -0.24765,0.3556 -0.08255,0.2413 -0.08255,0.6096 0,0.42545 0.04445,0.70485 0.0508,0.2794 0.20955,0.4191 0.15875,0.1397 0.48895,0.1397 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2139" />
+         id="path1815"
+         inkscape:connector-curvature="0" />
       <path
          d="m 85.758105,54.273811 1.46685,-5.1435 h 0.4064 l -1.46685,5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2141" />
+         id="path1817"
+         inkscape:connector-curvature="0" />
       <path
          d="m 88.099667,54.273811 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2143" />
+         id="path1819"
+         inkscape:connector-curvature="0" />
       <path
          d="m 92.631979,54.273811 v -1.50495 h -1.5494 v -0.4699 l 1.4605,-3.16865 h 0.5461 v 3.21945 h 0.59055 v 0.4191 h -0.59055 v 1.50495 z m -1.0795,-1.92405 h 1.0795 v -2.6035 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2145" />
+         id="path1821"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="10.10.1.12/24"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1660">
+       id="text1330">
       <path
          d="m 112.94775,54.349407 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2148" />
+         id="path1824"
+         inkscape:connector-curvature="0" />
       <path
          d="m 115.85089,54.412907 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0699,-0.254 0.0699,-0.56515 v -2.30505 q 0,-0.31115 -0.0699,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0698,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2150" />
+         id="path1826"
+         inkscape:connector-curvature="0" />
       <path
          d="m 117.88021,54.349407 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2152" />
+         id="path1828"
+         inkscape:connector-curvature="0" />
       <path
          d="m 119.71943,54.349407 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2154" />
+         id="path1830"
+         inkscape:connector-curvature="0" />
       <path
          d="m 122.62257,54.412907 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0699,-0.254 0.0699,-0.56515 v -2.30505 q 0,-0.31115 -0.0699,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0699,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2156" />
+         id="path1832"
+         inkscape:connector-curvature="0" />
       <path
          d="m 124.65189,54.349407 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2158" />
+         id="path1834"
+         inkscape:connector-curvature="0" />
       <path
          d="m 126.49111,54.349407 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2160" />
+         id="path1836"
+         inkscape:connector-curvature="0" />
       <path
          d="m 128.13695,54.349407 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2162" />
+         id="path1838"
+         inkscape:connector-curvature="0" />
       <path
          d="m 129.97617,54.349407 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2164" />
+         id="path1840"
+         inkscape:connector-curvature="0" />
       <path
          d="m 131.55216,54.349407 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2166" />
+         id="path1842"
+         inkscape:connector-curvature="0" />
       <path
          d="m 134.46919,54.349407 1.46685,-5.1435 h 0.4064 l -1.46685,5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2168" />
+         id="path1844"
+         inkscape:connector-curvature="0" />
       <path
          d="m 136.81075,54.349407 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2170" />
+         id="path1846"
+         inkscape:connector-curvature="0" />
       <path
          d="m 141.34307,54.349407 v -1.50495 h -1.5494 v -0.4699 l 1.4605,-3.16865 h 0.5461 v 3.21945 h 0.59055 v 0.4191 h -0.59055 v 1.50495 z m -1.0795,-1.92405 h 1.0795 v -2.6035 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2172" />
+         id="path1848"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="192.168.78.202/24"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1664">
+       id="text1334">
       <path
          d="m 151.80365,54.802971 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2175" />
+         id="path1851"
+         inkscape:connector-curvature="0" />
       <path
          d="m 154.66869,54.866471 q -0.38735,0 -0.6477,-0.13335 -0.26035,-0.13335 -0.3937,-0.40005 -0.127,-0.27305 -0.13335,-0.66675 0,-0.0127 0,-0.0508 0,-0.0381 0,-0.04445 h 0.4572 q 0,0.48895 0.1524,0.6985 0.15875,0.20955 0.5715,0.20955 0.2159,0 0.3683,-0.1016 0.15875,-0.1016 0.2413,-0.3429 0.0825,-0.24765 0.0825,-0.6604 v -0.97155 q -0.0952,0.1143 -0.3048,0.20955 -0.2032,0.09525 -0.5207,0.09525 -0.42545,0 -0.66675,-0.15875 -0.2413,-0.1651 -0.3429,-0.50165 -0.1016,-0.3429 -0.1016,-0.8763 0,-0.47625 0.12065,-0.8255 0.127,-0.34925 0.3937,-0.53975 0.27305,-0.19685 0.7112,-0.19685 0.4191,0 0.67945,0.19685 0.26035,0.1905 0.381,0.55245 0.12065,0.3556 0.12065,0.85725 v 2.05105 q 0,0.4699 -0.1143,0.83185 -0.1143,0.36195 -0.3683,0.56515 -0.24765,0.2032 -0.6858,0.2032 z m -0.019,-2.52095 q 0.27305,0 0.45085,-0.09525 0.1778,-0.1016 0.2667,-0.2032 v -0.88265 q 0,-0.4191 -0.0762,-0.6731 -0.0699,-0.26035 -0.2286,-0.37465 -0.15875,-0.12065 -0.4064,-0.12065 -0.24765,0 -0.4191,0.12065 -0.1651,0.1143 -0.24765,0.3556 -0.0825,0.2413 -0.0825,0.6096 0,0.42545 0.0445,0.70485 0.0508,0.2794 0.20955,0.4191 0.15875,0.1397 0.48895,0.1397 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2177" />
+         id="path1853"
+         inkscape:connector-curvature="0" />
       <path
          d="m 156.56704,54.802971 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2179" />
+         id="path1855"
+         inkscape:connector-curvature="0" />
       <path
          d="m 159.71267,54.802971 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2181" />
+         id="path1857"
+         inkscape:connector-curvature="0" />
       <path
          d="m 161.55189,54.802971 v -4.5212 q -0.0381,0.05715 -0.1524,0.1143 -0.1143,0.05715 -0.254,0.1016 -0.13335,0.04445 -0.24765,0.08255 -0.10795,0.03175 -0.1397,0.0381 v -0.37465 q 0.0889,-0.0254 0.20955,-0.06985 0.12065,-0.0508 0.2413,-0.127 0.12065,-0.0762 0.23495,-0.17145 0.1143,-0.09525 0.2032,-0.2159 h 0.37465 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2183" />
+         id="path1859"
+         inkscape:connector-curvature="0" />
       <path
          d="m 164.42328,54.866471 q -0.42545,0 -0.6858,-0.1905 -0.26035,-0.19685 -0.381,-0.5588 -0.12065,-0.36195 -0.12065,-0.8636 v -2.05105 q 0,-0.47625 0.1143,-0.83185 0.1143,-0.36195 0.37465,-0.5588 0.26035,-0.2032 0.69215,-0.2032 0.38735,0 0.64135,0.13335 0.254,0.13335 0.381,0.40005 0.13335,0.26035 0.13335,0.65405 0,0.0127 0,0.05715 0.006,0.0381 0.006,0.0508 h -0.46355 q 0,-0.4953 -0.15875,-0.70485 -0.1524,-0.20955 -0.52705,-0.20955 -0.20955,0 -0.381,0.10795 -0.1651,0.1016 -0.26035,0.3429 -0.0889,0.2413 -0.0889,0.65405 v 0.9779 q 0.1143,-0.1143 0.3302,-0.20955 0.22225,-0.09525 0.4953,-0.09525 0.42545,0 0.66675,0.15875 0.2413,0.15875 0.3429,0.4953 0.1016,0.33655 0.1016,0.8763 0,0.4699 -0.12065,0.8255 -0.12065,0.3556 -0.38735,0.55245 -0.2667,0.1905 -0.70485,0.1905 z m 0,-0.38735 q 0.254,0 0.41275,-0.10795 0.1651,-0.1143 0.24765,-0.3556 0.0826,-0.2413 0.0826,-0.62865 0,-0.4191 -0.0508,-0.6985 -0.0445,-0.2794 -0.2032,-0.4191 -0.1524,-0.1397 -0.48895,-0.1397 -0.1524,0 -0.2921,0.0508 -0.1397,0.04445 -0.254,0.1143 -0.1143,0.0635 -0.1778,0.127 v 0.889 q 0,0.41275 0.0762,0.6731 0.0762,0.26035 0.23495,0.381 0.1651,0.1143 0.41275,0.1143 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2185" />
+         id="path1861"
+         inkscape:connector-curvature="0" />
       <path
          d="m 167.56683,54.866471 q -0.4445,0 -0.7112,-0.1778 -0.26035,-0.1778 -0.381,-0.50165 -0.12065,-0.3302 -0.12065,-0.762 0,-0.33655 0.0635,-0.5588 0.0698,-0.2286 0.1778,-0.37465 0.10795,-0.14605 0.2413,-0.23495 0.13335,-0.0889 0.26035,-0.1524 -0.31115,-0.127 -0.50165,-0.4191 -0.1905,-0.29845 -0.1905,-0.7874 0,-0.37465 0.1143,-0.66675 0.1143,-0.2921 0.3683,-0.4572 0.26035,-0.1651 0.67945,-0.1651 0.4191,0 0.66675,0.17145 0.254,0.1651 0.3683,0.4572 0.1143,0.2921 0.1143,0.6731 0,0.48895 -0.1905,0.7747 -0.18415,0.28575 -0.4953,0.4191 0.127,0.0635 0.254,0.1524 0.13335,0.0889 0.2413,0.23495 0.10795,0.14605 0.1778,0.37465 0.0698,0.22225 0.0698,0.5588 0,0.4318 -0.12065,0.762 -0.12065,0.32385 -0.38735,0.50165 -0.26035,0.1778 -0.6985,0.1778 z m 0,-0.3683 q 0.254,0 0.4191,-0.1143 0.1651,-0.12065 0.24765,-0.3556 0.0825,-0.2413 0.0825,-0.60325 0,-0.3175 -0.0762,-0.55245 -0.0698,-0.2413 -0.23495,-0.38735 -0.15875,-0.14605 -0.43815,-0.1651 -0.2794,0.01905 -0.45085,0.1651 -0.1651,0.14605 -0.2413,0.38735 -0.0699,0.23495 -0.0699,0.55245 0,0.36195 0.0825,0.60325 0.0889,0.23495 0.254,0.3556 0.17145,0.1143 0.42545,0.1143 z m 0,-2.6035 q 0.2667,-0.0127 0.41275,-0.14605 0.1524,-0.13335 0.2159,-0.3556 0.0635,-0.22225 0.0635,-0.50165 0,-0.4445 -0.1651,-0.6731 -0.1651,-0.23495 -0.52705,-0.23495 -0.3683,0 -0.53975,0.23495 -0.1651,0.2286 -0.1651,0.6731 0,0.2794 0.0635,0.50165 0.0635,0.22225 0.2159,0.3556 0.15875,0.13335 0.42545,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2187" />
+         id="path1863"
+         inkscape:connector-curvature="0" />
       <path
          d="m 169.52292,54.802971 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2189" />
+         id="path1865"
+         inkscape:connector-curvature="0" />
       <path
          d="m 171.03829,54.802971 1.0033,-4.76885 h -1.55575 v -0.37465 h 2.032 v 0.2286 l -1.0287,4.9149 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2191" />
+         id="path1867"
+         inkscape:connector-curvature="0" />
       <path
          d="m 174.43773,54.866471 q -0.4445,0 -0.7112,-0.1778 -0.26035,-0.1778 -0.381,-0.50165 -0.12065,-0.3302 -0.12065,-0.762 0,-0.33655 0.0635,-0.5588 0.0699,-0.2286 0.1778,-0.37465 0.10795,-0.14605 0.2413,-0.23495 0.13335,-0.0889 0.26035,-0.1524 -0.31115,-0.127 -0.50165,-0.4191 -0.1905,-0.29845 -0.1905,-0.7874 0,-0.37465 0.1143,-0.66675 0.1143,-0.2921 0.3683,-0.4572 0.26035,-0.1651 0.67945,-0.1651 0.4191,0 0.66675,0.17145 0.254,0.1651 0.3683,0.4572 0.1143,0.2921 0.1143,0.6731 0,0.48895 -0.1905,0.7747 -0.18415,0.28575 -0.4953,0.4191 0.127,0.0635 0.254,0.1524 0.13335,0.0889 0.2413,0.23495 0.10795,0.14605 0.1778,0.37465 0.0699,0.22225 0.0699,0.5588 0,0.4318 -0.12065,0.762 -0.12065,0.32385 -0.38735,0.50165 -0.26035,0.1778 -0.6985,0.1778 z m 0,-0.3683 q 0.254,0 0.4191,-0.1143 0.1651,-0.12065 0.24765,-0.3556 0.0825,-0.2413 0.0825,-0.60325 0,-0.3175 -0.0762,-0.55245 -0.0699,-0.2413 -0.23495,-0.38735 -0.15875,-0.14605 -0.43815,-0.1651 -0.2794,0.01905 -0.45085,0.1651 -0.1651,0.14605 -0.2413,0.38735 -0.0699,0.23495 -0.0699,0.55245 0,0.36195 0.0826,0.60325 0.0889,0.23495 0.254,0.3556 0.17145,0.1143 0.42545,0.1143 z m 0,-2.6035 q 0.2667,-0.0127 0.41275,-0.14605 0.1524,-0.13335 0.2159,-0.3556 0.0635,-0.22225 0.0635,-0.50165 0,-0.4445 -0.1651,-0.6731 -0.1651,-0.23495 -0.52705,-0.23495 -0.3683,0 -0.53975,0.23495 -0.1651,0.2286 -0.1651,0.6731 0,0.2794 0.0635,0.50165 0.0635,0.22225 0.2159,0.3556 0.15875,0.13335 0.42545,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2193" />
+         id="path1869"
+         inkscape:connector-curvature="0" />
       <path
          d="m 176.39382,54.802971 v -0.6985 h 0.48895 v 0.6985 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2195" />
+         id="path1871"
+         inkscape:connector-curvature="0" />
       <path
          d="m 177.47739,54.802971 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2197" />
+         id="path1873"
+         inkscape:connector-curvature="0" />
       <path
          d="m 181.88032,54.866471 q -0.4572,0 -0.7239,-0.19685 -0.2667,-0.19685 -0.381,-0.53975 -0.1143,-0.3429 -0.1143,-0.78105 v -2.2352 q 0,-0.4445 0.1143,-0.78105 0.12065,-0.3429 0.38735,-0.5334 0.27305,-0.1905 0.71755,-0.1905 0.4572,0 0.7239,0.1905 0.2667,0.1905 0.381,0.5334 0.12065,0.33655 0.12065,0.78105 v 2.2352 q 0,0.4445 -0.1143,0.7874 -0.1143,0.3429 -0.381,0.53975 -0.2667,0.1905 -0.73025,0.1905 z m 0,-0.3683 q 0.29845,0 0.4572,-0.14605 0.1651,-0.1524 0.2286,-0.40005 0.0698,-0.254 0.0698,-0.56515 v -2.30505 q 0,-0.31115 -0.0698,-0.5588 -0.0635,-0.254 -0.22225,-0.40005 -0.15875,-0.14605 -0.46355,-0.14605 -0.2921,0 -0.4572,0.14605 -0.15875,0.14605 -0.2286,0.40005 -0.0635,0.24765 -0.0635,0.5588 v 2.30505 q 0,0.31115 0.0635,0.56515 0.0699,0.24765 0.23495,0.40005 0.1651,0.14605 0.45085,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2199" />
+         id="path1875"
+         inkscape:connector-curvature="0" />
       <path
          d="m 183.83979,54.802971 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2201" />
+         id="path1877"
+         inkscape:connector-curvature="0" />
       <path
          d="m 186.75682,54.802971 1.46685,-5.1435 h 0.4064 l -1.46685,5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2203" />
+         id="path1879"
+         inkscape:connector-curvature="0" />
       <path
          d="m 189.09839,54.802971 v -0.33655 l 1.3843,-2.12725 q 0.1524,-0.23495 0.28575,-0.45085 0.13335,-0.22225 0.2159,-0.46355 0.0889,-0.2413 0.0889,-0.5461 0,-0.41275 -0.17145,-0.6477 -0.1651,-0.23495 -0.51435,-0.23495 -0.3175,0 -0.48895,0.1397 -0.1651,0.1397 -0.23495,0.38735 -0.0635,0.2413 -0.0635,0.5461 v 0.1143 h -0.46355 v -0.127 q 0,-0.47625 0.127,-0.79375 0.127,-0.32385 0.3937,-0.48895 0.27305,-0.1651 0.7112,-0.1651 0.5842,0 0.8763,0.34925 0.2921,0.3429 0.2921,0.95885 0,0.31115 -0.0889,0.5715 -0.0889,0.26035 -0.2286,0.50165 -0.1397,0.23495 -0.2921,0.47625 l -1.28905,1.9431 h 1.7907 v 0.3937 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2205" />
+         id="path1881"
+         inkscape:connector-curvature="0" />
       <path
          d="m 193.6307,54.802971 v -1.50495 h -1.5494 v -0.4699 l 1.4605,-3.16865 h 0.5461 v 3.21945 h 0.59055 v 0.4191 h -0.59055 v 1.50495 z m -1.0795,-1.92405 h 1.0795 v -2.6035 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2207" />
+         id="path1883"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="Public network (NAT)"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1668">
+       id="text1338">
       <path
          d="m 11.034194,175.60423 v -5.1435 h 1.2319 q 0.46355,0 0.7239,0.17145 0.2667,0.17145 0.381,0.47625 0.1143,0.3048 0.1143,0.71755 0,0.36195 -0.12065,0.6731 -0.1143,0.3048 -0.38735,0.48895 -0.2667,0.18415 -0.70485,0.18415 h -0.75565 v 2.43205 z m 0.4826,-2.794 h 0.61595 q 0.31115,0 0.50165,-0.0889 0.19685,-0.0952 0.28575,-0.31115 0.0889,-0.2159 0.0889,-0.5842 0,-0.3937 -0.0762,-0.6096 -0.0762,-0.22225 -0.2667,-0.3048 -0.18415,-0.0889 -0.52705,-0.0889 h -0.6223 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2210" />
+         id="path1886"
+         inkscape:connector-curvature="0" />
       <path
          d="m 14.542073,175.66138 q -0.18415,0 -0.31115,-0.0889 -0.127,-0.0953 -0.19685,-0.2667 -0.0635,-0.1778 -0.0635,-0.42545 v -2.9464 h 0.46355 v 2.8448 q 0,0.28575 0.0889,0.4064 0.0889,0.1143 0.2667,0.1143 0.1651,0 0.3302,-0.1016 0.17145,-0.10795 0.3175,-0.2667 v -2.9972 h 0.46355 v 3.6703 h -0.46355 v -0.4064 q -0.1778,0.2032 -0.4064,0.33655 -0.2286,0.127 -0.48895,0.127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2212" />
+         id="path1888"
+         inkscape:connector-curvature="0" />
       <path
          d="m 17.743167,175.66138 q -0.22225,0 -0.38735,-0.1143 -0.158749,-0.1143 -0.266699,-0.23495 v 0.2921 h -0.46355 v -5.1435 h 0.46355 v 1.778 q 0.10795,-0.13335 0.279399,-0.24765 0.17145,-0.1143 0.4191,-0.1143 0.2667,0 0.4318,0.127 0.1651,0.12065 0.254,0.3302 0.0889,0.20955 0.1143,0.4699 0.03175,0.26035 0.03175,0.53975 v 0.76835 q 0,0.4699 -0.0762,0.81915 -0.0762,0.34925 -0.2667,0.53975 -0.1905,0.1905 -0.5334,0.1905 z m -0.08255,-0.36195 q 0.2159,0 0.3175,-0.13335 0.10795,-0.1397 0.1397,-0.40005 0.0381,-0.2667 0.0381,-0.64135 v -0.78105 q 0,-0.36195 -0.0381,-0.60325 -0.0381,-0.24765 -0.1397,-0.37465 -0.1016,-0.127 -0.32385,-0.127 -0.1778,0 -0.32385,0.0952 -0.146049,0.0952 -0.241299,0.1905 v 2.5019 q 0.1016,0.10795 0.247649,0.1905 0.14605,0.0825 0.32385,0.0825 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2214" />
+         id="path1890"
+         inkscape:connector-curvature="0" />
       <path
          d="m 19.324416,175.60423 v -5.1435 h 0.46355 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2216" />
+         id="path1892"
+         inkscape:connector-curvature="0" />
       <path
          d="m 20.589158,175.60423 v -3.6703 h 0.46355 v 3.6703 z m 0,-4.1783 v -0.62865 h 0.46355 v 0.62865 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2218" />
+         id="path1894"
+         inkscape:connector-curvature="0" />
       <path
          d="m 22.736252,175.66138 q -0.42545,0 -0.635,-0.1905 -0.20955,-0.1905 -0.2794,-0.51435 -0.0635,-0.3302 -0.0635,-0.74295 v -0.85725 q 0,-0.508 0.08255,-0.83185 0.08255,-0.3302 0.2921,-0.48895 0.2159,-0.15875 0.60325,-0.15875 0.3937,0 0.5969,0.14605 0.2032,0.14605 0.27305,0.41275 0.06985,0.2667 0.06985,0.6223 v 0.17145 h -0.4318 v -0.1778 q 0,-0.32385 -0.0508,-0.50165 -0.04445,-0.1778 -0.15875,-0.24765 -0.10795,-0.0762 -0.2921,-0.0762 -0.2159,0 -0.3302,0.1016 -0.1143,0.1016 -0.1524,0.33655 -0.0381,0.2286 -0.0381,0.61595 v 1.0287 q 0,0.55245 0.10795,0.78105 0.10795,0.22225 0.4191,0.22225 0.2159,0 0.32385,-0.0952 0.10795,-0.1016 0.1397,-0.29845 0.03175,-0.19685 0.03175,-0.48895 v -0.2032 h 0.4318 v 0.1778 q 0,0.3683 -0.06985,0.65405 -0.06985,0.2794 -0.27305,0.4445 -0.19685,0.15875 -0.5969,0.15875 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2220" />
+         id="path1896"
+         inkscape:connector-curvature="0" />
       <path
          d="m 25.586112,175.60423 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.06985,0.17145 0.06985,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2222" />
+         id="path1898"
+         inkscape:connector-curvature="0" />
       <path
          d="m 29.098952,175.66138 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.08255,0.3302 0.08255,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.05715,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0571 0.1778,-0.20955 0.06985,-0.15875 0.06985,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.03175,-0.4953 -0.03175,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2224" />
+         id="path1900"
+         inkscape:connector-curvature="0" />
       <path
          d="m 31.553426,175.64868 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.05715,0.381 0.0635,0.10795 0.2667,0.10795 0.05715,0 0.127,-0.006 0.06985,-0.0127 0.13335,-0.0191 v 0.34925 q -0.09525,0.019 -0.19685,0.0254 -0.09525,0.0127 -0.1905,0.0127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2226" />
+         id="path1902"
+         inkscape:connector-curvature="0" />
       <path
          d="m 32.895161,175.60423 -0.5969,-3.6703 h 0.3937 l 0.46355,3.06705 0.57785,-3.06705 h 0.40005 l 0.5842,3.05435 0.43815,-3.05435 h 0.40005 l -0.5969,3.6703 h -0.4318 l -0.59055,-2.9845 -0.5715,2.9845 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2228" />
+         id="path1904"
+         inkscape:connector-curvature="0" />
       <path
          d="m 37.011349,175.66138 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.08255,-0.31115 -0.08255,-0.75565 v -1.016 q 0,-0.4445 0.08255,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.08255,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.03175,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2230" />
+         id="path1906"
+         inkscape:connector-curvature="0" />
       <path
          d="m 38.665128,175.60423 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.01905,0 0.0381,0 0.01905,0 0.04445,0.006 v 0.4953 q -0.04445,-0.019 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2232" />
+         id="path1908"
+         inkscape:connector-curvature="0" />
       <path
          d="m 40.524884,175.60423 v -5.1435 h 0.46355 v 3.27025 l 1.22555,-1.79705 h 0.48895 l -0.9271,1.41605 0.889,2.25425 h -0.4699 l -0.7747,-1.9939 -0.4318,0.60325 v 1.39065 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2234" />
+         id="path1910"
+         inkscape:connector-curvature="0" />
       <path
          d="m 45.563709,176.65198 q -0.31115,-0.0191 -0.51435,-0.1905 -0.2032,-0.17145 -0.3175,-0.46355 -0.10795,-0.28575 -0.1651,-0.66675 -0.0508,-0.38735 -0.0635,-0.8382 -0.0063,-0.4572 -0.0063,-0.9525 0,-0.4953 0.0063,-0.9525 0.0127,-0.46355 0.0635,-0.8509 0.05715,-0.38735 0.1651,-0.67945 0.1143,-0.2921 0.3175,-0.4572 0.2032,-0.1651 0.51435,-0.1778 v 0.3302 q -0.23495,0.0191 -0.36195,0.254 -0.127,0.2286 -0.18415,0.61595 -0.0508,0.38735 -0.0635,0.88265 -0.0064,0.48895 -0.0064,1.03505 0,0.5461 0.0064,1.0414 0.0127,0.4953 0.0635,0.88265 0.05715,0.381 0.18415,0.6096 0.127,0.23495 0.36195,0.254 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2236" />
+         id="path1912"
+         inkscape:connector-curvature="0" />
       <path
          d="m 46.207241,175.60423 v -5.1435 h 0.34925 l 1.6383,3.99415 v -3.99415 h 0.4191 v 5.1435 h -0.3429 l -1.651,-4.0386 v 4.0386 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2238" />
+         id="path1914"
+         inkscape:connector-curvature="0" />
       <path
          d="m 49.226863,175.60423 1.08585,-5.1435 h 0.508 l 1.0922,5.1435 h -0.47625 l -0.254,-1.37795 h -1.22555 l -0.26035,1.37795 z m 0.8001,-1.7272 h 1.0922 l -0.55245,-2.77495 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2240" />
+         id="path1916"
+         inkscape:connector-curvature="0" />
       <path
          d="m 52.857377,175.60423 v -4.76885 h -0.97155 v -0.37465 h 2.39395 v 0.37465 h -0.9398 v 4.76885 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2242" />
+         id="path1918"
+         inkscape:connector-curvature="0" />
       <path
          d="m 54.591323,176.65198 v -0.32385 q 0.2413,-0.0254 0.3683,-0.26035 0.127,-0.2286 0.1778,-0.61595 0.05715,-0.38735 0.0635,-0.8763 0.0127,-0.4953 0.0127,-1.0414 0,-0.5461 -0.0127,-1.0414 -0.0064,-0.4953 -0.0635,-0.8763 -0.0508,-0.381 -0.1778,-0.6096 -0.127,-0.23495 -0.3683,-0.26035 v -0.32385 q 0.3175,0.0127 0.5207,0.1778 0.2032,0.15875 0.3175,0.45085 0.1143,0.2921 0.1651,0.67945 0.05715,0.38735 0.0635,0.84455 0.0127,0.4572 0.0127,0.95885 0,0.4953 -0.0127,0.9525 -0.0064,0.45085 -0.0635,0.8382 -0.0508,0.38735 -0.1651,0.6731 -0.1143,0.2921 -0.3175,0.46355 -0.2032,0.17145 -0.5207,0.1905 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2244" />
+         id="path1920"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="Node network:
 K8s control plane +
 Pod network underlay"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1676">
+       id="text1346">
       <path
          d="m 85.268713,174.84833 v -5.1435 h 0.34925 l 1.6383,3.99415 v -3.99415 h 0.4191 v 5.1435 h -0.3429 l -1.651,-4.0386 v 4.0386 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2247" />
+         id="path1923"
+         inkscape:connector-curvature="0" />
       <path
          d="m 89.380537,174.90548 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.08255,-0.31115 -0.08255,-0.75565 v -1.016 q 0,-0.4445 0.08255,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.08255,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.03175,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2249" />
+         id="path1925"
+         inkscape:connector-curvature="0" />
       <path
          d="m 91.815365,174.90548 q -0.4699,0 -0.67945,-0.3556 -0.2032,-0.3556 -0.2032,-1.1811 v -0.67945 q 0,-0.4826 0.06985,-0.83185 0.06985,-0.34925 0.254,-0.53975 0.1905,-0.19685 0.53975,-0.19685 0.2159,0 0.37465,0.1016 0.1651,0.0953 0.27305,0.2159 v -1.73355 h 0.46355 v 5.1435 h -0.46355 v -0.26035 q -0.10795,0.12065 -0.2667,0.22225 -0.1524,0.0953 -0.36195,0.0953 z m 0.09525,-0.36195 q 0.14605,0 0.28575,-0.0699 0.1397,-0.0762 0.24765,-0.1778 v -2.5527 q -0.09525,-0.0889 -0.23495,-0.17145 -0.1397,-0.0889 -0.31115,-0.0889 -0.3048,0 -0.4064,0.27305 -0.09525,0.2667 -0.09525,0.7874 v 0.8636 q 0,0.3683 0.0381,0.6223 0.04445,0.254 0.1524,0.38735 0.1143,0.127 0.32385,0.127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2251" />
+         id="path1927"
+         inkscape:connector-curvature="0" />
       <path
          d="m 94.54021,174.90548 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.08255,0.3302 0.08255,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.05715,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0571 0.1778,-0.20955 0.06985,-0.15875 0.06985,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.03175,-0.4953 -0.03175,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2253" />
+         id="path1929"
+         inkscape:connector-curvature="0" />
       <path
          d="m 97.414576,174.84833 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.06985,0.17145 0.06985,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2255" />
+         id="path1931"
+         inkscape:connector-curvature="0" />
       <path
          d="m 100.92742,174.90548 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.101603,-0.3175 -0.101603,-0.84455 v -0.9271 q 0,-0.5461 0.107953,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0571,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0571 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0318,-0.4953 -0.0317,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2257" />
+         id="path1933"
+         inkscape:connector-curvature="0" />
       <path
          d="m 103.38189,174.89278 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0571,0.381 0.0635,0.10795 0.2667,0.10795 0.0572,0 0.127,-0.006 0.0699,-0.0127 0.13335,-0.0191 v 0.34925 q -0.0952,0.019 -0.19685,0.0254 -0.0952,0.0127 -0.1905,0.0127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2259" />
+         id="path1935"
+         inkscape:connector-curvature="0" />
       <path
          d="m 104.72362,174.84833 -0.5969,-3.6703 h 0.3937 l 0.46355,3.06705 0.57785,-3.06705 h 0.40005 l 0.5842,3.05435 0.43815,-3.05435 h 0.40005 l -0.5969,3.6703 h -0.4318 l -0.59055,-2.9845 -0.5715,2.9845 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2261" />
+         id="path1937"
+         inkscape:connector-curvature="0" />
       <path
          d="m 108.83981,174.90548 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.0826,-0.31115 -0.0826,-0.75565 v -1.016 q 0,-0.4445 0.0826,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.0825,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.0318,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2263" />
+         id="path1939"
+         inkscape:connector-curvature="0" />
       <path
          d="m 110.49359,174.84833 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.019,0 0.0381,0 0.019,0 0.0444,0.006 v 0.4953 q -0.0444,-0.019 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2265" />
+         id="path1941"
+         inkscape:connector-curvature="0" />
       <path
          d="m 112.35335,174.84833 v -5.1435 h 0.46355 v 3.27025 l 1.22555,-1.79705 h 0.48895 l -0.9271,1.41605 0.889,2.25425 h -0.4699 l -0.7747,-1.9939 -0.4318,0.60325 v 1.39065 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2267" />
+         id="path1943"
+         inkscape:connector-curvature="0" />
       <path
          d="m 114.97203,172.16228 v -0.67945 h 0.4953 v 0.67945 z m 0,2.159 v -0.67945 h 0.4953 v 0.67945 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2269" />
+         id="path1945"
+         inkscape:connector-curvature="0" />
       <path
          d="m 85.262363,182.78583 v -5.1435 h 0.48895 v 2.7178 l 1.3716,-2.7178 h 0.46355 l -1.06045,2.2098 1.28905,2.9337 h -0.47625 l -1.1303,-2.57175 -0.4572,0.8382 v 1.73355 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2271" />
+         id="path1947"
+         inkscape:connector-curvature="0" />
       <path
          d="m 89.295109,182.84933 q -0.4445,0 -0.7112,-0.1778 -0.26035,-0.1778 -0.381,-0.50165 -0.12065,-0.3302 -0.12065,-0.762 0,-0.33655 0.0635,-0.5588 0.06985,-0.2286 0.1778,-0.37465 0.10795,-0.14605 0.2413,-0.23495 0.13335,-0.0889 0.26035,-0.1524 -0.31115,-0.127 -0.50165,-0.4191 -0.1905,-0.29845 -0.1905,-0.7874 0,-0.37465 0.1143,-0.66675 0.1143,-0.2921 0.3683,-0.4572 0.26035,-0.1651 0.67945,-0.1651 0.4191,0 0.66675,0.17145 0.254,0.1651 0.3683,0.4572 0.1143,0.2921 0.1143,0.6731 0,0.48895 -0.1905,0.7747 -0.18415,0.28575 -0.4953,0.4191 0.127,0.0635 0.254,0.1524 0.13335,0.0889 0.2413,0.23495 0.10795,0.14605 0.1778,0.37465 0.06985,0.22225 0.06985,0.5588 0,0.4318 -0.12065,0.762 -0.12065,0.32385 -0.38735,0.50165 -0.26035,0.1778 -0.6985,0.1778 z m 0,-0.3683 q 0.254,0 0.4191,-0.1143 0.1651,-0.12065 0.24765,-0.3556 0.08255,-0.2413 0.08255,-0.60325 0,-0.3175 -0.0762,-0.55245 -0.06985,-0.2413 -0.23495,-0.38735 -0.15875,-0.14605 -0.43815,-0.1651 -0.2794,0.0191 -0.45085,0.1651 -0.1651,0.14605 -0.2413,0.38735 -0.06985,0.23495 -0.06985,0.55245 0,0.36195 0.08255,0.60325 0.0889,0.23495 0.254,0.3556 0.17145,0.1143 0.42545,0.1143 z m 0,-2.6035 q 0.2667,-0.0127 0.41275,-0.14605 0.1524,-0.13335 0.2159,-0.3556 0.0635,-0.22225 0.0635,-0.50165 0,-0.4445 -0.1651,-0.6731 -0.1651,-0.23495 -0.52705,-0.23495 -0.3683,0 -0.53975,0.23495 -0.1651,0.2286 -0.1651,0.6731 0,0.2794 0.0635,0.50165 0.0635,0.22225 0.2159,0.3556 0.15875,0.13335 0.42545,0.14605 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2273" />
+         id="path1949"
+         inkscape:connector-curvature="0" />
       <path
          d="m 92.064007,182.84298 q -0.43815,0 -0.6985,-0.2794 -0.26035,-0.28575 -0.29845,-0.762 l 0.38735,-0.1143 q 0.0381,0.4191 0.19685,0.61595 0.15875,0.1905 0.4445,0.1905 0.2413,0 0.3683,-0.13335 0.13335,-0.1397 0.13335,-0.38735 0,-0.1778 -0.10795,-0.3556 -0.10795,-0.18415 -0.3429,-0.381 l -0.4953,-0.4318 q -0.24765,-0.20955 -0.37465,-0.4191 -0.127,-0.20955 -0.127,-0.50165 0,-0.2667 0.10795,-0.4445 0.1143,-0.18415 0.3048,-0.2794 0.19685,-0.1016 0.46355,-0.1016 0.4191,0 0.635,0.27305 0.2159,0.2667 0.23495,0.69215 l -0.3302,0.10795 q -0.0127,-0.24765 -0.0762,-0.4064 -0.0635,-0.1651 -0.1778,-0.2413 -0.10795,-0.0762 -0.2667,-0.0762 -0.20955,0 -0.3429,0.12065 -0.127,0.1143 -0.127,0.32385 0,0.1651 0.0635,0.2921 0.0635,0.127 0.23495,0.28575 l 0.5207,0.46355 q 0.1524,0.13335 0.2921,0.28575 0.1397,0.1524 0.2286,0.3429 0.0889,0.18415 0.0889,0.43815 0,0.28575 -0.12065,0.4826 -0.1143,0.1905 -0.32385,0.29845 -0.20955,0.1016 -0.4953,0.1016 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2275" />
+         id="path1951"
+         inkscape:connector-curvature="0" />
       <path
          d="m 95.730537,182.84298 q -0.42545,0 -0.635,-0.1905 -0.20955,-0.1905 -0.2794,-0.51435 -0.0635,-0.3302 -0.0635,-0.74295 v -0.85725 q 0,-0.508 0.08255,-0.83185 0.08255,-0.3302 0.2921,-0.48895 0.2159,-0.15875 0.60325,-0.15875 0.393699,0 0.596899,0.14605 0.2032,0.14605 0.27305,0.41275 0.06985,0.2667 0.06985,0.6223 v 0.17145 h -0.4318 v -0.1778 q 0,-0.32385 -0.0508,-0.50165 -0.04445,-0.1778 -0.15875,-0.24765 -0.10795,-0.0762 -0.292099,-0.0762 -0.2159,0 -0.3302,0.1016 -0.1143,0.1016 -0.1524,0.33655 -0.0381,0.2286 -0.0381,0.61595 v 1.0287 q 0,0.55245 0.10795,0.78105 0.10795,0.22225 0.4191,0.22225 0.215899,0 0.323849,-0.0952 0.10795,-0.1016 0.1397,-0.29845 0.03175,-0.19685 0.03175,-0.48895 v -0.2032 h 0.4318 v 0.1778 q 0,0.3683 -0.06985,0.65405 -0.06985,0.2794 -0.27305,0.4445 -0.19685,0.15875 -0.596899,0.15875 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2277" />
+         id="path1953"
+         inkscape:connector-curvature="0" />
       <path
          d="m 98.198603,182.84298 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.08255,-0.31115 -0.08255,-0.75565 v -1.016 q 0,-0.4445 0.08255,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.08255,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.03175,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2279" />
+         id="path1955"
+         inkscape:connector-curvature="0" />
       <path
          d="m 99.820632,182.78583 v -3.6703 h 0.463548 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.0698,0.17145 0.0698,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2281" />
+         id="path1957"
+         inkscape:connector-curvature="0" />
       <path
          d="m 103.28267,182.83028 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0572,0.381 0.0635,0.10795 0.2667,0.10795 0.0571,0 0.127,-0.006 0.0699,-0.0127 0.13335,-0.0191 v 0.34925 q -0.0952,0.019 -0.19685,0.0254 -0.0952,0.0127 -0.1905,0.0127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2283" />
+         id="path1959"
+         inkscape:connector-curvature="0" />
       <path
          d="m 104.21801,182.78583 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.019,0 0.0381,0 0.019,0 0.0444,0.006 v 0.4953 q -0.0444,-0.019 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2285" />
+         id="path1961"
+         inkscape:connector-curvature="0" />
       <path
          d="m 106.95466,182.84298 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.0825,-0.31115 -0.0825,-0.75565 v -1.016 q 0,-0.4445 0.0825,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.0825,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.0318,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2287" />
+         id="path1963"
+         inkscape:connector-curvature="0" />
       <path
          d="m 108.64019,182.78583 v -5.1435 h 0.46355 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2289" />
+         id="path1965"
+         inkscape:connector-curvature="0" />
       <path
          d="m 111.14397,183.99233 v -4.8768 h 0.46355 v 0.3048 q 0.1143,-0.13335 0.28575,-0.24765 0.17145,-0.1143 0.4191,-0.1143 0.2667,0 0.42545,0.127 0.1651,0.12065 0.254,0.3302 0.0889,0.20955 0.12065,0.4699 0.0318,0.26035 0.0318,0.53975 v 0.76835 q 0,0.4699 -0.0825,0.81915 -0.0762,0.34925 -0.2667,0.53975 -0.1905,0.1905 -0.5334,0.1905 -0.22225,0 -0.38735,-0.1143 -0.15875,-0.1143 -0.2667,-0.23495 v 1.4986 z m 1.0414,-1.5113 q 0.20955,0 0.3175,-0.13335 0.10795,-0.1397 0.1397,-0.40005 0.0381,-0.2667 0.0381,-0.64135 v -0.78105 q 0,-0.36195 -0.0381,-0.60325 -0.0318,-0.24765 -0.1397,-0.37465 -0.10795,-0.127 -0.32385,-0.127 -0.1778,0 -0.3302,0.0952 -0.14605,0.0952 -0.2413,0.1905 v 2.5019 q 0.1016,0.10795 0.24765,0.1905 0.1524,0.0825 0.3302,0.0825 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2291" />
+         id="path1967"
+         inkscape:connector-curvature="0" />
       <path
          d="m 113.86157,182.78583 v -5.1435 h 0.46355 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2293" />
+         id="path1969"
+         inkscape:connector-curvature="0" />
       <path
          d="m 115.70416,182.84298 q -0.2159,0 -0.381,-0.10795 -0.1651,-0.1143 -0.26035,-0.29845 -0.0952,-0.18415 -0.0952,-0.41275 0,-0.2794 0.0825,-0.47625 0.0825,-0.19685 0.254,-0.34925 0.1778,-0.15875 0.4572,-0.3048 0.28575,-0.1524 0.69215,-0.33655 v -0.26035 q 0,-0.33655 -0.0445,-0.52705 -0.0381,-0.19685 -0.1397,-0.2794 -0.0953,-0.0825 -0.27305,-0.0825 -0.14605,0 -0.26035,0.0571 -0.1143,0.0572 -0.18415,0.19685 -0.0699,0.13335 -0.0699,0.37465 v 0.127 l -0.4572,-0.006 q 0.006,-0.5588 0.23495,-0.8255 0.23495,-0.27305 0.762,-0.27305 0.48895,0 0.69215,0.29845 0.2032,0.2921 0.2032,0.9144 v 1.78435 q 0,0.0953 0,0.24765 0.006,0.14605 0.0127,0.2794 0.0127,0.13335 0.019,0.2032 h -0.41275 q -0.0191,-0.12065 -0.0444,-0.2667 -0.0191,-0.1524 -0.0254,-0.2413 -0.0762,0.22225 -0.27305,0.3937 -0.1905,0.17145 -0.48895,0.17145 z m 0.1524,-0.3937 q 0.1397,0 0.24765,-0.0635 0.1143,-0.0699 0.2032,-0.17145 0.0952,-0.1016 0.14605,-0.2032 v -1.143 q -0.27305,0.14605 -0.4699,0.26035 -0.1905,0.10795 -0.31115,0.2159 -0.12065,0.10795 -0.1778,0.24765 -0.0571,0.13335 -0.0571,0.3175 0,0.2921 0.12065,0.4191 0.127,0.12065 0.29845,0.12065 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2295" />
+         id="path1971"
+         inkscape:connector-curvature="0" />
       <path
          d="m 117.59319,182.78583 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2297" />
+         id="path1973"
+         inkscape:connector-curvature="0" />
       <path
          d="m 121.10603,182.84298 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0572,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0571 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0318,-0.4953 -0.0318,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2299" />
+         id="path1975"
+         inkscape:connector-curvature="0" />
       <path
          d="m 124.6535,181.32533 v -1.0033 h -0.88265 v -0.34925 h 0.88265 v -0.99695 h 0.3556 v 0.99695 h 0.89535 v 0.34925 h -0.89535 v 1.0033 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2301" />
+         id="path1977"
+         inkscape:connector-curvature="0" />
       <path
          d="m 85.268713,190.72333 v -5.1435 h 1.2319 q 0.46355,0 0.7239,0.17145 0.2667,0.17145 0.381,0.47625 0.1143,0.3048 0.1143,0.71755 0,0.36195 -0.12065,0.6731 -0.1143,0.3048 -0.38735,0.48895 -0.2667,0.18415 -0.70485,0.18415 h -0.75565 v 2.43205 z m 0.4826,-2.794 h 0.61595 q 0.31115,0 0.50165,-0.0889 0.19685,-0.0952 0.28575,-0.31115 0.0889,-0.2159 0.0889,-0.5842 0,-0.3937 -0.0762,-0.6096 -0.0762,-0.22225 -0.2667,-0.3048 -0.18415,-0.0889 -0.52705,-0.0889 h -0.6223 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2303" />
+         id="path1979"
+         inkscape:connector-curvature="0" />
       <path
          d="m 89.120088,190.78048 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.08255,-0.31115 -0.08255,-0.75565 v -1.016 q 0,-0.4445 0.08255,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.08255,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.03175,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2305" />
+         id="path1981"
+         inkscape:connector-curvature="0" />
       <path
          d="m 91.554916,190.78048 q -0.4699,0 -0.67945,-0.3556 -0.2032,-0.3556 -0.2032,-1.1811 v -0.67945 q 0,-0.4826 0.06985,-0.83185 0.06985,-0.34925 0.254,-0.53975 0.1905,-0.19685 0.53975,-0.19685 0.2159,0 0.37465,0.1016 0.1651,0.0953 0.27305,0.2159 v -1.73355 h 0.46355 v 5.1435 h -0.46355 v -0.26035 q -0.10795,0.12065 -0.2667,0.22225 -0.1524,0.0953 -0.36195,0.0953 z m 0.09525,-0.36195 q 0.14605,0 0.28575,-0.0699 0.1397,-0.0762 0.24765,-0.1778 v -2.5527 q -0.09525,-0.0889 -0.23495,-0.17145 -0.1397,-0.0889 -0.31115,-0.0889 -0.3048,0 -0.4064,0.27305 -0.09525,0.2667 -0.09525,0.7874 v 0.8636 q 0,0.3683 0.0381,0.6223 0.04445,0.254 0.1524,0.38735 0.1143,0.127 0.32385,0.127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2307" />
+         id="path1983"
+         inkscape:connector-curvature="0" />
       <path
          d="m 94.648854,190.72333 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.06985,0.17145 0.06985,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2309" />
+         id="path1985"
+         inkscape:connector-curvature="0" />
       <path
          d="m 98.161694,190.78048 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.08255,0.3302 0.08255,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.05715,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0571 0.1778,-0.20955 0.06985,-0.15875 0.06985,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.03175,-0.4953 -0.03175,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2311" />
+         id="path1987"
+         inkscape:connector-curvature="0" />
       <path
-         d="m 100.61617,190.76778 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.463553 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0572,0.381 0.0635,0.10795 0.2667,0.10795 0.0571,0 0.127,-0.006 0.0699,-0.0127 0.13335,-0.0191 v 0.34925 q -0.0952,0.019 -0.19685,0.0254 -0.0952,0.0127 -0.1905,0.0127 z"
+         d="m 100.61617,190.76778 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0572,0.381 0.0635,0.10795 0.2667,0.10795 0.0571,0 0.127,-0.006 0.0699,-0.0127 0.13335,-0.0191 v 0.34925 q -0.0952,0.019 -0.19685,0.0254 -0.0952,0.0127 -0.1905,0.0127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2313" />
+         id="path1989"
+         inkscape:connector-curvature="0" />
       <path
          d="m 101.9579,190.72333 -0.5969,-3.6703 h 0.3937 l 0.46355,3.06705 0.57785,-3.06705 h 0.40005 l 0.5842,3.05435 0.43815,-3.05435 h 0.40005 l -0.5969,3.6703 h -0.4318 l -0.59055,-2.9845 -0.5715,2.9845 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2315" />
+         id="path1991"
+         inkscape:connector-curvature="0" />
       <path
          d="m 106.07409,190.78048 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.0825,-0.31115 -0.0825,-0.75565 v -1.016 q 0,-0.4445 0.0825,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.0825,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.0318,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2317" />
+         id="path1993"
+         inkscape:connector-curvature="0" />
       <path
          d="m 107.72787,190.72333 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.019,0 0.0381,0 0.019,0 0.0444,0.006 v 0.4953 q -0.0444,-0.019 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2319" />
+         id="path1995"
+         inkscape:connector-curvature="0" />
       <path
          d="m 109.58763,190.72333 v -5.1435 h 0.46355 v 3.27025 l 1.22555,-1.79705 h 0.48895 l -0.9271,1.41605 0.889,2.25425 h -0.4699 l -0.7747,-1.9939 -0.4318,0.60325 v 1.39065 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2321" />
+         id="path1997"
+         inkscape:connector-curvature="0" />
       <path
          d="m 113.95335,190.78048 q -0.18415,0 -0.31115,-0.0889 -0.127,-0.0952 -0.19685,-0.2667 -0.0635,-0.1778 -0.0635,-0.42545 v -2.9464 h 0.46355 v 2.8448 q 0,0.28575 0.0889,0.4064 0.0889,0.1143 0.2667,0.1143 0.1651,0 0.3302,-0.1016 0.17145,-0.10795 0.3175,-0.2667 v -2.9972 h 0.46355 v 3.6703 h -0.46355 v -0.4064 q -0.1778,0.2032 -0.4064,0.33655 -0.2286,0.127 -0.48895,0.127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2323" />
+         id="path1999"
+         inkscape:connector-curvature="0" />
       <path
          d="m 116.03049,190.72333 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2325" />
+         id="path2001"
+         inkscape:connector-curvature="0" />
       <path
          d="m 119.43538,190.78048 q -0.4699,0 -0.67945,-0.3556 -0.2032,-0.3556 -0.2032,-1.1811 v -0.67945 q 0,-0.4826 0.0699,-0.83185 0.0699,-0.34925 0.254,-0.53975 0.1905,-0.19685 0.53975,-0.19685 0.2159,0 0.37465,0.1016 0.1651,0.0953 0.27305,0.2159 v -1.73355 h 0.46355 v 5.1435 h -0.46355 v -0.26035 q -0.10795,0.12065 -0.2667,0.22225 -0.1524,0.0953 -0.36195,0.0953 z m 0.0953,-0.36195 q 0.14605,0 0.28575,-0.0699 0.1397,-0.0762 0.24765,-0.1778 v -2.5527 q -0.0953,-0.0889 -0.23495,-0.17145 -0.1397,-0.0889 -0.31115,-0.0889 -0.3048,0 -0.4064,0.27305 -0.0953,0.2667 -0.0953,0.7874 v 0.8636 q 0,0.3683 0.0381,0.6223 0.0445,0.254 0.1524,0.38735 0.1143,0.127 0.32385,0.127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2327" />
+         id="path2003"
+         inkscape:connector-curvature="0" />
       <path
          d="m 122.16023,190.78048 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0571,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0571 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0318,-0.4953 -0.0317,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0825 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2329" />
+         id="path2005"
+         inkscape:connector-curvature="0" />
       <path
          d="m 123.7765,190.72333 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.019,0 0.0381,0 0.019,0 0.0444,0.006 v 0.4953 q -0.0444,-0.019 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2331" />
+         id="path2007"
+         inkscape:connector-curvature="0" />
       <path
          d="m 125.69341,190.72333 v -5.1435 h 0.46355 v 5.1435 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2333" />
+         id="path2009"
+         inkscape:connector-curvature="0" />
       <path
          d="m 127.536,190.78048 q -0.2159,0 -0.381,-0.10795 -0.1651,-0.1143 -0.26035,-0.29845 -0.0952,-0.18415 -0.0952,-0.41275 0,-0.2794 0.0825,-0.47625 0.0825,-0.19685 0.254,-0.34925 0.1778,-0.15875 0.4572,-0.3048 0.28575,-0.1524 0.69215,-0.33655 v -0.26035 q 0,-0.33655 -0.0445,-0.52705 -0.0381,-0.19685 -0.1397,-0.2794 -0.0952,-0.0825 -0.27305,-0.0825 -0.14605,0 -0.26035,0.0571 -0.1143,0.0572 -0.18415,0.19685 -0.0699,0.13335 -0.0699,0.37465 v 0.127 l -0.4572,-0.006 q 0.006,-0.5588 0.23495,-0.8255 0.23495,-0.27305 0.762,-0.27305 0.48895,0 0.69215,0.29845 0.2032,0.2921 0.2032,0.9144 v 1.78435 q 0,0.0953 0,0.24765 0.006,0.14605 0.0127,0.2794 0.0127,0.13335 0.019,0.2032 h -0.41275 q -0.019,-0.12065 -0.0445,-0.2667 -0.019,-0.1524 -0.0254,-0.2413 -0.0762,0.22225 -0.27305,0.3937 -0.1905,0.17145 -0.48895,0.17145 z m 0.1524,-0.3937 q 0.1397,0 0.24765,-0.0635 0.1143,-0.0699 0.2032,-0.17145 0.0952,-0.1016 0.14605,-0.2032 v -1.143 q -0.27305,0.14605 -0.4699,0.26035 -0.1905,0.10795 -0.31115,0.2159 -0.12065,0.10795 -0.1778,0.24765 -0.0571,0.13335 -0.0571,0.3175 0,0.2921 0.12065,0.4191 0.127,0.12065 0.29845,0.12065 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2335" />
+         id="path2011"
+         inkscape:connector-curvature="0" />
       <path
          d="m 129.32343,191.63773 v -0.36195 q 0.3175,0 0.47625,-0.0508 0.1651,-0.0444 0.2159,-0.13335 0.0572,-0.0825 0.0572,-0.19685 0,-0.1016 -0.0381,-0.2667 -0.0381,-0.1651 -0.0825,-0.3429 l -0.75565,-3.23215 h 0.4572 l 0.64135,3.1242 0.61595,-3.1242 h 0.46355 l -0.88265,3.93065 q -0.0508,0.23495 -0.18415,0.37465 -0.127,0.14605 -0.3429,0.20955 -0.20955,0.0699 -0.5207,0.0699 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2337" />
+         id="path2013"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        aria-label="Secondary network"
        style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text1680">
+       id="text1350">
       <path
          d="m 198.84664,176.04571 q -0.4191,0 -0.6985,-0.17145 -0.27305,-0.1778 -0.41275,-0.48895 -0.1397,-0.3175 -0.17145,-0.7366 l 0.42545,-0.127 q 0.0318,0.3175 0.1143,0.57785 0.0825,0.254 0.26035,0.4064 0.1778,0.14605 0.48895,0.14605 0.3429,0 0.5334,-0.1778 0.1905,-0.1778 0.1905,-0.56515 0,-0.33655 -0.17145,-0.5842 -0.1651,-0.254 -0.4572,-0.52705 l -0.90805,-0.86995 q -0.2413,-0.23495 -0.3556,-0.4826 -0.1143,-0.254 -0.1143,-0.55245 0,-0.5334 0.3175,-0.81915 0.3175,-0.28575 0.84455,-0.28575 0.27305,0 0.48895,0.0699 0.22225,0.0698 0.37465,0.2286 0.15875,0.1524 0.24765,0.40005 0.0889,0.24765 0.12065,0.60325 l -0.41275,0.10795 q -0.0254,-0.32385 -0.10795,-0.55245 -0.0762,-0.23495 -0.24765,-0.3556 -0.1651,-0.12065 -0.46355,-0.12065 -0.3175,0 -0.5207,0.1651 -0.2032,0.1651 -0.2032,0.51435 0,0.20955 0.0762,0.381 0.0825,0.17145 0.28575,0.3683 l 0.90805,0.85725 q 0.3048,0.28575 0.52705,0.635 0.22225,0.34925 0.22225,0.7874 0,0.38735 -0.1524,0.6477 -0.14605,0.26035 -0.41275,0.3937 -0.2667,0.127 -0.61595,0.127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2340" />
+         id="path2016"
+         inkscape:connector-curvature="0" />
       <path
          d="m 201.50689,176.03936 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0572,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0572 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0318,-0.4953 -0.0317,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0826 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2342" />
+         id="path2018"
+         inkscape:connector-curvature="0" />
       <path
          d="m 203.99947,176.03936 q -0.42545,0 -0.635,-0.1905 -0.20955,-0.1905 -0.2794,-0.51435 -0.0635,-0.3302 -0.0635,-0.74295 v -0.85725 q 0,-0.508 0.0825,-0.83185 0.0825,-0.3302 0.2921,-0.48895 0.2159,-0.15875 0.60325,-0.15875 0.3937,0 0.5969,0.14605 0.2032,0.14605 0.27305,0.41275 0.0699,0.2667 0.0699,0.6223 v 0.17145 h -0.4318 v -0.1778 q 0,-0.32385 -0.0508,-0.50165 -0.0445,-0.1778 -0.15875,-0.24765 -0.10795,-0.0762 -0.2921,-0.0762 -0.2159,0 -0.3302,0.1016 -0.1143,0.1016 -0.1524,0.33655 -0.0381,0.2286 -0.0381,0.61595 v 1.0287 q 0,0.55245 0.10795,0.78105 0.10795,0.22225 0.4191,0.22225 0.2159,0 0.32385,-0.0952 0.10795,-0.1016 0.1397,-0.29845 0.0318,-0.19685 0.0318,-0.48895 v -0.2032 h 0.4318 v 0.1778 q 0,0.3683 -0.0699,0.65405 -0.0699,0.2794 -0.27305,0.4445 -0.19685,0.15875 -0.5969,0.15875 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2344" />
+         id="path2020"
+         inkscape:connector-curvature="0" />
       <path
          d="m 206.46753,176.03936 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.0825,-0.31115 -0.0825,-0.75565 v -1.016 q 0,-0.4445 0.0825,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.0825,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.0318,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2346" />
+         id="path2022"
+         inkscape:connector-curvature="0" />
       <path
          d="m 208.08956,175.98221 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2348" />
+         id="path2024"
+         inkscape:connector-curvature="0" />
       <path
          d="m 211.49445,176.03936 q -0.4699,0 -0.67945,-0.3556 -0.2032,-0.3556 -0.2032,-1.1811 v -0.67945 q 0,-0.4826 0.0699,-0.83185 0.0699,-0.34925 0.254,-0.53975 0.1905,-0.19685 0.53975,-0.19685 0.2159,0 0.37465,0.1016 0.1651,0.0952 0.27305,0.2159 v -1.73355 h 0.46355 v 5.1435 h -0.46355 v -0.26035 q -0.10795,0.12065 -0.2667,0.22225 -0.1524,0.0952 -0.36195,0.0952 z m 0.0952,-0.36195 q 0.14605,0 0.28575,-0.0699 0.1397,-0.0762 0.24765,-0.1778 v -2.5527 q -0.0952,-0.0889 -0.23495,-0.17145 -0.1397,-0.0889 -0.31115,-0.0889 -0.3048,0 -0.4064,0.27305 -0.0953,0.2667 -0.0953,0.7874 v 0.8636 q 0,0.3683 0.0381,0.6223 0.0445,0.254 0.1524,0.38735 0.1143,0.127 0.32385,0.127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2350" />
+         id="path2026"
+         inkscape:connector-curvature="0" />
       <path
          d="m 213.92719,176.03936 q -0.2159,0 -0.381,-0.10795 -0.1651,-0.1143 -0.26035,-0.29845 -0.0953,-0.18415 -0.0953,-0.41275 0,-0.2794 0.0826,-0.47625 0.0825,-0.19685 0.254,-0.34925 0.1778,-0.15875 0.4572,-0.3048 0.28575,-0.1524 0.69215,-0.33655 v -0.26035 q 0,-0.33655 -0.0445,-0.52705 -0.0381,-0.19685 -0.1397,-0.2794 -0.0953,-0.0825 -0.27305,-0.0825 -0.14605,0 -0.26035,0.0572 -0.1143,0.0572 -0.18415,0.19685 -0.0699,0.13335 -0.0699,0.37465 v 0.127 l -0.4572,-0.006 q 0.006,-0.5588 0.23495,-0.8255 0.23495,-0.27305 0.762,-0.27305 0.48895,0 0.69215,0.29845 0.2032,0.2921 0.2032,0.9144 v 1.78435 q 0,0.0952 0,0.24765 0.006,0.14605 0.0127,0.2794 0.0127,0.13335 0.019,0.2032 h -0.41275 q -0.019,-0.12065 -0.0445,-0.2667 -0.019,-0.1524 -0.0254,-0.2413 -0.0762,0.22225 -0.27305,0.3937 -0.1905,0.17145 -0.48895,0.17145 z m 0.1524,-0.3937 q 0.1397,0 0.24765,-0.0635 0.1143,-0.0698 0.2032,-0.17145 0.0952,-0.1016 0.14605,-0.2032 v -1.143 q -0.27305,0.14605 -0.4699,0.26035 -0.1905,0.10795 -0.31115,0.2159 -0.12065,0.10795 -0.1778,0.24765 -0.0571,0.13335 -0.0571,0.3175 0,0.2921 0.12065,0.4191 0.127,0.12065 0.29845,0.12065 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2352" />
+         id="path2028"
+         inkscape:connector-curvature="0" />
       <path
          d="m 215.84797,175.98221 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.019,0 0.0381,0 0.019,0 0.0444,0.006 v 0.4953 q -0.0444,-0.0191 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2354" />
+         id="path2030"
+         inkscape:connector-curvature="0" />
       <path
          d="m 217.59978,176.89661 v -0.36195 q 0.3175,0 0.47625,-0.0508 0.1651,-0.0444 0.2159,-0.13335 0.0571,-0.0826 0.0571,-0.19685 0,-0.1016 -0.0381,-0.2667 -0.0381,-0.1651 -0.0825,-0.3429 l -0.75565,-3.23215 h 0.4572 l 0.64135,3.1242 0.61595,-3.1242 h 0.46355 l -0.88265,3.93065 q -0.0508,0.23495 -0.18415,0.37465 -0.127,0.14605 -0.3429,0.20955 -0.20955,0.0699 -0.5207,0.0699 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2356" />
+         id="path2032"
+         inkscape:connector-curvature="0" />
       <path
          d="m 221.40968,175.98221 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.0952 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.0952 -0.1651,0.0952 -0.31115,0.24765 v 3.0226 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2358" />
+         id="path2034"
+         inkscape:connector-curvature="0" />
       <path
          d="m 224.92252,176.03936 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0572,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0572 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0318,-0.4953 -0.0317,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.0825 -0.1143,0.0826 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2360" />
+         id="path2036"
+         inkscape:connector-curvature="0" />
       <path
          d="m 227.37699,176.02666 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0572,0.381 0.0635,0.10795 0.2667,0.10795 0.0572,0 0.127,-0.006 0.0699,-0.0127 0.13335,-0.019 v 0.34925 q -0.0952,0.019 -0.19685,0.0254 -0.0952,0.0127 -0.1905,0.0127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2362" />
+         id="path2038"
+         inkscape:connector-curvature="0" />
       <path
          d="m 228.71872,175.98221 -0.5969,-3.6703 h 0.3937 l 0.46355,3.06705 0.57785,-3.06705 h 0.40005 l 0.5842,3.05435 0.43815,-3.05435 h 0.40005 l -0.5969,3.6703 h -0.4318 l -0.59055,-2.9845 -0.5715,2.9845 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2364" />
+         id="path2040"
+         inkscape:connector-curvature="0" />
       <path
          d="m 232.83492,176.03936 q -0.37465,0 -0.59055,-0.15875 -0.2159,-0.1651 -0.3048,-0.4699 -0.0825,-0.31115 -0.0825,-0.75565 v -1.016 q 0,-0.4445 0.0825,-0.7493 0.0889,-0.31115 0.3048,-0.4699 0.2159,-0.1651 0.59055,-0.1651 0.381,0 0.59055,0.1651 0.2159,0.15875 0.29845,0.4699 0.0889,0.3048 0.0889,0.7493 v 1.016 q 0,0.4445 -0.0889,0.75565 -0.0825,0.3048 -0.29845,0.4699 -0.20955,0.15875 -0.59055,0.15875 z m 0,-0.34925 q 0.2413,0 0.34925,-0.127 0.1143,-0.127 0.1397,-0.3556 0.0254,-0.2286 0.0254,-0.52705 v -1.0668 q 0,-0.29845 -0.0254,-0.5207 -0.0254,-0.2286 -0.1397,-0.3556 -0.10795,-0.13335 -0.34925,-0.13335 -0.2413,0 -0.34925,0.13335 -0.10795,0.127 -0.1397,0.3556 -0.0254,0.22225 -0.0254,0.5207 v 1.0668 q 0,0.29845 0.0254,0.52705 0.0318,0.2286 0.1397,0.3556 0.10795,0.127 0.34925,0.127 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2366" />
+         id="path2042"
+         inkscape:connector-curvature="0" />
       <path
          d="m 234.48869,175.98221 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.019,0 0.0381,0 0.019,0 0.0445,0.006 v 0.4953 q -0.0445,-0.0191 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2368" />
+         id="path2044"
+         inkscape:connector-curvature="0" />
       <path
          d="m 236.34845,175.98221 v -5.1435 h 0.46355 v 3.27025 l 1.22555,-1.79705 h 0.48895 l -0.9271,1.41605 0.889,2.25425 h -0.4699 l -0.7747,-1.9939 -0.4318,0.60325 v 1.39065 z"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
-         id="path2370" />
+         id="path2046"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       aria-label="OVS bridge (br-int)"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888855px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text1354">
+      <path
+         d="m 84.818462,100.82837 q -0.508,0 -0.8001,-0.19685 -0.28575,-0.2032 -0.4064,-0.5588 -0.1143,-0.36195 -0.1143,-0.8255 v -2.1336 q 0,-0.4699 0.12065,-0.8128 0.127,-0.34925 0.41275,-0.53975 0.2921,-0.1905 0.7874,-0.1905 0.50165,0 0.7874,0.1905 0.2921,0.1905 0.41275,0.53975 0.12065,0.3429 0.12065,0.8128 v 2.13995 q 0,0.46355 -0.12065,0.81915 -0.1143,0.3556 -0.40005,0.5588 -0.28575,0.19685 -0.8001,0.19685 z m 0,-0.38735 q 0.3429,0 0.5207,-0.13335 0.1778,-0.1397 0.2413,-0.381 0.06985,-0.24765 0.06985,-0.5715 v -2.33045 q 0,-0.32385 -0.06985,-0.56515 -0.0635,-0.2413 -0.2413,-0.3683 -0.1778,-0.13335 -0.5207,-0.13335 -0.33655,0 -0.5207,0.13335 -0.1778,0.127 -0.24765,0.3683 -0.0635,0.2413 -0.0635,0.56515 v 2.33045 q 0,0.32385 0.0635,0.5715 0.06985,0.2413 0.24765,0.381 0.18415,0.13335 0.5207,0.13335 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2049"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 87.800283,100.76487 -1.2065,-5.1435 h 0.46355 l 0.97155,4.26085 0.9144,-4.26085 h 0.4572 l -1.16205,5.1435 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2051"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 91.060214,100.82837 q -0.4191,0 -0.6985,-0.17145 -0.27305,-0.1778 -0.41275,-0.48895 -0.1397,-0.3175 -0.17145,-0.7366 l 0.42545,-0.127 q 0.03175,0.3175 0.1143,0.57785 0.08255,0.254 0.26035,0.4064 0.1778,0.14605 0.48895,0.14605 0.3429,0 0.5334,-0.1778 0.1905,-0.1778 0.1905,-0.56515 0,-0.33655 -0.17145,-0.5842 -0.1651,-0.254 -0.4572,-0.52705 l -0.90805,-0.86995 q -0.2413,-0.23495 -0.3556,-0.4826 -0.1143,-0.254 -0.1143,-0.55245 0,-0.5334 0.3175,-0.81915 0.3175,-0.28575 0.84455,-0.28575 0.27305,0 0.48895,0.06985 0.22225,0.06985 0.37465,0.2286 0.15875,0.1524 0.24765,0.40005 0.0889,0.24765 0.12065,0.60325 l -0.41275,0.10795 q -0.0254,-0.32385 -0.10795,-0.55245 -0.0762,-0.23495 -0.24765,-0.3556 -0.1651,-0.12065 -0.46355,-0.12065 -0.3175,0 -0.5207,0.1651 -0.2032,0.1651 -0.2032,0.51435 0,0.20955 0.0762,0.381 0.08255,0.17145 0.28575,0.3683 l 0.90805,0.85725 q 0.3048,0.28575 0.52705,0.635 0.22225,0.34925 0.22225,0.7874 0,0.38735 -0.1524,0.6477 -0.14605,0.26035 -0.41275,0.3937 -0.2667,0.127 -0.61595,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2053"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 95.114293,100.82202 q -0.22225,0 -0.38735,-0.1143 -0.15875,-0.1143 -0.2667,-0.23495 v 0.2921 h -0.46355 v -5.1435 h 0.46355 v 1.778 q 0.10795,-0.13335 0.2794,-0.24765 0.17145,-0.1143 0.4191,-0.1143 0.2667,0 0.4318,0.127 0.1651,0.12065 0.254,0.3302 0.0889,0.20955 0.1143,0.4699 0.03175,0.26035 0.03175,0.53975 v 0.76835 q 0,0.4699 -0.0762,0.81915 -0.0762,0.34925 -0.2667,0.53975 -0.1905,0.1905 -0.5334,0.1905 z m -0.08255,-0.36195 q 0.2159,0 0.3175,-0.13335 0.10795,-0.1397 0.1397,-0.40005 0.0381,-0.2667 0.0381,-0.64135 v -0.78105 q 0,-0.36195 -0.0381,-0.60325 -0.0381,-0.24765 -0.1397,-0.37465 -0.1016,-0.127 -0.32385,-0.127 -0.1778,0 -0.32385,0.09525 -0.14605,0.09525 -0.2413,0.1905 v 2.5019 q 0.1016,0.10795 0.24765,0.1905 0.14605,0.0825 0.32385,0.0825 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2055"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 96.663792,100.76487 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.01905,0 0.0381,0 0.01905,0 0.04445,0.0063 v 0.4953 q -0.04445,-0.01905 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2057"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 98.567998,100.76487 v -3.6703 h 0.46355 v 3.6703 z m 0,-4.1783 v -0.62865 h 0.46355 v 0.62865 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2059"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 100.61984,100.82202 q -0.4699,0 -0.679449,-0.3556 -0.2032,-0.3556 -0.2032,-1.1811 v -0.67945 q 0,-0.4826 0.06985,-0.83185 0.06985,-0.34925 0.253999,-0.53975 0.1905,-0.19685 0.53975,-0.19685 0.2159,0 0.37465,0.1016 0.1651,0.09525 0.27305,0.2159 v -1.73355 h 0.46355 v 5.1435 h -0.46355 v -0.26035 q -0.10795,0.12065 -0.2667,0.22225 -0.1524,0.0952 -0.36195,0.0952 z m 0.0953,-0.36195 q 0.14605,0 0.28575,-0.0699 0.1397,-0.0762 0.24765,-0.1778 v -2.5527 q -0.0953,-0.0889 -0.23495,-0.17145 -0.1397,-0.0889 -0.31115,-0.0889 -0.3048,0 -0.4064,0.27305 -0.0953,0.2667 -0.0953,0.7874 v 0.8636 q 0,0.3683 0.0381,0.6223 0.0444,0.254 0.1524,0.38735 0.1143,0.127 0.32385,0.127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2061"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 103.35739,101.97137 q -0.36195,0 -0.62865,-0.0698 -0.2667,-0.0699 -0.41275,-0.22225 -0.1397,-0.14605 -0.1397,-0.37465 0,-0.18415 0.0889,-0.33655 0.0889,-0.1524 0.2286,-0.2667 0.1397,-0.12065 0.28575,-0.19685 -0.20955,-0.0571 -0.31115,-0.1524 -0.0952,-0.1016 -0.0952,-0.24765 0,-0.1905 0.1143,-0.3429 0.12065,-0.1524 0.32385,-0.32385 -0.254,-0.1778 -0.36195,-0.4572 -0.1016,-0.2794 -0.1016,-0.6604 0,-0.34925 0.10795,-0.635 0.10795,-0.2921 0.33655,-0.4699 0.2286,-0.1778 0.5842,-0.1778 0.32385,0 0.508,0.13335 0.18415,0.13335 0.2794,0.3302 0.0572,-0.09525 0.19685,-0.22225 0.1397,-0.13335 0.29845,-0.1905 l 0.0953,-0.0381 0.127,0.32385 q -0.1016,0.01905 -0.2286,0.0762 -0.12065,0.0508 -0.22225,0.1143 -0.1016,0.0635 -0.1524,0.127 0.0445,0.1143 0.0762,0.31115 0.0381,0.19685 0.0381,0.3302 0,0.36195 -0.1016,0.65405 -0.0953,0.2921 -0.3175,0.46355 -0.22225,0.1651 -0.59055,0.1651 -0.0952,0 -0.2032,-0.01905 -0.1016,-0.01905 -0.17145,-0.0381 -0.0952,0.09525 -0.17145,0.20955 -0.0762,0.10795 -0.0762,0.20955 0,0.0889 0.0699,0.1397 0.0762,0.0444 0.23495,0.0699 l 0.5842,0.0825 q 0.4445,0.0699 0.67945,0.27305 0.2413,0.19685 0.2413,0.57785 0,0.28575 -0.15875,0.47625 -0.1524,0.1905 -0.42545,0.2794 -0.27305,0.0952 -0.62865,0.0952 z m 0.0191,-0.37465 q 0.3683,0 0.5969,-0.1143 0.2286,-0.10795 0.2286,-0.3556 0,-0.12065 -0.0571,-0.22225 -0.0508,-0.0953 -0.2032,-0.15875 -0.14605,-0.0698 -0.43815,-0.1143 l -0.46355,-0.0635 q -0.0952,0.0635 -0.2032,0.15875 -0.10795,0.0889 -0.1905,0.2032 -0.0762,0.1143 -0.0762,0.26035 0,0.20955 0.19685,0.3048 0.19685,0.1016 0.6096,0.1016 z m 0.006,-2.31775 q 0.2032,0 0.3175,-0.08255 0.12065,-0.0889 0.1778,-0.2286 0.0635,-0.1397 0.0825,-0.31115 0.0254,-0.17145 0.0254,-0.33655 0,-0.1651 -0.0254,-0.3302 -0.0254,-0.1651 -0.0889,-0.3048 -0.0635,-0.14605 -0.18415,-0.2286 -0.1143,-0.0889 -0.3048,-0.0889 -0.1905,0 -0.3175,0.0889 -0.12065,0.0889 -0.1905,0.23495 -0.0635,0.1397 -0.0889,0.31115 -0.0254,0.1651 -0.0254,0.3175 0,0.1524 0.019,0.32385 0.0254,0.17145 0.0889,0.3175 0.0698,0.1397 0.1905,0.2286 0.127,0.0889 0.32385,0.0889 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2063"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 106.0484,100.82202 q -0.3429,0 -0.56515,-0.13335 -0.2159,-0.1397 -0.32385,-0.4572 -0.1016,-0.3175 -0.1016,-0.84455 v -0.9271 q 0,-0.5461 0.10795,-0.8509 0.10795,-0.31115 0.3302,-0.43815 0.22225,-0.13335 0.55245,-0.13335 0.3937,0 0.5969,0.1651 0.2032,0.1651 0.2794,0.50165 0.0825,0.3302 0.0825,0.8509 v 0.3302 h -1.4859 v 0.64135 q 0,0.3556 0.0508,0.56515 0.0572,0.2032 0.17145,0.2921 0.12065,0.0889 0.3048,0.0889 0.1397,0 0.254,-0.0508 0.1143,-0.0572 0.1778,-0.20955 0.0699,-0.15875 0.0699,-0.4445 v -0.254 h 0.45085 v 0.2032 q 0,0.50165 -0.20955,0.80645 -0.20955,0.29845 -0.74295,0.29845 z m -0.52705,-2.20345 h 1.0287 v -0.3048 q 0,-0.2921 -0.0318,-0.4953 -0.0318,-0.20955 -0.1397,-0.3175 -0.1016,-0.1143 -0.3302,-0.1143 -0.1905,0 -0.31115,0.08255 -0.1143,0.08255 -0.1651,0.29845 -0.0508,0.20955 -0.0508,0.60325 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2065"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 110.13561,101.81262 q -0.31115,-0.019 -0.51435,-0.1905 -0.2032,-0.17145 -0.3175,-0.46355 -0.10795,-0.28575 -0.1651,-0.66675 -0.0508,-0.38735 -0.0635,-0.8382 -0.006,-0.4572 -0.006,-0.9525 0,-0.4953 0.006,-0.9525 0.0127,-0.46355 0.0635,-0.8509 0.0571,-0.38735 0.1651,-0.67945 0.1143,-0.2921 0.3175,-0.4572 0.2032,-0.1651 0.51435,-0.1778 v 0.3302 q -0.23495,0.01905 -0.36195,0.254 -0.127,0.2286 -0.18415,0.61595 -0.0508,0.38735 -0.0635,0.88265 -0.006,0.48895 -0.006,1.03505 0,0.5461 0.006,1.0414 0.0127,0.4953 0.0635,0.88265 0.0571,0.381 0.18415,0.6096 0.127,0.23495 0.36195,0.254 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2067"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 111.80785,100.82202 q -0.22225,0 -0.38735,-0.1143 -0.15875,-0.1143 -0.2667,-0.23495 v 0.2921 h -0.46355 v -5.1435 h 0.46355 v 1.778 q 0.10795,-0.13335 0.2794,-0.24765 0.17145,-0.1143 0.4191,-0.1143 0.2667,0 0.4318,0.127 0.1651,0.12065 0.254,0.3302 0.0889,0.20955 0.1143,0.4699 0.0318,0.26035 0.0318,0.53975 v 0.76835 q 0,0.4699 -0.0762,0.81915 -0.0762,0.34925 -0.2667,0.53975 -0.1905,0.1905 -0.5334,0.1905 z m -0.0825,-0.36195 q 0.2159,0 0.3175,-0.13335 0.10795,-0.1397 0.1397,-0.40005 0.0381,-0.2667 0.0381,-0.64135 v -0.78105 q 0,-0.36195 -0.0381,-0.60325 -0.0381,-0.24765 -0.1397,-0.37465 -0.1016,-0.127 -0.32385,-0.127 -0.1778,0 -0.32385,0.09525 -0.14605,0.09525 -0.2413,0.1905 v 2.5019 q 0.1016,0.10795 0.24765,0.1905 0.14605,0.0825 0.32385,0.0825 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2069"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 113.35735,100.76487 v -3.6703 h 0.4699 v 0.50165 q 0.1778,-0.2921 0.4064,-0.41275 0.2286,-0.127 0.43815,-0.127 0.019,0 0.0381,0 0.019,0 0.0444,0.0063 v 0.4953 q -0.0444,-0.01905 -0.10795,-0.0254 -0.0635,-0.0127 -0.12065,-0.0127 -0.2159,0 -0.3937,0.1016 -0.17145,0.1016 -0.3048,0.32385 v 2.8194 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2071"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 115.1282,98.87892 v -0.3683 h 1.3462 v 0.3683 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2073"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 117.14671,100.76487 v -3.6703 h 0.46355 v 3.6703 z m 0,-4.1783 v -0.62865 h 0.46355 v 0.62865 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2075"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 118.38575,100.76487 v -3.6703 h 0.46355 v 0.381 q 0.1778,-0.1905 0.40005,-0.31115 0.22225,-0.127 0.4826,-0.127 0.18415,0 0.3048,0.09525 0.127,0.0889 0.1905,0.2667 0.0699,0.17145 0.0699,0.4191 v 2.9464 h -0.46355 v -2.8448 q 0,-0.28575 -0.0889,-0.40005 -0.0889,-0.12065 -0.2667,-0.12065 -0.1524,0 -0.3175,0.09525 -0.1651,0.09525 -0.31115,0.24765 v 3.0226 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2077"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 121.84779,100.80932 q -0.2667,0 -0.41275,-0.1016 -0.14605,-0.10795 -0.19685,-0.28575 -0.0508,-0.18415 -0.0508,-0.4191 v -2.6035 h -0.45085 v -0.3048 h 0.45085 v -1.13665 h 0.46355 v 1.13665 h 0.6096 v 0.3048 h -0.6096 v 2.55905 q 0,0.2667 0.0571,0.381 0.0635,0.10795 0.2667,0.10795 0.0572,0 0.127,-0.006 0.0699,-0.0127 0.13335,-0.019 v 0.34925 q -0.0953,0.0191 -0.19685,0.0254 -0.0953,0.0127 -0.1905,0.0127 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2079"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 122.58628,101.81262 v -0.32385 q 0.2413,-0.0254 0.3683,-0.26035 0.127,-0.2286 0.1778,-0.61595 0.0572,-0.38735 0.0635,-0.8763 0.0127,-0.4953 0.0127,-1.0414 0,-0.5461 -0.0127,-1.0414 -0.006,-0.4953 -0.0635,-0.8763 -0.0508,-0.381 -0.1778,-0.6096 -0.127,-0.23495 -0.3683,-0.26035 v -0.32385 q 0.3175,0.0127 0.5207,0.1778 0.2032,0.15875 0.3175,0.45085 0.1143,0.2921 0.1651,0.67945 0.0572,0.38735 0.0635,0.84455 0.0127,0.4572 0.0127,0.95885 0,0.4953 -0.0127,0.9525 -0.006,0.45085 -0.0635,0.8382 -0.0508,0.38735 -0.1651,0.6731 -0.1143,0.2921 -0.3175,0.46355 -0.2032,0.17145 -0.5207,0.1905 z"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:6.3499999px;font-family:Oswald;-inkscape-font-specification:'Oswald, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="path2081"
+         inkscape:connector-curvature="0" />
     </g>
   </g>
 </svg>

--- a/docs/cookbooks/multus/build/cni-dhcp-daemon/Dockerfile
+++ b/docs/cookbooks/multus/build/cni-dhcp-daemon/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:20.04 as cni-binary
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="A Docker which runs the dhcp daemon from the containernetworking project."
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends wget ca-certificates
+
+# Leading dot is required for the tar command below
+ENV CNI_PLUGINS="./dhcp"
+
+RUN mkdir -p /opt/cni/bin && \
+    wget -q -O - https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
+
+FROM ubuntu:20.04
+
+COPY --from=cni-binary /opt/cni/bin/* /usr/local/bin
+
+ENTRYPOINT ["dhcp", "daemon"]

--- a/docs/cookbooks/multus/build/cni-dhcp-daemon/README.md
+++ b/docs/cookbooks/multus/build/cni-dhcp-daemon/README.md
@@ -1,0 +1,16 @@
+# cni-dhcp-daemon
+
+This Docker image can be used to run the [DHCP daemon from the
+containernetworking
+project](https://github.com/containernetworking/plugins/tree/master/plugins/ipam/dhcp).
+
+If you need to build a new version of the image and push it to Dockerhub, you
+can run the following:
+
+```bash
+docker build -t antrea/cni-dhcp-daemon:latest .
+docker push antrea/cni-dhcp-daemon:latest
+```
+
+The `docker push` command will fail if you do not have permission to push to the
+`antrea` Dockerhub repository.

--- a/docs/cookbooks/multus/resources/dhcp-daemon.yml
+++ b/docs/cookbooks/multus/resources/dhcp-daemon.yml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: kube-system
+  name: dhcp-daemon
+  labels:
+    environment: antrea-multus-demo
+    app: dhcp-daemon
+spec:
+  selector:
+    matchLabels:
+      environment: antrea-multus-demo
+      app: dhcp-daemon
+  template:
+    metadata:
+      labels:
+        environment: antrea-multus-demo
+        app: dhcp-daemon
+    spec:
+      hostPID: true
+      hostNetwork: true
+      initContainers:
+      - name: sock-cleanup
+        image: ubuntu:20.04
+        command: ["rm", "-f", "/run/cni/dhcp.sock"]
+        volumeMounts:
+        - name: run
+          mountPath: /run
+      containers:
+      - name: dhcp-daemon
+        securityContext:
+          privileged: true
+        image: antrea/cni-dhcp-daemon:latest
+        imagePullPolicy: Always
+        args: [""]
+        volumeMounts:
+        - name: run
+          mountPath: /run
+        - name: netns
+          mountPath: /var/run/netns
+      volumes:
+      - hostPath:
+          path: /run
+        name: run
+      - hostPath:
+          path: /var/run/netns
+        name: netns
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists

--- a/docs/cookbooks/multus/resources/dhcp-server.yml
+++ b/docs/cookbooks/multus/resources/dhcp-server.yml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dhcp-server-conf
+  namespace: kube-system
+  labels:
+    environment: antrea-multus-demo
+data:
+  dhcpd.conf: |
+    subnet 192.168.78.0 netmask 255.255.255.0 {
+      range 192.168.78.200 192.168.78.250;
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: kube-system
+  name: dhcp-server
+  labels:
+    environment: antrea-multus-demo
+    app: dhcp-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      environment: antrea-multus-demo
+      app: dhcp-server
+  template:
+    metadata:
+      labels:
+        environment: antrea-multus-demo
+        app: dhcp-server
+    spec:
+      hostPID: true
+      hostNetwork: true
+      initContainers:
+      - name: wait-for-interface
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["sh"]
+        args: ["-c", "while ! ip link show mac0 | grep -q ',UP,'; do echo 'Waiting for mac0'; sleep 1; done"]
+      containers:
+      - name: dhcp-server
+        image: networkboot/dhcpd:latest
+        imagePullPolicy: IfNotPresent
+        args: ["mac0"]
+        volumeMounts:
+        - mountPath: /data/dhcpd.conf
+          name: dhcp-server-conf
+          readOnly: true
+          subPath: dhcpd.conf
+      volumes:
+      - configMap:
+          name: dhcp-server-conf
+        name: dhcp-server-conf
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical

--- a/docs/cookbooks/multus/resources/macvlan-host-init.yml
+++ b/docs/cookbooks/multus/resources/macvlan-host-init.yml
@@ -1,0 +1,62 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: macvlan-host-init
+  namespace: kube-system
+  labels:
+    environment: antrea-multus-demo
+    app: macvlan-host-init
+spec:
+  selector:
+    matchLabels:
+      environment: antrea-multus-demo
+      app: macvlan-host-init
+  template:
+    metadata:
+      labels:
+        environment: antrea-multus-demo
+        app: macvlan-host-init
+    spec:
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      containers:
+      - name: host-init
+        image: gcr.io/google-containers/startup-script:v1
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        env:
+          - name: STARTUP_SCRIPT
+            value: |
+              #! /bin/bash
+
+              set -o errexit
+              set -o pipefail
+              set -o nounset
+
+              if ip link show mac0; then
+                  exit 0
+              fi
+
+              parent="enp0s9"
+              inet=$(ip addr show $parent | grep "inet " | awk '{ print $2 }')
+              # does not work with that version of iproute
+              # ip link dev $parent promisc on
+              ifconfig $parent promisc
+              ip addr flush dev $parent
+
+              ip link add mac0 link $parent type macvlan mode bridge
+              ip addr add $inet dev mac0
+              ip link set dev mac0 up
+
+              echo "macvlan-host initialization completed"

--- a/docs/cookbooks/multus/resources/netAttachDef.yml
+++ b/docs/cookbooks/multus/resources/netAttachDef.yml
@@ -1,0 +1,14 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: macvlan-conf
+spec:
+  config: '{
+      "cniVersion": "0.3.0",
+      "type": "macvlan",
+      "master": "enp0s9",
+      "mode": "bridge",
+      "ipam": {
+        "type": "dhcp"
+      }
+    }'

--- a/docs/cookbooks/multus/resources/test.yml
+++ b/docs/cookbooks/multus/resources/test.yml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: samplepod
+  labels:
+    environment: antrea-multus-demo
+    app: samplepod
+spec:
+  replicas: 6
+  selector:
+    matchLabels:
+      environment: antrea-multus-demo
+      app: samplepod
+  template:
+    metadata:
+      labels:
+        environment: antrea-multus-demo
+        app: samplepod
+      annotations:
+        k8s.v1.cni.cncf.io/networks: macvlan-conf
+    spec:
+      containers:
+      - name: samplepod
+        command: ["/bin/bash", "-c", "PID=; trap 'kill $PID' TERM INT; sleep infinity & PID=$!; wait $PID"]
+        image: antoninbas/toolbox:latest
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/docs/cookbooks/multus/test/Vagrantfile
+++ b/docs/cookbooks/multus/test/Vagrantfile
@@ -1,0 +1,64 @@
+VAGRANTFILE_API_VERSION = "2"
+
+NUM_WORKERS = 2
+
+K8S_POD_NETWORK_CIDR = "10.10.0.0/16"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "ubuntu/bionic64"
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+    # 2 CPUS required to initialize k8s cluster with "kubeadm init"
+    v.cpus = 2
+
+    v.customize [
+                             "modifyvm", :id,
+                             "--nicpromisc3", "allow-all"
+                ]
+  end
+
+  groups = {
+    "master" => ["k8s-node-master"],
+    "workers" => ["k8s-node-worker-[1:#{NUM_WORKERS}]"],
+  }
+
+  config.vm.define "k8s-node-master" do |node|
+    node.vm.hostname = "k8s-node-master"
+    node_ip = "192.168.77.100"
+    node.vm.network "private_network", ip: node_ip
+    node.vm.network "private_network", ip: "192.168.78.100", virtualbox__intnet: true
+
+    node.vm.provision :ansible  do |ansible|
+      ansible.playbook = "playbook/k8s.yml"
+      ansible.groups = groups
+      ansible.extra_vars = {
+        # Ubuntu bionic does not ship with python2
+        ansible_python_interpreter:"/usr/bin/python3",
+        node_ip: node_ip,
+        node_name: "k8s-node-master",
+        k8s_pod_network_cidr: K8S_POD_NETWORK_CIDR,
+        k8s_api_server_ip: node_ip,
+      }
+    end
+  end
+
+  (1..NUM_WORKERS).each do |node_id|
+    config.vm.define "k8s-node-worker-#{node_id}" do |node|
+      node.vm.hostname = "k8s-node-worker-#{node_id}"
+      node_ip = "192.168.77.#{100 + node_id}"
+      node.vm.network "private_network", ip: node_ip
+      node.vm.network "private_network", ip: "192.168.78.#{100 + node_id}", virtualbox__intnet: true
+
+      node.vm.provision :ansible do |ansible|
+        ansible.playbook = "playbook/k8s.yml"
+        ansible.groups = groups
+        ansible.extra_vars = {
+          ansible_python_interpreter:"/usr/bin/python3",
+          node_ip: node_ip,
+          node_name: "k8s-node-worker-#{node_id}",
+        }
+      end
+    end
+  end
+end

--- a/docs/cookbooks/multus/test/Vagrantfile
+++ b/docs/cookbooks/multus/test/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048
-    # 2 CPUS required to initialize k8s cluster with "kubeadm init"
+    # 2 CPUS required to initialize K8s cluster with "kubeadm init"
     v.cpus = 2
 
     v.customize [

--- a/test/e2e/infra/vagrant/Vagrantfile
+++ b/test/e2e/infra/vagrant/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048
-    # 2 CPUS required to initialize k8s cluster with "kubeadm init"
+    # 2 CPUS required to initialize K8s cluster with "kubeadm init"
     v.cpus = 2
   end
 


### PR DESCRIPTION
We add documentation to show how Antrea can be used with Multus: Antrea
is used as the default CNI plugin and an "arbitrary" plugin (in our
case, macvlan) can be used to attach additional interfaces to designated
Pods. Nothing is required on the Antrea side to make it work, so this is
just to show how it can be used in practice.

Fixes #368