### PR TITLE
Set Traceflow TCP flag from antrea-octant-plugin

### DIFF
--- a/plugins/octant/cmd/antrea-octant-plugin/traceflow.go
+++ b/plugins/octant/cmd/antrea-octant-plugin/traceflow.go
@@ -241,6 +241,7 @@ func (p *antreaOctantPlugin) actionHandler(request *service.ActionRequest) error
 				tf.Spec.Packet.TransportHeader.TCP = &opsv1alpha1.TCPHeader{
 					SrcPort: int32(srcPort),
 					DstPort: int32(dstPort),
+					Flags:   2,
 				}
 			}
 		case opsv1alpha1.UDPProtocol:


### PR DESCRIPTION
antrea-octant-plugin sets Traceflow TCP flag 2
by default for Traceflow creation.

Related: #1376