### PR TITLE
Add Antrea NetworkPolicy CRD Validation web hook

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -257,6 +257,110 @@ spec:
     - anp
     singular: networkpolicy
   scope: Namespaced
+<<<<<<< HEAD
+=======
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            appliedTo:
+              items:
+                properties:
+                  podSelector:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              type: array
+            egress:
+              items:
+                properties:
+                  action:
+                    enum:
+                    - Allow
+                    - Drop
+                    type: string
+                  ports:
+                    items:
+                      properties:
+                        port:
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          type: string
+                      type: object
+                    type: array
+                  to:
+                    items:
+                      properties:
+                        externalEntitySelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        ipBlock:
+                          properties:
+                            cidr:
+                              format: cidr
+                              type: string
+                          type: object
+                        namespaceSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        podSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    type: array
+                required:
+                - action
+                type: object
+              type: array
+            ingress:
+              items:
+                properties:
+                  action:
+                    enum:
+                    - Allow
+                    - Drop
+                    type: string
+                  from:
+                    items:
+                      properties:
+                        externalEntitySelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        ipBlock:
+                          properties:
+                            cidr:
+                              format: cidr
+                              type: string
+                          type: object
+                        namespaceSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        podSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    type: array
+                  ports:
+                    items:
+                      properties:
+                        port:
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - action
+                type: object
+              type: array
+            priority:
+              format: float
+              maximum: 10000
+              minimum: 1
+              type: number
+            tier:
+              type: string
+          required:
+          - appliedTo
+          - priority
+          type: object
+      type: object
+>>>>>>> 860ca13... Validate ANP CRDs for Tier references
   versions:
   - additionalPrinterColumns:
     - description: The Tier to which this Antrea NetworkPolicy belongs to.
@@ -1583,5 +1687,27 @@ webhooks:
     resources:
     - clusternetworkpolicies
     scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/anp
+  name: anpvalidator.antrea.tanzu.vmware.com
+  rules:
+  - apiGroups:
+    - security.antrea.tanzu.vmware.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - networkpolicies
+    scope: Namespaced
   sideEffects: None
   timeoutSeconds: 5

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -257,110 +257,6 @@ spec:
     - anp
     singular: networkpolicy
   scope: Namespaced
-<<<<<<< HEAD
-=======
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            appliedTo:
-              items:
-                properties:
-                  podSelector:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                type: object
-              type: array
-            egress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                  to:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            ingress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  from:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            priority:
-              format: float
-              maximum: 10000
-              minimum: 1
-              type: number
-            tier:
-              type: string
-          required:
-          - appliedTo
-          - priority
-          type: object
-      type: object
->>>>>>> 860ca13... Validate ANP CRDs for Tier references
   versions:
   - additionalPrinterColumns:
     - description: The Tier to which this Antrea NetworkPolicy belongs to.
@@ -471,12 +367,6 @@ spec:
                 minimum: 1
                 type: number
               tier:
-                enum:
-                - Emergency
-                - SecurityOps
-                - NetworkOps
-                - Platform
-                - Application
                 type: string
             required:
             - appliedTo
@@ -1674,8 +1564,8 @@ webhooks:
     service:
       name: antrea
       namespace: kube-system
-      path: /validate/cnp
-  name: cnpvalidator.antrea.tanzu.vmware.com
+      path: /validate/acnp
+  name: acnpvalidator.antrea.tanzu.vmware.com
   rules:
   - apiGroups:
     - security.antrea.tanzu.vmware.com

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -257,110 +257,6 @@ spec:
     - anp
     singular: networkpolicy
   scope: Namespaced
-<<<<<<< HEAD
-=======
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            appliedTo:
-              items:
-                properties:
-                  podSelector:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                type: object
-              type: array
-            egress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                  to:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            ingress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  from:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            priority:
-              format: float
-              maximum: 10000
-              minimum: 1
-              type: number
-            tier:
-              type: string
-          required:
-          - appliedTo
-          - priority
-          type: object
-      type: object
->>>>>>> 860ca13... Validate ANP CRDs for Tier references
   versions:
   - additionalPrinterColumns:
     - description: The Tier to which this Antrea NetworkPolicy belongs to.
