### PR TITLE
Cleanup: remove send_redirects sysctl configuration

### DIFF
--- a/build/yamls/base/agent.yml
+++ b/build/yamls/base/agent.yml
@@ -109,7 +109,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
           securityContext:
-            # antrea-agent needs to manipulate "/proc/sys/net/ipv4/conf/XXX/send_redirects".
+            # antrea-agent needs to perform sysctl configuration.
             privileged: true
           volumeMounts:
           - name: antrea-config

--- a/docs/security.md
+++ b/docs/security.md
@@ -38,7 +38,7 @@ use a
 and restrict the set of allowed
 [volumes](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#volumes-and-file-systems)
 to exclude `hostPath`. **This guidance applies to all multi-tenancy clusters and
-is not specific to Antrea.**. To quote the K8s documentation:
+is not specific to Antrea.** To quote the K8s documentation:
 
 > There are many ways a container with unrestricted access to the host
   filesystem can escalate privileges, including reading data from other


### PR DESCRIPTION
With L3 flows, Pod-to-Pod traffic will no longer go through gateway interfaces. For Pod-to-Service traffic, Linux doesn't allow sending redirect packets for NAT'd connections. Therefore, setting send_redirects is no longer needed.

For #1363