### PR TITLE
Check and ignore ANP and ACNP in agent when AntreaPolicy is not enabled

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -166,7 +166,14 @@ func run(o *Options) error {
 	// notifying NetworkPolicyController to reconcile rules related to the
 	// updated Pods.
 	podUpdates := make(chan v1beta1.PodReference, 100)
-	networkPolicyController := networkpolicy.NewNetworkPolicyController(antreaClientProvider, ofClient, ifaceStore, nodeConfig.Name, podUpdates)
+	networkPolicyController := networkpolicy.NewNetworkPolicyController(
+		antreaClientProvider,
+		ofClient,
+		ifaceStore,
+		nodeConfig.Name,
+		podUpdates,
+		features.DefaultFeatureGate.Enabled(features.AntreaPolicy))
+
 	isChaining := false
 	if networkConfig.TrafficEncapMode.IsNetworkPolicyOnly() {
 		isChaining = true

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -49,7 +49,7 @@ func (g *antreaClientGetter) GetAntreaClient() (versioned.Interface, error) {
 func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 	clientset := &fake.Clientset{}
 	ch := make(chan v1beta1.PodReference, 100)
-	controller := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", ch)
+	controller := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", ch, true)
 	reconciler := newMockReconciler()
 	controller.reconciler = reconciler
 	return controller, clientset, reconciler


### PR DESCRIPTION
If the AntreaPolicy feature gate is not enabled on the Antrea Agent but
is enabled on the Antrea Controller (e.g. due to misconfiguration, or
Controller/Agents have not been all restarted after a configuration
change), Agent might crash with a segment fault when receiving and
processing ANP or ACNP messages from controller, so this commit adds
a check in Agent NetworkPolicyController to ingnore ANP and ACNP
messages when AntreaPolicy is not enabled.