### PR TITLE
Bug in enable verbose log patch

### DIFF
--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -142,7 +142,7 @@ if [ "$MODE" == "release" ] && [ -z "$IMG_TAG" ]; then
     exit 1
 fi
 
-if [ "$MODE" == "release" ] && [ ! -z "$VERBOSE_LOG" ]; then
+if [ "$MODE" == "release" ] && $VERBOSE_LOG; then
     echoerr "--verbose-log works only with 'dev' mode"
     print_help
     exit 1


### PR DESCRIPTION
manifest generation failing in release mode as the line checking for verbose log option assumes empty string initialization (old code).

Fixed the bug in PR #1142.