### PR TITLE
Add network policy info to IPFIX flow records as part of Flow Exporter

### DIFF
--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -90,11 +90,12 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 	ifaceStore interfacestore.InterfaceStore,
 	nodeName string,
 	podUpdates <-chan v1beta2.PodReference,
-	antreaPolicyEnabled bool) (*Controller, error) {
+	antreaPolicyEnabled bool,
+	asyncRuleDeleteInterval time.Duration) (*Controller, error) {
 	c := &Controller{
 		antreaClientProvider: antreaClientGetter,
 		queue:                workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "networkpolicyrule"),
-		reconciler:           newReconciler(ofClient, ifaceStore),
+		reconciler:           newReconciler(ofClient, ifaceStore, asyncRuleDeleteInterval),
 		ofClient:             ofClient,
 		antreaPolicyEnabled:  antreaPolicyEnabled,
 	}

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -52,7 +52,7 @@ func (g *antreaClientGetter) GetAntreaClient() (versioned.Interface, error) {
 func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 	clientset := &fake.Clientset{}
 	ch := make(chan v1beta2.PodReference, 100)
-	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", ch, true)
+	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", ch, true, testDeleteInterval)
 	reconciler := newMockReconciler()
 	controller.reconciler = reconciler
 	return controller, clientset, reconciler

--- a/pkg/agent/controller/networkpolicy/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/reconciler_test.go
@@ -173,7 +173,7 @@ func TestReconcilerForget(t *testing.T) {
 					mockOFClient.EXPECT().UninstallPolicyRuleFlows(ofID)
 				}
 			}
-			r := newReconciler(mockOFClient, ifaceStore)
+			r := newReconciler(mockOFClient, ifaceStore, testDeleteInterval)
 			for key, value := range tt.lastRealizeds {
 				r.lastRealizeds.Store(key, value)
 			}
