### PR TITLE
Add coverage support for conformance and antctl

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,6 +35,7 @@ jobs:
     - name: Codecov
       uses: codecov/codecov-action@v1
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: .coverage/coverage-unit.txt
         flags: unit-tests
         name: codecov-unit-test

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -87,6 +87,7 @@ jobs:
     - name: Codecov
       uses: codecov/codecov-action@v1
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: '*antrea*'
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap
@@ -143,6 +144,7 @@ jobs:
     - name: Codecov
       uses: codecov/codecov-action@v1
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: '*antrea*'
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap-proxy
@@ -199,6 +201,7 @@ jobs:
     - name: Codecov
       uses: codecov/codecov-action@v1
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: '*antrea*'
         flags: kind-e2e-tests
         name: codecov-test-e2e-noencap
@@ -255,6 +258,7 @@ jobs:
     - name: Codecov
       uses: codecov/codecov-action@v1
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: '*antrea*'
         flags: kind-e2e-tests
         name: codecov-test-e2e-hybrid
@@ -311,6 +315,7 @@ jobs:
     - name: Codecov
       uses: codecov/codecov-action@v1
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: '*antrea*'
         flags: kind-e2e-tests
         name: codecov-test-e2e-np-encap

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,11 @@ antctl-ubuntu:
 	@mkdir -p $(BINDIR)
 	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' github.com/vmware-tanzu/antrea/cmd/antctl
 
+.PHONY: antctl-instr-binary
+antctl-instr-binary:
+	@mkdir -p $(BINDIR)
+	GOOS=linux $(GO) test -tags testbincover -covermode count -coverpkg=github.com/vmware-tanzu/antrea/pkg/... -c -o $(BINDIR)/antctl-coverage $(GOFLAGS) -ldflags '$(LDFLAGS)' github.com/vmware-tanzu/antrea/cmd/antctl
+
 .PHONY: windows-bin
 windows-bin:
 	@mkdir -p $(BINDIR)

--- a/build/images/Dockerfile.build.coverage
+++ b/build/images/Dockerfile.build.coverage
@@ -8,7 +8,7 @@ RUN go mod download
 
 COPY . /antrea
 
-RUN make antrea-agent antrea-controller antrea-cni antctl-ubuntu antrea-controller-instr-binary antrea-agent-instr-binary
+RUN make antrea-agent antrea-controller antrea-cni antctl-ubuntu antrea-controller-instr-binary antrea-agent-instr-binary antctl-instr-binary
 
 
 FROM antrea/base-ubuntu:2.14.0

--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -12,7 +12,7 @@
         - shell: |-
             #!/bin/bash
             set -e
-            ./ci/jenkins/test-vmc.sh --testcase integration
+            ./ci/jenkins/test-vmc.sh --testcase integration --coverage --codecov-token "${CODECOV_TOKEN}"
 
 - builder:
     name: builder-eks-cluster-cleanup
@@ -101,15 +101,7 @@
       - shell: |-
           #!/bin/bash
           set -ex
-          ./ci/jenkins/test-vmc.sh --cluster-name "${JOB_NAME}-${BUILD_NUMBER}" --testcase e2e
-
-- builder:
-    name: builder-e2e-coverage
-    builders:
-      - shell: |-
-          #!/bin/bash
-          set -ex
-          ./ci/jenkins/test-vmc.sh --cluster-name "${JOB_NAME}-${BUILD_NUMBER}" --testcase e2e --coverage
+          ./ci/jenkins/test-vmc.sh --cluster-name "${JOB_NAME}-${BUILD_NUMBER}" --testcase e2e --coverage --codecov-token "${CODECOV_TOKEN}"
 
 - builder:
     name: builder-conformance
@@ -117,7 +109,7 @@
       - shell: |-
           #!/bin/bash
           set -ex
-          ./ci/jenkins/test-vmc.sh --cluster-name "${{JOB_NAME}}-${{BUILD_NUMBER}}" --testcase '{conformance_type}'
+          ./ci/jenkins/test-vmc.sh --cluster-name "${{JOB_NAME}}-${{BUILD_NUMBER}}" --testcase '{conformance_type}' --coverage --codecov-token "${{CODECOV_TOKEN}}"
 
 - builder:
     name: builder-elk-flow-collector

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -122,8 +122,7 @@
           builders:
           - builder-integration
           trigger_phrase: null
-          white_list_target_branches:
-          - ipv6
+          white_list_target_branches: []
           allow_whitelist_orgs_as_admins: false
           admin_list: []
           org_list: []
