### PR TITLE
Aggregate cluster edit and view roles for Traceflow CRDs

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -613,6 +613,45 @@ kind: ClusterRole
 metadata:
   labels:
     app: antrea
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: aggregate-traceflows-edit
+rules:
+- apiGroups:
+  - ops.antrea.tanzu.vmware.com
+  resources:
+  - traceflows
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: aggregate-traceflows-view
+rules:
+- apiGroups:
+  - ops.antrea.tanzu.vmware.com
+  resources:
+  - traceflows
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
   name: antctl
 rules:
 - apiGroups:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -613,6 +613,45 @@ kind: ClusterRole
 metadata:
   labels:
     app: antrea
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: aggregate-traceflows-edit
+rules:
+- apiGroups:
+  - ops.antrea.tanzu.vmware.com
+  resources:
+  - traceflows
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: aggregate-traceflows-view
+rules:
+- apiGroups:
+  - ops.antrea.tanzu.vmware.com
+  resources:
+  - traceflows
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
   name: antctl
 rules:
 - apiGroups:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -613,6 +613,45 @@ kind: ClusterRole
 metadata:
   labels:
     app: antrea
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: aggregate-traceflows-edit
+rules:
+- apiGroups:
+  - ops.antrea.tanzu.vmware.com
+  resources:
+  - traceflows
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: aggregate-traceflows-view
+rules:
+- apiGroups:
+  - ops.antrea.tanzu.vmware.com
+  resources:
+  - traceflows
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
   name: antctl
 rules:
 - apiGroups:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -613,6 +613,45 @@ kind: ClusterRole
 metadata:
   labels:
     app: antrea
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: aggregate-traceflows-edit
+rules:
+- apiGroups:
+  - ops.antrea.tanzu.vmware.com
+  resources:
+  - traceflows
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: aggregate-traceflows-view
+rules:
+- apiGroups:
+  - ops.antrea.tanzu.vmware.com
+  resources:
+  - traceflows
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
   name: antctl
 rules:
 - apiGroups:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -613,6 +613,45 @@ kind: ClusterRole
 metadata:
   labels:
     app: antrea
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: aggregate-traceflows-edit
+rules:
+- apiGroups:
+  - ops.antrea.tanzu.vmware.com
+  resources:
+  - traceflows
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: aggregate-traceflows-view
+rules:
+- apiGroups:
+  - ops.antrea.tanzu.vmware.com
+  resources:
+  - traceflows
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
   name: antctl
 rules:
 - apiGroups:

--- a/build/yamls/base/crds-rbac.yml
+++ b/build/yamls/base/crds-rbac.yml
@@ -23,3 +23,28 @@ rules:
 - apiGroups: ["security.antrea.tanzu.vmware.com"]
   resources: ["clusternetworkpolicies", "networkpolicies"]
   verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregate-traceflows-edit
+  labels:
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["ops.antrea.tanzu.vmware.com"]
+  resources: ["traceflows"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-traceflows-view
+  labels:
+    # Add these permissions to the "view" default role.
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups: ["ops.antrea.tanzu.vmware.com"]
+  resources: ["traceflows"]
+  verbs: ["get", "list", "watch"]

--- a/docs/traceflow-guide.md
+++ b/docs/traceflow-guide.md
@@ -15,6 +15,7 @@ result via CRD, Antctl or UI graph.
   - [Using Octant with antrea-octant-plugin](#Using-Octant-with-antrea-octant-plugin)
 - [View Traceflow Result and Graph](#View-Traceflow-Result-and-Graph)
 - [View Traceflow CRDs](#View-Traceflow-CRDs)
+- [RBAC](#rbac)
 
 ## Prerequisites
 You need to switch on traceflow from featureGates defined in antrea.yml for both Controller and Agent.
@@ -111,3 +112,17 @@ in the Octant UI. You can generate a trace graph for any of these CRDs, as expla
 Also, you can view all the traceflow CRDs from the Tracflow page by clicking the right tab named "Traceflow Info" like below.
 
 <img src="https://s3-us-west-2.amazonaws.com/downloads.antrea.io/static/tf_table.png" width="600" alt="Traceflow CRDs">
+
+## RBAC
+
+Traceflow CRDs are meant for admins to troubleshoot and diagnose the network
+by injecting a packet from a source workload to a destination workload. Thus,
+access to manage these CRDs must be granted to subjects which
+have the authority to perform these diagnostic actions. On cluster
+initialization, Antrea grants the permissions to edit these CRDs with `admin`
+and the `edit` ClusterRole. In addition to this, Antrea also grants the
+permission to view these CRDs with the `view` ClusterRole. Cluster admins can
+therefore grant these ClusterRoles to any subject who may be responsible to
+troubleshoot the network. The admins may also decide to share the `view`
+ClusterRole to a wider range of subjects to allow them to read the traceflows
+that are active in the cluster.


### PR DESCRIPTION
Aggregate the Traceflow CRUD permissions to "admin" and "edit" ClusterRoles so that any user granted these roles may have edit permissions. In addition to this, aggregate the READ-ONLY permissions to "view" ClusterRole, so that any user granted this role may be able to view the Traceflow resources.