### PR TITLE
[CI] Fix validating elk-flow-collector ci

### DIFF
--- a/ci/test-elk-flow-collector.sh
+++ b/ci/test-elk-flow-collector.sh
@@ -61,6 +61,8 @@ setup_flow_collector() {
   kubectl wait --for=condition=ready pod -l app=kibana -n elk-flow-collector --timeout=600s
   kubectl wait --for=condition=ready pod -l app=logstash -n elk-flow-collector --timeout=600s
   kubectl wait --for=condition=ready pod -l app=elasticsearch -n elk-flow-collector --timeout=600s
+  # wait some time for logstash to connect to elasticsearch
+  sleep 30s
   # get cluster-ip of logstash
   LOGSTASH_IP=$(kubectl get svc logstash -n elk-flow-collector -o jsonpath='{.spec.clusterIP}')
   if [ ${LOGSTASH_PROTOCOL} = "udp" ]; then


### PR DESCRIPTION
After trying to reproduce ci failure for validating elk-flow-collector manifests in the last two days, found that the problem may lie in logstash readiness when Antrea starts to send flow records. Add wait for 30s for logstash to be ready.