### PR TITLE
Cache licensing info about dependencies in golicense workflow

### DIFF
--- a/.github/workflows/golicense.yml
+++ b/.github/workflows/golicense.yml
@@ -13,7 +13,23 @@ on:
       - created
 
 jobs:
+  check-changes:
+    name: Check whether tests need to be run based on diff
+    runs-on: [ubuntu-18.04]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: vmware-tanzu/antrea/ci/gh-actions/has-changes@master
+      id: check_diff
+      with:
+        args: docs/* ci/jenkins/* *.md
+    outputs:
+      has_changes: ${{ steps.check_diff.outputs.has_changes }}
+
   golicense:
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name != 'pull_request' }}
     runs-on: [ubuntu-latest]
     steps:
     - name: Set up Go 1.13

--- a/.github/workflows/golicense.yml
+++ b/.github/workflows/golicense.yml
@@ -4,8 +4,6 @@ on:
     branches:
     - master
     - release-*
-    paths:
-    - '**go.mod'
   push:
     branches:
     - master

--- a/.github/workflows/golicense.yml
+++ b/.github/workflows/golicense.yml
@@ -23,7 +23,15 @@ jobs:
       with:
         go-version: 1.13
     - uses: actions/checkout@v2
-    - run: mkdir antrea-bins license-reports
+    - name: Cache licensing information for dependencies
+      uses: actions/cache@v2
+      id: cache
+      env:
+        cache-name: cache-deps-licensing-info
+      with:
+        path: license-reports
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/go.sum') }}
+    - run: mkdir antrea-bins
     - name: Build assets
       run: |
         export VERSION="$(head VERSION)"
@@ -31,6 +39,14 @@ jobs:
     - name: Build Linux binaries
       run: BINDIR=./antrea-bins make bin
     - name: Run golicense
+      if: steps.cache.outputs.cache-hit != 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: ./ci/golicense/run.sh ./antrea-bins ./license-reports
+      run: |
+        mkdir license-reports
+        ./ci/golicense/run.sh ./antrea-bins ./license-reports
+    - name: Upload licensing information
+      uses: actions/upload-artifact@v1
+      with:
+        name: licenses.deps
+        path: license-reports/ALL.deps.txt


### PR DESCRIPTION
The golicense workflow makes a lot of Github API calls and very often
runs into the limit for Github actions (1,000) which slows down the
workflow considerably and may even impact other workflows.

This enables caching for the workflow, using a hash of all the go.sum
files for the repo as the cache key, to avoid running the golicense tool
unless it is necessary. However, we always build the binary assets, as
this workflow is also meant to verify that
hack/release/prepare-assets.sh is not broken.

Fixes #1303