### PR TITLE
Add legacy networking API group for backward compatibility

### DIFF
--- a/.github/workflows/kind_upgrade.yml
+++ b/.github/workflows/kind_upgrade.yml
@@ -103,3 +103,65 @@ jobs:
     - name: Run test
       run: |
         ./ci/kind/test-upgrade-antrea.sh --from-version-n-minus 2
+
+  compatible-N-1:
+    name: API compatible with client version N-1
+    needs: build-antrea-image
+    runs-on: [ubuntu-18.04]
+    steps:
+      - name: Free disk space
+        # https://github.com/actions/virtual-environments/issues/709
+        run: |
+          sudo apt-get clean
+          df -h
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+      - name: Download Antrea image from previous job
+        uses: actions/download-artifact@v1
+        with:
+          name: antrea-ubuntu
+      - name: Load Antrea image
+        run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
+      - name: Install Kind
+        env:
+          KIND_VERSION: v0.7.0
+        run: |
+          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
+          chmod +x ./kind
+          sudo mv kind /usr/local/bin
+      - name: Run test
+        run: |
+          ./ci/kind/test-upgrade-antrea.sh --from-version-n-minus 1 --controller-only
+
+  compatible-N-2:
+    name: API compatible with client version N-2
+    needs: build-antrea-image
+    runs-on: [ubuntu-18.04]
+    steps:
+      - name: Free disk space
+        # https://github.com/actions/virtual-environments/issues/709
+        run: |
+          sudo apt-get clean
+          df -h
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+      - name: Download Antrea image from previous job
+        uses: actions/download-artifact@v1
+        with:
+          name: antrea-ubuntu
+      - name: Load Antrea image
+        run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
+      - name: Install Kind
+        env:
+          KIND_VERSION: v0.7.0
+        run: |
+          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
+          chmod +x ./kind
+          sudo mv kind /usr/local/bin
+      - name: Run test
+        run: |
+          ./ci/kind/test-upgrade-antrea.sh --from-version-n-minus 2 --controller-only

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -656,6 +656,7 @@ metadata:
 rules:
 - apiGroups:
   - controlplane.antrea.tanzu.vmware.com
+  - networking.antrea.tanzu.vmware.com
   resources:
   - networkpolicies
   - appliedtogroups
@@ -730,6 +731,7 @@ rules:
   - delete
 - apiGroups:
   - controlplane.antrea.tanzu.vmware.com
+  - networking.antrea.tanzu.vmware.com
   resources:
   - networkpolicies
   - appliedtogroups
@@ -861,19 +863,12 @@ rules:
   resourceNames:
   - v1beta1.system.antrea.tanzu.vmware.com
   - v1beta1.controlplane.antrea.tanzu.vmware.com
+  - v1beta1.networking.antrea.tanzu.vmware.com
   resources:
   - apiservices
   verbs:
   - get
   - update
-- apiGroups:
-  - apiregistration.k8s.io
-  resourceNames:
-  - v1beta1.networking.antrea.tanzu.vmware.com
-  resources:
-  - apiservices
-  verbs:
-  - delete
 - apiGroups:
   - security.antrea.tanzu.vmware.com
   resources:
@@ -1218,6 +1213,21 @@ metadata:
   name: v1beta1.controlplane.antrea.tanzu.vmware.com
 spec:
   group: controlplane.antrea.tanzu.vmware.com
+  groupPriorityMinimum: 100
+  service:
+    name: antrea
+    namespace: kube-system
+  version: v1beta1
+  versionPriority: 100
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    app: antrea
+  name: v1beta1.networking.antrea.tanzu.vmware.com
+spec:
+  group: networking.antrea.tanzu.vmware.com
   groupPriorityMinimum: 100
   service:
     name: antrea

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -656,6 +656,7 @@ metadata:
 rules:
 - apiGroups:
   - controlplane.antrea.tanzu.vmware.com
+  - networking.antrea.tanzu.vmware.com
   resources:
   - networkpolicies
   - appliedtogroups
@@ -730,6 +731,7 @@ rules:
   - delete
 - apiGroups:
   - controlplane.antrea.tanzu.vmware.com
