### PR TITLE
Update documentation for e2e tests on kind cluster

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -151,6 +151,15 @@ manifest to the master Docker container:
 go test -v github.com/vmware-tanzu/antrea/test/e2e -provider=kind
 ```
 
+As part of code development, if you want to run the tests with local changes,
+then make the code changes on the local repo and
+[build the image](/CONTRIBUTING.md#building-and-testing-your-change).
+You can load the new image into the kind cluster using the command below:
+
+```
+kind load docker-image antrea/antrea-ubuntu:latest --name <kind_cluster_name>
+```
+
 ## Running the performance test
 To run all benchmarks, without the standard e2e tests:
 ```bash


### PR DESCRIPTION
Add details on running the e2e tests on a kind cluster
with the local Antrea image.

Felt these additional details in the documentation for dev process on kind cluster.