### PR TITLE
Download all artifacts from https://downloads.antrea.io

### DIFF
--- a/docs/network-flow-visibility.md
+++ b/docs/network-flow-visibility.md
@@ -26,7 +26,7 @@ to enhance the performance and security aspects of Pod workloads.
 For visualizing the network flows, Antrea monitors the flows in Linux conntrack module. These flows are converted to flow records
 and are sent to the configured flow controller. High-level design is given below:
 
-<img src="https://s3-us-west-2.amazonaws.com/downloads.antrea.io/static/netviz.png" width="600" alt="Network Flow Visibilty">
+<img src="https://downloads.antrea.io/static/netviz.png" width="600" alt="Network Flow Visibilty">
 
 ## Flow Exporter feature
 
@@ -150,7 +150,7 @@ visualization.
 #### Overview
 An overview of Pod-based flow records information is provided.
 
-<img src="https://s3-us-west-2.amazonaws.com/downloads.antrea.io/static/flow-visualization-overview.png" width="900" alt="Flow
+<img src="https://downloads.antrea.io/static/flow-visualization-overview.png" width="900" alt="Flow
 Visualization Overview Dashboard"> 
 
 #### Flows
@@ -158,35 +158,35 @@ Visualization Overview Dashboard">
 Pod-to-Pod Tx and Rx traffic is shown in sankey diagrams. Corresponding 
 source or destination Pod throughput is visualized using stacked line graph. 
 
-<img src="https://s3-us-west-2.amazonaws.com/downloads.antrea.io/static/flow-visualization-flow-1.png" width="900" alt="Flow
+<img src="https://downloads.antrea.io/static/flow-visualization-flow-1.png" width="900" alt="Flow
 Visualization Flows Dashboard"> 
 
-<img src="https://s3-us-west-2.amazonaws.com/downloads.antrea.io/static/flow-visualization-flow-2.png" width="900" alt="Flow
+<img src="https://downloads.antrea.io/static/flow-visualization-flow-2.png" width="900" alt="Flow
 Visualization Flow Dashboard"> 
 
 ##### Pod-to-Service Traffic
 Pod-to-Service traffic is presented similar to Pod-to-Pod traffic.
 Corresponding source or destination IP addresses are shown in tooltips.
 
-<img src="https://s3-us-west-2.amazonaws.com/downloads.antrea.io/static/flow-visualization-flow-3.png" width="900" alt="Flow
+<img src="https://downloads.antrea.io/static/flow-visualization-flow-3.png" width="900" alt="Flow
 Visualization Flows Dashboard"> 
 
-<img src="https://s3-us-west-2.amazonaws.com/downloads.antrea.io/static/flow-visualization-flow-4.png" width="900" alt="Flow
+<img src="https://downloads.antrea.io/static/flow-visualization-flow-4.png" width="900" alt="Flow
 Visualization Flow Dashboard"> 
 
 #### Flow Records 
 Flow Records dashboard shows the raw flow records over time with support 
 for filters.
 
-<img src="https://s3-us-west-2.amazonaws.com/downloads.antrea.io/static/flow-visualization-flow-record.png" width="900" alt="Flow
+<img src="https://downloads.antrea.io/static/flow-visualization-flow-record.png" width="900" alt="Flow
 Visualization Flow Record Dashboard">
 
 #### Node Throughput
 Node Throughput dashboard shows the visualization of inter-Node and 
 intra-Node traffic by aggregating all the Pod traffic per Node.
 
-<img src="https://s3-us-west-2.amazonaws.com/downloads.antrea.io/static/flow-visualization-node-1.png" width="900" alt="Flow
+<img src="https://downloads.antrea.io/static/flow-visualization-node-1.png" width="900" alt="Flow
 Visualization Node Throughput Dashboard">
 
-<img src="https://s3-us-west-2.amazonaws.com/downloads.antrea.io/static/flow-visualization-node-2.png" width="900" alt="Flow
+<img src="https://downloads.antrea.io/static/flow-visualization-node-2.png" width="900" alt="Flow
 Visualization Node Throughput Dashboard">