@@ -471,12 +367,6 @@ spec:
                 minimum: 1
                 type: number
               tier:
-                enum:
-                - Emergency
-                - SecurityOps
-                - NetworkOps
-                - Platform
-                - Application
                 type: string
             required:
             - appliedTo
@@ -1676,8 +1566,8 @@ webhooks:
     service:
       name: antrea
       namespace: kube-system
-      path: /validate/cnp
-  name: cnpvalidator.antrea.tanzu.vmware.com
+      path: /validate/acnp
+  name: acnpvalidator.antrea.tanzu.vmware.com
   rules:
   - apiGroups:
     - security.antrea.tanzu.vmware.com

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -257,6 +257,110 @@ spec:
     - anp
     singular: networkpolicy
   scope: Namespaced
+<<<<<<< HEAD
+=======
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            appliedTo:
+              items:
+                properties:
+                  podSelector:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              type: array
+            egress:
+              items:
+                properties:
+                  action:
+                    enum:
+                    - Allow
+                    - Drop
+                    type: string
+                  ports:
+                    items:
+                      properties:
+                        port:
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          type: string
+                      type: object
+                    type: array
+                  to:
+                    items:
+                      properties:
+                        externalEntitySelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        ipBlock:
+                          properties:
+                            cidr:
+                              format: cidr
+                              type: string
+                          type: object
+                        namespaceSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        podSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    type: array
+                required:
+                - action
+                type: object
+              type: array
+            ingress:
+              items:
+                properties:
+                  action:
+                    enum:
+                    - Allow
+                    - Drop
+                    type: string
+                  from:
+                    items:
+                      properties:
+                        externalEntitySelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        ipBlock:
+                          properties:
+                            cidr:
+                              format: cidr
+                              type: string
+                          type: object
+                        namespaceSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        podSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    type: array
+                  ports:
+                    items:
+                      properties:
+                        port:
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - action
+                type: object
+              type: array
+            priority:
+              format: float
+              maximum: 10000
+              minimum: 1
+              type: number
+            tier:
+              type: string
+          required:
+          - appliedTo
+          - priority
+          type: object
+      type: object
+>>>>>>> 860ca13... Validate ANP CRDs for Tier references
   versions:
   - additionalPrinterColumns:
     - description: The Tier to which this Antrea NetworkPolicy belongs to.
@@ -1585,5 +1689,27 @@ webhooks:
     resources:
     - clusternetworkpolicies
     scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/anp
+  name: anpvalidator.antrea.tanzu.vmware.com
+  rules:
+  - apiGroups:
+    - security.antrea.tanzu.vmware.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - networkpolicies
+    scope: Namespaced
   sideEffects: None
   timeoutSeconds: 5

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -257,6 +257,110 @@ spec:
     - anp
     singular: networkpolicy
   scope: Namespaced
+<<<<<<< HEAD
+=======
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            appliedTo:
+              items:
+                properties:
+                  podSelector:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              type: array
+            egress:
+              items:
+                properties:
+                  action:
+                    enum:
+                    - Allow
+                    - Drop
+                    type: string
+                  ports:
+                    items:
+                      properties:
+                        port:
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          type: string
+                      type: object
+                    type: array
+                  to:
+                    items:
+                      properties:
+                        externalEntitySelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        ipBlock:
+                          properties:
+                            cidr:
+                              format: cidr
+                              type: string
+                          type: object
+                        namespaceSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        podSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    type: array
+                required:
+                - action
+                type: object
+              type: array
+            ingress:
+              items:
+                properties:
+                  action:
+                    enum:
+                    - Allow
+                    - Drop
+                    type: string
+                  from:
+                    items:
+                      properties:
+                        externalEntitySelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        ipBlock:
+                          properties:
+                            cidr:
+                              format: cidr
+                              type: string
+                          type: object
+                        namespaceSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        podSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    type: array
+                  ports:
+                    items:
+                      properties:
+                        port:
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - action
+                type: object
+              type: array
+            priority:
+              format: float
+              maximum: 10000
+              minimum: 1
+              type: number
+            tier:
+              type: string
+          required:
+          - appliedTo
+          - priority
+          type: object
+      type: object
+>>>>>>> 860ca13... Validate ANP CRDs for Tier references
   versions:
   - additionalPrinterColumns:
     - description: The Tier to which this Antrea NetworkPolicy belongs to.
