### PR TITLE
Implement antctl supportbundle Node name list support

### DIFF
--- a/pkg/antctl/raw/supportbundle/command.go
+++ b/pkg/antctl/raw/supportbundle/command.go
@@ -15,6 +15,7 @@
 package supportbundle
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -64,6 +65,7 @@ var option = &struct {
 	dir            string
 	labelSelector  string
 	controllerOnly bool
+	nodeListFile   string
 }{}
 
 var remoteControllerLongDescription = strings.TrimSpace(`
@@ -71,15 +73,19 @@ Generate support bundles for the cluster, which include: information about each 
 `)
 
 var remoteControllerExample = strings.Trim(`
-  Generate support bundles of controller and agent on all Nodes and save them to current working dir
+  Generate support bundles of the controller and agents on all Nodes and save them to current working dir
   $ antctl supportbundle
-  Generate support bundle of controller
+  Generate support bundle of the controller
   $ antctl supportbundle --controller-only
-  Generate support bundles of agent on specific Nodes filtered by name, with support for wildcard expressions
+  Generate support bundles of agents on specific Nodes filtered by name list, no wildcard support
+  $ antctl supportbundle node_a node_b node_c
+  Generate support bundles of agents on specific Nodes filtered by names in a file (one Node name per line)
+  $ antctl supportbundle -f ~/nodelistfile
+  Generate support bundles of agents on specific Nodes filtered by name, with support for wildcard expressions
   $ antctl supportbundle '*worker*'
-  Generate support bundles of agent on specific Nodes filtered by name and label selectors
+  Generate support bundles of agents on specific Nodes filtered by name and label selectors
   $ antctl supportbundle '*worker*' -l kubernetes.io/os=linux
-  Generate support bundles of controller and agent on all Nodes and save them to specific dir
+  Generate support bundles of the controller and agents on all Nodes and save them to specific dir
   $ antctl supportbundle -d ~/Downloads
 `, "\n")
 
@@ -96,13 +102,13 @@ func init() {
 		Command.RunE = controllerLocalRunE
 		Command.Long = "Generate the support bundle of current Antrea controller."
 	} else if runtime.Mode == runtime.ModeController && !runtime.InPod {
-		Command.Args = cobra.MaximumNArgs(1)
-		Command.Use += " [nodeName]"
+		Command.Use += " [nodeName...]"
 		Command.Long = remoteControllerLongDescription
 		Command.Example = remoteControllerExample
 		Command.Flags().StringVarP(&option.dir, "dir", "d", "", "support bundles output dir, the path will be created if it doesn't exist")
 		Command.Flags().StringVarP(&option.labelSelector, "label-selector", "l", "", "selector (label query) to filter Nodes for agent bundles, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 		Command.Flags().BoolVar(&option.controllerOnly, "controller-only", false, "only collect the support bundle of Antrea controller")
+		Command.Flags().StringVarP(&option.nodeListFile, "node-list-file", "f", "", "only collect the support bundle of Antrea controller")
 		Command.RunE = controllerRemoteRunE
 	}
 }
@@ -280,7 +286,8 @@ func downloadAll(agentClients map[string]*rest.RESTClient, controllerClient *res
 	)
 }
 
-func createAgentClients(k8sClientset kubernetes.Interface, antreaClientset antrea.Interface, cfgTmpl *rest.Config, nameFilter string) (map[string]*rest.RESTClient, error) {
+// createAgentClients creates clients for agents on specified nodes. If nameList is set, then nameFilter will be ignored.
+func createAgentClients(k8sClientset kubernetes.Interface, antreaClientset antrea.Interface, cfgTmpl *rest.Config, nameFilter string, nameList []string) (map[string]*rest.RESTClient, error) {
 	clients := map[string]*rest.RESTClient{}
 	nodeAgentInfoMap := map[string]string{}
 	agentInfoList, err := antreaClientset.ClusterinformationV1beta1().AntreaAgentInfos().List(context.TODO(), metav1.ListOptions{ResourceVersion: "0"})
@@ -294,8 +301,24 @@ func createAgentClients(k8sClientset kubernetes.Interface, antreaClientset antre
 	if err != nil {
 		return nil, err
 	}
+	var matcher func(name string) bool
+	if len(nameList) > 0 {
+		matchSet := make(map[string]struct{})
+		for _, name := range nameList {
+			matchSet[name] = struct{}{}
+		}
+		matcher = func(name string) bool {
+			_, ok := matchSet[name]
+			return ok
+		}
+	} else {
+		matcher = func(name string) bool {
+			hit, _ := filepath.Match(nameFilter, name)
+			return hit
+		}
+	}
 	for _, node := range nodeList.Items {
-		if match, _ := filepath.Match(nameFilter, node.Name); !match {
+		if !matcher(node.Name) {
 			continue
 		}
 		port, ok := nodeAgentInfoMap[node.Name]
@@ -471,7 +494,7 @@ func controllerRemoteRunE(cmd *cobra.Command, args []string) error {
 
 	// Collect controller bundle when no Node name or label filter is specified, or
 	// when --controller-only is set.
-	if (len(args) == 0 && option.labelSelector == "") || option.controllerOnly {
+	if (len(args) == 0 && len(option.nodeListFile) == 0 && option.labelSelector == "") || option.controllerOnly {
 		controllerClient, err = createControllerClient(k8sClientset, antreaClientset, restconfigTmpl)
 		if err != nil {
 			return fmt.Errorf("error when creating controller client: %w", err)
@@ -479,10 +502,28 @@ func controllerRemoteRunE(cmd *cobra.Command, args []string) error {
 	}
 	if !option.controllerOnly {
 		nameFilter := "*"
+		var nameList []string
 		if len(args) == 1 {
 			nameFilter = args[0]
+		} else if len(option.nodeListFile) != 0 {
+			nodeListFile, err := filepath.Abs(option.nodeListFile)
+			if err != nil {
+				return fmt.Errorf("error when resolving node-list-file path: %w", err)
+			}
+			f, err := os.Open(nodeListFile)
+			if err != nil {
+				return fmt.Errorf("error when opening node-list-file: %w", err)
+			}
+			defer f.Close()
+			scanner := bufio.NewScanner(f)
+			scanner.Split(bufio.ScanLines)
+			for scanner.Scan() {
+				nameList = append(nameList, strings.TrimSpace(scanner.Text()))
+			}
+		} else if len(args) > 1 {
+			nameList = args
 		}
-		agentClients, err = createAgentClients(k8sClientset, antreaClientset, restconfigTmpl, nameFilter)
+		agentClients, err = createAgentClients(k8sClientset, antreaClientset, restconfigTmpl, nameFilter, nameList)
 		if err != nil {
 			return fmt.Errorf("error when creating agent clients: %w", err)
 		}


### PR DESCRIPTION
Make the antctl supportbundle command to support filter nodes by
Node name list or a file contains Node names.

E.g.:
```
  Generate support bundles of agent on specific Nodes filtered by name list, no wildcard support
  $ antctl supportbundle node_a node_b node_c
  Generate support bundles of agent on specific Nodes filtered by names in a file (one Node name per line)
  $ antctl supportbundle -f ~/nodenamelist
```