+  - networking.antrea.tanzu.vmware.com
   resources:
   - networkpolicies
   - appliedtogroups
@@ -861,19 +863,12 @@ rules:
   resourceNames:
   - v1beta1.system.antrea.tanzu.vmware.com
   - v1beta1.controlplane.antrea.tanzu.vmware.com
+  - v1beta1.networking.antrea.tanzu.vmware.com
   resources:
   - apiservices
   verbs:
   - get
   - update
-- apiGroups:
-  - apiregistration.k8s.io
-  resourceNames:
-  - v1beta1.networking.antrea.tanzu.vmware.com
-  resources:
-  - apiservices
-  verbs:
-  - delete
 - apiGroups:
   - security.antrea.tanzu.vmware.com
   resources:
@@ -1218,6 +1213,21 @@ metadata:
   name: v1beta1.controlplane.antrea.tanzu.vmware.com
 spec:
   group: controlplane.antrea.tanzu.vmware.com
+  groupPriorityMinimum: 100
+  service:
+    name: antrea
+    namespace: kube-system
+  version: v1beta1
+  versionPriority: 100
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    app: antrea
+  name: v1beta1.networking.antrea.tanzu.vmware.com
+spec:
+  group: networking.antrea.tanzu.vmware.com
   groupPriorityMinimum: 100
   service:
     name: antrea

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -656,6 +656,7 @@ metadata:
 rules:
 - apiGroups:
   - controlplane.antrea.tanzu.vmware.com
+  - networking.antrea.tanzu.vmware.com
   resources:
   - networkpolicies
   - appliedtogroups
@@ -730,6 +731,7 @@ rules:
   - delete
 - apiGroups:
   - controlplane.antrea.tanzu.vmware.com
+  - networking.antrea.tanzu.vmware.com
   resources:
   - networkpolicies
   - appliedtogroups
@@ -861,19 +863,12 @@ rules:
   resourceNames:
   - v1beta1.system.antrea.tanzu.vmware.com
   - v1beta1.controlplane.antrea.tanzu.vmware.com
+  - v1beta1.networking.antrea.tanzu.vmware.com
   resources:
   - apiservices
   verbs:
   - get
   - update
-- apiGroups:
-  - apiregistration.k8s.io
-  resourceNames:
-  - v1beta1.networking.antrea.tanzu.vmware.com
-  resources:
-  - apiservices
-  verbs:
-  - delete
 - apiGroups:
   - security.antrea.tanzu.vmware.com
   resources:
@@ -1218,6 +1213,21 @@ metadata:
   name: v1beta1.controlplane.antrea.tanzu.vmware.com
 spec:
   group: controlplane.antrea.tanzu.vmware.com
+  groupPriorityMinimum: 100
+  service:
+    name: antrea
+    namespace: kube-system
+  version: v1beta1
+  versionPriority: 100
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    app: antrea
+  name: v1beta1.networking.antrea.tanzu.vmware.com
+spec:
+  group: networking.antrea.tanzu.vmware.com
   groupPriorityMinimum: 100
   service:
     name: antrea

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -656,6 +656,7 @@ metadata:
 rules:
 - apiGroups:
   - controlplane.antrea.tanzu.vmware.com
+  - networking.antrea.tanzu.vmware.com
   resources:
   - networkpolicies
   - appliedtogroups
@@ -730,6 +731,7 @@ rules:
   - delete
 - apiGroups:
   - controlplane.antrea.tanzu.vmware.com
+  - networking.antrea.tanzu.vmware.com
   resources:
   - networkpolicies
   - appliedtogroups
@@ -861,19 +863,12 @@ rules:
   resourceNames:
   - v1beta1.system.antrea.tanzu.vmware.com
   - v1beta1.controlplane.antrea.tanzu.vmware.com
+  - v1beta1.networking.antrea.tanzu.vmware.com
   resources:
   - apiservices
   verbs:
   - get
   - update
