### PR TITLE
Fix indentation of egress field in ACNP yamls

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -91,44 +91,44 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
-              ingress:
+              egress:
                 items:
-                  egress:
-                    items:
-                      properties:
-                        action:
-                          enum:
-                          - Allow
-                          - Drop
-                          type: string
-                        ports:
-                          items:
+                  properties:
+                    action:
+                      enum:
+                      - Allow
+                      - Drop
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      items:
+                        properties:
+                          ipBlock:
                             properties:
-                              port:
-                                x-kubernetes-int-or-string: true
-                              protocol:
+                              cidr:
+                                format: cidr
                                 type: string
                             type: object
-                          type: array
-                        to:
-                          items:
-                            properties:
-                              ipBlock:
-                                properties:
-                                  cidr:
-                                    format: cidr
-                                    type: string
-                                type: object
-                              namespaceSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                              podSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                          type: array
-                      required:
-                      - action
-                      type: object
-                    type: array
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                items:
                   properties:
                     action:
                       enum:
@@ -137,21 +137,6 @@ spec:
                       type: string
                     from:
                       items:
-                        from:
-                          items:
-                            properties:
-                              ipBlock:
-                                properties:
-                                  cidr:
-                                    format: cidr
-                                    type: string
-                                type: object
-                              namespaceSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                              podSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                          type: array
                         properties:
                           ipBlock:
                             properties:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -140,9 +140,8 @@ spec:
                         properties:
                           ipBlock:
                             properties:
-                              port:
-                                x-kubernetes-int-or-string: true
-                              protocol:
+                              cidr:
+                                format: cidr
                                 type: string
                             type: object
                           namespaceSelector:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -91,44 +91,44 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
-              ingress:
+              egress:
                 items:
-                  egress:
-                    items:
-                      properties:
-                        action:
-                          enum:
-                          - Allow
-                          - Drop
-                          type: string
-                        ports:
-                          items:
+                  properties:
+                    action:
+                      enum:
+                      - Allow
+                      - Drop
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      items:
+                        properties:
+                          ipBlock:
                             properties:
-                              port:
-                                x-kubernetes-int-or-string: true
-                              protocol:
+                              cidr:
+                                format: cidr
                                 type: string
                             type: object
-                          type: array
-                        to:
-                          items:
-                            properties:
-                              ipBlock:
-                                properties:
-                                  cidr:
-                                    format: cidr
-                                    type: string
-                                type: object
-                              namespaceSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                              podSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                          type: array
-                      required:
-                      - action
-                      type: object
-                    type: array
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                items:
                   properties:
                     action:
                       enum:
@@ -137,21 +137,6 @@ spec:
                       type: string
                     from:
                       items:
-                        from:
-                          items:
-                            properties:
-                              ipBlock:
-                                properties:
-                                  cidr:
-                                    format: cidr
-                                    type: string
-                                type: object
-                              namespaceSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                              podSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                          type: array
                         properties:
                           ipBlock:
                             properties:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -140,9 +140,8 @@ spec:
                         properties:
                           ipBlock:
                             properties:
-                              port:
-                                x-kubernetes-int-or-string: true
-                              protocol:
+                              cidr:
+                                format: cidr
                                 type: string
                             type: object
                           namespaceSelector:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -91,44 +91,44 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
-              ingress:
+              egress:
                 items:
-                  egress:
-                    items:
-                      properties:
-                        action:
-                          enum:
-                          - Allow
-                          - Drop
-                          type: string
-                        ports:
-                          items:
+                  properties:
+                    action:
+                      enum:
+                      - Allow
+                      - Drop
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      items:
+                        properties:
+                          ipBlock:
                             properties:
-                              port:
-                                x-kubernetes-int-or-string: true
-                              protocol:
+                              cidr:
+                                format: cidr
                                 type: string
                             type: object
-                          type: array
-                        to:
-                          items:
-                            properties:
-                              ipBlock:
-                                properties:
-                                  cidr:
-                                    format: cidr
-                                    type: string
-                                type: object
-                              namespaceSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                              podSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                          type: array
-                      required:
-                      - action
-                      type: object
-                    type: array
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                items:
                   properties:
                     action:
                       enum:
@@ -137,21 +137,6 @@ spec:
                       type: string
                     from:
                       items:
-                        from:
-                          items:
-                            properties:
-                              ipBlock:
-                                properties:
-                                  cidr:
-                                    format: cidr
-                                    type: string
-                                type: object
-                              namespaceSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                              podSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                          type: array
                         properties:
                           ipBlock:
                             properties:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -140,9 +140,8 @@ spec:
                         properties:
                           ipBlock:
                             properties:
-                              port:
-                                x-kubernetes-int-or-string: true
-                              protocol:
+                              cidr:
+                                format: cidr
                                 type: string
                             type: object
                           namespaceSelector:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -91,44 +91,44 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
-              ingress:
+              egress:
                 items:
-                  egress:
-                    items:
-                      properties:
-                        action:
-                          enum:
-                          - Allow
-                          - Drop
-                          type: string
-                        ports:
-                          items:
+                  properties:
+                    action:
+                      enum:
+                      - Allow
+                      - Drop
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      items:
+                        properties:
+                          ipBlock:
                             properties:
-                              port:
-                                x-kubernetes-int-or-string: true
-                              protocol:
+                              cidr:
+                                format: cidr
                                 type: string
                             type: object
-                          type: array
-                        to:
-                          items:
-                            properties:
-                              ipBlock:
-                                properties:
-                                  cidr:
-                                    format: cidr
-                                    type: string
-                                type: object
-                              namespaceSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                              podSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                          type: array
-                      required:
-                      - action
-                      type: object
-                    type: array
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                items:
                   properties:
                     action:
                       enum:
@@ -137,21 +137,6 @@ spec:
                       type: string
                     from:
                       items:
-                        from:
-                          items:
-                            properties:
-                              ipBlock:
-                                properties:
-                                  cidr:
-                                    format: cidr
-                                    type: string
-                                type: object
-                              namespaceSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                              podSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                          type: array
                         properties:
                           ipBlock:
                             properties:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -140,9 +140,8 @@ spec:
                         properties:
                           ipBlock:
                             properties:
-                              port:
-                                x-kubernetes-int-or-string: true
-                              protocol:
+                              cidr:
+                                format: cidr
                                 type: string
                             type: object
                           namespaceSelector:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -91,44 +91,44 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
-              ingress:
+              egress:
                 items:
-                  egress:
-                    items:
-                      properties:
-                        action:
-                          enum:
-                          - Allow
-                          - Drop
-                          type: string
-                        ports:
-                          items:
+                  properties:
+                    action:
+                      enum:
+                      - Allow
+                      - Drop
+                      type: string
+                    ports:
+                      items:
+                        properties:
+                          port:
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      items:
+                        properties:
+                          ipBlock:
                             properties:
-                              port:
-                                x-kubernetes-int-or-string: true
-                              protocol:
+                              cidr:
+                                format: cidr
                                 type: string
                             type: object
-                          type: array
-                        to:
-                          items:
-                            properties:
-                              ipBlock:
-                                properties:
-                                  cidr:
-                                    format: cidr
-                                    type: string
-                                type: object
-                              namespaceSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                              podSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                          type: array
-                      required:
-                      - action
-                      type: object
-                    type: array
+                          namespaceSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                          podSelector:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                items:
                   properties:
                     action:
                       enum:
@@ -137,21 +137,6 @@ spec:
                       type: string
                     from:
                       items:
-                        from:
-                          items:
-                            properties:
-                              ipBlock:
-                                properties:
-                                  cidr:
-                                    format: cidr
-                                    type: string
-                                type: object
-                              namespaceSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                              podSelector:
-                                x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                          type: array
                         properties:
                           ipBlock:
                             properties:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -140,9 +140,8 @@ spec:
                         properties:
                           ipBlock:
                             properties:
-                              port:
-                                x-kubernetes-int-or-string: true
-                              protocol:
+                              cidr:
+                                format: cidr
                                 type: string
                             type: object
                           namespaceSelector:

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -335,56 +335,41 @@ spec:
                                   type: string
                                 port:
                                   x-kubernetes-int-or-string: true
-                          from:
-                            type: array
-                            items:
+                egress:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - action
+                    properties:
+                      # Ensure that Action field allows only ALLOW and DROP values
+                      action:
+                        type: string
+                        enum: ['Allow', 'Drop']
+                      ports:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            protocol:
+                              type: string
+                            port:
+                              x-kubernetes-int-or-string: true
+                      to:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            podSelector:
+                              x-kubernetes-preserve-unknown-fields: true
+                            namespaceSelector:
+                              x-kubernetes-preserve-unknown-fields: true
+                            ipBlock:
                               type: object
                               properties:
-                                podSelector:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                namespaceSelector:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                ipBlock:
-                                  type: object
-                                  properties:
-                                    cidr:
-                                      type: string
-                                      format: cidr
-                    egress:
-                      type: array
-                      items:
-                        type: object
-                        required:
-                          - action
-                        properties:
-                          # Ensure that Action field allows only ALLOW and DROP values
-                          action:
-                            type: string
-                            enum: ['Allow', 'Drop']
-                          ports:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                protocol:
+                                cidr:
                                   type: string
-                                port:
-                                  x-kubernetes-int-or-string: true
-                          to:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                podSelector:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                namespaceSelector:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                ipBlock:
-                                  type: object
-                                  properties:
-                                    cidr:
-                                      type: string
-                                      format: cidr
+                                  format: cidr
   scope: Cluster
   names:
     plural: clusternetworkpolicies

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -331,10 +331,9 @@ spec:
                             ipBlock:
                               type: object
                               properties:
-                                protocol:
+                                cidr:
                                   type: string
-                                port:
-                                  x-kubernetes-int-or-string: true
+                                  format: cidr
                 egress:
                   type: array
                   items:

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -106,7 +106,6 @@ func skipIfAntreaPolicyDisabled(tb testing.TB, data *TestData) {
 	if !enabled {
 		tb.Skipf("Skipping test as it required CNP to be enabled")
 	}
-	tb.Skipf("Skipping test temporarily. Unskip with PR #1237")
 }
 
 func applyDefaultDenyToAllNamespaces(k8s *KubernetesUtils, namespaces []string) error {


### PR DESCRIPTION
This causes validation errors in ClusterNetworkPolicies when egress rules are specified. In addition to the fix to validation also
re-enable Antrea NetworkPolicy e2e tests.