@@ -517,7 +517,7 @@ func TestReconcilerReconcile(t *testing.T) {
 			for i := 0; i < len(tt.expectedOFRules); i++ {
 				mockOFClient.EXPECT().InstallPolicyRuleFlows(gomock.Any())
 			}
-			r := newReconciler(mockOFClient, ifaceStore)
+			r := newReconciler(mockOFClient, ifaceStore, testDeleteInterval)
 			if err := r.Reconcile(tt.args); (err != nil) != tt.wantErr {
 				t.Fatalf("Reconcile() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -627,7 +627,7 @@ func TestReconcilerBatchReconcile(t *testing.T) {
 			mockOFClient := openflowtest.NewMockClient(controller)
 			mockOFClient.EXPECT().IsIPv4Enabled().Return(true).AnyTimes()
 			mockOFClient.EXPECT().IsIPv6Enabled().Return(false).AnyTimes()
-			r := newReconciler(mockOFClient, ifaceStore)
+			r := newReconciler(mockOFClient, ifaceStore, testDeleteInterval)
 			if tt.numInstalledRules > 0 {
 				// BatchInstall should skip rules already installed
 				r.lastRealizeds.Store(tt.args[0].ID, newLastRealized(tt.args[0]))
@@ -843,7 +843,7 @@ func TestReconcilerUpdate(t *testing.T) {
 			if len(tt.expectedDeletedTo) > 0 {
 				mockOFClient.EXPECT().DeletePolicyRuleAddress(gomock.Any(), types.DstAddress, gomock.Eq(tt.expectedDeletedTo), priority)
 			}
-			r := newReconciler(mockOFClient, ifaceStore)
+			r := newReconciler(mockOFClient, ifaceStore, testDeleteInterval)
 			if err := r.Reconcile(tt.originalRule); (err != nil) != tt.wantErr {
 				t.Fatalf("Reconcile() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -1349,7 +1349,7 @@ func TestReconcilerReconcileIPv6Only(t *testing.T) {
 			for i := 0; i < len(tt.expectedOFRules); i++ {
 				mockOFClient.EXPECT().InstallPolicyRuleFlows(gomock.Any())
 			}
-			r := newReconciler(mockOFClient, ifaceStore)
+			r := newReconciler(mockOFClient, ifaceStore, testDeleteInterval)
 			if err := r.Reconcile(tt.args); (err != nil) != tt.wantErr {
 				t.Fatalf("Reconcile() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -1752,7 +1752,7 @@ func TestReconcilerReconcileDualStack(t *testing.T) {
 			for i := 0; i < len(tt.expectedOFRules); i++ {
 				mockOFClient.EXPECT().InstallPolicyRuleFlows(gomock.Any())
 			}
-			r := newReconciler(mockOFClient, ifaceStore)
+			r := newReconciler(mockOFClient, ifaceStore, testDeleteInterval)
 			if err := r.Reconcile(tt.args); (err != nil) != tt.wantErr {
 				t.Fatalf("Reconcile() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/agent/flowexporter/connections/connections_test.go
+++ b/pkg/agent/flowexporter/connections/connections_test.go
@@ -15,6 +15,7 @@
 package connections
 
 import (
+	"encoding/binary"
 	"fmt"
 	"net"
 	"strings"
@@ -35,8 +36,25 @@ import (
 	interfacestoretest "github.com/vmware-tanzu/antrea/pkg/agent/interfacestore/testing"
 	"github.com/vmware-tanzu/antrea/pkg/agent/metrics"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
+	cpv1beta "github.com/vmware-tanzu/antrea/pkg/apis/controlplane/v1beta2"
+	queriertest "github.com/vmware-tanzu/antrea/pkg/querier/testing"
 	k8sproxy "github.com/vmware-tanzu/antrea/third_party/proxy"
 	k8proxytest "github.com/vmware-tanzu/antrea/third_party/proxy/testing"
+)
+
+var (
+	np1 = cpv1beta.NetworkPolicyReference{
+		Type:      cpv1beta.K8sNetworkPolicy,
+		Namespace: "foo",
+		Name:      "bar",
+		UID:       "uid1",
+	}
+	np2 = cpv1beta.NetworkPolicyReference{
+		Type:      cpv1beta.K8sNetworkPolicy,
+		Namespace: "foo",
+		Name:      "baz",
+		UID:       "uid2",
+	}
 )
 
 const testPollInterval = 0 // Not used in these tests, hence 0.
@@ -91,12 +109,20 @@ func TestConnectionStore_addAndUpdateConn(t *testing.T) {
 		TupleReply:      revTuple2,
 		IsActive:        true,
 	}
-	// To test service name mapping
+	// To test service name mapping.
 	tuple3, revTuple3 := makeTuple(&net.IP{10, 10, 10, 10}, &net.IP{20, 20, 20, 20}, 6, 5000, 80)
 	testFlow3 := flowexporter.Connection{
 		TupleOrig:  tuple3,
 		TupleReply: revTuple3,
 		Mark:       openflow.ServiceCTMark,
+		IsActive:   true,
+	}
+	// To test NetworkPolicy mapping.
+	tuple4, revTuple4 := makeTuple(&net.IP{30, 30, 30, 30}, &net.IP{20, 20, 20, 20}, 6, 5000, 80)
+	testFlow4 := flowexporter.Connection{
+		TupleOrig:  tuple4,
+		TupleReply: revTuple4,
+		Labels:     []byte{0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x2},
 		IsActive:   true,
 	}
 	// Create copy of old conntrack flow for testing purposes.
@@ -138,7 +164,8 @@ func TestConnectionStore_addAndUpdateConn(t *testing.T) {
 	mockIfaceStore := interfacestoretest.NewMockInterfaceStore(ctrl)
 	mockConnDumper := connectionstest.NewMockConnTrackDumper(ctrl)
 	mockProxier := k8proxytest.NewMockProvider(ctrl)
-	connStore := NewConnectionStore(mockConnDumper, mockIfaceStore, mockProxier, testPollInterval)
+	npQuerier := queriertest.NewMockAgentNetworkPolicyInfoQuerier(ctrl)
+	connStore := NewConnectionStore(mockConnDumper, mockIfaceStore, mockProxier, npQuerier, testPollInterval)
 
 	// Add flow1conn to the Connection map
 	testFlow1Tuple := flowexporter.NewConnectionKey(&testFlow1)
@@ -149,22 +176,28 @@ func TestConnectionStore_addAndUpdateConn(t *testing.T) {
 	addOrUpdateConnTests := []struct {
 		flow flowexporter.Connection
 	}{
-		{testFlow1}, // To test update part of function
-		{testFlow2}, // To test add part of function
-		{testFlow3}, // To test service name realization
+		{testFlow1}, // To test update part of function.
+		{testFlow2}, // To test add part of function.
+		{testFlow3}, // To test service name mapping.
+		{testFlow4}, // To test NetworkPolicy mapping.
 	}
 	for i, test := range addOrUpdateConnTests {
 		flowTuple := flowexporter.NewConnectionKey(&test.flow)
 		expConn := test.flow
-		if i == 0 {
+		switch i {
+		case 0:
+			// Tests update part of the function.
 			expConn.SourcePodNamespace = "ns1"
 			expConn.SourcePodName = "pod1"
-		} else if i == 1 {
-			expConn.DestinationPodNamespace = "ns2"
-			expConn.DestinationPodName = "pod2"
+		case 1:
+			// Tests add part of the function.
 			mockIfaceStore.EXPECT().GetInterfaceByIP(test.flow.TupleOrig.SourceAddress.String()).Return(nil, false)
 			mockIfaceStore.EXPECT().GetInterfaceByIP(test.flow.TupleReply.SourceAddress.String()).Return(interfaceFlow2, true)
-		} else {
+
+			expConn.DestinationPodNamespace = "ns2"
+			expConn.DestinationPodName = "pod2"
+		case 2:
+			// Tests service name mapping.
 			mockIfaceStore.EXPECT().GetInterfaceByIP(expConn.TupleOrig.SourceAddress.String()).Return(nil, false)
 			mockIfaceStore.EXPECT().GetInterfaceByIP(expConn.TupleReply.SourceAddress.String()).Return(nil, false)
 
@@ -172,6 +205,20 @@ func TestConnectionStore_addAndUpdateConn(t *testing.T) {
 			serviceStr := fmt.Sprintf("%s:%d/%s", expConn.TupleOrig.DestinationAddress.String(), expConn.TupleOrig.DestinationPort, protocol)
 			mockProxier.EXPECT().GetServiceByIP(serviceStr).Return(servicePortName, true)
 			expConn.DestinationServicePortName = servicePortName.String()
+		case 3:
+			// Tests NetworkPolicy mapping.
+			mockIfaceStore.EXPECT().GetInterfaceByIP(expConn.TupleOrig.SourceAddress.String()).Return(nil, false)
+			mockIfaceStore.EXPECT().GetInterfaceByIP(expConn.TupleReply.SourceAddress.String()).Return(nil, false)
+
+			ingressOfID := binary.LittleEndian.Uint32(test.flow.Labels[:4])
+			npQuerier.EXPECT().GetNetworkPolicyByRuleFlowID(ingressOfID).Return(&np1)
+			expConn.IngressNetworkPolicyName = np1.Name
+			expConn.IngressNetworkPolicyNamespace = np1.Namespace
+
+			egressOfID := binary.LittleEndian.Uint32(test.flow.Labels[4:8])
+			npQuerier.EXPECT().GetNetworkPolicyByRuleFlowID(egressOfID).Return(&np2)
+			expConn.EgressNetworkPolicyName = np2.Name
+			expConn.EgressNetworkPolicyNamespace = np2.Namespace
 		}
 		connStore.addOrUpdateConn(&test.flow)
 		actualConn, ok := connStore.GetConnByKey(flowTuple)
@@ -221,7 +268,7 @@ func TestConnectionStore_ForAllConnectionsDo(t *testing.T) {
 	// Create ConnectionStore
 	mockIfaceStore := interfacestoretest.NewMockInterfaceStore(ctrl)
 	mockConnDumper := connectionstest.NewMockConnTrackDumper(ctrl)
-	connStore := NewConnectionStore(mockConnDumper, mockIfaceStore, nil, testPollInterval)
+	connStore := NewConnectionStore(mockConnDumper, mockIfaceStore, nil, nil, testPollInterval)
 	// Add flows to the Connection store
 	for i, flow := range testFlows {
 		connStore.connections[*testFlowKeys[i]] = *flow
@@ -286,7 +333,7 @@ func TestConnectionStore_DeleteConnectionByKey(t *testing.T) {
 	// Create ConnectionStore
 	mockIfaceStore := interfacestoretest.NewMockInterfaceStore(ctrl)
 	mockConnDumper := connectionstest.NewMockConnTrackDumper(ctrl)
-	connStore := NewConnectionStore(mockConnDumper, mockIfaceStore, nil, testPollInterval)
+	connStore := NewConnectionStore(mockConnDumper, mockIfaceStore, nil, nil, testPollInterval)
 	// Add flows to the connection store.
 	for i, flow := range testFlows {
 		connStore.connections[*testFlowKeys[i]] = *flow
@@ -310,7 +357,7 @@ func TestConnectionStore_MetricSettingInPoll(t *testing.T) {
 	// Create ConnectionStore
 	mockIfaceStore := interfacestoretest.NewMockInterfaceStore(ctrl)
 	mockConnDumper := connectionstest.NewMockConnTrackDumper(ctrl)
-	connStore := NewConnectionStore(mockConnDumper, mockIfaceStore, nil, testPollInterval)
+	connStore := NewConnectionStore(mockConnDumper, mockIfaceStore, nil, nil, testPollInterval)
 	// Hard-coded conntrack occupancy metrics for test
 	TotalConnections := 0
 	MaxConnections := 300000

--- a/pkg/agent/flowexporter/connections/conntrack_linux.go
+++ b/pkg/agent/flowexporter/connections/conntrack_linux.go
@@ -136,6 +136,8 @@ func netlinkFlowToAntreaConnection(conn *conntrack.Flow) *flowexporter.Connectio
 		DoExport:                true,
 		Zone:                    conn.Zone,
 		Mark:                    conn.Mark,
+		Labels:                  conn.Labels,
+		LabelsMask:              conn.LabelsMask,
 		StatusFlag:              uint32(conn.Status.Value),
 		TupleOrig:               tupleOrig,
 		TupleReply:              tupleReply,

--- a/pkg/agent/flowexporter/exporter/exporter.go
+++ b/pkg/agent/flowexporter/exporter/exporter.go
@@ -58,6 +58,10 @@ var (
 		"destinationNodeName",
 		"destinationClusterIPv4",
 		"destinationServicePortName",
+		"ingressNetworkPolicyName",
+		"ingressNetworkPolicyNamespace",
+		"egressNetworkPolicyName",
+		"egressNetworkPolicyNamespace",
 	}
 )
 
@@ -332,11 +336,15 @@ func (exp *flowExporter) sendDataRecord(dataRec ipfix.IPFIXRecord, record flowex
 				_, err = dataRec.AddInfoElement(ie, net.IP{0, 0, 0, 0})
 			}
 		case "destinationServicePortName":
-			if record.Conn.DestinationServicePortName != "" {
-				_, err = dataRec.AddInfoElement(ie, record.Conn.DestinationServicePortName)
-			} else {
-				_, err = dataRec.AddInfoElement(ie, "")
-			}
+			_, err = dataRec.AddInfoElement(ie, record.Conn.DestinationServicePortName)
+		case "ingressNetworkPolicyName":
+			_, err = dataRec.AddInfoElement(ie, record.Conn.IngressNetworkPolicyName)
+		case "ingressNetworkPolicyNamespace":
+			_, err = dataRec.AddInfoElement(ie, record.Conn.IngressNetworkPolicyNamespace)
+		case "egressNetworkPolicyName":
+			_, err = dataRec.AddInfoElement(ie, record.Conn.EgressNetworkPolicyName)
+		case "egressNetworkPolicyNamespace":
+			_, err = dataRec.AddInfoElement(ie, record.Conn.EgressNetworkPolicyNamespace)
 		}
 		if err != nil {
 			return fmt.Errorf("error while adding info element: %s to data record: %v", ie.Name, err)

--- a/pkg/agent/flowexporter/exporter/exporter_test.go
+++ b/pkg/agent/flowexporter/exporter/exporter_test.go
@@ -176,6 +176,8 @@ func TestFlowExporter_sendDataRecord(t *testing.T) {
 			mockDataRec.EXPECT().AddInfoElement(ie, uint64(0)).Return(tempBytes, nil)
 		case "sourcePodName", "sourcePodNamespace", "sourceNodeName", "destinationPodName", "destinationPodNamespace", "destinationNodeName", "destinationServicePortName":
 			mockDataRec.EXPECT().AddInfoElement(ie, "").Return(tempBytes, nil)
+		case "ingressNetworkPolicyName", "ingressNetworkPolicyNamespace", "egressNetworkPolicyName", "egressNetworkPolicyNamespace":
+			mockDataRec.EXPECT().AddInfoElement(ie, "").Return(tempBytes, nil)
 		}
 	}
 	mockDataRec.EXPECT().GetRecord().Return(dataRecord)

--- a/pkg/agent/flowexporter/types.go
+++ b/pkg/agent/flowexporter/types.go
@@ -43,20 +43,25 @@ type Connection struct {
 	// IsActive flag helps in cleaning up connections when they are not in conntrack any module more.
 	IsActive bool
 	// DoExport flag helps in tagging connections that can be exported by Flow Exporter
-	DoExport   bool
-	Zone       uint16
-	Mark       uint32
-	StatusFlag uint32
+	DoExport           bool
+	Zone               uint16
+	Mark               uint32
+	StatusFlag         uint32
+	Labels, LabelsMask []byte
 	// TODO: Have a separate field for protocol. No need to keep it in Tuple.
 	TupleOrig, TupleReply          Tuple
 	OriginalPackets, OriginalBytes uint64
 	ReversePackets, ReverseBytes   uint64
 	// Fields specific to Antrea
-	SourcePodNamespace         string
-	SourcePodName              string
-	DestinationPodNamespace    string
-	DestinationPodName         string
-	DestinationServicePortName string
+	SourcePodNamespace            string
+	SourcePodName                 string
+	DestinationPodNamespace       string
+	DestinationPodName            string
+	DestinationServicePortName    string
+	IngressNetworkPolicyName      string
+	IngressNetworkPolicyNamespace string
+	EgressNetworkPolicyName       string
+	EgressNetworkPolicyNamespace  string
 }
 
 type FlowRecord struct {

--- a/pkg/agent/stats/collector.go
+++ b/pkg/agent/stats/collector.go
@@ -110,7 +110,7 @@ func (m *Collector) collect() *statsCollection {
 		policyRef := m.networkPolicyQuerier.GetNetworkPolicyByRuleFlowID(ofID)
 		if policyRef == nil {
 			// This should not happen because the rule flow ID to rule mapping is
-			// preserved for 5 seconds even after the rule deletion.
+			// preserved for at least 5 seconds even after the rule deletion.
 			klog.Warningf("Cannot find NetworkPolicy that has ofID %v", ofID)
 			continue
 		}

--- a/test/e2e/performance_test.go
+++ b/test/e2e/performance_test.go
@@ -230,7 +230,7 @@ func httpRequest(requests, policyRules int, data *TestData, b *testing.B) {
 	}
 
 	b.Log("Waiting for the workload network policy to be realized")
-	err = waitNetworkPolicyRealize(policyRules, data)
+	err = WaitNetworkPolicyRealize(policyRules, data)
 	if err != nil {
 		b.Fatalf("Checking network policies realization failed: %v", err)
 	}
@@ -258,7 +258,7 @@ func networkPolicyRealize(policyRules int, data *TestData, b *testing.B) {
 			err := populateWorkloadNetworkPolicy(generateWorkloadNetworkPolicy(policyRules), data)
 			if err != nil {
 				// cannot use Fatal in a goroutine
-				// if populating policies fails, waitNetworkPolicyRealize will
+				// if populating policies fails, WaitNetworkPolicyRealize will
 				// eventually time out and the test will fail, although it would be
 				// better to fail early in that case.
 				b.Errorf("Error when populating workload network policy: %v", err)
@@ -267,7 +267,7 @@ func networkPolicyRealize(policyRules int, data *TestData, b *testing.B) {
 
 		b.Log("Waiting for the network policy to be realized")
 		b.StartTimer()
-		err := waitNetworkPolicyRealize(policyRules, data)
+		err := WaitNetworkPolicyRealize(policyRules, data)
 		if err != nil {
 			b.Fatalf("Checking network policies realization failed: %v", err)
 		}
@@ -281,7 +281,7 @@ func networkPolicyRealize(policyRules int, data *TestData, b *testing.B) {
 	}
 }
 
-func waitNetworkPolicyRealize(policyRules int, data *TestData) error {
+func WaitNetworkPolicyRealize(policyRules int, data *TestData) error {
 	return wait.PollImmediate(50*time.Millisecond, *realizeTimeout, func() (bool, error) {
 		return checkRealize(policyRules, data)
 	})

--- a/test/integration/agent/flowexporter_test.go
+++ b/test/integration/agent/flowexporter_test.go
@@ -34,6 +34,7 @@ import (
 	interfacestoretest "github.com/vmware-tanzu/antrea/pkg/agent/interfacestore/testing"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util/sysctl"
+	queriertest "github.com/vmware-tanzu/antrea/pkg/querier/testing"
 )
 
 const testPollInterval = 0 // Not used in the test, hence 0.
@@ -142,8 +143,9 @@ func TestConnectionStoreAndFlowRecords(t *testing.T) {
 	// Create ConnectionStore, FlowRecords and associated mocks
 	connDumperMock := connectionstest.NewMockConnTrackDumper(ctrl)
 	ifStoreMock := interfacestoretest.NewMockInterfaceStore(ctrl)
+	npQuerier := queriertest.NewMockAgentNetworkPolicyInfoQuerier(ctrl)
 	// TODO: Enhance the integration test by testing service.
-	connStore := connections.NewConnectionStore(connDumperMock, ifStoreMock, nil, testPollInterval)
+	connStore := connections.NewConnectionStore(connDumperMock, ifStoreMock, nil, npQuerier, testPollInterval)
 	// Expect calls for connStore.poll and other callees
 	connDumperMock.EXPECT().DumpFlows(uint16(openflow.CtZone)).Return(testConns, 0, nil)
 	connDumperMock.EXPECT().GetMaxConnections().Return(0, nil)


### PR DESCRIPTION
Network policy info (name and namespace), both ingress and egress
policies are added.

Async rule cache in idAllocator is configured with asyncDeleteInterval that is maximum of either 5s or configured flowPollInterval in Antrea Agent.