-- apiGroups:
-  - apiregistration.k8s.io
-  resourceNames:
-  - v1beta1.networking.antrea.tanzu.vmware.com
-  resources:
-  - apiservices
-  verbs:
-  - delete
 - apiGroups:
   - security.antrea.tanzu.vmware.com
   resources:
@@ -1232,6 +1227,21 @@ metadata:
   name: v1beta1.controlplane.antrea.tanzu.vmware.com
 spec:
   group: controlplane.antrea.tanzu.vmware.com
+  groupPriorityMinimum: 100
+  service:
+    name: antrea
+    namespace: kube-system
+  version: v1beta1
+  versionPriority: 100
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    app: antrea
+  name: v1beta1.networking.antrea.tanzu.vmware.com
+spec:
+  group: networking.antrea.tanzu.vmware.com
   groupPriorityMinimum: 100
   service:
     name: antrea

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -656,6 +656,7 @@ metadata:
 rules:
 - apiGroups:
   - controlplane.antrea.tanzu.vmware.com
+  - networking.antrea.tanzu.vmware.com
   resources:
   - networkpolicies
   - appliedtogroups
@@ -730,6 +731,7 @@ rules:
   - delete
 - apiGroups:
   - controlplane.antrea.tanzu.vmware.com
+  - networking.antrea.tanzu.vmware.com
   resources:
   - networkpolicies
   - appliedtogroups
@@ -861,19 +863,12 @@ rules:
   resourceNames:
   - v1beta1.system.antrea.tanzu.vmware.com
   - v1beta1.controlplane.antrea.tanzu.vmware.com
+  - v1beta1.networking.antrea.tanzu.vmware.com
   resources:
   - apiservices
   verbs:
   - get
   - update
-- apiGroups:
-  - apiregistration.k8s.io
-  resourceNames:
-  - v1beta1.networking.antrea.tanzu.vmware.com
-  resources:
-  - apiservices
-  verbs:
-  - delete
 - apiGroups:
   - security.antrea.tanzu.vmware.com
   resources:
@@ -1223,6 +1218,21 @@ metadata:
   name: v1beta1.controlplane.antrea.tanzu.vmware.com
 spec:
   group: controlplane.antrea.tanzu.vmware.com
+  groupPriorityMinimum: 100
+  service:
+    name: antrea
+    namespace: kube-system
+  version: v1beta1
+  versionPriority: 100
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    app: antrea
+  name: v1beta1.networking.antrea.tanzu.vmware.com
+spec:
+  group: networking.antrea.tanzu.vmware.com
   groupPriorityMinimum: 100
   service:
     name: antrea

--- a/build/yamls/base/agent-rbac.yml
+++ b/build/yamls/base/agent-rbac.yml
@@ -39,6 +39,7 @@ rules:
       - delete
   - apiGroups:
       - controlplane.antrea.tanzu.vmware.com
+      - networking.antrea.tanzu.vmware.com
     resources:
       - networkpolicies
       - appliedtogroups

--- a/build/yamls/base/antctl.yml
+++ b/build/yamls/base/antctl.yml
@@ -12,6 +12,7 @@ metadata:
 rules:
   - apiGroups:
       - controlplane.antrea.tanzu.vmware.com
+      - networking.antrea.tanzu.vmware.com
     resources:
       - networkpolicies
       - appliedtogroups

--- a/build/yamls/base/controller-rbac.yml
+++ b/build/yamls/base/controller-rbac.yml
@@ -88,19 +88,10 @@ rules:
     resourceNames:
       - v1beta1.system.antrea.tanzu.vmware.com
       - v1beta1.controlplane.antrea.tanzu.vmware.com
+      - v1beta1.networking.antrea.tanzu.vmware.com
     verbs:
       - get
       - update
-  - apiGroups:
-      - apiregistration.k8s.io
-    resources:
-      - apiservices
-    resourceNames:
-      # Add the APIServices for the deprecated APIGroups here. antrea-controller
-      # will try to delete the APIServices if they are registered.
-      - v1beta1.networking.antrea.tanzu.vmware.com
-    verbs:
-      - delete
   - apiGroups:
       - security.antrea.tanzu.vmware.com
     resources:

--- a/build/yamls/base/controller.yml
+++ b/build/yamls/base/controller.yml
@@ -29,6 +29,20 @@ spec:
     name: antrea
     namespace: kube-system
 ---
+# Deprecated in v0.10, planned for removal in v0.12.
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta1.networking.antrea.tanzu.vmware.com
+spec:
+  group: networking.antrea.tanzu.vmware.com
+  groupPriorityMinimum: 100
+  version: v1beta1
+  versionPriority: 100
+  service:
+    name: antrea
+    namespace: kube-system
+---
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:

--- a/build/yamls/patches/kind/onDeleteUpdateStrategy.yml
+++ b/build/yamls/patches/kind/onDeleteUpdateStrategy.yml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: antrea-agent
+spec:
+  updateStrategy:
+    type: OnDelete

--- a/pkg/apis/networking/doc.go
+++ b/pkg/apis/networking/doc.go
@@ -1,0 +1,20 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package networking contains the latest (or "internal") version of the Antrea
+// NetworkPolicy API messages. This is the API messages as represented in memory.
+// The contract presented to clients is located in the versioned packages,
+// which are sub-directories. The first one is "v1beta1".
+// It's superseded by package controlplane in v0.9.3, and planned for removal in v0.12.
+package networking

--- a/pkg/apis/networking/install/install.go
+++ b/pkg/apis/networking/install/install.go
@@ -1,0 +1,30 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	"github.com/vmware-tanzu/antrea/pkg/apis/networking"
+	"github.com/vmware-tanzu/antrea/pkg/apis/networking/v1beta1"
+)
+
+// Install registers the API group and adds types to a scheme
+func Install(scheme *runtime.Scheme) {
+	utilruntime.Must(networking.AddToScheme(scheme))
+	utilruntime.Must(v1beta1.AddToScheme(scheme))
+	utilruntime.Must(scheme.SetVersionPriority(v1beta1.SchemeGroupVersion))
+}

--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -1,0 +1,60 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networking
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane"
+)
+
+// GroupName is the group name used in this package.
+const GroupName = "networking.antrea.tanzu.vmware.com"
+
+// SchemeGroupVersion is group version used to register these objects.
+var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}
+
+// Kind takes an unqualified kind and returns a Group qualified GroupKind.
+func Kind(kind string) schema.GroupKind {
+	return SchemeGroupVersion.WithKind(kind).GroupKind()
+}
+
+// Resource takes an unqualified resource and returns a Group qualified GroupResource.
+func Resource(resource string) schema.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}
+
+var (
+	// SchemeBuilder points to a list of functions added to Scheme.
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	// AddToScheme applies all the stored functions to the scheme.
+	AddToScheme = SchemeBuilder.AddToScheme
+)
+
+// Adds the list of known types to the given scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&controlplane.AppliedToGroup{},
+		&controlplane.AppliedToGroupPatch{},
+		&controlplane.AppliedToGroupList{},
+		&controlplane.AddressGroup{},
+		&controlplane.AddressGroupPatch{},
+		&controlplane.AddressGroupList{},
+		&controlplane.NetworkPolicy{},
+		&controlplane.NetworkPolicyList{},
+	)
+	return nil
+}

--- a/pkg/apis/networking/v1beta1/conversion.go
+++ b/pkg/apis/networking/v1beta1/conversion.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Antrea Authors
+// Copyright 2020 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/networking/v1beta1/doc.go
+++ b/pkg/apis/networking/v1beta1/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v1beta1 is the v1beta1 version of the Antrea NetworkPolicy API messages.
+package v1beta1

