### PR TITLE
Ensure appliedTo and priority is required for ACNP

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -170,6 +170,9 @@ spec:
                 type: number
               tier:
                 type: string
+            required:
+            - appliedTo
+            - priority
             type: object
         type: object
     served: true

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -170,6 +170,9 @@ spec:
                 type: number
               tier:
                 type: string
+            required:
+            - appliedTo
+            - priority
             type: object
         type: object
     served: true

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -170,6 +170,9 @@ spec:
                 type: number
               tier:
                 type: string
+            required:
+            - appliedTo
+            - priority
             type: object
         type: object
     served: true

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -170,6 +170,9 @@ spec:
                 type: number
               tier:
                 type: string
+            required:
+            - appliedTo
+            - priority
             type: object
         type: object
     served: true

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -170,6 +170,9 @@ spec:
                 type: number
               tier:
                 type: string
+            required:
+            - appliedTo
+            - priority
             type: object
         type: object
     served: true

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -279,6 +279,10 @@ spec:
           type: object
           properties:
             spec:
+              # Ensure that Spec.AppliedTo and Spec.Priority fields are set
+              required:
+                - appliedTo
+                - priority
               type: object
               properties:
                 tier:

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -148,13 +149,12 @@ func testInvalidACNPNoPriority(t *testing.T) {
 	invalidNpErr := errors.New("invalid Antrea ClusterNetworkPolicy accepted")
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("acnp-no-priority").SetAppliedToGroup(map[string]string{"pod": "a"}, nil, nil, nil)
-	np := metav1.Object{builder.Get()}
-	if acnp, ok := np.(*secv1alpha1.ClusterNetworkPolicy); ok {
-		log.Debugf("creating ACNP %v", acnp.Name)
-		_, err := k8sUtils.CreateOrUpdateCNP(acnp)
-		if err != nil {
-			failOnError(invalidNpErr, t)
-		}
+	acnp := builder.Get()
+	log.Debugf("creating ACNP %v", acnp.Name)
+	_, err := k8sUtils.CreateOrUpdateCNP(acnp)
+	// Above creation of ACNP must fail as it is an invalid spec.
+	if err == nil {
+		failOnError(invalidNpErr, t)
 	}
 }
 

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -146,7 +145,7 @@ func cleanupDefaultDenyNPs(k8s *KubernetesUtils, namespaces []string) error {
 }
 
 func testInvalidACNPNoPriority(t *testing.T) {
-	invalidNpErr := errors.New("invalid Antrea ClusterNetworkPolicy accepted")
+	invalidNpErr := fmt.Errorf("invalid Antrea ClusterNetworkPolicy accepted")
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("acnp-no-priority").SetAppliedToGroup(map[string]string{"pod": "a"}, nil, nil, nil)
 	acnp := builder.Get()
@@ -750,7 +749,7 @@ func TestAntreaPolicy(t *testing.T) {
 	defer teardownTest(t, data)
 	initialize(t, data)
 
-	t.Run("TestGroupValidateACNP", func(t *testing.T) {
+	t.Run("TestGroupValidateAntreaNativePolicies", func(t *testing.T) {
 		t.Run("Case=ACNPNoPriority", func(t *testing.T) { testInvalidACNPNoPriority(t) })
 	})
 


### PR DESCRIPTION
Update yaml to ensure appliedTo and Priority is required for ACNP as is the case with ANP. Add an e2e test to validate this
scenario.