### PR TITLE
Refresh gif image in getting-started.md

### DIFF
--- a/docs/cookbooks/multus/README.md
+++ b/docs/cookbooks/multus/README.md
@@ -59,7 +59,7 @@ git clone https://github.com/vmware-tanzu/antrea.git
 cd antrea
 cp docs/cookbooks/multus/test/Vagrantfile test/e2e/infra/vagrant/
 cd test/e2e/infra/vagrant
-./infra/vagrant/provision.sh
+./provision.sh
 ```
 
 The last command will take around 10 to 15 minutes to complete. After that, your

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ Antrea is super easy to install. All the Antrea components are
 containerized and can be installed using the Kubernetes deployment
 manifest.
 
-![antrea-demo](https://user-images.githubusercontent.com/2495809/71284428-8de47100-2317-11ea-86a0-f5ff673352ea.gif)
+![antrea-demo](https://user-images.githubusercontent.com/2495809/94325574-e7876500-ff53-11ea-9ecd-6dedef339fac.gif)
 
 ## Ensuring requirements are satisfied
 

--- a/docs/maintainers/getting-started-gif.md
+++ b/docs/maintainers/getting-started-gif.md
@@ -1,0 +1,11 @@
+To refresh the gif image included in [getting-started.md](/docs/getting-started.md), follow these
+steps:
+
+ * install [asciinema](https://asciinema.org/)
+ * set `PS1="> "` in your bash profile file (e.g. `.bashrc`, `zshrc`, ...) to simplify the prompt
+ * record the cast with the correct shell, e.g. `SHELL=zsh asciinema rec my.cast`
+ * convert the cast file to a gif file: `docker run --rm -v $PWD:/data -w /data asciinema/asciicast2gif -s 3 -w 120 -h 20 my.cast my.gif`
+ * upload the gif file to Github's CDN by following these
+   [instructions](https://gist.github.com/vinkla/dca76249ba6b73c5dd66a4e986df4c8d)
+ * update the link in [getting-started.md](/docs/getting-started.md) by opening
+   a PR

--- a/pkg/agent/flowexporter/connections/connections.go
+++ b/pkg/agent/flowexporter/connections/connections.go
@@ -122,9 +122,9 @@ func (cs *ConnectionStore) addOrUpdateConn(conn *flowexporter.Connection) {
 			conn.DestinationPodNamespace = dIface.ContainerInterfaceConfig.PodNamespace
 		}
 		// Do not export flow records of connections whose destination is local Pod and source is remote Pod.
-		// We export flow records only form "source node", where the connection is originated from. This is to avoid
+		// We export flow records only from "source node", where the connection is originated from. This is to avoid
 		// 2 copies of flow records at flow collector. This restriction will be removed when flow records store network policy rule ID.
-		// TODO: Remove this when network policy rule ID are added to flow records.
+		// TODO: Remove this when network policy rule IDs are added to flow records.
 		if !srcFound && dstFound {
 			conn.DoExport = false
 		}

--- a/pkg/agent/util/sysctl/sysctl_linux.go
+++ b/pkg/agent/util/sysctl/sysctl_linux.go
@@ -42,15 +42,17 @@ func GetSysctlNet(sysctl string) (int, error) {
 	return val, nil
 }
 
-// SetSysctlNet modifies the specified sysctl nt.* settings to the new value
+// SetSysctlNet sets the specified sysctl net.* parameter to the new value.
 func SetSysctlNet(sysctl string, newVal int) error {
 	return ioutil.WriteFile(path.Join(sysctlNet, sysctl), []byte(strconv.Itoa(newVal)), 0640)
 }
 
+// EnsureSysctlNetValue checks if the specified sysctl net.* parameter is already set to the
+// provided value, and if not, it makes it so.
 func EnsureSysctlNetValue(sysctl string, value int) error {
 	val, err := GetSysctlNet(sysctl)
 	if err != nil {
-		// If permission error, please provide access to sysctl setting_
+		// If permission error, please provide access to sysctl setting
 		klog.Errorf("Error when getting %s: %v", sysctl, err)
 		return err
 	} else if val != value {


### PR DESCRIPTION
To show the latest version of Antrea (v0.10.0) and avoid using Kind as
the example cluster (confusing because Kind requires a different Antrea
YAML manifest).

Also fix a few typos I found over the last couple of weeks.