@@ -153,6 +152,9 @@
               - text:
                   credential-id: GOVC_PASSWORD
                   variable: GOVC_PASSWORD
+              - text:
+                  credential-id: CODECOV_TOKEN # Jenkins secret that stores codecov token
+                  variable: CODECOV_TOKEN
           publishers: []
       - '{name}-{test_name}-for-pull-request':
           test_name: e2e-pending-label
@@ -203,6 +205,10 @@
           triggered_status: null
           started_status: null
           wrappers:
+          - credentials-binding:
+            - text:
+                credential-id: CODECOV_TOKEN # Jenkins secret that stores codecov token
+                variable: CODECOV_TOKEN
           - timeout:
               fail: true
               timeout: 80
@@ -210,7 +216,7 @@
           publishers:
           - archive:
               allow-empty: true
-              artifacts: antrea-test-logs.tar.gz
+              artifacts: antrea-test-logs.tar.gz, e2e-coverage.tar.gz
               case-sensitive: true
               default-excludes: true
               fingerprint: false
@@ -231,91 +237,6 @@
           trigger_phrase: ^(?!Thanks for your PR).*/skip-(e2e|all).*
           white_list_target_branches: []
           status_context: jenkins-e2e
-          status_url: --none--
-          success_status: Skipped test. Mark as succeeded.
-          failure_status: Skipped test. Mark as succeeded.
-          error_status: Skipped test. Mark as succeeded.
-          triggered_status: null
-          started_status: null
-          wrappers: []
-          publishers: []
-      - '{name}-{test_name}-for-pull-request':
-          test_name: e2e-coveage-pending-label
-          node: null
-          description: 'This is for marking PR as pending for e2e test with coverage.'
-          branches:
-          - ${{sha1}}
-          builders:
-            - builder-pending-label
-          trigger_phrase: null
-          white_list_target_branches: []
-          allow_whitelist_orgs_as_admins: false
-          admin_list: []
-          org_list: []
-          white_list: []
-          only_trigger_phrase: false
-          trigger_permit_all: true
-          status_context: jenkins-e2e-coverage
-          status_url: --none--
-          success_status: Pending test. Mark as failure. Add comment /test-e2e-coverage to trigger.
-          failure_status: Pending test. Mark as failure. Add comment /test-e2e-coverage to trigger.
-          error_status: Pending test. Mark as failure. Add comment /test-e2e-coverage to trigger.
-          triggered_status: null
-          started_status: null
-          wrappers: []
-          publishers: []
-      - '{name}-{test_name}-for-pull-request':
-          test_name: e2e-coverage
-          node: 'antrea-test-node'
-          description: 'This is the {test_name} test for {name}.'
-          branches:
-          - ${{sha1}}
-          builders:
-            - builder-e2e-coverage
-          trigger_phrase: ^(?!Thanks for your PR).*/test-e2e-coverage.*
-          white_list_target_branches: []
-          allow_whitelist_orgs_as_admins: true
-          admin_list: '{antrea_admin_list}'
-          org_list: '{antrea_org_list}'
-          white_list: '{antrea_white_list}'
-          only_trigger_phrase: true
-          trigger_permit_all: false
-          status_context: jenkins-e2e-coverage
-          status_url: null
-          success_status: Build finished.
-          failure_status: Failed. Add comment /test-e2e-coverage to re-trigger.
-          error_status: Failed. Add comment /test-e2e-coverage to re-trigger.
-          triggered_status: null
-          started_status: null
-          wrappers:
-          - timeout:
-              fail: true
-              timeout: 80
-              type: absolute
-          publishers:
-          - archive:
-              allow-empty: true
-              artifacts: antrea-test-logs.tar.gz, e2e-coverage.tar.gz
-              case-sensitive: true
-              default-excludes: true
-              fingerprint: false
-              only-if-success: false
-      - '{name}-{test_name}-for-pull-request':
-          test_name: e2e-coverage-skip
-          node: null
-          description: 'This is for marking PR as passed.'
-          branches:
-          - ${{sha1}}
-          builders: []
-          allow_whitelist_orgs_as_admins: true
-          admin_list: '{antrea_admin_list}'
-          org_list: '{antrea_org_list}'
-          white_list: '{antrea_white_list}'
-          only_trigger_phrase: true
-          trigger_permit_all: false
-          trigger_phrase: ^(?!Thanks for your PR).*/skip-e2e-coverage.*
-          white_list_target_branches: []
-          status_context: jenkins-e2e-coverage
           status_url: --none--
           success_status: Skipped test. Mark as succeeded.
           failure_status: Skipped test. Mark as succeeded.
