### PR TITLE
Update kind-setup.sh for kind.x-k8s.io/v1alpha4

### DIFF
--- a/ci/kind/kind-setup.sh
+++ b/ci/kind/kind-setup.sh
@@ -29,6 +29,12 @@ ENCAP_MODE=""
 PROXY=false
 PROMETHEUS=false
 
+# The kind api versino changed between 3 and 4
+KIND_API_VERSION="kind.sigs.k8s.io/v1alpha3"
+if [[ ! `kind version | grep -q 9` ]] ; then 
+    KIND_API_VERSION="kind.x-k8s.io/v1alpha4"
+fi
+
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 set -eo pipefail
@@ -228,7 +234,7 @@ function create {
   config_file="/tmp/kind.yml"
   cat <<EOF > $config_file
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: ${KIND_API_VERSION}
 networking:
   disableDefaultCNI: true
   podSubnet: $POD_CIDR


### PR DESCRIPTION
The newer kind versions (0.9) have a new API thingy for v1alpha4... I think this should work.
assuming CI will keep me honest 