### PR TITLE
Restrict read permissions for OVSDB

### DIFF
--- a/build/images/scripts/start_ovs
+++ b/build/images/scripts/start_ovs
@@ -76,6 +76,10 @@ fi
 
 start_ovs $offload
 
+# Restrict read permissions for "others"
+# See discussion in https://github.com/vmware-tanzu/antrea/issues/1292
+chmod 0640 $OVS_DB_FILE
+
 log_info $CONTAINER_NAME "Started the loop that checks OVS status every 30 seconds"
 while true; do
     # we run sleep in the background so that we can immediately exit when we

--- a/build/images/scripts/start_ovs_netdev
+++ b/build/images/scripts/start_ovs_netdev
@@ -80,6 +80,10 @@ trap "quit" INT TERM
 fix_ovs_ctl
 start_ovs
 
+# Restrict read permissions for "others"
+# See discussion in https://github.com/vmware-tanzu/antrea/issues/1292
+chmod 0640 $OVS_DB_FILE
+
 if [[ "$#" -ge 1 ]] && [[ "$1" == "--start-ovs-only" ]]; then
   exit 0
 fi


### PR DESCRIPTION
This patch removes "read" permissions for "others". The idea is to
improve security for OVSDB, which notably stores the PSK in plaintext
when using IPsec.

This is not perfect, as there is a time window between creation of the
db.conf file and the call to chmod.

See full discussion in #1292