### PR TITLE
Upgrade the Kind version used for CI

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -11,6 +11,9 @@ on:
     - release-*
     - ipv6
 
+env:
+  KIND_VERSION: v0.9.0
+
 jobs:
   check-changes:
     name: Check whether tests need to be run based on diff
@@ -63,8 +66,6 @@ jobs:
     - name: Load Antrea image
       run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
     - name: Install Kind
-      env:
-        KIND_VERSION: v0.9.0
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
         chmod +x ./kind
@@ -119,8 +120,6 @@ jobs:
     - name: Load Antrea image
       run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
     - name: Install Kind
-      env:
-        KIND_VERSION: v0.9.0
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
         chmod +x ./kind
@@ -175,8 +174,6 @@ jobs:
     - name: Load Antrea image
       run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
     - name: Install Kind
-      env:
-        KIND_VERSION: v0.9.0
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
         chmod +x ./kind
@@ -231,8 +228,6 @@ jobs:
     - name: Load Antrea image
       run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
     - name: Install Kind
-      env:
-        KIND_VERSION: v0.9.0
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
         chmod +x ./kind
@@ -287,8 +282,6 @@ jobs:
     - name: Load Antrea image
       run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
     - name: Install Kind
-      env:
-        KIND_VERSION: v0.9.0
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
         chmod +x ./kind
@@ -359,8 +352,6 @@ jobs:
     - name: Load Antrea image
       run:  docker load -i antrea-ubuntu-netpol/antrea-ubuntu-netpol.tar
     - name: Install Kind
-      env:
-        KIND_VERSION: v0.9.0
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
         chmod +x ./kind
@@ -393,8 +384,6 @@ jobs:
       - name: Load Antrea image
         run:  docker load -i antrea-ubuntu-netpol/antrea-ubuntu-netpol.tar
       - name: Install Kind
-        env:
-          KIND_VERSION: v0.9.0
         run: |
           curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
           chmod +x ./kind

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -394,7 +394,7 @@ jobs:
         run:  docker load -i antrea-ubuntu-netpol/antrea-ubuntu-netpol.tar
       - name: Install Kind
         env:
-          KIND_VERSION: v0.7.0
+          KIND_VERSION: v0.9.0
         run: |
           curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
           chmod +x ./kind

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -64,7 +64,7 @@ jobs:
       run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
     - name: Install Kind
       env:
-        KIND_VERSION: v0.7.0
+        KIND_VERSION: v0.9.0
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
         chmod +x ./kind
@@ -120,7 +120,7 @@ jobs:
       run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
     - name: Install Kind
       env:
-        KIND_VERSION: v0.7.0
+        KIND_VERSION: v0.9.0
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
         chmod +x ./kind
@@ -176,7 +176,7 @@ jobs:
       run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
     - name: Install Kind
       env:
-        KIND_VERSION: v0.7.0
+        KIND_VERSION: v0.9.0
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
         chmod +x ./kind
@@ -232,7 +232,7 @@ jobs:
       run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
     - name: Install Kind
       env:
-        KIND_VERSION: v0.7.0
+        KIND_VERSION: v0.9.0
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
         chmod +x ./kind
@@ -288,7 +288,7 @@ jobs:
       run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
     - name: Install Kind
       env:
-        KIND_VERSION: v0.7.0
+        KIND_VERSION: v0.9.0
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
         chmod +x ./kind
@@ -360,7 +360,7 @@ jobs:
       run:  docker load -i antrea-ubuntu-netpol/antrea-ubuntu-netpol.tar
     - name: Install Kind
       env:
-        KIND_VERSION: v0.7.0
+        KIND_VERSION: v0.9.0
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
         chmod +x ./kind

--- a/.github/workflows/kind_upgrade.yml
+++ b/.github/workflows/kind_upgrade.yml
@@ -9,6 +9,9 @@ on:
     - master
     - release-*
 
+env:
+  KIND_VERSION: v0.9.0
+
 jobs:
   check-changes:
     name: Check whether tests need to be run based on diff
@@ -63,8 +66,6 @@ jobs:
     - name: Load Antrea image
       run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
     - name: Install Kind
-      env:
-        KIND_VERSION: v0.9.0
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
         chmod +x ./kind
