### PR TITLE
Register consecutive priorities in batch

### DIFF
--- a/pkg/agent/controller/networkpolicy/cache_test.go
+++ b/pkg/agent/controller/networkpolicy/cache_test.go
@@ -28,6 +28,10 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane/v1beta1"
 )
 
+var (
+	k8sNPMaxPriority = int32(-1)
+)
+
 func TestAddressGroupIndexFunc(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -385,14 +389,26 @@ func TestRuleCacheReplaceNetworkPolicies(t *testing.T) {
 		ObjectMeta:      metav1.ObjectMeta{UID: "policy1"},
 		Rules:           []v1beta1.NetworkPolicyRule{*networkPolicyRule1},
 		AppliedToGroups: []string{"addressGroup1"},
+		SourceRef: &v1beta1.NetworkPolicyReference{
+			Type:      v1beta1.K8sNetworkPolicy,
+			Namespace: "ns1",
+			Name:      "name1",
+			UID:       "policy1",
+		},
 	}
 	networkPolicy2 := &v1beta1.NetworkPolicy{
 		ObjectMeta:      metav1.ObjectMeta{UID: "policy1"},
 		Rules:           []v1beta1.NetworkPolicyRule{*networkPolicyRule1},
 		AppliedToGroups: []string{"addressGroup2"},
+		SourceRef: &v1beta1.NetworkPolicyReference{
+			Type:      v1beta1.K8sNetworkPolicy,
+			Namespace: "ns1",
+			Name:      "name1",
+			UID:       "policy1",
+		},
 	}
-	rule1 := toRule(networkPolicyRule1, networkPolicy1)
-	rule2 := toRule(networkPolicyRule1, networkPolicy2)
+	rule1 := toRule(networkPolicyRule1, networkPolicy1, k8sNPMaxPriority)
+	rule2 := toRule(networkPolicyRule1, networkPolicy2, k8sNPMaxPriority)
 	tests := []struct {
 		name               string
 		rules              []*rule
@@ -530,14 +546,26 @@ func TestRuleCacheAddNetworkPolicy(t *testing.T) {
 		ObjectMeta:      metav1.ObjectMeta{UID: "policy1", Namespace: "ns1", Name: "name1"},
 		Rules:           nil,
 		AppliedToGroups: []string{"appliedToGroup1"},
+		SourceRef: &v1beta1.NetworkPolicyReference{
+			Type:      v1beta1.K8sNetworkPolicy,
+			Namespace: "ns1",
+			Name:      "name1",
+			UID:       "policy1",
+		},
 	}
 	networkPolicy2 := &v1beta1.NetworkPolicy{
 		ObjectMeta:      metav1.ObjectMeta{UID: "policy2", Namespace: "ns2", Name: "name2"},
 		Rules:           []v1beta1.NetworkPolicyRule{*networkPolicyRule1, *networkPolicyRule2},
 		AppliedToGroups: []string{"appliedToGroup1"},
+		SourceRef: &v1beta1.NetworkPolicyReference{
+			Type:      v1beta1.K8sNetworkPolicy,
+			Namespace: "ns2",
+			Name:      "name2",
+			UID:       "policy2",
+		},
 	}
-	rule1 := toRule(networkPolicyRule1, networkPolicy2)
-	rule2 := toRule(networkPolicyRule2, networkPolicy2)
+	rule1 := toRule(networkPolicyRule1, networkPolicy2, k8sNPMaxPriority)
+	rule2 := toRule(networkPolicyRule2, networkPolicy2, k8sNPMaxPriority)
 	tests := []struct {
 		name               string
 		args               *v1beta1.NetworkPolicy
@@ -904,20 +932,38 @@ func TestRuleCacheUpdateNetworkPolicy(t *testing.T) {
 		ObjectMeta:      metav1.ObjectMeta{UID: "policy1"},
 		Rules:           []v1beta1.NetworkPolicyRule{*networkPolicyRule1},
 		AppliedToGroups: []string{"addressGroup1"},
+		SourceRef: &v1beta1.NetworkPolicyReference{
+			Type:      v1beta1.K8sNetworkPolicy,
+			Namespace: "ns1",
+			Name:      "name1",
+			UID:       "policy1",
+		},
 	}
 	networkPolicy2 := &v1beta1.NetworkPolicy{
 		ObjectMeta:      metav1.ObjectMeta{UID: "policy1"},
 		Rules:           []v1beta1.NetworkPolicyRule{*networkPolicyRule1},
 		AppliedToGroups: []string{"addressGroup2"},
+		SourceRef: &v1beta1.NetworkPolicyReference{
+			Type:      v1beta1.K8sNetworkPolicy,
+			Namespace: "ns1",
+			Name:      "name1",
+			UID:       "policy1",
+		},
 	}
 	networkPolicy3 := &v1beta1.NetworkPolicy{
 		ObjectMeta:      metav1.ObjectMeta{UID: "policy1"},
 		Rules:           []v1beta1.NetworkPolicyRule{*networkPolicyRule1, *networkPolicyRule2},
 		AppliedToGroups: []string{"addressGroup1"},
+		SourceRef: &v1beta1.NetworkPolicyReference{
+			Type:      v1beta1.K8sNetworkPolicy,
+			Namespace: "ns1",
+			Name:      "name1",
+			UID:       "policy1",
+		},
 	}
-	rule1 := toRule(networkPolicyRule1, networkPolicy1)
-	rule2 := toRule(networkPolicyRule1, networkPolicy2)
-	rule3 := toRule(networkPolicyRule2, networkPolicy3)
+	rule1 := toRule(networkPolicyRule1, networkPolicy1, k8sNPMaxPriority)
+	rule2 := toRule(networkPolicyRule1, networkPolicy2, k8sNPMaxPriority)
+	rule3 := toRule(networkPolicyRule2, networkPolicy3, k8sNPMaxPriority)
 	tests := []struct {
 		name               string
 		rules              []*rule

--- a/pkg/agent/controller/networkpolicy/cache_test.go
+++ b/pkg/agent/controller/networkpolicy/cache_test.go
@@ -110,6 +110,62 @@ func TestAppliedToGroupIndexFunc(t *testing.T) {
 	}
 }
 
+func TestGetMaxPriority(t *testing.T) {
+	networkPolicyRule1 := &v1beta1.NetworkPolicyRule{
+		Direction: v1beta1.DirectionIn,
+		From:      v1beta1.NetworkPolicyPeer{AddressGroups: []string{"addressGroup1"}},
+		To:        v1beta1.NetworkPolicyPeer{},
+		Services:  nil,
+	}
+	networkPolicyRule2 := &v1beta1.NetworkPolicyRule{
+		Direction: v1beta1.DirectionIn,
+		From:      v1beta1.NetworkPolicyPeer{AddressGroups: []string{"addressGroup2"}},
+		To:        v1beta1.NetworkPolicyPeer{},
+		Services:  nil,
+		Priority:  0,
+	}
+	networkPolicyRule3 := &v1beta1.NetworkPolicyRule{
+		Direction: v1beta1.DirectionIn,
+		From:      v1beta1.NetworkPolicyPeer{AddressGroups: []string{"addressGroup3"}},
+		To:        v1beta1.NetworkPolicyPeer{},
+		Services:  nil,
+		Priority:  1,
+	}
+	networkPolicyRule4 := &v1beta1.NetworkPolicyRule{
+		Direction: v1beta1.DirectionOut,
+		From:      v1beta1.NetworkPolicyPeer{AddressGroups: []string{"addressGroup4"}},
+		To:        v1beta1.NetworkPolicyPeer{},
+		Services:  nil,
+		Priority:  0,
+	}
+	k8sNP := &v1beta1.NetworkPolicy{
+		ObjectMeta:      metav1.ObjectMeta{UID: "policy1"},
+		Rules:           []v1beta1.NetworkPolicyRule{*networkPolicyRule1},
+		AppliedToGroups: []string{"addressGroup1"},
+		SourceRef: &v1beta1.NetworkPolicyReference{
+			Type:      v1beta1.K8sNetworkPolicy,
+			Namespace: "ns1",
+			Name:      "name1",
+			UID:       "policy1",
+		},
+	}
+	acnpPriority, acnpTier := 1.0, int32(250)
+	antreaNP := &v1beta1.NetworkPolicy{
+		ObjectMeta:      metav1.ObjectMeta{UID: "policy2"},
+		Priority:        &acnpPriority,
+		TierPriority:    &acnpTier,
+		Rules:           []v1beta1.NetworkPolicyRule{*networkPolicyRule2, *networkPolicyRule3, *networkPolicyRule4},
+		AppliedToGroups: []string{"addressGroup1"},
+		SourceRef: &v1beta1.NetworkPolicyReference{
+			Type: v1beta1.AntreaClusterNetworkPolicy,
+			Name: "acnp1",
+			UID:  "policy-acnp",
+		},
+	}
+	assert.Equal(t, int32(-1), getMaxPriority(k8sNP), "got unexpected maxPriority for K8s NetworkPolicy")
+	assert.Equal(t, int32(1), getMaxPriority(antreaNP), "got unexpected maxPriority for AntreaPolicy")
+}
+
 type dirtyRuleRecorder struct {
 	rules   sets.String
 	eventCh chan string

--- a/pkg/agent/types/networkpolicy.go
+++ b/pkg/agent/types/networkpolicy.go
@@ -81,6 +81,19 @@ func (p *Priority) Equals(p2 Priority) bool {
 	return p.TierPriority == p2.TierPriority && p.PolicyPriority == p2.PolicyPriority && p.RulePriority == p2.RulePriority
 }
 
+// InSamePriorityZone returns if two Priorities are of the same Tier and same priority at policy level.
+func (p *Priority) InSamePriorityZone(p2 Priority) bool {
+	return p.PolicyPriority == p2.PolicyPriority && p.TierPriority == p2.TierPriority
+}
+
+// IsConsecutive returns if two Priorties are immediately next to each other.
+func (p *Priority) IsConsecutive(p2 Priority) bool {
+	if !p.InSamePriorityZone(p2) {
+		return false
+	}
+	return p.RulePriority-p2.RulePriority == 1 || p2.RulePriority-p.RulePriority == 1
+}
+
 // ByPriority sorts a list of Priority by their relative TierPriority, PolicyPriority and RulePriority, in that order.
 // It implements sort.Interface.
 type ByPriority []Priority

--- a/pkg/agent/types/networkpolicy.go
+++ b/pkg/agent/types/networkpolicy.go
@@ -81,12 +81,12 @@ func (p *Priority) Equals(p2 Priority) bool {
 	return p.TierPriority == p2.TierPriority && p.PolicyPriority == p2.PolicyPriority && p.RulePriority == p2.RulePriority
 }
 
-// InSamePriorityZone returns if two Priorities are of the same Tier and same priority at policy level.
+// InSamePriorityZone returns true if two Priorities are of the same Tier and same priority at policy level.
 func (p *Priority) InSamePriorityZone(p2 Priority) bool {
 	return p.PolicyPriority == p2.PolicyPriority && p.TierPriority == p2.TierPriority
 }
 
-// IsConsecutive returns if two Priorties are immediately next to each other.
+// IsConsecutive returns true if two Priorties are immediately next to each other.
 func (p *Priority) IsConsecutive(p2 Priority) bool {
 	if !p.InSamePriorityZone(p2) {
 		return false


### PR DESCRIPTION
This PR aims to improve the efficiency of registering Antrea-native policy priorities in the OpenFlow priority space. Fundamental idea is to take advantage of the fact that, when the agent receives internal NP created for those policies, it already knows the number of absolute consecutive Priorities that needs to be registered. Those Priorities will have the same Tier and Policy priority, and consecutive rule priorities as they correspond to the 1st, 2nd, and etc. rules of the ingress/egress rule of that policy.

Thus, when registering priorities, we can break these priorities into zones (each zone of same Tier and Policy priority), and register each zone in batch. This eliminates the problematic scenario where asynchronously registering a series of priorities cause existing priorities to be reassigned each time.

The priorityAssigner module is refactored to accommodate this change. The following illustrations demonstrates the new algorithm that it uses to insert consecutive priorities. For each diagram, the first row depicts the current ofPriority space, and where the initial heuristic function puts in the inserting priorities. 

**Case 1** The spaces computed by the heuristic function is unoccupied, AND the priorities immediately lower than those being inserted, if exists, are registered below these ofPriorities, AND the priorities immediately higher than those being inserted, if exists, are registered above these ofPriorities. In this case, we simply assign the ofPriorities returned by the heuristic function.
![image](https://user-images.githubusercontent.com/11527024/94870242-f2cb0c80-03fb-11eb-84a9-1db87d71c860.png)

**Case 2** The ofPriorities returned by the heuristic function overlaps with existing priorities/are out of place. If the priorities to be registered overlaps with lower priorities/are lower than the lower priorities, and the gap between lowerBound for insertion and upperBound for insertion is very large, then we insert these priorities above the lowerBound, offsetted by a constant zoneOffset. This offset gives buffer in case priorities are again created in between those zone. Vice versa for priorities overlaps with/higher than higher priorities.
![image](https://user-images.githubusercontent.com/11527024/94870569-af24d280-03fc-11eb-89a6-87733993a742.png)

**Case 3** The ofPriorities returned by the heuristic function overlaps with existing priorities/are out of place, and the gap between lowerBound for insertion and upperBound for insertion is tight. In that case, we simply register the priorities in the middle of the gap.
![image](https://user-images.githubusercontent.com/11527024/94870623-dc718080-03fc-11eb-8f83-ddb7995e3a33.png)

**Case 4** The gap between lowerBound for insertion and upperBound for insertion is not big enough for insertion. In this case, we push lower priorities and/or higher priorities towards each side in attempt to make enough room for the registering priorities, while in the meantime try to reassign as few existing priorities as possible. For example, in the following diagram, the yellow Priorities will be kept where they were to save reassignments.
![image](https://user-images.githubusercontent.com/11527024/95159664-72860d80-0753-11eb-8860-66049874da31.png)