@@ -374,6 +295,10 @@
           triggered_status: null
           started_status: null
           wrappers:
+          - credentials-binding:
+            - text:
+                credential-id: CODECOV_TOKEN # Jenkins secret that stores codecov token
+                variable: CODECOV_TOKEN
           - timeout:
               fail: true
               timeout: 80
@@ -381,7 +306,7 @@
           publishers:
           - archive:
               allow-empty: true
-              artifacts: 'ci/jenkins/*sonobuoy*.tar.gz'
+              artifacts: 'ci/jenkins/*sonobuoy*.tar.gz, conformance-coverage.tar.gz'
               case-sensitive: true
               default-excludes: true
               fingerprint: false
@@ -460,6 +385,10 @@
           triggered_status: null
           started_status: null
           wrappers:
+          - credentials-binding:
+            - text:
+                credential-id: CODECOV_TOKEN # Jenkins secret that stores codecov token
+                variable: CODECOV_TOKEN
           - timeout:
               fail: true
               timeout: 80
@@ -521,6 +450,10 @@
           triggered_status: null
           started_status: null
           wrappers:
+          - credentials-binding:
+            - text:
+                credential-id: CODECOV_TOKEN # Jenkins secret that stores codecov token
+                variable: CODECOV_TOKEN
           - timeout:
               fail: true
               timeout: 150
@@ -528,7 +461,7 @@
           publishers:
           - archive:
               allow-empty: true
-              artifacts: 'ci/jenkins/*sonobuoy*.tar.gz'
+              artifacts: 'ci/jenkins/*sonobuoy*.tar.gz, whole-conformance-coverage.tar.gz'
               case-sensitive: true
               default-excludes: true
               fingerprint: false
@@ -607,6 +540,10 @@
           triggered_status: null
           started_status: null
           wrappers:
+          - credentials-binding:
+            - text:
+                credential-id: CODECOV_TOKEN # Jenkins secret that stores codecov token
+                variable: CODECOV_TOKEN
           - timeout:
               fail: true
               timeout: 80
@@ -614,7 +551,7 @@
           publishers:
           - archive:
               allow-empty: true
-              artifacts: 'ci/jenkins/*sonobuoy*.tar.gz'
+              artifacts: 'ci/jenkins/*sonobuoy*.tar.gz, networkpolicy-coverage.tar.gz'
               case-sensitive: true
               default-excludes: true
               fingerprint: false

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -32,6 +32,7 @@ RUN_CLEANUP_ONLY=false
 COVERAGE=false
 RUN_TEST_ONLY=false
 TESTCASE=""
+CODECOV_TOKEN=""
 SECRET_EXIST=false
 TEST_FAILURE=false
 CLUSTER_READY=false
@@ -51,7 +52,8 @@ Setup a VMC cluster to run K8s e2e community tests (E2e, Conformance, all featur
         --setup-only             Only perform setting up the cluster and run test.
         --cleanup-only           Only perform cleaning up the cluster.
         --coverage               Run e2e with coverage.
-        --test-only              Only run test on current cluster. Not set up/clean up the cluster."
+        --test-only              Only run test on current cluster. Not set up/clean up the cluster.
+        --codecov-token          Token used to upload coverage report(s) to Codecov."
 
 function print_usage {
     echoerr "$_usage"
@@ -100,10 +102,15 @@ case $key in
     ;;
     --coverage)
     COVERAGE=true
+    shift
     ;;
     --test-only)
     RUN_TEST_ONLY=true
     shift
+    ;;
+    --codecov-token)
+    CODECOV_TOKEN="$2"
+    shift 2
     ;;
     -h|--help)
     print_usage