@@ -94,8 +95,6 @@ jobs:
     - name: Load Antrea image
       run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
     - name: Install Kind
-      env:
-        KIND_VERSION: v0.9.0
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
         chmod +x ./kind
@@ -125,8 +124,6 @@ jobs:
       - name: Load Antrea image
         run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
       - name: Install Kind
-        env:
-          KIND_VERSION: v0.9.0
         run: |
           curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
           chmod +x ./kind
@@ -156,8 +153,6 @@ jobs:
       - name: Load Antrea image
         run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
       - name: Install Kind
-        env:
-          KIND_VERSION: v0.9.0
         run: |
           curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
           chmod +x ./kind

--- a/.github/workflows/kind_upgrade.yml
+++ b/.github/workflows/kind_upgrade.yml
@@ -64,7 +64,7 @@ jobs:
       run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
     - name: Install Kind
       env:
-        KIND_VERSION: v0.7.0
+        KIND_VERSION: v0.9.0
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
         chmod +x ./kind
@@ -95,7 +95,7 @@ jobs:
       run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
     - name: Install Kind
       env:
-        KIND_VERSION: v0.7.0
+        KIND_VERSION: v0.9.0
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
         chmod +x ./kind
@@ -126,7 +126,7 @@ jobs:
         run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
       - name: Install Kind
         env:
-          KIND_VERSION: v0.7.0
+          KIND_VERSION: v0.9.0
         run: |
           curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
           chmod +x ./kind
@@ -157,7 +157,7 @@ jobs:
         run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
       - name: Install Kind
         env:
-          KIND_VERSION: v0.7.0
+          KIND_VERSION: v0.9.0
         run: |
           curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
           chmod +x ./kind

