### PR TITLE
Upload test logs to Github actions when kind tests failed

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -71,7 +71,17 @@ jobs:
         sudo mv kind /usr/local/bin
     - name: Run e2e tests
       run: |
-        ./ci/kind/test-e2e-kind.sh --encap-mode encap
+        mkdir log
+        ANTREA_LOG_DIR=$PWD/log ./ci/kind/test-e2e-kind.sh --encap-mode encap
+    - name: Tar log files
+      if: ${{ failure() }}
+      run: tar -czf log.tar.gz log
+    - name: Upload test log
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: e2e-kind-encap.tar.gz
+        path: log.tar.gz
 
   test-e2e-encap-proxy:
     name: E2e tests on a Kind cluster on Linux with proxy enabled
@@ -102,7 +112,17 @@ jobs:
         sudo mv kind /usr/local/bin
     - name: Run e2e tests
       run: |
-        ./ci/kind/test-e2e-kind.sh --encap-mode encap --proxy
+        mkdir log
+        ANTREA_LOG_DIR=$PWD/log ./ci/kind/test-e2e-kind.sh --encap-mode encap --proxy
+    - name: Tar log files
+      if: ${{ failure() }}
+      run: tar -czf log.tar.gz log
+    - name: Upload test log
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: e2e-kind-encap-proxy.tar.gz
+        path: log.tar.gz
 
   test-e2e-noencap:
     name: E2e tests on a Kind cluster on Linux (noEncap)
@@ -133,7 +153,17 @@ jobs:
         sudo mv kind /usr/local/bin
     - name: Run e2e tests
       run: |
-        ./ci/kind/test-e2e-kind.sh --encap-mode noEncap
+        mkdir log
+        ANTREA_LOG_DIR=$PWD/log ./ci/kind/test-e2e-kind.sh --encap-mode noEncap
+    - name: Tar log files
+      if: ${{ failure() }}
+      run: tar -czf log.tar.gz log
+    - name: Upload test log
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: e2e-kind-noencap.tar.gz
+        path: log.tar.gz
 
   test-e2e-hybrid:
     name: E2e tests on a Kind cluster on Linux (hybrid)
@@ -164,7 +194,17 @@ jobs:
         sudo mv kind /usr/local/bin
     - name: Run e2e tests
       run: |
-        ./ci/kind/test-e2e-kind.sh --encap-mode hybrid
+        mkdir log
+        ANTREA_LOG_DIR=$PWD/log ./ci/kind/test-e2e-kind.sh --encap-mode hybrid
+    - name: Tar log files
+      if: ${{ failure() }}
+      run: tar -czf log.tar.gz log
+    - name: Upload test log
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: e2e-kind-hybrid.tar.gz
+        path: log.tar.gz
 
   test-e2e-encap-np:
     name: E2e tests on a Kind cluster on Linux with Antrea NetworkPolicies enabled
@@ -195,7 +235,17 @@ jobs:
         sudo mv kind /usr/local/bin
     - name: Run e2e tests
       run: |
-        ./ci/kind/test-e2e-kind.sh --encap-mode encap --np
+        mkdir log
+        ANTREA_LOG_DIR=$PWD/log ./ci/kind/test-e2e-kind.sh --encap-mode encap --np
+    - name: Tar log files
+      if: ${{ failure() }}
+      run: tar -czf log.tar.gz log
+    - name: Upload test log
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: e2e-kind-hybrid.tar.gz
+        path: log.tar.gz
 
   test-netpol-tmp:
     name: Run experimental network policy tests (netpol) on Kind cluster

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -95,7 +95,7 @@ function run_test {
 
   $YML_CMD --kind --encap-mode $current_mode $manifest_args | docker exec -i kind-control-plane dd of=/root/antrea.yml
   sleep 1
-  go test -v -timeout=30m github.com/vmware-tanzu/antrea/test/e2e -provider=kind
+  go test -v -timeout=30m github.com/vmware-tanzu/antrea/test/e2e -provider=kind --logs-export-dir=$ANTREA_LOG_DIR
   $TESTBED_CMD destroy kind
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -278,7 +278,7 @@ section introduces these modes.
 
 * ***Hybrid*** When two Nodes are in two different subnets, Pod traffic between
 the two Nodes is encapsulated; when the two Nodes are in the same subnet, Pod
-traffic between them is not encapsulated, instead the traffic is routed from one
+traffic between them is not encapsulated, instead the traffic is routed from on3e
 Node to another. Antrea Agent adds routes on the Node to enable the routing
 within the same Node subnet. For every remote Node in the same subnet as the
 local Node, Agent adds a static route entry that uses the remote Node IP as the


### PR DESCRIPTION
I have verified this workflow in https://github.com/vmware-tanzu/antrea/actions/runs/258851376.
Developers can download the logs in the artifacts dropdown menu of the check.