### PR TITLE
Support get/set log verbosity level by antctl and controller/agent API

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -731,6 +731,7 @@ rules:
   - /agentinfo
   - /addressgroups
   - /appliedtogroups
+  - /loglevel
   - /networkpolicies
   - /ovsflows
   - /ovstracing

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -731,6 +731,7 @@ rules:
   - /agentinfo
   - /addressgroups
   - /appliedtogroups
+  - /loglevel
   - /networkpolicies
   - /ovsflows
   - /ovstracing

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -731,6 +731,7 @@ rules:
   - /agentinfo
   - /addressgroups
   - /appliedtogroups
+  - /loglevel
   - /networkpolicies
   - /ovsflows
   - /ovstracing

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -731,6 +731,7 @@ rules:
   - /agentinfo
   - /addressgroups
   - /appliedtogroups
+  - /loglevel
   - /networkpolicies
   - /ovsflows
   - /ovstracing

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -731,6 +731,7 @@ rules:
   - /agentinfo
   - /addressgroups
   - /appliedtogroups
+  - /loglevel
   - /networkpolicies
   - /ovsflows
   - /ovstracing

--- a/build/yamls/base/antctl.yml
+++ b/build/yamls/base/antctl.yml
@@ -53,6 +53,7 @@ rules:
       - /agentinfo
       - /addressgroups
       - /appliedtogroups
+      - /loglevel
       - /networkpolicies
       - /ovsflows
       - /ovstracing

