### PR TITLE
Remove ServiceCIDR dependency in Flow Exporter

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -262,9 +262,8 @@ func run(o *Options) error {
 	// Initialize flow exporter to start go routines to poll conntrack flows and export IPFIX flow records
 	if features.DefaultFeatureGate.Enabled(features.FlowExporter) {
 		connStore := connections.NewConnectionStore(
-			connections.InitializeConnTrackDumper(nodeConfig, serviceCIDRNet, o.config.OVSDatapathType),
+			connections.InitializeConnTrackDumper(nodeConfig, serviceCIDRNet, o.config.OVSDatapathType, features.DefaultFeatureGate.Enabled(features.AntreaProxy)),
 			ifaceStore,
-			serviceCIDRNet,
 			proxier,
 			o.pollInterval)
 		pollDone := make(chan struct{})

--- a/pkg/agent/flowexporter/connections/connections_test.go
+++ b/pkg/agent/flowexporter/connections/connections_test.go
@@ -91,10 +91,12 @@ func TestConnectionStore_addAndUpdateConn(t *testing.T) {
 		TupleReply:      revTuple2,
 		IsActive:        true,
 	}
+	// To test service name mapping
 	tuple3, revTuple3 := makeTuple(&net.IP{10, 10, 10, 10}, &net.IP{20, 20, 20, 20}, 6, 5000, 80)
 	testFlow3 := flowexporter.Connection{
 		TupleOrig:  tuple3,
 		TupleReply: revTuple3,
+		Mark:       openflow.ServiceCTMark,
 		IsActive:   true,
 	}
 	// Create copy of old conntrack flow for testing purposes.
@@ -124,10 +126,6 @@ func TestConnectionStore_addAndUpdateConn(t *testing.T) {
 		IP:                       net.IP{8, 7, 6, 5},
 		ContainerInterfaceConfig: podConfigFlow2,
 	}
-	serviceCIDR := &net.IPNet{
-		IP:   net.IP{20, 20, 20, 0},
-		Mask: net.IPMask(net.ParseIP("255.255.255.0").To4()),
-	}
 	servicePortName := k8sproxy.ServicePortName{
 		NamespacedName: types.NamespacedName{
 			Namespace: "serviceNS1",
@@ -140,7 +138,7 @@ func TestConnectionStore_addAndUpdateConn(t *testing.T) {
 	mockIfaceStore := interfacestoretest.NewMockInterfaceStore(ctrl)
 	mockConnDumper := connectionstest.NewMockConnTrackDumper(ctrl)
 	mockProxier := proxytest.NewMockProxier(ctrl)
-	connStore := NewConnectionStore(mockConnDumper, mockIfaceStore, serviceCIDR, mockProxier, testPollInterval)
+	connStore := NewConnectionStore(mockConnDumper, mockIfaceStore, mockProxier, testPollInterval)
 
 	// Add flow1conn to the Connection map
 	testFlow1Tuple := flowexporter.NewConnectionKey(&testFlow1)
@@ -223,7 +221,7 @@ func TestConnectionStore_ForAllConnectionsDo(t *testing.T) {
 	// Create ConnectionStore
 	mockIfaceStore := interfacestoretest.NewMockInterfaceStore(ctrl)
 	mockConnDumper := connectionstest.NewMockConnTrackDumper(ctrl)
-	connStore := NewConnectionStore(mockConnDumper, mockIfaceStore, nil, nil, testPollInterval)
+	connStore := NewConnectionStore(mockConnDumper, mockIfaceStore, nil, testPollInterval)
 	// Add flows to the Connection store
 	for i, flow := range testFlows {
 		connStore.connections[*testFlowKeys[i]] = *flow
@@ -288,7 +286,7 @@ func TestConnectionStore_DeleteConnectionByKey(t *testing.T) {
 	// Create ConnectionStore
 	mockIfaceStore := interfacestoretest.NewMockInterfaceStore(ctrl)
 	mockConnDumper := connectionstest.NewMockConnTrackDumper(ctrl)
-	connStore := NewConnectionStore(mockConnDumper, mockIfaceStore, nil, nil, testPollInterval)
+	connStore := NewConnectionStore(mockConnDumper, mockIfaceStore, nil, testPollInterval)
 	// Add flows to the connection store.
 	for i, flow := range testFlows {
 		connStore.connections[*testFlowKeys[i]] = *flow
@@ -312,7 +310,7 @@ func TestConnectionStore_MetricSettingInPoll(t *testing.T) {
 	// Create ConnectionStore
 	mockIfaceStore := interfacestoretest.NewMockInterfaceStore(ctrl)
 	mockConnDumper := connectionstest.NewMockConnTrackDumper(ctrl)
-	connStore := NewConnectionStore(mockConnDumper, mockIfaceStore, nil, nil, testPollInterval)
+	connStore := NewConnectionStore(mockConnDumper, mockIfaceStore, nil, testPollInterval)
 	// Hard-coded conntrack occupancy metrics for test
 	TotalConnections := 0
 	MaxConnections := 300000

--- a/pkg/agent/flowexporter/connections/conntrack_linux.go
+++ b/pkg/agent/flowexporter/connections/conntrack_linux.go
@@ -32,12 +32,13 @@ import (
 var _ ConnTrackDumper = new(connTrackSystem)
 
 type connTrackSystem struct {
-	nodeConfig  *config.NodeConfig
-	serviceCIDR *net.IPNet
-	connTrack   NetFilterConnTrack
+	nodeConfig           *config.NodeConfig
+	serviceCIDR          *net.IPNet
+	isAntreaProxyEnabled bool
+	connTrack            NetFilterConnTrack
 }
 
-func NewConnTrackSystem(nodeConfig *config.NodeConfig, serviceCIDR *net.IPNet) *connTrackSystem {
+func NewConnTrackSystem(nodeConfig *config.NodeConfig, serviceCIDR *net.IPNet, isAntreaProxyEnabled bool) *connTrackSystem {
 	if err := SetupConntrackParameters(); err != nil {
 		// Do not fail, but continue after logging an error as we can still dump flows with missing information.
 		klog.Errorf("Error when setting up conntrack parameters, some information may be missing from exported flows: %v", err)
@@ -45,6 +46,7 @@ func NewConnTrackSystem(nodeConfig *config.NodeConfig, serviceCIDR *net.IPNet) *
 	return &connTrackSystem{
 		nodeConfig,
 		serviceCIDR,
+		isAntreaProxyEnabled,
 		&netFilterConnTrack{},
 	}
 }
@@ -65,7 +67,7 @@ func (ct *connTrackSystem) DumpFlows(zoneFilter uint16) ([]*flowexporter.Connect
 		return nil, 0, fmt.Errorf("error when dumping flows from conntrack: %v", err)
 	}
 
-	filteredConns := filterAntreaConns(conns, ct.nodeConfig, ct.serviceCIDR, zoneFilter)
+	filteredConns := filterAntreaConns(conns, ct.nodeConfig, ct.serviceCIDR, zoneFilter, ct.isAntreaProxyEnabled)
 	klog.V(2).Infof("No. of flow exporter considered flows in Antrea zoneID: %d", len(filteredConns))
 
 	return filteredConns, len(conns), nil
@@ -132,6 +134,7 @@ func netlinkFlowToAntreaConnection(conn *conntrack.Flow) *flowexporter.Connectio
 		IsActive:                true,
 		DoExport:                true,
 		Zone:                    conn.Zone,
+		Mark:                    conn.Mark,
 		StatusFlag:              uint32(conn.Status.Value),
 		TupleOrig:               tupleOrig,
 		TupleReply:              tupleReply,

--- a/pkg/agent/flowexporter/connections/conntrack_linux_test.go
+++ b/pkg/agent/flowexporter/connections/conntrack_linux_test.go
@@ -71,6 +71,10 @@ func TestConnTrackSystem_DumpFlows(t *testing.T) {
 	}
 	nodeConfig := &config.NodeConfig{
 		GatewayConfig: gwConfig,
+		PodCIDR: &net.IPNet{
+			IP:   net.IP{1, 2, 3, 0},
+			Mask: net.IPMask{255, 255, 255, 0},
+		},
 	}
 	// Create serviceCIDR
 	serviceCIDR := &net.IPNet{
@@ -79,7 +83,7 @@ func TestConnTrackSystem_DumpFlows(t *testing.T) {
 	}
 	// Test the DumpFlows implementation of connTrackSystem
 	mockNetlinkCT := connectionstest.NewMockNetFilterConnTrack(ctrl)
-	connDumperDPSystem := NewConnTrackSystem(nodeConfig, serviceCIDR)
+	connDumperDPSystem := NewConnTrackSystem(nodeConfig, serviceCIDR, false)
 
 	connDumperDPSystem.connTrack = mockNetlinkCT
 	// Set expects for mocks
@@ -118,11 +122,12 @@ func TestConnTrackOvsAppCtl_DumpFlows(t *testing.T) {
 		nodeConfig,
 		serviceCIDR,
 		mockOVSCtlClient,
+		false,
 	}
 	// Set expect call for mock ovsCtlClient
 	ovsctlCmdOutput := []byte("tcp,orig=(src=127.0.0.1,dst=127.0.0.1,sport=45218,dport=2379,packets=320108,bytes=24615344),reply=(src=127.0.0.1,dst=127.0.0.1,sport=2379,dport=45218,packets=239595,bytes=24347883),start=2020-07-24T05:07:03.998,id=3750535678,status=SEEN_REPLY|ASSURED|CONFIRMED|SRC_NAT_DONE|DST_NAT_DONE,timeout=86399,protoinfo=(state_orig=ESTABLISHED,state_reply=ESTABLISHED,wscale_orig=7,wscale_reply=7,flags_orig=WINDOW_SCALE|SACK_PERM|MAXACK_SET,flags_reply=WINDOW_SCALE|SACK_PERM|MAXACK_SET)\n" +
 		"tcp,orig=(src=127.0.0.1,dst=8.7.6.5,sport=45170,dport=2379,packets=80743,bytes=5416239),reply=(src=8.7.6.5,dst=127.0.0.1,sport=2379,dport=45170,packets=63361,bytes=4811261),start=2020-07-24T05:07:01.591,id=462801621,zone=65520,status=SEEN_REPLY|ASSURED|CONFIRMED|SRC_NAT_DONE|DST_NAT_DONE,timeout=86397,protoinfo=(state_orig=ESTABLISHED,state_reply=ESTABLISHED,wscale_orig=7,wscale_reply=7,flags_orig=WINDOW_SCALE|SACK_PERM|MAXACK_SET,flags_reply=WINDOW_SCALE|SACK_PERM|MAXACK_SET)\n" +
-		"tcp,orig=(src=100.10.0.105,dst=10.96.0.1,sport=41284,dport=443,packets=343260,bytes=19340621),reply=(src=192.168.86.82,dst=100.10.0.105,sport=6443,dport=41284,packets=381035,bytes=181176472),start=2020-07-25T08:40:08.959,id=982464968,zone=65520,status=SEEN_REPLY|ASSURED|CONFIRMED|DST_NAT|DST_NAT_DONE,timeout=86399,mark=33,protoinfo=(state_orig=ESTABLISHED,state_reply=ESTABLISHED,wscale_orig=7,wscale_reply=7,flags_orig=WINDOW_SCALE|SACK_PERM|MAXACK_SET,flags_reply=WINDOW_SCALE|SACK_PERM|MAXACK_SET)")
+		"tcp,orig=(src=100.10.0.105,dst=10.96.0.1,sport=41284,dport=443,packets=343260,bytes=19340621),reply=(src=100.10.0.106,dst=100.10.0.105,sport=6443,dport=41284,packets=381035,bytes=181176472),start=2020-07-25T08:40:08.959,id=982464968,zone=65520,status=SEEN_REPLY|ASSURED|CONFIRMED|DST_NAT|DST_NAT_DONE,timeout=86399,mark=33,protoinfo=(state_orig=ESTABLISHED,state_reply=ESTABLISHED,wscale_orig=7,wscale_reply=7,flags_orig=WINDOW_SCALE|SACK_PERM|MAXACK_SET,flags_reply=WINDOW_SCALE|SACK_PERM|MAXACK_SET)")
 	outputFlow := strings.Split(string(ovsctlCmdOutput), "\n")
 	expConn := &flowexporter.Connection{
 		ID:         982464968,
@@ -133,6 +138,7 @@ func TestConnTrackOvsAppCtl_DumpFlows(t *testing.T) {
 		DoExport:   true,
 		Zone:       65520,
 		StatusFlag: 302,
+		Mark:       0x21,
 		TupleOrig: flowexporter.Tuple{
 			SourceAddress:      net.ParseIP("100.10.0.105"),
 			DestinationAddress: net.ParseIP("10.96.0.1"),
@@ -141,7 +147,7 @@ func TestConnTrackOvsAppCtl_DumpFlows(t *testing.T) {
 			DestinationPort:    uint16(443),
 		},
 		TupleReply: flowexporter.Tuple{
-			SourceAddress:      net.ParseIP("192.168.86.82"),
+			SourceAddress:      net.ParseIP("100.10.0.106"),
 			DestinationAddress: net.ParseIP("100.10.0.105"),
 			Protocol:           6,
 			SourcePort:         6443,
@@ -168,7 +174,7 @@ func TestConnTrackOvsAppCtl_DumpFlows(t *testing.T) {
 }
 
 func TestConnTrackSystem_GetMaxConnections(t *testing.T) {
-	connDumperDPSystem := NewConnTrackSystem(&config.NodeConfig{}, &net.IPNet{})
+	connDumperDPSystem := NewConnTrackSystem(&config.NodeConfig{}, &net.IPNet{}, false)
 	maxConns, err := connDumperDPSystem.GetMaxConnections()
 	assert.NoErrorf(t, err, "GetMaxConnections function returned error: %v", err)
 	expMaxConns, err := sysctl.GetSysctlNet("netfilter/nf_conntrack_max")
@@ -187,6 +193,7 @@ func TestConnTrackOvsAppCtl_GetMaxConnections(t *testing.T) {
 		&config.NodeConfig{},
 		&net.IPNet{},
 		mockOVSCtlClient,
+		false,
 	}
 	maxConns, err := connDumper.GetMaxConnections()
 	assert.NoErrorf(t, err, "GetMaxConnections function returned error: %v", err)

--- a/pkg/agent/flowexporter/connections/conntrack_windows.go
+++ b/pkg/agent/flowexporter/connections/conntrack_windows.go
@@ -22,6 +22,6 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 )
 
-func NewConnTrackSystem(nodeConfig *config.NodeConfig, serviceCIDR *net.IPNet) *connTrackOvsCtl {
-	return NewConnTrackOvsAppCtl(nodeConfig, serviceCIDR)
+func NewConnTrackSystem(nodeConfig *config.NodeConfig, serviceCIDR *net.IPNet, isAntreaProxyEnabled bool) *connTrackOvsCtl {
+	return NewConnTrackOvsAppCtl(nodeConfig, serviceCIDR, isAntreaProxyEnabled)
 }

--- a/pkg/agent/flowexporter/types.go
+++ b/pkg/agent/flowexporter/types.go
@@ -45,6 +45,7 @@ type Connection struct {
 	// DoExport flag helps in tagging connections that can be exported by Flow Exporter
 	DoExport   bool
 	Zone       uint16
+	Mark       uint32
 	StatusFlag uint32
 	// TODO: Have a separate field for protocol. No need to keep it in Tuple.
 	TupleOrig, TupleReply          Tuple

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -222,7 +222,7 @@ const (
 
 	gatewayCTMark = 0x20
 	snatCTMark    = 0x40
-	serviceCTMark = 0x21
+	ServiceCTMark = 0x21
 )
 
 var (
@@ -521,7 +521,7 @@ func (c *client) connectionTrackFlows(category cookie.Category) []binding.Flow {
 				Done(),
 			connectionTrackCommitTable.BuildFlow(priorityLow).MatchProtocol(binding.ProtocolIP).
 				MatchCTStateTrk(true).
-				MatchCTMark(serviceCTMark, nil).
+				MatchCTMark(ServiceCTMark, nil).
 				MatchRegRange(int(serviceLearnReg), marksRegServiceSelected, serviceLearnRegRange).
 				Cookie(c.cookieAllocator.Request(category).Raw()).
 				Action().GotoTable(connectionTrackCommitTable.GetNext()).
@@ -600,7 +600,7 @@ func (c *client) ctRewriteDstMACFlow(gatewayMAC net.HardwareAddr, category cooki
 func (c *client) serviceLBBypassFlow() binding.Flow {
 	connectionTrackStateTable := c.pipeline[conntrackStateTable]
 	return connectionTrackStateTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
-		MatchCTMark(serviceCTMark, nil).
+		MatchCTMark(ServiceCTMark, nil).
 		MatchCTStateNew(false).MatchCTStateTrk(true).
 		Action().LoadRegRange(int(marksReg), macRewriteMark, macRewriteMarkRange).
 		Action().GotoTable(EgressRuleTable).
@@ -956,7 +956,7 @@ func (c *client) conjunctionActionFlow(conjunctionID uint32, tableID binding.Tab
 		MatchConjID(conjunctionID).
 		MatchPriority(ofPriority).
 		Action().LoadRegRange(int(conjReg), conjunctionID, binding.Range{0, 31}). // Traceflow.
-		Action().CT(true, nextTable, CtZone).                                     // CT action requires commit flag if actions other than NAT without arguments are specified.
+		Action().CT(true, nextTable, CtZone). // CT action requires commit flag if actions other than NAT without arguments are specified.
 		LoadToLabelRange(uint64(conjunctionID), &labelRange).
 		CTDone().
 		Cookie(c.cookieAllocator.Request(cookie.Policy).Raw()).
@@ -1322,7 +1322,7 @@ func (c *client) endpointDNATFlow(endpointIP net.IP, endpointPort uint16, protoc
 			&binding.IPRange{StartIP: endpointIP, EndIP: endpointIP},
 			&binding.PortRange{StartPort: endpointPort, EndPort: endpointPort},
 		).
-		LoadToMark(serviceCTMark).
+		LoadToMark(ServiceCTMark).
 		CTDone().
 		Done()
 }

--- a/test/integration/agent/flowexporter_test.go
+++ b/test/integration/agent/flowexporter_test.go
@@ -127,7 +127,7 @@ func TestConnectionStoreAndFlowRecords(t *testing.T) {
 	connDumperMock := connectionstest.NewMockConnTrackDumper(ctrl)
 	ifStoreMock := interfacestoretest.NewMockInterfaceStore(ctrl)
 	// TODO: Enhance the integration test by testing service.
-	connStore := connections.NewConnectionStore(connDumperMock, ifStoreMock, nil, nil, testPollInterval)
+	connStore := connections.NewConnectionStore(connDumperMock, ifStoreMock, nil, testPollInterval)
 	// Expect calls for connStore.poll and other callees
 	connDumperMock.EXPECT().DumpFlows(uint16(openflow.CtZone)).Return(testConns, 0, nil)
 	connDumperMock.EXPECT().GetMaxConnections().Return(0, nil)


### PR DESCRIPTION
With Antrea Proxy enabled, Flow Exporter checks for ct_mark rather than
serviceCIDR for Pod-To-Service flows.
With Kube Proxy enabled, Flow Exporter ignores the duplicate
flow with ClusterIPs using podCIDR in nodeConfig for Pod-To-Service flows.

Fixes: #1369 