### PR TITLE
Upgrade eksctl and its default k8s cluster version

### DIFF
--- a/ci/jenkins/README.md
+++ b/ci/jenkins/README.md
@@ -50,7 +50,7 @@ should be deleted. This ensures that all tests are run on a clean testbed.
   
   |  K8s Version |    Node Type    |  Node AMI Family |  Status  |
   | :----------: | :-------------: | :--------------: | :------: |
-  |     1.15     |  EC2 t3.medium  |   AmazonLinux2   |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-eks-conformance-net-policy)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-eks-conformance-net-policy/)|
+  |     1.17     |  EC2 t3.medium  |   AmazonLinux2   |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-eks-conformance-net-policy)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-eks-conformance-net-policy/)|
   
 * [GKE conformance/network policy [bi-daily]](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-gke-conformance-net-policy/)
   community tests on GKE cluster using sonobuoy, focusing on "Conformance" and "Feature:NetworkPolicy", skipping the same regexes as in job __conformance__ above.\
@@ -58,7 +58,7 @@ should be deleted. This ensures that all tests are run on a clean testbed.
     
   |  K8s Version   |     Node OS     | VPC Native Mode (on by default) |  Status  |
   | :------------: | :-------------: | :-----------------------------: |:-------: |
-  | 1.16.13-gke.1  |     Ubuntu      |  On                             |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-gke-conformance-net-policy)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-gke-conformance-net-policy/)|
+  |    1.16.13     |     Ubuntu      |  On                             |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-gke-conformance-net-policy)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-gke-conformance-net-policy/)|
   
 * [AKS conformance/network policy [bi-daily]](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-aks-conformance-net-policy/)
   community tests on AKS cluster using sonobuoy, focusing on "Conformance" and "Feature:NetworkPolicy", skipping the same regexes as in job __conformance__ above.\
@@ -66,7 +66,7 @@ should be deleted. This ensures that all tests are run on a clean testbed.
 
   |  K8s Version   |  Node Type          |  Node OS        |  Status  |
   | :------------: | :-----------------: | :-------------: | :------: |
-  | 1.16.10        |  Standard_DS2_v2    |  Ubuntu 16.04   |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-aks-conformance-net-policy)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-aks-conformance-net-policy/)|
+  |    1.16.10     |  Standard_DS2_v2    |  Ubuntu 16.04   |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-aks-conformance-net-policy)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-aks-conformance-net-policy/)|
 
 * [daily-elk-flow-collector-validate](https://jenkins.antrea-ci.rocks/job/antrea-daily-elk-flow-collector-validate-for-period/):
   [![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=antrea-daily-elk-flow-collector-validate-for-period)](http://jenkins.antrea-ci.rocks/view/cloud/job/antrea-daily-elk-flow-collector-validate-for-period/)

--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -21,7 +21,7 @@
           #!/bin/bash
           set -ex
           source /home/ubuntu/.bashrc
-          ./ci/test-conformance-eks.sh --cluster-name "${CLUSTERNAME}" --cleanup-only
+          sudo ./ci/test-conformance-eks.sh --cluster-name "${CLUSTERNAME}" --cleanup-only
 
 - builder:
     name: builder-gke-cluster-cleanup

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -538,8 +538,8 @@
               # gcloud auth login requires verification code from url
               ${{GCLOUD_PATH}} auth activate-service-account --key-file=${{GCLOUD_KEY_PATH}}
               sudo ./ci/test-conformance-gke.sh --cluster-name antrea-gke-${{BUILD_NUMBER}} \
-                --k8s-version 1.16.11-gke.5 --svc-account antrea-gcp@antrea.iam.gserviceaccount.com \
-                --gcloud-path ${{GCLOUD_PATH}} --log-mode detail --setup-only
+                --svc-account antrea-gcp@antrea.iam.gserviceaccount.com --gcloud-path ${{GCLOUD_PATH}} \
+                --log-mode detail --setup-only
           triggers:
           - timed: H H */2 * *
           publishers:

--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -21,7 +21,7 @@ function echoerr {
 }
 
 REGION="us-east-2"
-K8S_VERSION="1.15"
+K8S_VERSION="1.17"
 AWS_NODE_TYPE="t3.medium"
 SSH_KEY_PATH="$HOME/.ssh/id_rsa.pub"
 SSH_PRIVATE_KEY_PATH="$HOME/.ssh/id_rsa"
@@ -40,7 +40,7 @@ Setup a EKS cluster to run K8s e2e community tests (Conformance & Network Policy
 
         --cluster-name           The cluster name to be used for the generated EKS cluster. Must be specified if not run in Jenkins environment.
         --kubeconfig             Path to save kubeconfig of generated EKS cluster.
-        --k8s-version            GKE K8s cluster version. Defaults to 1.15.
+        --k8s-version            GKE K8s cluster version. Defaults to 1.17.
         --aws-access-key         AWS Acess Key for logging in to awscli.
         --aws-secret-key         AWS Secret Key for logging in to awscli.
         --aws-region             The AWS region where the cluster will be initiated. Defaults to us-east-2.
@@ -134,6 +134,9 @@ ${AWS_SECRET_KEY}
 ${REGION}
 JSON
 EOF
+    echo "=== Installing latest version of eksctl ==="
+    curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+    sudo mv /tmp/eksctl /usr/local/bin
     set -e
     printf "\n"
     echo "=== Using the following kubectl ==="


### PR DESCRIPTION
Also fixing an issue in GKE Jenkins job description where static version is still used instead of relying on the script to fetch the latest supported master version.