--- a/build/images/ethtool/Dockerfile
+++ b/build/images/ethtool/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:18.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
-LABEL description="A Docker image based on Ubuntu 18.04 which includes ethtool and ip tools."
+LABEL description="A Docker image based on Ubuntu 18.04 which includes ethtool, ip tools and iptables."
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ethtool iproute2 && \
+    apt-get install -y --no-install-recommends ethtool iproute2 iptables && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/*

--- a/build/images/ethtool/README.md
+++ b/build/images/ethtool/README.md
@@ -1,7 +1,7 @@
 # images/ethtool
 
 This Docker image is a very lightweight image based on Ubuntu 18.04 which
-includes ethtool and the ip tools.
+includes ethtool, the ip tools and iptables.
 
 If you need to build a new version of the image and push it to Dockerhub, you
 can run the following:

--- a/ci/kind/config-2nodes.yml
+++ b/ci/kind/config-2nodes.yml
@@ -1,5 +1,5 @@
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   disableDefaultCNI: true
   podSubnet: 10.10.0.0/16

--- a/ci/kind/config-3nodes.yml
+++ b/ci/kind/config-3nodes.yml
@@ -1,5 +1,5 @@
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   disableDefaultCNI: true
   podSubnet: 10.10.0.0/16

--- a/ci/kind/kind-setup.sh
+++ b/ci/kind/kind-setup.sh
@@ -52,8 +52,8 @@ where:
   --prometheus: enable Prometheus metrics listener for Antrea Controller and Agents, default is false
   --num-workers: specifies number of worker nodes in kind cluster, default is $NUM_WORKERS
   --images: specifies images loaded to kind cluster, default is $IMAGES
-  --subnets: a subnet creates a separate docker bridge network with assigned subnet that worker nodes may connect to. Default is empty all worker
-    Node connected to docker0 bridge network
+  --subnets: a subnet creates a separate docker bridge network (named 'antrea-<idx>') with assigned subnet that worker nodes may connect to. Default is empty: all worker
+    Node connected to default docker bridge network created by Kind.
 "
 
 function print_usage {
@@ -84,10 +84,10 @@ function modify {
 
 function configure_networks {
   echo "Configuring networks"
-  networks=$(docker network ls -f name=$CLUSTER_NAME --format '{{.Name}}')
+  networks=$(docker network ls -f name=antrea --format '{{.Name}}')
   networks="$(echo $networks)"
   if [[ -z $SUBNETS ]] && [[ -z $networks ]]; then
-    echo "Using default docker bridges"
+    echo "Using default kind docker network"
     return
   fi
 
@@ -105,7 +105,7 @@ function configure_networks {
   nodes="$(kind get nodes --name $CLUSTER_NAME | grep worker)"
   node_cnt=$(kind get nodes --name $CLUSTER_NAME | grep worker | wc -l)
   nodes=$(echo $nodes)
-  networks+=" bridge"
+  networks+=" kind"
   echo "removing worker nodes $nodes from networks $networks"
   for n in $networks; do
     rm_nodes=$(docker network inspect $n --format '{{range $i, $conf:=.Containers}}{{$conf.Name}} {{end}}')
@@ -115,7 +115,7 @@ function configure_networks {
         echo "disconnected worker $rn from network $n"
       fi
     done
-    if [[ $n != "bridge" ]]; then
+    if [[ $n != "kind" ]]; then
       docker network rm $n > /dev/null 2>&1
       echo "removed network $n"
     fi
@@ -125,7 +125,7 @@ function configure_networks {
   i=0
   networks=()
   for s in $SUBNETS; do
-    network=$CLUSTER_NAME-$i
+    network=antrea-$i
     echo "creating network $network with $s"
     docker network create -d bridge --subnet $s $network >/dev/null 2>&1
     networks+=($network)
@@ -134,7 +134,7 @@ function configure_networks {
 
   num_networks=${#networks[@]}
   if [[ $num_networks -eq 0 ]]; then
-    networks+=("bridge")
+    networks+=("kind")
     num_networks=$((num_networks+1))
   fi
 
@@ -177,7 +177,7 @@ function configure_networks {
 }
 
 function delete_networks {
-  networks=$(docker network ls -f name=$CLUSTER_NAME --format '{{.Name}}')
+  networks=$(docker network ls -f name=antrea --format '{{.Name}}')
   networks="$(echo $networks)"
   if [[ ! -z $networks ]]; then
     docker network rm $networks > /dev/null 2>&1
@@ -228,7 +228,7 @@ function create {
   config_file="/tmp/kind.yml"
   cat <<EOF > $config_file
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   disableDefaultCNI: true
   podSubnet: $POD_CIDR
@@ -241,7 +241,7 @@ EOF
   kind create cluster --name $CLUSTER_NAME --config $config_file
 
   # force coredns to run on control-plane node because it
-  # is attached to docker0 bridge and uses host dns.
+  # is attached to kind bridge and uses host dns.
   # Worker Node may be configured to attach to custom bridges
   # which use dockerd as dns, causing coredns to detect
   # dns loop and crash

--- a/ci/kind/kind-setup.sh
+++ b/ci/kind/kind-setup.sh
@@ -94,9 +94,9 @@ function configure_networks {
   # Inject allow all iptables to preempt docker bridge isolation rules
   if [[ ! -z $SUBNETS ]]; then
     set +e
-    sudo iptables -C DOCKER-USER -j ACCEPT > /dev/null 2>&1
+    docker run --net=host --privileged antrea/ethtool:latest iptables -C DOCKER-USER -j ACCEPT > /dev/null 2>&1
     if [[ $? -ne 0 ]]; then
-      sudo iptables -I DOCKER-USER -j ACCEPT
+      docker run --net=host --privileged antrea/ethtool:latest iptables -I DOCKER-USER -j ACCEPT
     fi
     set -e
   fi

--- a/docs/kind.md
+++ b/docs/kind.md
@@ -46,7 +46,7 @@ look like this:
 
 ```yaml
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   disableDefaultCNI: true
   podSubnet: 10.10.0.0/16


### PR DESCRIPTION
From v0.7.0 (K8s v1.17.0) to v0.9.0 (K8s v1.19.1).

In Kind v0.8.0, the default docker network for Nodes changed to "kind"
(user-defined docker bridge) instead of the default docker bridge
(docker0). Because of this, the kind-setup.sh script has to be updated
to use a different prefix ("kind-*" -> "antrea-*") when creating
additional user-defined bridges. We recommend that users of this script
delete their existing clusters and upgrade their Kind version to v0.9.0
before creating new clusters. The script should keep working with Kind
v0.7.0, but some manual clean-up of docker networks may be necessary for
existing clusters when using Antrea modes other than the default
"encap".