### PR TITLE
Fix integration test issue with case "TestBundleErrorWhenOVSRestart"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 replace (
 	// antrea/plugins/octant/go.mod also has this replacement since replace statement in dependencies
 	// were ignored. We need to change antrea/plugins/octant/go.mod if there is any change here.
-	github.com/contiv/ofnet => github.com/wenyingd/ofnet v0.0.0-20200812094731-56e62d82092a
+	github.com/contiv/ofnet => github.com/wenyingd/ofnet v0.0.0-20200911061943-60f892dbc243
 	// fake.NewSimpleClientset is quite slow when it's initialized with massive objects due to
 	// https://github.com/kubernetes/kubernetes/issues/89574. It takes more than tens of minutes to
 	// init a fake client with 200k objects, which makes it hard to run the NetworkPolicy scale test.

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,8 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7Zo
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vmware/go-ipfix v0.1.0 h1:qbS1kJcs50vaTmyqN1VIk9I1YVikpuS+Uleze/wfYCA=
 github.com/vmware/go-ipfix v0.1.0/go.mod h1:8suqePBGCX20vEh/4/ekuRjX4BsZ2zYWcD22NpAWHVU=
-github.com/wenyingd/ofnet v0.0.0-20200812094731-56e62d82092a h1:bP9FHcDcj/Pz9xy+gKC4KS3joEAqBMonqhGHnEDsQV8=
-github.com/wenyingd/ofnet v0.0.0-20200812094731-56e62d82092a/go.mod h1:oF9872TvzJqLzLKDGVMItRLWJHlnwXluuIuNbOP5WKM=
+github.com/wenyingd/ofnet v0.0.0-20200911061943-60f892dbc243 h1:sT4AqDhQcyt4+9OruERD+CH5vZHiw6Ld668U5YnhljY=
+github.com/wenyingd/ofnet v0.0.0-20200911061943-60f892dbc243/go.mod h1:oF9872TvzJqLzLKDGVMItRLWJHlnwXluuIuNbOP5WKM=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -425,6 +425,7 @@ func TestBundleErrorWhenOVSRestart(t *testing.T) {
 	for i < loop {
 		// Sending Bundle message in parallel.
 		go func() {
+			defer wg.Done()
 			// Sending OpenFlow messages when OVS is disconnected is not in this case's scope.
 			if !bridge.IsConnected() {
 				return
@@ -453,7 +454,6 @@ func TestBundleErrorWhenOVSRestart(t *testing.T) {
 			case <-ch:
 				successCount++
 			}
-			wg.Done()
 		}()
 		i++
 	}


### PR DESCRIPTION
1. Bump up ofnet version to resolve a goroutine leak issue introduced
   when failing to begin a Bundle.
2. Modify the integration test to ensure the case doesn't stuck at
   wg.Wait().

Fixes #1234 