### PR TITLE
Add introductions of features to getting-started and architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The Antrea community welcomes new contributors. We are waiting for your PRs!
 [Code of Conduct](CODE_OF_CONDUCT.md).
 * Check out the Antrea [Contributor Guide](/CONTRIBUTING.md) for information
 about setting up your development environment and our contribution workflow.
-* Learn about Antrea's [Architecture and design](/docs/architecture.md).
+* Learn about Antrea's [Architecture and Design](/docs/architecture.md).
 Your feedback is more than welcome!
 * Check out [Open Issues](https://github.com/vmware-tanzu/antrea/issues).
 * Join the [Kubernetes Slack](http://slack.k8s.io/) and look for our

--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -1,4 +1,4 @@
-# Antrea Policy CRDs
+# Antrea Network Policy CRDs
 
 ## Table of Contents
 

--- a/docs/eks-terraform.md
+++ b/docs/eks-terraform.md
@@ -1,7 +1,7 @@
-# Deploying Antrea on a cloud provider
+# Deploying EKS with Antrea
 
-Antrea may run in networkPolicyOnly mode in some cloud managed clusters. This document describes
- steps to create EKS using terraform.
+Antrea may run in networkPolicyOnly mode in AKS and EKS clusters. This document
+describes the steps to create an EKS cluster with Antrea using terraform.
 
 ## Common Prerequisites
 1. To run EKS cluster, install and configure AWS cli(either version 1 or 2), see

--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -65,7 +65,7 @@ handled by Antrea controller. `ClusterNetworkPolicy` is an Antrea-specific exten
 NetworkPolicies, which enables cluster admins to define security policies which
 apply to the entire cluster. `Antrea NetworkPolicy` also complements K8s NetworkPolicies
 by supporting policy priorities and rule actions.
-Refer to this [document](network-policy.md) for more information.
+Refer to this [document](antrea-network-policy.md) for more information.
 
 #### Requirements for this Feature
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,4 +1,4 @@
-# Getting started
+# Getting Started
 
 Antrea is super easy to install. All the Antrea components are
 containerized and can be installed using the Kubernetes deployment
@@ -124,11 +124,6 @@ cluster, and enforce NetworkPolicies for the cluster.
 * To deploy Antrea in an EKS cluster, please refer to [the EKS installation guide](/docs/eks-installation.md).
 * To deploy Antrea in a GKE cluster, please refer to [the GKE installation guide](/docs/gke-installation.md).
 
-### Deploying Antrea with IPsec Encryption
-
-Antrea supports encrypting GRE tunnel traffic with IPsec. To deploy Antrea with
-IPsec encryption enabled, please refer to this [guide](/docs/ipsec-tunnel.md).
-
 ### Deploying Antrea with Custom Certificates
 
 By default, Antrea generates the certificates needed for itself to run. To
@@ -138,3 +133,41 @@ provide your own certificates, please refer to [Securing Control Plane](/docs/se
 
 To use antctl, the Antrea command-line tool, please refer to this
 [guide](/docs/antctl.md).
+
+## Features
+
+### Antrea Network Policy
+Besides Kubernetes NetworkPolicy, Antrea also implements its own Network Policy
+CRDs, which provide advanced features including: policy priority, tiering, deny
+action, external entity, and policy statistics. For more information on usage of
+Antrea Network Policies, refer to the [Antrea Network Policy document](antrea-network-policy.md).
+
+### IPsec Encryption
+Antrea supports encrypting GRE tunnel traffic with IPsec. To deploy Antrea with
+IPsec encryption enabled, please refer to [this guide](/docs/ipsec-tunnel.md).
+
+### Network Flow Visibility
+Antrea supports exporting network flow information using IPFIX, and provides a
+reference cookbook on how to visualize the exported network flows using Elastic
+Stack and Kibana dashboards. For more information, refer to the [network flow
+visibility document](network-flow-visibility.md).
+
+### Octant UI
+Antrea ships with an Octant UI plugin which can show runtime information of Antrea
+components and perform Antrea Traceflow operations. Refer to [this guide](octant-plugin-installation.md)
+to learn how to install Octant and the Antrea plugin.
+
+### OVS Hardware Offload
+Antrea can offload OVS flow processing to the NICs that support OVS kernel
+hardware offload using TC. The hardware offload can improve OVS performance
+significantly. For more information on how to configure OVS offload, refer to
+the [OVS hardware offload guide](ovs-offload.md).
+
+### Prometheus Metrics
+Antrea supports exporting metrics to Prometheus. For more information, refer to
+the [Prometheus integration document](prometheus-integration.md).
+
+### Traceflow
+Traceflow is a very useful network diagnosis feature in Antrea. It can trace
+and report the forwarding path of a specified packet in the Antrea network.
+For usage of this feature, refer to the [Traceflow user guide](traceflow-guide.md).

--- a/docs/ovs-pipeline.md
+++ b/docs/ovs-pipeline.md
@@ -124,7 +124,7 @@ you will see these addresses show up in the OVS flows.
 ## Antrea Network Policy CRD Implementation
 
 In addition to the above tables created for K8s NetworkPolicy, Antrea creates
-additional dedicated tables to support the [ClusterNetworkPolicy](network-policy.md) CRD
+additional dedicated tables to support the [ClusterNetworkPolicy](antrea-network-policy.md) CRD
 ([CnpEgressRuleTables] and [CnpIngressRuleTables]).
 
 Consider the following ClusterNetworkPolicy in the Application tier as an


### PR DESCRIPTION
Add introductions and doc links of different features.
Rename cloud.md to eks-terraform.md, and network-policy.md to
antrea-network-policy.md.