@@ -1583,5 +1687,27 @@ webhooks:
     resources:
     - clusternetworkpolicies
     scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/anp
+  name: anpvalidator.antrea.tanzu.vmware.com
+  rules:
+  - apiGroups:
+    - security.antrea.tanzu.vmware.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - networkpolicies
+    scope: Namespaced
   sideEffects: None
   timeoutSeconds: 5

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -257,110 +257,6 @@ spec:
     - anp
     singular: networkpolicy
   scope: Namespaced
-<<<<<<< HEAD
-=======
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            appliedTo:
-              items:
-                properties:
-                  podSelector:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                type: object
-              type: array
-            egress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                  to:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            ingress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  from:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            priority:
-              format: float
-              maximum: 10000
-              minimum: 1
-              type: number
-            tier:
-              type: string
-          required:
-          - appliedTo
-          - priority
-          type: object
-      type: object
->>>>>>> 860ca13... Validate ANP CRDs for Tier references
   versions:
   - additionalPrinterColumns:
     - description: The Tier to which this Antrea NetworkPolicy belongs to.
@@ -471,12 +367,6 @@ spec:
                 minimum: 1
                 type: number
               tier:
-                enum:
-                - Emergency
-                - SecurityOps
-                - NetworkOps
-                - Platform
-                - Application
                 type: string
             required:
             - appliedTo
@@ -1674,8 +1564,8 @@ webhooks:
     service:
       name: antrea
       namespace: kube-system
-      path: /validate/cnp
-  name: cnpvalidator.antrea.tanzu.vmware.com
+      path: /validate/acnp
+  name: acnpvalidator.antrea.tanzu.vmware.com
   rules:
   - apiGroups:
     - security.antrea.tanzu.vmware.com

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -257,110 +257,6 @@ spec:
     - anp
     singular: networkpolicy
   scope: Namespaced
-<<<<<<< HEAD
-=======
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            appliedTo:
-              items:
-                properties:
-                  podSelector:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                type: object
-              type: array
-            egress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                  to:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            ingress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  from:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            priority:
-              format: float
-              maximum: 10000
-              minimum: 1
-              type: number
-            tier:
-              type: string
-          required:
-          - appliedTo
-          - priority
-          type: object
-      type: object
->>>>>>> 860ca13... Validate ANP CRDs for Tier references
   versions:
   - additionalPrinterColumns:
     - description: The Tier to which this Antrea NetworkPolicy belongs to.
@@ -471,12 +367,6 @@ spec:
                 minimum: 1
                 type: number
               tier:
-                enum:
-                - Emergency
-                - SecurityOps
-                - NetworkOps
-                - Platform
-                - Application
                 type: string
             required:
             - appliedTo
@@ -1723,8 +1613,8 @@ webhooks:
     service:
       name: antrea
       namespace: kube-system
-      path: /validate/cnp
-  name: cnpvalidator.antrea.tanzu.vmware.com
+      path: /validate/acnp
+  name: acnpvalidator.antrea.tanzu.vmware.com
   rules:
   - apiGroups:
     - security.antrea.tanzu.vmware.com

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -257,6 +257,110 @@ spec:
     - anp
     singular: networkpolicy
   scope: Namespaced