--- a/docs/traceflow-guide.md
+++ b/docs/traceflow-guide.md
@@ -84,7 +84,7 @@ Please refer to the corresponding [Antctl page](https://github.com/vmware-tanzu/
 
 ### Using Octant with antrea-octant-plugin
 
-<img src="https://s3-us-west-2.amazonaws.com/downloads.antrea.io/static/tf_create.1.png" width="600" alt="Start a New Trace">
+<img src="https://downloads.antrea.io/static/tf_create.1.png" width="600" alt="Start a New Trace">
 
 From Octant dashboard, you need to click on left navigation bar named "Antrea" and then
 choose category named "Traceflow" to lead you to the Traceflow UI displayed on the right side.
@@ -98,28 +98,28 @@ You can always view Traceflow result directly via Traceflow CRD status and see i
 or somehow dropped by certain packet-processing stage. Antrea also provides a more user-friendly way by showing the
 Traceflow result via a trace graph on UI.
 
-<img src="https://s3-us-west-2.amazonaws.com/downloads.antrea.io/static/tf_graph_success.png" width="600" alt="Show Successful Trace">
+<img src="https://downloads.antrea.io/static/tf_graph_success.png" width="600" alt="Show Successful Trace">
 
 From the graph above, we can see the inter-node traffic between two Pods has been successfully delivered.
 Sometimes the traffic may not be successfully delivered and we can always easily identify where the traffic is dropped
 via a trace graph like below.
 
-<img src="https://s3-us-west-2.amazonaws.com/downloads.antrea.io/static/tf_graph_failure.png" width="600" alt="Show Failing Trace">
+<img src="https://downloads.antrea.io/static/tf_graph_failure.png" width="600" alt="Show Failing Trace">
 
 You can also generate a historical trace graph by providing a specific Traceflow CRD name (assuming the CRD has not been deleted yet)
 as shown below.
 
-<img src="https://s3-us-west-2.amazonaws.com/downloads.antrea.io/static/tf_historical_graph.png" width="600" alt="Generate Historical Trace">
+<img src="https://downloads.antrea.io/static/tf_historical_graph.png" width="600" alt="Generate Historical Trace">
 
 ## View Traceflow CRDs
 
-<img src="https://s3-us-west-2.amazonaws.com/downloads.antrea.io/static/tf_overview.png" width="600" alt="Antrea Overview">
+<img src="https://downloads.antrea.io/static/tf_overview.png" width="600" alt="Antrea Overview">
 
 As shown above, you can check the existing Traceflow CRDs in the "Traceflow Info" table of the Antrea Overview web page
 in the Octant UI. You can generate a trace graph for any of these CRDs, as explained in the previous section.
 Also, you can view all the traceflow CRDs from the Tracflow page by clicking the right tab named "Traceflow Info" like below.
 
-<img src="https://s3-us-west-2.amazonaws.com/downloads.antrea.io/static/tf_table.png" width="600" alt="Traceflow CRDs">
+<img src="https://downloads.antrea.io/static/tf_table.png" width="600" alt="Traceflow CRDs">
 
 ## RBAC
 

--- a/hack/windows/Install-OVS.ps1
+++ b/hack/windows/Install-OVS.ps1
@@ -8,7 +8,7 @@ $ErrorActionPreference = "Stop"
 # TODO: set up HTTPS so that the archive can be downloaded securely. In the
 # meantime, we use a SHA256 hash to ensure that the downloaded archive is
 # correct.
-$OVSDownloadURL = "http://downloads.antrea.io/ovs/ovs-2.14.0-antrea.1-win64.zip"
+$OVSDownloadURL = "https://downloads.antrea.io/ovs/ovs-2.14.0-antrea.1-win64.zip"
 $OVSPublishedHash = 'E81800A6B8E157C948BAE548E5AFB425B2AD98CE18BC8C6148AB5B7F81E76B7D'
 $OVSDownloadDir = [System.IO.Path]::GetDirectoryName($myInvocation.MyCommand.Definition)
 $InstallLog = "$OVSDownloadDir\install.log"


### PR DESCRIPTION
Fixes #1254

The SHA256 checksum verification for the OVS Windows binaries is no
longer required for security reasons, but it may be a good idea to keep
it (there is no real maintenance burden, we just need to update it
whenever the link is updated). It can help ensure that there is no issue
on our side and that the file that was uploaded to S3 by us is the
correct one. There is no burden on users. We can also remove that code
altogether.