--- a/pkg/apis/networking/v1beta1/register.go
+++ b/pkg/apis/networking/v1beta1/register.go
@@ -1,0 +1,57 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane/v1beta1"
+)
+
+// GroupName is the group name used in this package.
+const GroupName = "networking.antrea.tanzu.vmware.com"
+
+// SchemeGroupVersion is group version used to register these objects.
+var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1beta1"}
+
+// Resource takes an unqualified resource and returns a Group qualified GroupResource.
+func Resource(resource string) schema.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}
+
+var (
+	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
+	localSchemeBuilder = &SchemeBuilder
+	AddToScheme        = localSchemeBuilder.AddToScheme
+)
+
+// Adds the list of known types to the given scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&v1beta1.AppliedToGroup{},
+		&v1beta1.AppliedToGroupPatch{},
+		&v1beta1.AppliedToGroupList{},
+		&v1beta1.AddressGroup{},
+		&v1beta1.AddressGroupPatch{},
+		&v1beta1.AddressGroupList{},
+		&v1beta1.NetworkPolicy{},
+		&v1beta1.NetworkPolicyList{},
+	)
+
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}

--- a/pkg/apiserver/certificate/cacert_controller.go
+++ b/pkg/apiserver/certificate/cacert_controller.go
@@ -43,6 +43,7 @@ var (
 	// apiServiceNames contains all the APIServices backed by antrea-controller.
 	apiServiceNames = []string{
 		"v1beta1.controlplane.antrea.tanzu.vmware.com",
+		"v1beta1.networking.antrea.tanzu.vmware.com",
 		"v1beta1.system.antrea.tanzu.vmware.com",
 	}
 )

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -284,9 +284,13 @@ func (data *TestData) deployAntreaCommon(yamlFile string, extraOptions string) e
 	if err != nil || rc != 0 {
 		return fmt.Errorf("error when deploying Antrea; is %s available on the master Node?", yamlFile)
 	}
+	rc, _, _, err = provider.RunCommandOnNode(masterNodeName(), fmt.Sprintf("kubectl -n %s rollout status deploy/%s --timeout=%v", antreaNamespace, antreaDeployment, defaultTimeout))
+	if err != nil || rc != 0 {
+		return fmt.Errorf("error when waiting for antrea-controller rollout to complete")
+	}
 	rc, _, _, err = provider.RunCommandOnNode(masterNodeName(), fmt.Sprintf("kubectl -n %s rollout status ds/%s --timeout=%v", antreaNamespace, antreaDaemonSet, defaultTimeout))
 	if err != nil || rc != 0 {
-		return fmt.Errorf("error when waiting for Antrea rollout to complete")
+		return fmt.Errorf("error when waiting for antrea-agent rollout to complete")
 	}
 
 	return nil

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -36,7 +36,10 @@ func TestDifferentNamedPorts(t *testing.T) {
 		t.Fatalf("Error when setting up test: %v", err)
 	}
 	defer teardownTest(t, data)
+	data.testDifferentNamedPorts(t)
+}
 
+func (data *TestData) testDifferentNamedPorts(t *testing.T) {
 	server0Port := 80
 	_, server0IP, cleanupFunc := createAndWaitForPod(t, data, func(name string, nodeName string) error {
 		return data.createServerPod(name, "http", server0Port, false)
@@ -57,10 +60,10 @@ func TestDifferentNamedPorts(t *testing.T) {
 
 	// Both clients can connect to both servers.
 	for _, clientName := range []string{client0Name, client1Name} {
-		if err = data.runNetcatCommandFromTestPod(clientName, server0IP, server0Port); err != nil {
+		if err := data.runNetcatCommandFromTestPod(clientName, server0IP, server0Port); err != nil {
 			t.Fatalf("Pod %s should be able to connect %s:%d, but was not able to connect", clientName, server0IP, server0Port)
 		}
-		if err = data.runNetcatCommandFromTestPod(clientName, server1IP, server1Port); err != nil {
+		if err := data.runNetcatCommandFromTestPod(clientName, server1IP, server1Port); err != nil {
 			t.Fatalf("Pod %s should be able to connect %s:%d, but was not able to connect", clientName, server1IP, server1Port)
 		}
 	}


### PR DESCRIPTION
Package networking is superseded by package controlplane in v0.9.3, to keep backward compatibility with up to two minor versions of antrea-agents, the API group should remain for two more minor releases.

This patch adds the APIs back and serves them with the same storage as controlplane API. Also, kind tests are added to make sure basic functionalities are not broken when only controller is upgraded.

Fixes #1250