### PR TITLE
Add weekly matrix test for Antrea-CI 

### DIFF
--- a/ci/cluster-api/vsphere/templates/cluster.yaml
+++ b/ci/cluster-api/vsphere/templates/cluster.yaml
@@ -109,7 +109,7 @@ spec:
       numCPUs: 2
       resourcePool: RESOURCEPOOLPATH
       server: VCENTERNAME
-      template: ubuntu-1804-kube-v1.17.3
+      template: OVATEMPLATENAME
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
@@ -153,7 +153,7 @@ spec:
       - SSHAUTHORIZEDKEYS
       sudo: ALL=(ALL) NOPASSWD:ALL
   replicas: 1
-  version: v1.17.3
+  version: K8SVERSION
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
@@ -209,5 +209,4 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: VSphereMachineTemplate
         name: CLUSTERNAME
-      version: v1.17.3
-
+      version: K8SVERSION

--- a/ci/jenkins/README.md
+++ b/ci/jenkins/README.md
@@ -19,47 +19,57 @@ should be deleted. This ensures that all tests are run on a clean testbed.
 
 * [e2e [gated check-in]](https://jenkins.antrea-ci.rocks/job/antrea-e2e-for-pull-request/):
   [end-to-end tests](/test/e2e) for Antrea.
+
 * [conformance [gated check-in]](https://jenkins.antrea-ci.rocks/job/antrea-conformance-for-pull-request/):
   community tests using sonobuoy, focusing on "Conformance", and skipping "Slow",
   "Serial", "Disruptive", "Flaky", "Feature", "sig-cli",
   "sig-storage", "sig-auth", "sig-api-machinery", "sig-apps" and "sig-node".
+
 * [network policy [gated check-in]](https://jenkins.antrea-ci.rocks/job/antrea-networkpolicy-for-pull-request/):
   community tests using sonobuoy, focusing on "Feature:NetworkPolicy".
+
 * windows conformance: community tests on Windows cluster, focusing on "Conformance|sig-windows" and "sig-network",
   and skipping "LinuxOnly", "Slow", "Serial", "Disruptive", "Flaky", "Feature", "sig-cli", "sig-storage", "sig-auth",
   "sig-api-machinery", "sig-apps", "sig-node", "Privileged", "should be able to change the type from", "[sig-network]
   Services should be able to create a functioning NodePort service [Conformance]", "Service endpoints latency should not
   be very high".
+
 * windows network policy: community tests on Windows cluster, focusing on "Feature:NetworkPolicy".
+
 * [whole-conformance [daily]](https://jenkins.antrea-ci.rocks/job/antrea-whole-conformance-for-pull-request/):
   community tests using sonobuoy, with certified-conformance mode.
+
 * [daily-whole-conformance](https://jenkins.antrea-ci.rocks/job/antrea-daily-whole-conformance-for-period/):
   daily community tests using sonobuoy, with certified-conformance mode. If build fails, Jenkins will
   send an email to projectantrea-dev@googlegroups.com for notification.
+
 * Microsoft Windows conformance: community tests related to Microsoft Windows.
   It focuses on: "[sig-network].+[Conformance]|[sig-windows]".
   It skips: "[LinuxOnly]|[Slow]|[Serial]|[Disruptive]|[Flaky]|[Feature:.+]|[sig-cli]|[sig-storage]|[sig-auth]|[sig-api-machinery]|[sig-apps]|[sig-node]|[Privileged]|should be able to change the type from|[sig-network] Services should be able to create a functioning NodePort service [Conformance]".
+
 * Jenkins jobs validator [gated check-in]: this job only executes for PRs that include changes to
   [ci/jenkins/jobs](/ci/jenkins/jobs). It validates the syntax of the jenkins jobs'
   configuration.
+
 * Jenkins Windows OVS validator: this job only executes for PRs that include changes to [hack/windows/Install-OVS.ps1](hack/windows/Install-OVS.ps1). It validates
   if Windows OVS can be installed correctly.
+
 * [EKS conformance/network policy [bi-daily]](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-eks-conformance-net-policy/)
   community tests on EKS cluster using sonobuoy, focusing on "Conformance" and "Feature:NetworkPolicy", skipping the same regexes as in job __conformance__ above, as well as "NodePort" (See [#690](https://github.com/vmware-tanzu/antrea/issues/690)).\
   Current test environment matrix:
-  
+
   |  K8s Version |    Node Type    |  Node AMI Family |  Status  |
   | :----------: | :-------------: | :--------------: | :------: |
   |     1.17     |  EC2 t3.medium  |   AmazonLinux2   |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-eks-conformance-net-policy)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-eks-conformance-net-policy/)|
-  
+
 * [GKE conformance/network policy [bi-daily]](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-gke-conformance-net-policy/)
   community tests on GKE cluster using sonobuoy, focusing on "Conformance" and "Feature:NetworkPolicy", skipping the same regexes as in job __conformance__ above.\
   Current test environment matrix:
-    
+
   |  K8s Version   |     Node OS     | VPC Native Mode (on by default) |  Status  |
   | :------------: | :-------------: | :-----------------------------: |:-------: |
   |    1.17.12     |     Ubuntu      |  On                             |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-gke-conformance-net-policy)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-gke-conformance-net-policy/)|
-  
+
 * [AKS conformance/network policy [bi-daily]](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-aks-conformance-net-policy/)
   community tests on AKS cluster using sonobuoy, focusing on "Conformance" and "Feature:NetworkPolicy", skipping the same regexes as in job __conformance__ above.\
   Current test environment matrix:
@@ -70,8 +80,17 @@ should be deleted. This ensures that all tests are run on a clean testbed.
 
 * [daily-elk-flow-collector-validate](https://jenkins.antrea-ci.rocks/job/antrea-daily-elk-flow-collector-validate-for-period/):
   [![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=antrea-daily-elk-flow-collector-validate-for-period)](http://jenkins.antrea-ci.rocks/view/cloud/job/antrea-daily-elk-flow-collector-validate-for-period/)
-  daily validation of elk flow collector manifest. If build fails, Jenkins will send an email to 
+  daily validation of elk flow collector manifest. If build fails, Jenkins will send an email to
   projectantrea-dev@googlegroups.com for notification.
+
+* [matrix-test [weekly]](https://jenkins.antrea-ci.rocks/job/antrea-weekly-matrix-compatibility-test/):
+  runs Antrea e2e, K8s Conformance and NetworkPolicy tests, using different combinations of various operating systems and K8s releases.
+  |  K8s Version   |  Node OS        |  Status  |
+  | :------------: | :-------------: | :------: |
+  |    1.17.5      |  CentOS 7       |[![Build Status](https://jenkins.antrea-ci.rocks/buildStatus/icon?job=antrea-weekly-matrix-compatibility-test%2FIS_MATRIX_TEST%3DTrue%2CK8S_VERSION%3Dv1.17.5%2CTEST_OS%3Dcentos-7%2Clabels%3Dantrea-test-node)](https://jenkins.antrea-ci.rocks/job/antrea-weekly-matrix-compatibility-test/IS_MATRIX_TEST=True,K8S_VERSION=v1.17.5,TEST_OS=centos-7,labels=antrea-test-node/)|
+  |    1.17.5      |  Photon 3.0     |[![Build Status](https://jenkins.antrea-ci.rocks/buildStatus/icon?job=antrea-weekly-matrix-compatibility-test%2FIS_MATRIX_TEST%3DTrue%2CK8S_VERSION%3Dv1.17.5%2CTEST_OS%3Dphoton-3%2Clabels%3Dantrea-test-node)](https://jenkins.antrea-ci.rocks/job/antrea-weekly-matrix-compatibility-test/IS_MATRIX_TEST=True,K8S_VERSION=v1.17.5,TEST_OS=photon-3,labels=antrea-test-node/)|
+  |    1.18.2      |  CentOS 7       |[![Build Status](https://jenkins.antrea-ci.rocks/buildStatus/icon?job=antrea-weekly-matrix-compatibility-test%2FIS_MATRIX_TEST%3DTrue%2CK8S_VERSION%3Dv1.18.2%2CTEST_OS%3Dcentos-7%2Clabels%3Dantrea-test-node)](https://jenkins.antrea-ci.rocks/job/antrea-weekly-matrix-compatibility-test/IS_MATRIX_TEST=True,K8S_VERSION=v1.18.2,TEST_OS=centos-7,labels=antrea-test-node/)|
+  |    1.18.2      |  Photon 3.0     |[![Build Status](https://jenkins.antrea-ci.rocks/buildStatus/icon?job=antrea-weekly-matrix-compatibility-test%2FIS_MATRIX_TEST%3DTrue%2CK8S_VERSION%3Dv1.18.2%2CTEST_OS%3Dphoton-3%2Clabels%3Dantrea-test-node)](https://jenkins.antrea-ci.rocks/job/antrea-weekly-matrix-compatibility-test/IS_MATRIX_TEST=True,K8S_VERSION=v1.18.2,TEST_OS=photon-3,labels=antrea-test-node/)|
 
 If you need to run the K8s community tests locally, you may use the
 [ci/run-k8s-e2e-tests.sh](/ci/run-k8s-e2e-tests.sh) script. It takes care of

--- a/ci/jenkins/jobs/job-templates.yaml
+++ b/ci/jenkins/jobs/job-templates.yaml
@@ -183,3 +183,45 @@
          url: https://github.com/vmware-tanzu/antrea
      publishers: '{publishers}'
      wrappers: '{wrappers}'
+
+- job-template:
+    name: '{name}-{test_name}-matrix-compatibility-test'
+    node: '{node}'
+    block-downstream: false
+    block-upstream: false
+    builders: '{builders}'
+    concurrent: true
+    description: '{description}'
+    project-type: matrix
+    execution-strategy:
+      sequential: true
+    scm:
+    - git:
+        branches: '{branches}'
+        credentials-id: '{git_credentials_id}'
+        name: origin
+        refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
+        url: 'https://github.com/{org_repo}'
+        wipe-workspace: true
+        included-regions: '{included_regions}'
+    triggers:
+    - pollscm:
+        cron: '{cron}'
+        ignore-post-commit-hooks: '{ignore_post_commit_hooks}'
+    axes: '{axes}'
+    properties:
+    - build-discarder:
+        artifact-days-to-keep: -1
+        artifact-num-to-keep: -1
+        days-to-keep: 7
+        num-to-keep: 30
+    - throttle:
+        option: project
+        max-per-node: 2
+        max-total: 2
+        parameters-limit: true
+        matrix-configs: true
+        matrix-builds: true
+    publishers: '{publishers}'
+    parameters: '{parameters}'
+    wrappers: '{wrappers}'

--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -135,3 +135,29 @@
           fi
           echo "=== FAILURE !!! ==="
           exit 1
+
+- builder:
+    name: builder-matrix
+    builders:
+      - shell: |-
+          #!/bin/bash
+          set -ex
+          TEST_FAIL_E2E=0
+          TEST_FAIL_NP=0
+          TEST_FAIL_CONFORMANCE=0
+          export JOB_NAME="matrix-${TEST_OS}-k8s-${K8S_VERSION//./-}-build-num"
+          ./ci/jenkins/test-vmc.sh --cluster-name "${JOB_NAME}-${BUILD_NUMBER}" --setup-only
+          ./ci/jenkins/test-vmc.sh --cluster-name "${JOB_NAME}-${BUILD_NUMBER}" --testcase 'whole-conformance' --test-only || TEST_FAIL_CONFORMANCE=1
+          ./ci/jenkins/test-vmc.sh --cluster-name "${JOB_NAME}-${BUILD_NUMBER}" --testcase 'networkpolicy' --test-only || TEST_FAIL_NP=1
+          ./ci/jenkins/test-vmc.sh --cluster-name "${JOB_NAME}-${BUILD_NUMBER}" --testcase e2e --test-only || TEST_FAIL_E2E=1
+          ./ci/jenkins/test-vmc.sh --cluster-name "${JOB_NAME}-${BUILD_NUMBER}" --cleanup-only
+          if [ "${TEST_FAIL_E2E}" -eq 1 ]; then
+            echo "E2E Test failed!"
+          fi
+          if [ "${TEST_FAIL_NP}" -eq 1 ]; then
+            echo "Network Policy Test failed!"
+          fi
+          if [ "${TEST_FAIL_CONFORMANCE}" -eq 1 ]; then
+            echo "Whole Conformance Test failed!"
+          fi
+          exit $((TEST_FAIL_E2E + TEST_FAIL_NP + TEST_FAIL_CONFORMANCE))

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -719,3 +719,80 @@
               send-to-individuals: false
           triggers: []
           wrappers: []
+      - '{name}-{test_name}-matrix-compatibility-test':
+          test_name: weekly
+          node: 'antrea-test-node'
+          description: 'This is weekly matrix compatibility test for Antrea.'
+          axes:
+            - axis:
+               type: user-defined
+               name: TEST_OS
+               values:
+                - centos-7
+                - photon-3
+            - axis:
+               type: user-defined
+               name: K8S_VERSION
+               values:
+                - v1.17.5
+                - v1.18.2
+            - axis:
+               type: user-defined
+               name: IS_MATRIX_TEST
+               values:
+                - true
+            - axis:
+               type: slave
+               name: labels
+               values:
+                - antrea-test-node
+          builders:
+            - builder-matrix
+          branches:
+          - '${{GIT_BRANCH}}'
+          included_regions: []
+          cron: 'H 20 * * 6'
+          ignore_post_commit_hooks: false
+          parameters:
+          - string:
+              default: 'master'
+              description: |-
+                  The branch name of the original repo. It must match one of the following patterns:
+                  - <branchName>
+                  - refs/heads/<branchName>
+                  - <remoteRepoName>/<branchName>
+                  - remotes/<remoteRepoName>/<branchName>
+                  - refs/remotes/<remoteRepoName>/<branchName>
+                  Tracks/checks out the specified branch.
+                  E.g. master, feature1, refs/heads/master, refs/heads/feature1/master, origin/master, remotes/origin/master, refs/remotes/origin/master, ...
+                  - <commitId>
+                  Checks out the specified commit.
+                  E.g. 5062ac843f2b947733e6a3b105977056821bd352, 5062ac84, ...
+                  - refs/tags/<tagName>
+                  Tracks/checks out the specified tag.
+                  E.g. refs/tags/git-2.3.0
+                  - <Wildcards>
+                  The syntax is of the form: REPOSITORYNAME/BRANCH. In addition, BRANCH is recognized as a shorthand of */BRANCH, '*' is recognized as a wildcard, and '**' is recognized as wildcard that includes the separator '/'. Therefore, origin/branches* would match origin/branches-foo but not origin/branches/foo, while origin/branches** would match both origin/branches-foo and origin/branches/foo.
+                  - :<regular expression>
+                  The syntax is of the form: :regexp. Regular expression syntax in branches to build will only build those branches whose names match the regular expression.
+                  Examples:
+                      - :^(?!(origin/prefix)).*
+                      matches: origin or origin/master or origin/feature
+                      does not match: origin/prefix or origin/prefix_123 or origin/prefix-abc
+              name: GIT_BRANCH
+              trim: 'true'
+          publishers:
+          - archive:
+              allow-empty: true
+              artifacts: 'IS_MATRIX_TEST/*/K8S_VERSION/*/TEST_OS/*/labels/antrea-test-node/antrea-test-logs.tar.gz, IS_MATRIX_TEST/*/K8S_VERSION/*/TEST_OS/*/labels/antrea-test-node/ci/jenkins/*sonobuoy*.tar.gz'
+              case-sensitive: true
+              default-excludes: true
+              fingerprint: false
+              only-if-success: false
+          - email:
+              recipients: projectantrea-dev@googlegroups.com
+          wrappers:
+             - workspace-cleanup
+             - timeout:
+                 timeout: 600
+                 type: absolute

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -30,6 +30,7 @@ RUN_GARBAGE_COLLECTION=false
 RUN_SETUP_ONLY=false
 RUN_CLEANUP_ONLY=false
 COVERAGE=false
+RUN_TEST_ONLY=false
 TESTCASE=""
 SECRET_EXIST=false
 TEST_FAILURE=false
@@ -37,7 +38,7 @@ CLUSTER_READY=false
 
 _usage="Usage: $0 [--cluster-name <VMCClusterNameToUse>] [--kubeconfig <KubeconfigSavePath>] [--workdir <HomePath>]
                   [--log-mode <SonobuoyResultLogLevel>] [--testcase <e2e|conformance|whole-conformance|networkpolicy>]
-                  [--garbage-collection] [--setup-only] [--cleanup-only] [--coverage]
+                  [--garbage-collection] [--setup-only] [--cleanup-only] [--coverage] [--test-only]
 
 Setup a VMC cluster to run K8s e2e community tests (E2e, Conformance, whole Conformance & Network Policy).
 
@@ -49,7 +50,8 @@ Setup a VMC cluster to run K8s e2e community tests (E2e, Conformance, whole Conf
         --garbage-collection     Do garbage collection to clean up some unused testbeds.
         --setup-only             Only perform setting up the cluster and run test.
         --cleanup-only           Only perform cleaning up the cluster.
-        --coverage               Run e2e with coverage."
+        --coverage               Run e2e with coverage.
+        --test-only              Only run test on current cluster. Not set up/clean up the cluster."
 
 function print_usage {
     echoerr "$_usage"
@@ -98,6 +100,9 @@ case $key in
     ;;
     --coverage)
     COVERAGE=true
+    ;;
+    --test-only)
+    RUN_TEST_ONLY=true
     shift
     ;;
     -h|--help)
@@ -143,6 +148,13 @@ function saveLogs() {
 
 function setup_cluster() {
     export KUBECONFIG=$KUBECONFIG_PATH
+    if [ -z $K8S_VERSION ]; then
+      export K8S_VERSION=v1.17.3
+    fi
+    if [ -z $TEST_OS ]; then
+      export TEST_OS=ubuntu-1804
+    fi
+    export OVA_TEMPLATE_NAME=${TEST_OS}-kube-${K8S_VERSION}
     rm -rf ${GIT_CHECKOUT_DIR}/jenkins || true
 
     echo '=== Generate key pair ==='
@@ -154,6 +166,8 @@ function setup_cluster() {
     mkdir -p ${GIT_CHECKOUT_DIR}/jenkins/out
     cp ${GIT_CHECKOUT_DIR}/ci/cluster-api/vsphere/templates/* ${GIT_CHECKOUT_DIR}/jenkins/out
     sed -i "s/CLUSTERNAMESPACE/${CLUSTER}/g" ${GIT_CHECKOUT_DIR}/jenkins/out/cluster.yaml
+    sed -i "s/K8SVERSION/${K8S_VERSION}/g" ${GIT_CHECKOUT_DIR}/jenkins/out/cluster.yaml
+    sed -i "s/OVATEMPLATENAME/${OVA_TEMPLATE_NAME}/g" ${GIT_CHECKOUT_DIR}/jenkins/out/cluster.yaml
     sed -i "s/CLUSTERNAME/${CLUSTER}/g" ${GIT_CHECKOUT_DIR}/jenkins/out/cluster.yaml
     sed -i "s|SSHAUTHORIZEDKEYS|${publickey}|g" ${GIT_CHECKOUT_DIR}/jenkins/out/cluster.yaml
     sed -i "s/CLUSTERNAMESPACE/${CLUSTER}/g" ${GIT_CHECKOUT_DIR}/jenkins/out/namespace.yaml
@@ -169,7 +183,7 @@ function setup_cluster() {
     kubectl apply -f "${GIT_CHECKOUT_DIR}/jenkins/out/namespace.yaml"
     kubectl apply -f "${GIT_CHECKOUT_DIR}/jenkins/out/cluster.yaml"
 
-    echo '=== Wait for for 10 min to get workload cluster secret ==='
+    echo '=== Wait for 10 min to get workload cluster secret ==='
     for t in {1..10}
     do
         sleep 1m
@@ -246,7 +260,7 @@ function deliver_antrea {
         echo "=== Antrea Image build failed ==="
         exit 1
     fi
-    
+
     antrea_yml="antrea.yml"
     if [[ "$COVERAGE" == true ]]; then
         make manifest-coverage -C $GIT_CHECKOUT_DIR
@@ -258,15 +272,15 @@ function deliver_antrea {
     # Configure and append antrea-prometheus.yml to antrea.yml
     sed -i "s|#enablePrometheusMetrics: false|enablePrometheusMetrics: true|g" $GIT_CHECKOUT_DIR/build/yamls/$antrea_yml
     echo "---" >> $GIT_CHECKOUT_DIR/build/yamls/$antrea_yml
-    cat $GIT_CHECKOUT_DIR/build/yamls/antrea-prometheus.yml >> $GIT_CHECKOUT_DIR/build/yamls/$antrea_yml 
+    cat $GIT_CHECKOUT_DIR/build/yamls/antrea-prometheus.yml >> $GIT_CHECKOUT_DIR/build/yamls/$antrea_yml
 
     echo "====== Delivering Antrea to all the Nodes ======"
     export KUBECONFIG=${GIT_CHECKOUT_DIR}/jenkins/out/kubeconfig
     DOCKER_IMG_VERSION=$CLUSTER
-   
+
     if [[ "$COVERAGE" == true ]]; then
         docker save -o antrea-ubuntu-coverage.tar antrea/antrea-ubuntu-coverage:${DOCKER_IMG_VERSION}
-    else 
+    else
         docker save -o antrea-ubuntu.tar antrea/antrea-ubuntu:${DOCKER_IMG_VERSION}
     fi
 
@@ -279,8 +293,14 @@ function deliver_antrea {
         if [[ "$COVERAGE" == true ]]; then
             antrea_image="antrea-ubuntu-coverage"
         fi
-        rsync -avr --progress --inplace -e "ssh -q -o StrictHostKeyChecking=no -i ${GIT_CHECKOUT_DIR}/jenkins/key/antrea-ci-key" $antrea_image.tar capv@${IP}:/home/capv/$antrea_image.tar
-        ssh -q -o StrictHostKeyChecking=no -i ${GIT_CHECKOUT_DIR}/jenkins/key/antrea-ci-key -n capv@${IP} "sudo crictl images | grep $antrea_image | awk '{print \$3}' | xargs -r crictl rmi ; sudo ctr -n=k8s.io images import /home/capv/$antrea_image.tar ; sudo ctr -n=k8s.io images tag docker.io/antrea/$antrea_image:${DOCKER_IMG_VERSION} docker.io/antrea/$antrea_image:latest ; sudo crictl images | grep '<none>' | awk '{print \$3}' | xargs -r crictl rmi" || true
+        ssh-keygen -f "/var/lib/jenkins/.ssh/known_hosts" -R ${IP}
+        scp -o StrictHostKeyChecking=no -i ${GIT_CHECKOUT_DIR}/jenkins/key/antrea-ci-key $antrea_image.tar capv@${IP}:/home/capv
+        if [ $TEST_OS == 'centos-7' ]; then
+            ssh -q -o StrictHostKeyChecking=no -i ${GIT_CHECKOUT_DIR}/jenkins/key/antrea-ci-key -n capv@${IP} "sudo chmod 777 /run/containerd/containerd.sock"
+            ssh -q -o StrictHostKeyChecking=no -i ${GIT_CHECKOUT_DIR}/jenkins/key/antrea-ci-key -n capv@${IP} "sudo crictl images | grep $antrea_image | awk '{print \$3}' | xargs -r crictl rmi ; ctr -n=k8s.io images import /home/capv/$antrea_image.tar ; ctr -n=k8s.io images tag docker.io/antrea/$antrea_image:${DOCKER_IMG_VERSION} docker.io/antrea/$antrea_image:latest ; sudo crictl images | grep '<none>' | awk '{print \$3}' | xargs -r crictl rmi"
+        else
+            ssh -q -o StrictHostKeyChecking=no -i ${GIT_CHECKOUT_DIR}/jenkins/key/antrea-ci-key -n capv@${IP} "sudo crictl images | grep $antrea_image | awk '{print \$3}' | xargs -r crictl rmi ; sudo ctr -n=k8s.io images import /home/capv/$antrea_image.tar ; sudo ctr -n=k8s.io images tag docker.io/antrea/$antrea_image:${DOCKER_IMG_VERSION} docker.io/antrea/$antrea_image:latest ; sudo crictl images | grep '<none>' | awk '{print \$3}' | xargs -r crictl rmi"
+        fi
     done
 }
 
@@ -318,7 +338,7 @@ function run_e2e {
     echo "=== Master node ip: ${master_ip} ==="
     sed -i "s/MASTERNODEIP/${master_ip}/g" $GIT_CHECKOUT_DIR/test/e2e/infra/vagrant/ssh-config
     echo "=== Move kubeconfig to master ==="
-    ssh -q -o StrictHostKeyChecking=no -i $GIT_CHECKOUT_DIR/jenkins/key/antrea-ci-key -n capv@${master_ip} "mkdir -p .kube"
+    ssh -q -o StrictHostKeyChecking=no -i $GIT_CHECKOUT_DIR/jenkins/key/antrea-ci-key -n capv@${master_ip} "if [ ! -d ".kube" ]; then mkdir .kube; fi"
     scp -q -o StrictHostKeyChecking=no -i $GIT_CHECKOUT_DIR/jenkins/key/antrea-ci-key $GIT_CHECKOUT_DIR/jenkins/out/kubeconfig capv@${master_ip}:~/.kube/config
     sed -i "s/CONTROLPLANENODE/${master_name}/g" $GIT_CHECKOUT_DIR/test/e2e/infra/vagrant/ssh-config
     echo "    IdentityFile ${GIT_CHECKOUT_DIR}/jenkins/key/antrea-ci-key" >> $GIT_CHECKOUT_DIR/test/e2e/infra/vagrant/ssh-config
@@ -370,7 +390,7 @@ function run_conformance {
 
     master_ip="$(kubectl get nodes -o wide --no-headers=true | awk '$3 == "master" {print $6}')"
     echo "=== Move kubeconfig to master ==="
-    ssh -q -o StrictHostKeyChecking=no -i $GIT_CHECKOUT_DIR/jenkins/key/antrea-ci-key -n capv@${master_ip} "mkdir -p .kube"
+    ssh -q -o StrictHostKeyChecking=no -i $GIT_CHECKOUT_DIR/jenkins/key/antrea-ci-key -n capv@${master_ip} "if [ ! -d ".kube" ]; then mkdir .kube; fi"
     scp -q -o StrictHostKeyChecking=no -i $GIT_CHECKOUT_DIR/jenkins/key/antrea-ci-key $GIT_CHECKOUT_DIR/jenkins/out/kubeconfig capv@${master_ip}:~/.kube/config
 
     if [[ "$TESTCASE" == "conformance" ]]; then
@@ -443,15 +463,23 @@ fi
 if [[ "$TESTCASE" == "integration" ]]; then
     run_integration
 elif [[ "$TESTCASE" == "e2e" ]]; then
-    setup_cluster
-    deliver_antrea
-    run_e2e
-    cleanup_cluster
+    if [[ "$RUN_TEST_ONLY" == true ]]; then
+        run_e2e
+    else
+        setup_cluster
+        deliver_antrea
+        run_e2e
+        cleanup_cluster
+    fi
 else
-    setup_cluster
-    deliver_antrea
-    run_conformance
-    cleanup_cluster
+    if [[ "$RUN_TEST_ONLY" == true ]]; then
+        run_conformance
+    else
+        setup_cluster
+        deliver_antrea
+        run_conformance
+        cleanup_cluster
+    fi
 fi
 
 if [[ "$TEST_FAILURE" == true ]]; then


### PR DESCRIPTION
In this patch, we add a weekly Jenkins job which covers the combinations of specific OSs (CentOS 7, Photon 3) and K8S versions (v1.17.5, v1.18.2) and runs Antrea E2E, K8S Conformance and NetworkPolicy tests under each combination.

Will merge after #1240 is merged.