### PR TITLE
[IPv6] adjust MTU for IPv6 overhead

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -577,18 +577,11 @@ func (i *Initializer) initNodeLocalConfig() error {
 		return fmt.Errorf("failed to get local IPNet:  %v", err)
 	}
 
-	mtu, err := i.getNodeMTU(localIntf)
-	if err != nil {
-		return err
-	}
-	klog.Infof("Setting Node MTU=%d", mtu)
-
 	i.nodeConfig = &config.NodeConfig{
 		Name:            nodeName,
 		OVSBridge:       i.ovsBridge,
 		DefaultTunName:  defaultTunInterfaceName,
 		NodeIPAddr:      localAddr,
-		NodeMTU:         mtu,
 		UplinkNetConfig: new(config.AdapterNetConfig)}
 
 	if i.networkConfig.TrafficEncapMode.IsNetworkPolicyOnly() {
@@ -619,25 +612,31 @@ func (i *Initializer) initNodeLocalConfig() error {
 				klog.V(2).Infof("Configure IPv6 Subnet CIDR %s on this Node", localSubnet.String())
 			}
 		}
-		return nil
+	} else {
+		// Spec.PodCIDR can be empty due to misconfiguration.
+		if node.Spec.PodCIDR == "" {
+			klog.Errorf("Spec.PodCIDR is empty for Node %s. Please make sure --allocate-node-cidrs is enabled "+
+				"for kube-controller-manager and --cluster-cidr specifies a sufficient CIDR range", nodeName)
+			return fmt.Errorf("CIDR string is empty for node %s", nodeName)
+		}
+		_, localSubnet, err := net.ParseCIDR(node.Spec.PodCIDR)
+		if err != nil {
+			klog.Errorf("Failed to parse subnet from CIDR string %s: %v", node.Spec.PodCIDR, err)
+			return err
+		}
+		if localSubnet.IP.To4() != nil {
+			i.nodeConfig.PodIPv4CIDR = localSubnet
+		} else {
+			i.nodeConfig.PodIPv6CIDR = localSubnet
+		}
 	}
 
-	// Spec.PodCIDR can be empty due to misconfiguration.
-	if node.Spec.PodCIDR == "" {
-		klog.Errorf("Spec.PodCIDR is empty for Node %s. Please make sure --allocate-node-cidrs is enabled "+
-			"for kube-controller-manager and --cluster-cidr specifies a sufficient CIDR range", nodeName)
-		return fmt.Errorf("CIDR string is empty for node %s", nodeName)
-	}
-	_, localSubnet, err := net.ParseCIDR(node.Spec.PodCIDR)
+	mtu, err := i.getNodeMTU(localIntf)
 	if err != nil {
-		klog.Errorf("Failed to parse subnet from CIDR string %s: %v", node.Spec.PodCIDR, err)
 		return err
 	}
-	if localSubnet.IP.To4() != nil {
-		i.nodeConfig.PodIPv4CIDR = localSubnet
-	} else {
-		i.nodeConfig.PodIPv6CIDR = localSubnet
-	}
+	i.nodeConfig.NodeMTU = mtu
+	klog.Infof("Setting Node MTU=%d", mtu)
 	return nil
 }
 
@@ -729,6 +728,9 @@ func (i *Initializer) getNodeMTU(localIntf *net.Interface) (int, error) {
 	}
 	if i.networkConfig.EnableIPSecTunnel {
 		mtu -= config.IpsecESPOverhead
+	}
+	if i.nodeConfig.PodIPv6CIDR != nil {
+		mtu -= config.IPv6ExtraOverhead
 	}
 	return mtu, nil
 }

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -39,7 +39,8 @@ const (
 	GREOverhead    = 38
 	// IPsec ESP can add a maximum of 38 bytes to the packet including the ESP
 	// header and trailer.
-	IpsecESPOverhead = 38
+	IpsecESPOverhead  = 38
+	IPv6ExtraOverhead = 20
 )
 
 type GatewayConfig struct {

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -301,6 +301,8 @@ func (c *client) InstallNodeFlows(hostname string,
 			flows = append(flows, c.arpResponderFlow(peerGatewayIP, cookie.Node))
 		}
 		if c.encapMode.NeedsEncapToPeer(tunnelPeerIP, c.nodeConfig.NodeIPAddr) {
+			// tunnelPeerIP is the Node Internal Address. In a dual-stack setup, whether this address is an IPv4 address or an
+			// IPv6 one is decided by the address family of Node Internal Address.
 			flows = append(flows, c.l3FwdFlowToRemote(localGatewayMAC, *peerPodCIDR, tunnelPeerIP, tunOFPort, cookie.Node))
 		} else {
 			flows = append(flows, c.l3FwdFlowToRemoteViaGW(localGatewayMAC, *peerPodCIDR, cookie.Node))


### PR DESCRIPTION
If MTU is too large for IPv6 environment, large packet with overhead 
IPv6ExtraOverhead, 20 is from observation of IPv4 and IPv6 packets under same situation.