### PR TITLE
Add name of rule to CRDs

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -108,6 +108,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                     to:
                       items:
                         properties:
@@ -159,6 +161,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                   required:
                   - action
                   type: object
@@ -289,6 +293,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                     to:
                       items:
                         properties:
@@ -344,6 +350,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                   required:
                   - action
                   type: object

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -99,6 +99,8 @@ spec:
                       - Allow
                       - Drop
                       type: string
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -108,8 +110,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                     to:
                       items:
                         properties:
@@ -152,6 +152,8 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -161,8 +163,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                   required:
                   - action
                   type: object
@@ -284,6 +284,8 @@ spec:
                       - Allow
                       - Drop
                       type: string
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -293,8 +295,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                     to:
                       items:
                         properties:
@@ -341,6 +341,8 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -350,8 +352,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                   required:
                   - action
                   type: object

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -108,6 +108,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                     to:
                       items:
                         properties:
@@ -159,6 +161,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                   required:
                   - action
                   type: object
@@ -289,6 +293,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                     to:
                       items:
                         properties:
@@ -344,6 +350,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                   required:
                   - action
                   type: object

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -99,6 +99,8 @@ spec:
                       - Allow
                       - Drop
                       type: string
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -108,8 +110,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                     to:
                       items:
                         properties:
@@ -152,6 +152,8 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -161,8 +163,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                   required:
                   - action
                   type: object
@@ -284,6 +284,8 @@ spec:
                       - Allow
                       - Drop
                       type: string
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -293,8 +295,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                     to:
                       items:
                         properties:
@@ -341,6 +341,8 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -350,8 +352,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                   required:
                   - action
                   type: object

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -108,6 +108,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                     to:
                       items:
                         properties:
@@ -159,6 +161,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                   required:
                   - action
                   type: object
@@ -289,6 +293,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                     to:
                       items:
                         properties:
@@ -344,6 +350,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                   required:
                   - action
                   type: object

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -99,6 +99,8 @@ spec:
                       - Allow
                       - Drop
                       type: string
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -108,8 +110,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                     to:
                       items:
                         properties:
@@ -152,6 +152,8 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -161,8 +163,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                   required:
                   - action
                   type: object
@@ -284,6 +284,8 @@ spec:
                       - Allow
                       - Drop
                       type: string
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -293,8 +295,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                     to:
                       items:
                         properties:
@@ -341,6 +341,8 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -350,8 +352,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                   required:
                   - action
                   type: object

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -108,6 +108,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                     to:
                       items:
                         properties:
@@ -159,6 +161,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                   required:
                   - action
                   type: object
@@ -289,6 +293,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                     to:
                       items:
                         properties:
@@ -344,6 +350,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                   required:
                   - action
                   type: object

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -99,6 +99,8 @@ spec:
                       - Allow
                       - Drop
                       type: string
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -108,8 +110,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                     to:
                       items:
                         properties:
@@ -152,6 +152,8 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -161,8 +163,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                   required:
                   - action
                   type: object
@@ -284,6 +284,8 @@ spec:
                       - Allow
                       - Drop
                       type: string
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -293,8 +295,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                     to:
                       items:
                         properties:
@@ -341,6 +341,8 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -350,8 +352,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                   required:
                   - action
                   type: object

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -108,6 +108,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                     to:
                       items:
                         properties:
@@ -159,6 +161,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                   required:
                   - action
                   type: object
@@ -289,6 +293,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                     to:
                       items:
                         properties:
@@ -344,6 +350,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    ruleName:
+                      type: string
                   required:
                   - action
                   type: object

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -99,6 +99,8 @@ spec:
                       - Allow
                       - Drop
                       type: string
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -108,8 +110,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                     to:
                       items:
                         properties:
@@ -152,6 +152,8 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -161,8 +163,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                   required:
                   - action
                   type: object
@@ -284,6 +284,8 @@ spec:
                       - Allow
                       - Drop
                       type: string
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -293,8 +295,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                     to:
                       items:
                         properties:
@@ -341,6 +341,8 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
+                    name:
+                      type: string
                     ports:
                       items:
                         properties:
@@ -350,8 +352,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    ruleName:
-                      type: string
                   required:
                   - action
                   type: object

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -338,6 +338,8 @@ spec:
                                 cidr:
                                   type: string
                                   format: cidr
+                      ruleName:
+                        type: string
                 egress:
                   type: array
                   items:
@@ -373,6 +375,8 @@ spec:
                                 cidr:
                                   type: string
                                   format: cidr
+                      ruleName:
+                        type: string
   scope: Cluster
   names:
     plural: clusternetworkpolicies
@@ -471,6 +475,8 @@ spec:
                                 cidr:
                                   type: string
                                   format: cidr
+                      ruleName:
+                        type: string
                 egress:
                   type: array
                   items:
@@ -508,6 +514,8 @@ spec:
                                 cidr:
                                   type: string
                                   format: cidr
+                      ruleName:
+                        type: string
   scope: Namespaced
   names:
     plural: networkpolicies

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -338,7 +338,7 @@ spec:
                                 cidr:
                                   type: string
                                   format: cidr
-                      ruleName:
+                      name:
                         type: string
                 egress:
                   type: array
@@ -375,7 +375,7 @@ spec:
                                 cidr:
                                   type: string
                                   format: cidr
-                      ruleName:
+                      name:
                         type: string
   scope: Cluster
   names:
@@ -475,7 +475,7 @@ spec:
                                 cidr:
                                   type: string
                                   format: cidr
-                      ruleName:
+                      name:
                         type: string
                 egress:
                   type: array
@@ -514,7 +514,7 @@ spec:
                                 cidr:
                                   type: string
                                   format: cidr
-                      ruleName:
+                      name:
                         type: string
   scope: Namespaced
   names:

--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -211,6 +211,7 @@ spec:
         ports:
           - protocol: TCP
             port: 8080
+        name: AllowFromFrontend
     egress:
       - action: Drop
         to:
@@ -219,6 +220,7 @@ spec:
         ports:
           - protocol: TCP
             port: 5978
+        name: DropToThirdParty
 ```
 
 **spec**: The ClusterNetworkPolicy `spec` has all the information needed to
@@ -251,6 +253,7 @@ default tier i.e. the "application" Tier.
 **ingress**: Each ClusterNetworkPolicy may consist of zero or more ordered
 set of ingress rules. Each rule, depending on the `action` field of the rule,
 allows or drops traffic which matches both the `from` and `ports` sections.
+Also, each rule has a `name` field which describes the intention of this rule.
 The example policy contains a single rule, which allows matched traffic on a
 single port, from one of two sources: the first specified by a `podSelector`
 and the second specified by a combination of a `podSelector` and a
@@ -260,9 +263,10 @@ be enforced in the order in which they are written.
 
 **egress**: Each ClusterNetworkPolicy may consist of zero or more ordered set
 of egress rules. Each rule, depending on the `action` field of the rule, allows
-or drops traffic which matches both the `to` and `ports` sections. The example
-policy contains a single rule, which drops matched traffic on a single port,
-to the 10.0.10.0/24 subnet specified by the `ipBlock` field.
+or drops traffic which matches both the `to` and `ports` sections. Also, each 
+rule has a `name` field which describes the intention of this rule.
+The example policy contains a single rule, which drops matched traffic on a 
+single port, to the 10.0.10.0/24 subnet specified by the `ipBlock` field. 
 **Note**: The order in which the egress rules are set matter, i.e. rules will
 be enforced in the order in which they are written.
 
@@ -368,6 +372,7 @@ spec:
         ports:
           - protocol: TCP
             port: 8080
+        name: AllowFromFrontend
     egress:
       - action: Drop
         to:
@@ -376,6 +381,7 @@ spec:
         ports:
           - protocol: TCP
             port: 5978
+        name: DropToThirdParty
 ```
 
 ### Key differences from Antrea ClusterNetworkPolicy

--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -253,7 +253,8 @@ default tier i.e. the "application" Tier.
 **ingress**: Each ClusterNetworkPolicy may consist of zero or more ordered
 set of ingress rules. Each rule, depending on the `action` field of the rule,
 allows or drops traffic which matches both the `from` and `ports` sections.
-Also, each rule has a `name` field which describes the intention of this rule.
+Also, each rule has an optional `name` field, which is unique within the policy 
+describing the intention of this rule.
 The example policy contains a single rule, which allows matched traffic on a
 single port, from one of two sources: the first specified by a `podSelector`
 and the second specified by a combination of a `podSelector` and a
@@ -263,8 +264,9 @@ be enforced in the order in which they are written.
 
 **egress**: Each ClusterNetworkPolicy may consist of zero or more ordered set
 of egress rules. Each rule, depending on the `action` field of the rule, allows
-or drops traffic which matches both the `to` and `ports` sections. Also, each 
-rule has a `name` field which describes the intention of this rule.
+or drops traffic which matches both the `to` and `ports` sections. 
+Also, each rule has an optional `name` field, which is unique within the policy 
+describing the intention of this rule.
 The example policy contains a single rule, which drops matched traffic on a 
 single port, to the 10.0.10.0/24 subnet specified by the `ipBlock` field. 
 **Note**: The order in which the egress rules are set matter, i.e. rules will

--- a/hack/netpol/go.sum
+++ b/hack/netpol/go.sum
@@ -10,7 +10,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v0.0.0-20160705203006-01aeca54ebda/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
-github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e h1:p1yVGRW3nmb85p1Sh1ZJSDm4A4iKLS5QNbvUHMgGu/M=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -31,7 +30,6 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v0.0.0-20160524151835-7d79101e329e/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
@@ -55,12 +53,9 @@ github.com/json-iterator/go v1.1.8 h1:QiWkFLKq0T7mpzwOTu6BzNDbfTE8OLrYhVKYMLF46O
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -82,7 +77,6 @@ github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -96,7 +90,6 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20181025213731-e84da0312774/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
@@ -132,10 +125,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20181011042414-1f849cf54d09/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
-google.golang.org/appengine v1.5.0 h1:KxkO13IPW4Lslp2bz+KHP2E3gtFlrIGNThxkZQ3g+4c=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/pkg/apis/security/v1alpha1/types.go
+++ b/pkg/apis/security/v1alpha1/types.go
@@ -77,6 +77,9 @@ type Rule struct {
 	// destinations.
 	// +optional
 	To []NetworkPolicyPeer `json:"to"`
+	// RuleName describes the intention of this rule.
+	// +optional
+	RuleName string `json:"ruleName"`
 }
 
 // NetworkPolicyPeer describes the grouping selector of workloads.

--- a/pkg/apis/security/v1alpha1/types.go
+++ b/pkg/apis/security/v1alpha1/types.go
@@ -77,9 +77,10 @@ type Rule struct {
 	// destinations.
 	// +optional
 	To []NetworkPolicyPeer `json:"to"`
-	// RuleName describes the intention of this rule.
+	// Name describes the intention of this rule.
+	// Name should be unique within the policy.
 	// +optional
-	RuleName string `json:"ruleName"`
+	Name string `json:"name"`
 }
 
 // NetworkPolicyPeer describes the grouping selector of workloads.


### PR DESCRIPTION
This PR add properties: name to each ingress or egreee rule of CRDs:

Add a name field at jsonPath:  .spec.ingress/egress[*].name to describe the intention of this rule

Fixes issue #1319 