+<<<<<<< HEAD
+=======
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            appliedTo:
+              items:
+                properties:
+                  podSelector:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              type: array
+            egress:
+              items:
+                properties:
+                  action:
+                    enum:
+                    - Allow
+                    - Drop
+                    type: string
+                  ports:
+                    items:
+                      properties:
+                        port:
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          type: string
+                      type: object
+                    type: array
+                  to:
+                    items:
+                      properties:
+                        externalEntitySelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        ipBlock:
+                          properties:
+                            cidr:
+                              format: cidr
+                              type: string
+                          type: object
+                        namespaceSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        podSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    type: array
+                required:
+                - action
+                type: object
+              type: array
+            ingress:
+              items:
+                properties:
+                  action:
+                    enum:
+                    - Allow
+                    - Drop
+                    type: string
+                  from:
+                    items:
+                      properties:
+                        externalEntitySelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        ipBlock:
+                          properties:
+                            cidr:
+                              format: cidr
+                              type: string
+                          type: object
+                        namespaceSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        podSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    type: array
+                  ports:
+                    items:
+                      properties:
+                        port:
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - action
+                type: object
+              type: array
+            priority:
+              format: float
+              maximum: 10000
+              minimum: 1
+              type: number
+            tier:
+              type: string
+          required:
+          - appliedTo
+          - priority
+          type: object
+      type: object
+>>>>>>> 860ca13... Validate ANP CRDs for Tier references
   versions:
   - additionalPrinterColumns:
     - description: The Tier to which this Antrea NetworkPolicy belongs to.
@@ -1632,5 +1736,27 @@ webhooks:
     resources:
     - clusternetworkpolicies
     scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/anp
+  name: anpvalidator.antrea.tanzu.vmware.com
+  rules:
+  - apiGroups:
+    - security.antrea.tanzu.vmware.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - networkpolicies
+    scope: Namespaced
   sideEffects: None
   timeoutSeconds: 5

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -257,6 +257,110 @@ spec:
     - anp
     singular: networkpolicy
   scope: Namespaced
+<<<<<<< HEAD
+=======
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            appliedTo:
+              items:
+                properties:
+                  podSelector:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              type: array
+            egress:
+              items:
+                properties:
+                  action:
+                    enum:
+                    - Allow
+                    - Drop
+                    type: string
+                  ports:
+                    items:
+                      properties:
+                        port:
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          type: string
+                      type: object
+                    type: array
+                  to:
+                    items:
+                      properties:
+                        externalEntitySelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        ipBlock:
+                          properties:
+                            cidr:
+                              format: cidr
+                              type: string
+                          type: object
+                        namespaceSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        podSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    type: array
+                required:
+                - action
+                type: object
+              type: array
+            ingress:
+              items:
+                properties:
+                  action:
+                    enum:
+                    - Allow
+                    - Drop
+                    type: string
+                  from:
+                    items:
+                      properties:
+                        externalEntitySelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        ipBlock:
+                          properties:
+                            cidr:
+                              format: cidr
+                              type: string
+                          type: object
+                        namespaceSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        podSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    type: array
+                  ports:
+                    items:
+                      properties:
+                        port:
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - action
+                type: object
+              type: array
+            priority:
+              format: float
+              maximum: 10000
+              minimum: 1
+              type: number
+            tier:
+              type: string
+          required:
+          - appliedTo
+          - priority
+          type: object
+      type: object
+>>>>>>> 860ca13... Validate ANP CRDs for Tier references
   versions:
   - additionalPrinterColumns:
     - description: The Tier to which this Antrea NetworkPolicy belongs to.
@@ -1588,5 +1692,27 @@ webhooks:
     resources:
     - clusternetworkpolicies
     scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/anp
+  name: anpvalidator.antrea.tanzu.vmware.com
+  rules:
+  - apiGroups:
+    - security.antrea.tanzu.vmware.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - networkpolicies
+    scope: Namespaced
   sideEffects: None
   timeoutSeconds: 5

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -257,110 +257,6 @@ spec:
     - anp
     singular: networkpolicy
   scope: Namespaced
