### PR TITLE
Update short-names for Antrea NetworkPolicy CRDs

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -63,7 +63,7 @@ spec:
     kind: ClusterNetworkPolicy
     plural: clusternetworkpolicies
     shortNames:
-    - cnp
+    - acnp
     singular: clusternetworkpolicy
   preserveUnknownFields: false
   scope: Cluster
@@ -247,6 +247,7 @@ spec:
     plural: networkpolicies
     shortNames:
     - netpol
+    - anp
     singular: networkpolicy
   preserveUnknownFields: false
   scope: Namespaced

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -63,6 +63,7 @@ spec:
     kind: ClusterNetworkPolicy
     plural: clusternetworkpolicies
     shortNames:
+    - cnp
     - acnp
     singular: clusternetworkpolicy
   preserveUnknownFields: false

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -63,7 +63,7 @@ spec:
     kind: ClusterNetworkPolicy
     plural: clusternetworkpolicies
     shortNames:
-    - cnp
+    - acnp
     singular: clusternetworkpolicy
   preserveUnknownFields: false
   scope: Cluster
@@ -247,6 +247,7 @@ spec:
     plural: networkpolicies
     shortNames:
     - netpol
+    - anp
     singular: networkpolicy
   preserveUnknownFields: false
   scope: Namespaced

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -63,6 +63,7 @@ spec:
     kind: ClusterNetworkPolicy
     plural: clusternetworkpolicies
     shortNames:
+    - cnp
     - acnp
     singular: clusternetworkpolicy
   preserveUnknownFields: false

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -63,7 +63,7 @@ spec:
     kind: ClusterNetworkPolicy
     plural: clusternetworkpolicies
     shortNames:
-    - cnp
+    - acnp
     singular: clusternetworkpolicy
   preserveUnknownFields: false
   scope: Cluster
@@ -247,6 +247,7 @@ spec:
     plural: networkpolicies
     shortNames:
     - netpol
+    - anp
     singular: networkpolicy
   preserveUnknownFields: false
   scope: Namespaced

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -63,6 +63,7 @@ spec:
     kind: ClusterNetworkPolicy
     plural: clusternetworkpolicies
     shortNames:
+    - cnp
     - acnp
     singular: clusternetworkpolicy
   preserveUnknownFields: false

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -63,7 +63,7 @@ spec:
     kind: ClusterNetworkPolicy
     plural: clusternetworkpolicies
     shortNames:
-    - cnp
+    - acnp
     singular: clusternetworkpolicy
   preserveUnknownFields: false
   scope: Cluster
@@ -247,6 +247,7 @@ spec:
     plural: networkpolicies
     shortNames:
     - netpol
+    - anp
     singular: networkpolicy
   preserveUnknownFields: false
   scope: Namespaced

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -63,6 +63,7 @@ spec:
     kind: ClusterNetworkPolicy
     plural: clusternetworkpolicies
     shortNames:
+    - cnp
     - acnp
     singular: clusternetworkpolicy
   preserveUnknownFields: false

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -63,7 +63,7 @@ spec:
     kind: ClusterNetworkPolicy
     plural: clusternetworkpolicies
     shortNames:
-    - cnp
+    - acnp
     singular: clusternetworkpolicy
   preserveUnknownFields: false
   scope: Cluster
@@ -247,6 +247,7 @@ spec:
     plural: networkpolicies
     shortNames:
     - netpol
+    - anp
     singular: networkpolicy
   preserveUnknownFields: false
   scope: Namespaced

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -63,6 +63,7 @@ spec:
     kind: ClusterNetworkPolicy
     plural: clusternetworkpolicies
     shortNames:
+    - cnp
     - acnp
     singular: clusternetworkpolicy
   preserveUnknownFields: false

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -263,6 +263,8 @@ spec:
     singular: clusternetworkpolicy
     kind: ClusterNetworkPolicy
     shortNames:
+      # Short name cnp is deprecated and will be removed in 0.12 release
+      - cnp
       - acnp
   # Prune any unknown fields
   preserveUnknownFields: false
@@ -395,6 +397,7 @@ spec:
     singular: networkpolicy
     kind: NetworkPolicy
     shortNames:
+      # Short name netpol is deprecated and will be removed in 0.12 release
       - netpol
       - anp
   # Prune any unknown fields

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -263,7 +263,7 @@ spec:
     singular: clusternetworkpolicy
     kind: ClusterNetworkPolicy
     shortNames:
-      - cnp
+      - acnp
   # Prune any unknown fields
   preserveUnknownFields: false
   additionalPrinterColumns:
@@ -396,6 +396,7 @@ spec:
     kind: NetworkPolicy
     shortNames:
       - netpol
+      - anp
   # Prune any unknown fields
   preserveUnknownFields: false
   additionalPrinterColumns:


### PR DESCRIPTION
This PR updates short-names for Antrea Policy CRDs as follows:

ClusterNetworkPolicy
Existing short name: cnp
New short name: acnp

NetworkPolicy
Existing short name: netpol
New short name: anp

Existing short-name "cnp" and "netpol" are deprecated in favor of new short names and shall be removed in Antrea 0.12.0
release.