@@ -316,6 +323,9 @@ function run_integration {
     set -x
     echo "===== Run Integration test ====="
     ssh -q -o StrictHostKeyChecking=no -i "${WORKDIR}/utils/key" -n jenkins@${VM_IP} "git clone ${ghprbAuthorRepoGitUrl} antrea && cd antrea && git checkout ${GIT_BRANCH} && make docker-test-integration"
+    if [[ "$COVERAGE" == true ]]; then
+        ssh -q -o StrictHostKeyChecking=no -i "${WORKDIR}/utils/key" -n jenkins@${VM_IP} "curl -s https://codecov.io/bash | bash -s -- -c -t ${CODECOV_TOKEN} -F integration-tests -f '.coverage/coverage-integration.txt'"
+    fi
 }
 
 function run_e2e {
@@ -364,11 +374,9 @@ function run_e2e {
     fi
 
     tar -zcf ${GIT_CHECKOUT_DIR}/antrea-test-logs.tar.gz ${GIT_CHECKOUT_DIR}/antrea-test-logs
-
     if [[ "$COVERAGE" == true ]]; then
         tar -zcf ${GIT_CHECKOUT_DIR}/e2e-coverage.tar.gz ${GIT_CHECKOUT_DIR}/e2e-coverage
-        export CODECOV_TOKEN="a2b1c854-8627-4747-89cb-c312da33227d"
-        curl -s https://codecov.io/bash | bash -s -- -c -F jenkins-e2e -f '*antrea*' -s ${GIT_CHECKOUT_DIR}/e2e-coverage
+        curl -s https://codecov.io/bash | bash -s -- -c -t ${CODECOV_TOKEN} -F e2e-tests -f '*antrea*' -s ${GIT_CHECKOUT_DIR}/e2e-coverage
     fi
 }
 
@@ -382,12 +390,22 @@ function run_conformance {
     export PATH=$GOROOT/bin:$PATH
     export KUBECONFIG=$GIT_CHECKOUT_DIR/jenkins/out/kubeconfig
 
-    if [[ "$TESTCASE" == "all-features-conformance" ]]; then
-      $GIT_CHECKOUT_DIR/hack/generate-manifest.sh --mode dev --all-features > $GIT_CHECKOUT_DIR/build/yamls/antrea-all.yml
-      kubectl apply -f $GIT_CHECKOUT_DIR/build/yamls/antrea-all.yml
-    else
-      kubectl apply -f $GIT_CHECKOUT_DIR/build/yamls/antrea.yml
+    antrea_yml="antrea.yml"
+    if [[ "$COVERAGE" == true ]]; then
+        antrea_yml="antrea-coverage.yml"
     fi
+
+    if [[ "$TESTCASE" == "all-features-conformance" ]]; then
+      if [[ "$COVERAGE" == true ]]; then
+        $GIT_CHECKOUT_DIR/hack/generate-manifest.sh --mode dev --all-features --coverage > $GIT_CHECKOUT_DIR/build/yamls/antrea-all-coverage.yml
+        antrea_yml="antrea-all-coverage.yml"
+      else
+        $GIT_CHECKOUT_DIR/hack/generate-manifest.sh --mode dev --all-features > $GIT_CHECKOUT_DIR/build/yamls/antrea-all.yml
+        antrea_yml="antrea-all.yml"
+      fi
+    fi
+
+    kubectl apply -f $GIT_CHECKOUT_DIR/build/yamls/$antrea_yml
     kubectl rollout restart deployment/coredns -n kube-system
     kubectl rollout status --timeout=5m deployment/coredns -n kube-system
     kubectl rollout status --timeout=5m deployment.apps/antrea-controller -n kube-system
@@ -416,6 +434,31 @@ function run_conformance {
     else
         echo "All tests passed."
     fi
+
+    if [[ "$COVERAGE" == true ]]; then
+        rm -rf ${GIT_CHECKOUT_DIR}/conformance-coverage
+        mkdir -p ${GIT_CHECKOUT_DIR}/conformance-coverage
+        collect_coverage
+        tar -zcf ${GIT_CHECKOUT_DIR}/$TESTCASE-coverage.tar.gz ${GIT_CHECKOUT_DIR}/conformance-coverage
+        curl -s https://codecov.io/bash | bash -s -- -c -t ${CODECOV_TOKEN} -F e2e-tests -f '*antrea*' -s ${GIT_CHECKOUT_DIR}/conformance-coverage
+    fi
+}
+
+function collect_coverage() {
+        antrea_controller_pod_name="$(kubectl get pods --selector=app=antrea,component=antrea-controller -n kube-system --no-headers=true | awk '{ print $1 }')"
+        controller_pid="$(kubectl exec -i $antrea_controller_pod_name -n kube-system -- pgrep antrea)"
+        kubectl exec -i $antrea_controller_pod_name -n kube-system -- kill -SIGINT $controller_pid
+        timestamp=$(date +%Y%m%d%H%M%S)
+        kubectl cp kube-system/$antrea_controller_pod_name:antrea-controller.cov.out ${GIT_CHECKOUT_DIR}/conformance-coverage/$antrea_controller_pod_name-$timestamp
+
+        antrea_agent_pod_names="$(kubectl get pods --selector=app=antrea,component=antrea-agent -n kube-system --no-headers=true | awk '{ print $1 }')"
+        for agent in ${antrea_agent_pod_names}
+        do
+            agent_pid="$(kubectl exec -i $agent -n kube-system -- pgrep antrea)"
+            kubectl exec -i $agent -c antrea-agent -n kube-system -- kill -SIGINT $agent_pid
+            timestamp=$(date +%Y%m%d%H%M%S)
+            kubectl cp kube-system/$agent:antrea-agent.cov.out -c antrea-agent ${GIT_CHECKOUT_DIR}/conformance-coverage/$agent-$timestamp
+        done
 }
 
 function cleanup_cluster() {

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -110,7 +110,7 @@ function run_test {
   fi
   sleep 1
   if $coverage; then
-      go test -v -timeout=40m github.com/vmware-tanzu/antrea/test/e2e -provider=kind --logs-export-dir=$ANTREA_LOG_DIR --coverage --coverage-dir $ANTREA_COV_DIR
+      go test -v -timeout=35m github.com/vmware-tanzu/antrea/test/e2e -provider=kind --logs-export-dir=$ANTREA_LOG_DIR --coverage --coverage-dir $ANTREA_COV_DIR
   else
       go test -v -timeout=30m github.com/vmware-tanzu/antrea/test/e2e -provider=kind --logs-export-dir=$ANTREA_LOG_DIR
   fi

--- a/cmd/antctl/bincover_run_main_test.go
+++ b/cmd/antctl/bincover_run_main_test.go
@@ -1,0 +1,13 @@
+// +build testbincover
+
+package main
+
+import (
+	"testing"
+
+	"github.com/confluentinc/bincover"
+)
+
+func TestBincoverRunMain(t *testing.T) {
+	bincover.RunTest(main)
+}

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,5 +1,4 @@
 codecov:
-  token: a2b1c854-8627-4747-89cb-c312da33227d
   require_ci_to_pass: no
 
 comment:
@@ -9,6 +8,24 @@ comment:
   require_base: no
   require_head: no
   after_n_builds: 1
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+      antrea-unit-tests:
+        target: auto
+        flags:
+          - unit-tests
+      antrea-integration-tests:
+        target: auto
+        flags:
+          - integration-tests
+      antrea-e2e-tests:
+        target: auto
+        flags:
+          - e2e-tests
 
 ignore:
   - "**/testing/mock_*.go"

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -657,7 +657,7 @@ func (i *Initializer) initializeIPSec() error {
 	// PID files before starting the OVS daemons, it is safe to assume that
 	// if this file exists, the IPsec monitor is indeed running.
 	const ovsMonitorIPSecPID = "/var/run/openvswitch/ovs-monitor-ipsec.pid"
-	timer := time.NewTimer(5 * time.Second)
+	timer := time.NewTimer(10 * time.Second)
 	defer timer.Stop()
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -131,6 +131,9 @@ func gracefulExitAntrea(testData *TestData) {
 		if err := testData.gracefulExitAntreaAgent(testOptions.coverageDir, "all"); err != nil {
 			log.Fatalf("Error when gracefully exit antrea agent: %v", err)
 		}
+		if err := testData.collectAntctlCovFilesFromMasterNode(testOptions.coverageDir); err != nil {
+			log.Fatalf("Error when collecting antctl coverage files from master node: %v", err)
+		}
 
 	}
 }

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -677,6 +677,8 @@ func createAndWaitForPod(t *testing.T, data *TestData, createFunc func(name stri
 func waitForAgentCondition(t *testing.T, data *TestData, podName string, conditionType v1beta1.AgentConditionType, expectedStatus corev1.ConditionStatus) {
 	if err := wait.Poll(1*time.Second, defaultTimeout, func() (bool, error) {
 		cmds := []string{"antctl", "get", "agentinfo", "-o", "json"}
+		t.Logf("cmds: %s", cmds)
+
 		stdout, _, err := runAntctl(podName, cmds, data)
 		if err != nil {
 			return true, err


### PR DESCRIPTION
Add coverage support for conformance and antctl

This PR made the below changes:
Add coverage support for antctl:
1. generates an instrumented binary for antctl
2. if coverage is enabled, run antctl instrumented binary
   antctl-coverage for antctl cmds. When the cmds finish,
   generate a coverage file for antctl.
3. when all e2e tests finish, copy the antctl coverage files out.
Add coverage support for running conformance test:
1. after run conformance tests using sonobuoy on instrumented binary
   for antrea-controller and antrea-agent, collect coverage files
   for them and copy them to coverage directory.
