### PR TITLE
[IPv6] E2e bug fixes

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -1194,19 +1194,12 @@ func (data *TestData) runPingCommandFromTestPod(podName string, targetPodIPs *Po
 }
 
 func (data *TestData) runNetcatCommandFromTestPod(podName string, server string, port int) error {
-	var cmdStr string
 	// Retrying several times to avoid flakes as the test may involve DNS (coredns) and Service/Endpoints (kube-proxy).
-	if net.ParseIP(server).To4() != nil {
-		cmdStr = fmt.Sprintf("for i in $(seq 1 5); do nc -vz -w 4 %s %d && exit 0 || sleep 1; done; exit 1",
-			server, port)
-	} else {
-		cmdStr = fmt.Sprintf("for i in $(seq 1 5); do nc -vz -w 4 -6 %s %d && exit 0 || sleep 1; done; exit 1",
-			server, port)
-	}
 	cmd := []string{
 		"/bin/sh",
 		"-c",
-		cmdStr,
+		fmt.Sprintf("for i in $(seq 1 5); do nc -vz -w 4 %s %d && exit 0 || sleep 1; done; exit 1",
+			server, port),
 	}
 	stdout, stderr, err := data.runCommandFromPod(testNamespace, podName, busyboxContainerName, cmd)
 	if err == nil {

--- a/test/e2e/security_test.go
+++ b/test/e2e/security_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"testing"
@@ -173,7 +174,13 @@ func testCert(t *testing.T, data *TestData, expectedCABundle string, restartPod 
 		}
 		trans, _ := restclient.TransportFor(&clientConfig)
 		hc := &http.Client{Transport: trans, Timeout: 5 * time.Second}
-		req, err := http.NewRequest("GET", fmt.Sprintf("https://%s:%d/healthz", antreaController.Status.PodIP, apis.AntreaControllerAPIPort), nil)
+		var reqURL string
+		if net.ParseIP(antreaController.Status.PodIP).To4() != nil {
+			reqURL = fmt.Sprintf("https://%s:%d/healthz", antreaController.Status.PodIP, apis.AntreaControllerAPIPort)
+		} else {
+			reqURL = fmt.Sprintf("https://[%s]:%d/healthz", antreaController.Status.PodIP, apis.AntreaControllerAPIPort)
+		}
+		req, err := http.NewRequest("GET", reqURL, nil)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
1. No -6 option in busybox nc
So, no need to distinguish if it is an IPv6 environment for runNetcatCommandFromTestPod()
nc
BusyBox v1.31.1 (2019-10-28 18:40:01 UTC) multi-call binary.

Usage: nc [OPTIONS] HOST PORT  - connect
nc [OPTIONS] -l -p PORT [HOST] [PORT]  - listen

	-e PROG	Run PROG after connect (must be last)
	-l	Listen mode, for inbound connects
	-lk	With -e, provides persistent server
	-p PORT	Local port
	-s ADDR	Local address
	-w SEC	Timeout for connects and final net reads
	-i SEC	Delay interval for lines sent
	-n	Don't do DNS resolution
	-u	UDP mode
	-v	Verbose
	-o FILE	Hex dump traffic
	-z	Zero-I/O mode (scanning)
2. testCert
* IPv6 address should be in "[]"
* CA bundle verification takes a long time, usually 100+ second on Kind or Jenkins. Increase interval to 20 second.