### PR TITLE
[IPv6] Skip IPsec e2e test

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -127,6 +127,17 @@ type PodIPs struct {
 	ipStrings []string
 }
 
+func (p PodIPs) String() string {
+	res := ""
+	if p.ipv4 != nil {
+		res += fmt.Sprintf("IPv4: %s, ", p.ipv4.String())
+	}
+	if p.ipv6 != nil {
+		res += fmt.Sprintf("IPv6: %s, ", p.ipv6.String())
+	}
+	return fmt.Sprintf("%sIP strings: %s", res, strings.Join(p.ipStrings, ", "))
+}
+
 func (p *PodIPs) hasSameIP(p1 *PodIPs) bool {
 	if len(p.ipStrings) == 0 && len(p1.ipStrings) == 0 {
 		return true

--- a/test/e2e/ipsec_test.go
+++ b/test/e2e/ipsec_test.go
@@ -59,6 +59,7 @@ func (data *TestData) readSecurityAssociationsStatus(nodeName string) (up int, c
 // them ping each other.
 func TestIPSecTunnelConnectivity(t *testing.T) {
 	skipIfProviderIs(t, "kind", "IPSec tunnel does not work with Kind")
+	skipIfIPv6Cluster(t)
 	skipIfNumNodesLessThan(t, 2)
 
 	data, err := setupTest(t)
@@ -92,6 +93,7 @@ func TestIPSecTunnelConnectivity(t *testing.T) {
 // correctly.
 func TestIPSecDeleteStaleTunnelPorts(t *testing.T) {
 	skipIfProviderIs(t, "kind", "IPSec tunnel does not work with Kind")
+	skipIfIPv6Cluster(t)
 	skipIfNumNodesLessThan(t, 2)
 
 	data, err := setupTest(t)


### PR DESCRIPTION
* With OVS v2.14.0, IPsec in IPv6 envinronment is not supported.
* More user-friendly output for PodIPs.
From:
`Retrieved all Pod IPs: map[test-pod-0-upgp1ung:0xc000708960 test-pod-1-pbva9007:0xc0006ec8a0]`
To:
`Retrieved all Pod IPs: map[test-pod-0-mudzj847:IPv6: fd74:ca9b:172:16::4, IP strings: fd74:ca9b:172:16::4 test-pod-1-apcmyd30:IPv6: fd74:ca9b:172:16:1::3c, IP strings: fd74:ca9b:172:16:1::3c]`