-<<<<<<< HEAD
-=======
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            appliedTo:
-              items:
-                properties:
-                  podSelector:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                type: object
-              type: array
-            egress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                  to:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            ingress:
-              items:
-                properties:
-                  action:
-                    enum:
-                    - Allow
-                    - Drop
-                    type: string
-                  from:
-                    items:
-                      properties:
-                        externalEntitySelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        ipBlock:
-                          properties:
-                            cidr:
-                              format: cidr
-                              type: string
-                          type: object
-                        namespaceSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                        podSelector:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    type: array
-                  ports:
-                    items:
-                      properties:
-                        port:
-                          x-kubernetes-int-or-string: true
-                        protocol:
-                          type: string
-                      type: object
-                    type: array
-                required:
-                - action
-                type: object
-              type: array
-            priority:
-              format: float
-              maximum: 10000
-              minimum: 1
-              type: number
-            tier:
-              type: string
-          required:
-          - appliedTo
-          - priority
-          type: object
-      type: object
->>>>>>> 860ca13... Validate ANP CRDs for Tier references
   versions:
   - additionalPrinterColumns:
     - description: The Tier to which this Antrea NetworkPolicy belongs to.
@@ -471,12 +367,6 @@ spec:
                 minimum: 1
                 type: number
               tier:
-                enum:
-                - Emergency
-                - SecurityOps
-                - NetworkOps
-                - Platform
-                - Application
                 type: string
             required:
             - appliedTo
@@ -1679,8 +1569,8 @@ webhooks:
     service:
       name: antrea
       namespace: kube-system
-      path: /validate/cnp
-  name: cnpvalidator.antrea.tanzu.vmware.com
+      path: /validate/acnp
+  name: acnpvalidator.antrea.tanzu.vmware.com
   rules:
   - apiGroups:
     - security.antrea.tanzu.vmware.com

--- a/build/yamls/base/controller.yml
+++ b/build/yamls/base/controller.yml
@@ -76,12 +76,12 @@ webhooks:
   admissionReviewVersions: ["v1", "v1beta1"]
   sideEffects: None
   timeoutSeconds: 5
-- name: "cnpvalidator.antrea.tanzu.vmware.com"
+- name: "acnpvalidator.antrea.tanzu.vmware.com"
   clientConfig:
     service:
       name: "antrea"
       namespace: "kube-system"
-      path: "/validate/cnp"
+      path: "/validate/acnp"
   rules:
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["security.antrea.tanzu.vmware.com"]

--- a/build/yamls/base/controller.yml
+++ b/build/yamls/base/controller.yml
@@ -91,6 +91,21 @@ webhooks:
   admissionReviewVersions: ["v1", "v1beta1"]
   sideEffects: None
   timeoutSeconds: 5
+- name: "anpvalidator.antrea.tanzu.vmware.com"
+  clientConfig:
+    service:
+      name: "antrea"
+      namespace: "kube-system"
+      path: "/validate/anp"
+  rules:
+  - operations: ["CREATE", "UPDATE"]
+    apiGroups: ["security.antrea.tanzu.vmware.com"]
+    apiVersions: ["v1alpha1"]
+    resources: ["networkpolicies"]
+    scope: "Namespaced"
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None
+  timeoutSeconds: 5
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -431,7 +431,6 @@ spec:
               properties:
                 tier:
                   type: string