--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -15,6 +15,7 @@ running in two different modes:
 <!-- toc -->
 - [Installation](#installation)
 - [Usage](#usage)
+  - [Showing or changing log verbosity level](#showing-or-changing-log-verbosity-level)
   - [Collecting support information](#collecting-support-information)
   - [controllerinfo and agentinfo commands](#controllerinfo-and-agentinfo-commands)
   - [NetworkPolicy commands](#networkpolicy-commands)
@@ -74,6 +75,25 @@ one by setting the `KUBECONFIG` environment variable or with `--kubeconfig`
 
 The following sub-sections introduce a few commands which are useful for
 troubleshooting the Antrea system.
+
+### Showing or changing log verbosity level
+Starting from version 0.10.0, Antrea supports showing or changing the log
+verbosity level of Antrea Controller or Agent using the `antctl log-level`
+command. The command can only run locally inside the `antrea-controller` or
+`antrea-agent` container.
+
+The following command prints the current log verbosity level:
+
+```bash
+antctl log-level
+```
+
+This command updates the log verbosity level (the `level` argument must be an
+integer):
+
+```bash
+antctl log-level <level>
+```
 
 ### Collecting support information
 

--- a/pkg/agent/apiserver/apiserver.go
+++ b/pkg/agent/apiserver/apiserver.go
@@ -40,6 +40,7 @@ import (
 	agentquerier "github.com/vmware-tanzu/antrea/pkg/agent/querier"
 	systeminstall "github.com/vmware-tanzu/antrea/pkg/apis/system/install"
 	systemv1beta1 "github.com/vmware-tanzu/antrea/pkg/apis/system/v1beta1"
+	"github.com/vmware-tanzu/antrea/pkg/apiserver/handlers/loglevel"
 	"github.com/vmware-tanzu/antrea/pkg/apiserver/registry/system/supportbundle"
 	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsctl"
 	"github.com/vmware-tanzu/antrea/pkg/querier"
@@ -69,6 +70,7 @@ func (s *agentAPIServer) Run(stopCh <-chan struct{}) error {
 }
 
 func installHandlers(aq agentquerier.AgentQuerier, npq querier.AgentNetworkPolicyInfoQuerier, s *genericapiserver.GenericAPIServer) {
+	s.Handler.NonGoRestfulMux.HandleFunc("/loglevel", loglevel.HandleFunc())
 	s.Handler.NonGoRestfulMux.HandleFunc("/agentinfo", agentinfo.HandleFunc(aq))
 	s.Handler.NonGoRestfulMux.HandleFunc("/podinterfaces", podinterface.HandleFunc(aq))
 	s.Handler.NonGoRestfulMux.HandleFunc("/networkpolicies", networkpolicy.HandleFunc(aq))

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -59,7 +59,45 @@ var CommandList = &commandList{
 				},
 				addonTransform: version.AgentTransform,
 			},
+
 			transformedResponse: reflect.TypeOf(version.Response{}),
+		},
+		{
+			use:   "log-level",
+			short: "Show or set log verbosity level",
+			long:  "Show or set the log verbosity level of ${component}",
+			example: `  Show the current log verbosity level
+  $ antctl log-level
+  Set the log verbosity level to 2
+  $ antctl log-level 2`,
+			commandGroup: flat,
+			controllerEndpoint: &endpoint{
+				nonResourceEndpoint: &nonResourceEndpoint{
+					path: "/loglevel",
+					params: []flagInfo{
+						{
+							name:  "level",
+							usage: "The integer log verbosity level to set",
+							arg:   true,
+						},
+					},
+					outputType: single,
+				},
+			},
+			agentEndpoint: &endpoint{
+				nonResourceEndpoint: &nonResourceEndpoint{
+					path: "/loglevel",
+					params: []flagInfo{
+						{
+							name:  "level",
+							usage: "The integer log verbosity level to set",
+							arg:   true,
+						},
+					},
+					outputType: single,
+				},
+			},
+			transformedResponse: reflect.TypeOf(0),
 		},
 		{
 			use:     "networkpolicy",

--- a/pkg/antctl/command_list.go
+++ b/pkg/antctl/command_list.go
@@ -112,6 +112,10 @@ func (cl *commandList) GetDebugCommands(mode string) [][]string {
 		if def.commandGroup == query {
 			continue
 		}
+		if mode == runtime.ModeController && def.use == "log-level" {
+			// log-level command does not support remote execution.
+			continue
+		}
 		if mode == runtime.ModeAgent && def.agentEndpoint != nil ||
 			mode == runtime.ModeController && def.controllerEndpoint != nil {
 			var currentCommand []string

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -38,6 +38,7 @@ import (
 	system "github.com/vmware-tanzu/antrea/pkg/apis/system/v1beta1"
 	"github.com/vmware-tanzu/antrea/pkg/apiserver/certificate"
 	"github.com/vmware-tanzu/antrea/pkg/apiserver/handlers/endpoint"
+	"github.com/vmware-tanzu/antrea/pkg/apiserver/handlers/loglevel"
 	"github.com/vmware-tanzu/antrea/pkg/apiserver/handlers/webhook"
 	"github.com/vmware-tanzu/antrea/pkg/apiserver/registry/controlplane/nodestatssummary"
 	"github.com/vmware-tanzu/antrea/pkg/apiserver/registry/networkpolicy/addressgroup"
@@ -225,6 +226,7 @@ func CleanupDeprecatedAPIServices(aggregatorClient clientset.Interface) error {
 }
 
 func installHandlers(c *ExtraConfig, s *genericapiserver.GenericAPIServer) {
+	s.Handler.NonGoRestfulMux.HandleFunc("/loglevel", loglevel.HandleFunc())
 	s.Handler.NonGoRestfulMux.HandleFunc("/endpoint", endpoint.HandleFunc(c.endpointQuerier))
 	if features.DefaultFeatureGate.Enabled(features.AntreaPolicy) {
 		// Get new NetworkPolicyValidator

--- a/pkg/apiserver/handlers/loglevel/handler.go
+++ b/pkg/apiserver/handlers/loglevel/handler.go
@@ -1,0 +1,46 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loglevel
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"k8s.io/klog"
+
+	"github.com/vmware-tanzu/antrea/pkg/log"
+)
+
+// HandleFunc returns the function which can handle the /loglevel API request.
+func HandleFunc() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		level := r.URL.Query().Get("level")
+		if level != "" {
+			err := log.SetLogLevel(level)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+		} else {
+			levelNum, _ := strconv.Atoi(log.GetCurrentLogLevel())
+			err := json.NewEncoder(w).Encode(levelNum)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				klog.Errorf("Error when encoding log level to json: %v", err)
+			}
+		}
+	}
+}

--- a/pkg/log/log_level.go
+++ b/pkg/log/log_level.go
@@ -1,0 +1,46 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"flag"
+
+	"k8s.io/klog"
+)
+
+const logVerbosityFlag = "v"
+
+// GetCurrentLogLevel returns the current log verbosity level.
+func GetCurrentLogLevel() string {
+	return flag.Lookup(logVerbosityFlag).Value.String()
+}
+
+// SetLogLevel sets the log verbosity level. level must be a string
+// representation of a decimal integer.
+func SetLogLevel(level string) error {
+	oldLevel := GetCurrentLogLevel()
+	if oldLevel == level {
+		return nil
+	}
+
+	var l klog.Level
+	err := l.Set(level)
+	if err != nil {
+		return err
+	}
+	klog.Infof("Changed log level from %s to %s", oldLevel, level)
+	return nil
+
+}


### PR DESCRIPTION
Add antctl log-level command that calls controller or agent /loglevel
API to get/set the log verbosity level of controller or agent in the
runtime.
Change antctl to allow an empty response of an controller or agent
call.