### PR TITLE
collect all antrea-agent pod logs before redeploying antrea - e2e tests

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -109,6 +109,8 @@ mkdir antrea-test-logs
 go test -count=1 -v -run=TestDeletePod github.com/vmware-tanzu/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs
 ```
 
+If the user provides a log directory which was used for a previous run, existing 
+contents (subdirectories for each test case) will be overridden.  
 By default the description and logs for Antrea Pods are only written to disk if a
 test fails. You can choose to dump this information unconditionally with
 `--logs-export-on-success`.

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -194,7 +194,7 @@ func (data *TestData) redeployAntrea(t *testing.T, enableIPSec bool) {
 	var err error
 	// export logs before deleting Antrea
 	if enableIPSec {
-		exportLogs(t, data, "beforeRedeployAntreaWithIPSecEnabled", false)
+		exportLogs(t, data, "beforeRedeployWithIPsec", false)
 	} else {
 		exportLogs(t, data, "beforeRedploy", false)
 	}

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -192,7 +192,12 @@ func TestPodConnectivityDifferentNodes(t *testing.T) {
 
 func (data *TestData) redeployAntrea(t *testing.T, enableIPSec bool) {
 	var err error
-
+	// export logs before deleting Antrea
+	if enableIPSec {
+		exportLogs(t, data, "beforeEnableIPSec", false)
+	} else {
+		exportLogs(t, data, "beforeDisableIPSec", false)
+	}
 	t.Logf("Deleting Antrea Agent DaemonSet")
 	if err = data.deleteAntrea(defaultTimeout); err != nil {
 		t.Fatalf("Error when deleting Antrea DaemonSet: %v", err)

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -194,9 +194,9 @@ func (data *TestData) redeployAntrea(t *testing.T, enableIPSec bool) {
 	var err error
 	// export logs before deleting Antrea
 	if enableIPSec {
-		exportLogs(t, data, "beforeEnableIPSec", false)
+		exportLogs(t, data, "beforeRedeployAntreaWithIPSecEnabled", false)
 	} else {
-		exportLogs(t, data, "beforeDisableIPSec", false)
+		exportLogs(t, data, "beforeRedploy", false)
 	}
 	t.Logf("Deleting Antrea Agent DaemonSet")
 	if err = data.deleteAntrea(defaultTimeout); err != nil {

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"testing"
 	"time"

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -69,10 +69,7 @@ func ensureAntreaRunning(tb testing.TB, data *TestData) error {
 }
 
 func createDirectory(path string) error {
-	if err := os.Mkdir(path, 0700); err != nil {
-		return err
-	}
-	return nil
+	return os.Mkdir(path, 0700)
 }
 
 func (data *TestData) setupLogDirectoryForTest(testName string) error {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -107,11 +107,12 @@ var provider providers.ProviderInterface
 
 // TestData stores the state required for each test case.
 type TestData struct {
-	kubeConfig       *restclient.Config
-	clientset        kubernetes.Interface
-	aggregatorClient aggregatorclientset.Interface
-	securityClient   secv1alpha1.SecurityV1alpha1Interface
-	crdClient        crdclientset.Interface
+	kubeConfig         *restclient.Config
+	clientset          kubernetes.Interface
+	aggregatorClient   aggregatorclientset.Interface
+	securityClient     secv1alpha1.SecurityV1alpha1Interface
+	crdClient          crdclientset.Interface
+	logsDirForTestCase string
 }
 
 var testData *TestData


### PR DESCRIPTION
Fixes #1226
Add log collection for antrea-agent pods when antrea is redeployed. This PR would lead to following behavioral change -  
If the user provides a log directory which was used for a previous run, existing contents (subdirectories for each test case) will be overridden.
To give overview of dir tree, running tests for TestIPSecTunnelConnectivity & TestPodConnectivityDifferentNodes (e2e) with `--logs-export-on-success` would result in the following dir tree -
```
── TestIPSecTunnelConnectivity
│   ├── beforeRedploy.Sep22-09-31-52
│   │   ├── k8s-node-master-antrea-agent-vnmwb-describe
│   │   ├── k8s-node-master-antrea-agent-vnmwb-logs
│   │   ├── k8s-node-worker-1-antrea-agent-kr9v4-describe
│   │   ├── k8s-node-worker-1-antrea-agent-kr9v4-logs
│   │   ├── k8s-node-worker-1-antrea-controller-6fbdccbd67-m8vht-describe
│   │   └── k8s-node-worker-1-antrea-controller-6fbdccbd67-m8vht-logs
│   ├── beforeRedeployWithIPsec.Sep22-09-30-38
│   │   ├── k8s-node-master-antrea-agent-zslgr-describe
│   │   ├── k8s-node-master-antrea-agent-zslgr-logs
│   │   ├── k8s-node-worker-1-antrea-agent-wtbps-describe
│   │   ├── k8s-node-worker-1-antrea-agent-wtbps-logs
│   │   ├── k8s-node-worker-1-antrea-controller-6df878958d-dj67t-describe
│   │   └── k8s-node-worker-1-antrea-controller-6df878958d-dj67t-logs
│   └── beforeTeardown.Sep22-09-32-48
│       ├── k8s-node-master-antrea-agent-9z6sx-describe
│       ├── k8s-node-master-antrea-agent-9z6sx-logs
│       ├── k8s-node-master-kubelet
│       ├── k8s-node-worker-1-antrea-agent-qm2d6-describe
│       ├── k8s-node-worker-1-antrea-agent-qm2d6-logs
│       ├── k8s-node-worker-1-antrea-controller-6df878958d-542ss-describe
│       ├── k8s-node-worker-1-antrea-controller-6df878958d-542ss-logs
│       └── k8s-node-worker-1-kubelet
└── TestPodConnectivityDifferentNodes
    └── beforeTeardown.Sep22-09-54-28
        ├── k8s-node-master-antrea-agent-9z6sx-describe
        ├── k8s-node-master-antrea-agent-9z6sx-logs
        ├── k8s-node-master-kubelet
        ├── k8s-node-worker-1-antrea-agent-qm2d6-describe
        ├── k8s-node-worker-1-antrea-agent-qm2d6-logs
        ├── k8s-node-worker-1-antrea-controller-6df878958d-542ss-describe
        ├── k8s-node-worker-1-antrea-controller-6df878958d-542ss-logs
        └── k8s-node-worker-1-kubelet

```