-                  enum: ['Emergency', 'SecurityOps', 'NetworkOps', 'Platform', 'Application']
                 priority:
                   type: number
                   format: float

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -71,6 +71,7 @@ var allowedPaths = []string{
 	"/healthz",
 	"/validate/tier",
 	"/validate/cnp",
+	"/validate/anp",
 }
 
 // run starts Antrea Controller with the given options and waits for termination signal.

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -70,7 +70,7 @@ const (
 var allowedPaths = []string{
 	"/healthz",
 	"/validate/tier",
-	"/validate/cnp",
+	"/validate/acnp",
 	"/validate/anp",
 }
 

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -206,6 +206,7 @@ func installHandlers(c *ExtraConfig, s *genericapiserver.GenericAPIServer) {
 		// Install handlers for NetworkPolicy related validation
 		s.Handler.NonGoRestfulMux.HandleFunc("/validate/tier", webhook.HandleValidationNetworkPolicy(v))
 		s.Handler.NonGoRestfulMux.HandleFunc("/validate/cnp", webhook.HandleValidationNetworkPolicy(v))
+		s.Handler.NonGoRestfulMux.HandleFunc("/validate/anp", webhook.HandleValidationNetworkPolicy(v))
 		// Install a post start hook to initialize Tiers on start-up
 		s.AddPostStartHook("initialize-tiers", func(context genericapiserver.PostStartHookContext) error {
 			go c.networkPolicyController.InitializeTiers()

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -205,7 +205,7 @@ func installHandlers(c *ExtraConfig, s *genericapiserver.GenericAPIServer) {
 		v := controllernetworkpolicy.NewNetworkPolicyValidator(c.networkPolicyController)
 		// Install handlers for NetworkPolicy related validation
 		s.Handler.NonGoRestfulMux.HandleFunc("/validate/tier", webhook.HandleValidationNetworkPolicy(v))
-		s.Handler.NonGoRestfulMux.HandleFunc("/validate/cnp", webhook.HandleValidationNetworkPolicy(v))
+		s.Handler.NonGoRestfulMux.HandleFunc("/validate/acnp", webhook.HandleValidationNetworkPolicy(v))
 		s.Handler.NonGoRestfulMux.HandleFunc("/validate/anp", webhook.HandleValidationNetworkPolicy(v))
 		// Install a post start hook to initialize Tiers on start-up
 		s.AddPostStartHook("initialize-tiers", func(context genericapiserver.PostStartHookContext) error {

--- a/pkg/apiserver/handlers/webhook/validation_crd.go
+++ b/pkg/apiserver/handlers/webhook/validation_crd.go
@@ -28,7 +28,7 @@ import (
 
 func HandleValidationNetworkPolicy(v *networkpolicy.NetworkPolicyValidator) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		klog.V(2).Info("Received request to validate Antrea NP/Tier CRD")
+		klog.V(2).Info("Received request to validate Antrea Policy/Tier CRD")
 		var reqBody []byte
 		if r.Body != nil {
 			reqBody, _ = ioutil.ReadAll(r.Body)

--- a/pkg/apiserver/handlers/webhook/validation_crd.go
+++ b/pkg/apiserver/handlers/webhook/validation_crd.go
@@ -45,11 +45,6 @@ func HandleValidationNetworkPolicy(v *networkpolicy.NetworkPolicyValidator) http
 			http.Error(w, "invalid Content-Type, expected `application/json`", http.StatusUnsupportedMediaType)
 			return
 		}
-		if r.URL.Path != "/validate/tier" && r.URL.Path != "/validate/cnp" {
-			klog.Errorf("Invalid path received for Antrea NP/Tier validation")
-			http.Error(w, "invalid path", http.StatusBadRequest)
-			return
-		}
 		var admissionResponse *admv1.AdmissionResponse
 		ar := admv1.AdmissionReview{}
 		ar.TypeMeta.Kind = "AdmissionReview"

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -296,6 +296,17 @@ func NewNetworkPolicyController(kubeClient clientset.Interface,
 			},
 			resyncPeriod,
 		)
+		anpInformer.Informer().AddIndexers(
+			cache.Indexers{
+				TierIndex: func(obj interface{}) ([]string, error) {
+					anp, ok := obj.(*secv1alpha1.NetworkPolicy)
+					if !ok {
+						return []string{}, nil
+					}
+					return []string{anp.Spec.Tier}, nil
+				},
+			},
+		)
 		anpInformer.Informer().AddEventHandlerWithResyncPeriod(
 			cache.ResourceEventHandlerFuncs{
 				AddFunc:    n.addANP,


### PR DESCRIPTION
This PR adds validation for ANP CRUD via the use of a ValidatingWebhookConfiguration. Following validation is performed:

Tier DELETE
Check for referenced ANPs

ANP CREATE/UPDATE
Check if referenced Tier exists