### PR TITLE
Add a config option to disable SNAT in the noEncap mode

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1044,7 +1044,8 @@ data:
     # feature that supports priorities, rule actions and externalEntities in the future.
     #  AntreaPolicy: false
 
-    # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each agent to a configured collector.
+    # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each
+    # agent to a configured collector.
     #  FlowExporter: false
 
     # Enable collecting and exposing NetworkPolicy statistics.
@@ -1065,7 +1066,26 @@ data:
     # Make sure it doesn't conflict with your existing interfaces.
     #hostGateway: antrea-gw0
 
-    # Encapsulation mode for communication between Pods across Nodes, supported values:
+    # Determines how traffic is encapsulated. It has the following options:
+    # encap(default):    Inter-node Pod traffic is always encapsulated and Pod to external network
+    #                    traffic is SNAT'd.
+    # noEncap:           Inter-node Pod traffic is not encapsulated; Pod to exteranl network traffic is
+    #                    SNAT'd if noSNAT is not set to true. Underlying network must be capable of
+    #                    supporting Pod traffic across IP subnets.
+    # hybrid:            noEncap if source and destination Nodes are on the same subnet, otherwise encap.
+    # networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod
+    #                    IPAM and connectivity to the primary CNI.
+    #
+    trafficEncapMode: networkPolicyOnly
+
+    # Whether or not to SNAT (using the Node IP) the egress traffic from a Pod to the external network.
+    # This option is for the noEncap traffic mode only, and the default value is false. In the noEncap
+    # mode, if the cluster's Pod CIDR is reachable from the external network, then the Pod traffic to
+    # the external network needs not be SNAT'd. In the networkPolicyOnly mode, antrea-agent never
+    # performs SNAT and this option will be ignored; for other modes it must be set to false.
+    #noSNAT: false
+
+    # Tunnel protocols used for encapsulating traffic across Nodes. Supported values:
     # - geneve (default)
     # - vxlan
     # - gre
@@ -1080,15 +1100,6 @@ data:
     # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
     # for the GRE tunnel type.
     #enableIPSecTunnel: false
-
-    # Determines how traffic is encapsulated. It has the following options
-    # encap(default): Inter-node Pod traffic is always encapsulated and Pod to outbound traffic is masqueraded.
-    # noEncap: Inter-node Pod traffic is not encapsulated, but Pod to outbound traffic is masqueraded.
-    #          Underlying network must be capable of supporting Pod traffic across IP subnet.
-    # hybrid: noEncap if worker Nodes on same subnet, otherwise encap.
-    # networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod IPAM and connectivity to primary CNI.
-    #
-    trafficEncapMode: networkPolicyOnly
 
     # The port for the antrea-agent APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -1164,7 +1175,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-8hk5mt9mg7
+  name: antrea-config-8c5mfk22m2
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1271,7 +1282,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-8hk5mt9mg7
+          name: antrea-config-8c5mfk22m2
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1520,7 +1531,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-8hk5mt9mg7
+          name: antrea-config-8c5mfk22m2
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1044,7 +1044,8 @@ data:
     # feature that supports priorities, rule actions and externalEntities in the future.
     #  AntreaPolicy: false
 
-    # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each agent to a configured collector.
+    # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each
+    # agent to a configured collector.
     #  FlowExporter: false
 
     # Enable collecting and exposing NetworkPolicy statistics.
@@ -1065,7 +1066,26 @@ data:
     # Make sure it doesn't conflict with your existing interfaces.
     #hostGateway: antrea-gw0
 
-    # Encapsulation mode for communication between Pods across Nodes, supported values:
+    # Determines how traffic is encapsulated. It has the following options:
+    # encap(default):    Inter-node Pod traffic is always encapsulated and Pod to external network
+    #                    traffic is SNAT'd.
+    # noEncap:           Inter-node Pod traffic is not encapsulated; Pod to exteranl network traffic is
+    #                    SNAT'd if noSNAT is not set to true. Underlying network must be capable of
+    #                    supporting Pod traffic across IP subnets.
+    # hybrid:            noEncap if source and destination Nodes are on the same subnet, otherwise encap.
+    # networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod
+    #                    IPAM and connectivity to the primary CNI.
+    #
+    trafficEncapMode: networkPolicyOnly
+
+    # Whether or not to SNAT (using the Node IP) the egress traffic from a Pod to the external network.
+    # This option is for the noEncap traffic mode only, and the default value is false. In the noEncap
+    # mode, if the cluster's Pod CIDR is reachable from the external network, then the Pod traffic to
+    # the external network needs not be SNAT'd. In the networkPolicyOnly mode, antrea-agent never
+    # performs SNAT and this option will be ignored; for other modes it must be set to false.
+    #noSNAT: false
+
+    # Tunnel protocols used for encapsulating traffic across Nodes. Supported values:
     # - geneve (default)
     # - vxlan
     # - gre
@@ -1080,15 +1100,6 @@ data:
     # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
     # for the GRE tunnel type.
     #enableIPSecTunnel: false
-
-    # Determines how traffic is encapsulated. It has the following options
-    # encap(default): Inter-node Pod traffic is always encapsulated and Pod to outbound traffic is masqueraded.
-    # noEncap: Inter-node Pod traffic is not encapsulated, but Pod to outbound traffic is masqueraded.
-    #          Underlying network must be capable of supporting Pod traffic across IP subnet.
-    # hybrid: noEncap if worker Nodes on same subnet, otherwise encap.
-    # networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod IPAM and connectivity to primary CNI.
-    #
-    trafficEncapMode: networkPolicyOnly
 
     # The port for the antrea-agent APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -1164,7 +1175,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-8hk5mt9mg7
+  name: antrea-config-8c5mfk22m2
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1271,7 +1282,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-8hk5mt9mg7
+          name: antrea-config-8c5mfk22m2
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1522,7 +1533,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-8hk5mt9mg7
+          name: antrea-config-8c5mfk22m2
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1044,7 +1044,8 @@ data:
     # feature that supports priorities, rule actions and externalEntities in the future.
     #  AntreaPolicy: false
 
-    # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each agent to a configured collector.
+    # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each
+    # agent to a configured collector.
     #  FlowExporter: false
 
     # Enable collecting and exposing NetworkPolicy statistics.
@@ -1065,7 +1066,26 @@ data:
     # Make sure it doesn't conflict with your existing interfaces.
     #hostGateway: antrea-gw0
 
-    # Encapsulation mode for communication between Pods across Nodes, supported values:
+    # Determines how traffic is encapsulated. It has the following options:
+    # encap(default):    Inter-node Pod traffic is always encapsulated and Pod to external network
+    #                    traffic is SNAT'd.
+    # noEncap:           Inter-node Pod traffic is not encapsulated; Pod to exteranl network traffic is
+    #                    SNAT'd if noSNAT is not set to true. Underlying network must be capable of
+    #                    supporting Pod traffic across IP subnets.
+    # hybrid:            noEncap if source and destination Nodes are on the same subnet, otherwise encap.
+    # networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod
+    #                    IPAM and connectivity to the primary CNI.
+    #
+    trafficEncapMode: noEncap
+
+    # Whether or not to SNAT (using the Node IP) the egress traffic from a Pod to the external network.
+    # This option is for the noEncap traffic mode only, and the default value is false. In the noEncap
+    # mode, if the cluster's Pod CIDR is reachable from the external network, then the Pod traffic to
+    # the external network needs not be SNAT'd. In the networkPolicyOnly mode, antrea-agent never
+    # performs SNAT and this option will be ignored; for other modes it must be set to false.
+    #noSNAT: false
+
+    # Tunnel protocols used for encapsulating traffic across Nodes. Supported values:
     # - geneve (default)
     # - vxlan
     # - gre
@@ -1080,15 +1100,6 @@ data:
     # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
     # for the GRE tunnel type.
     #enableIPSecTunnel: false
-
-    # Determines how traffic is encapsulated. It has the following options
-    # encap(default): Inter-node Pod traffic is always encapsulated and Pod to outbound traffic is masqueraded.
-    # noEncap: Inter-node Pod traffic is not encapsulated, but Pod to outbound traffic is masqueraded.
-    #          Underlying network must be capable of supporting Pod traffic across IP subnet.
-    # hybrid: noEncap if worker Nodes on same subnet, otherwise encap.
-    # networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod IPAM and connectivity to primary CNI.
-    #
-    trafficEncapMode: noEncap
 
     # The port for the antrea-agent APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -1164,7 +1175,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-26mthf882c
+  name: antrea-config-78kch9fmgd
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1271,7 +1282,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-26mthf882c
+          name: antrea-config-78kch9fmgd
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1520,7 +1531,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-26mthf882c
+          name: antrea-config-78kch9fmgd
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1044,7 +1044,8 @@ data:
     # feature that supports priorities, rule actions and externalEntities in the future.
     #  AntreaPolicy: false
 
-    # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each agent to a configured collector.
+    # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each
+    # agent to a configured collector.
     #  FlowExporter: false
 
     # Enable collecting and exposing NetworkPolicy statistics.
@@ -1065,7 +1066,26 @@ data:
     # Make sure it doesn't conflict with your existing interfaces.
     #hostGateway: antrea-gw0
 
-    # Encapsulation mode for communication between Pods across Nodes, supported values:
+    # Determines how traffic is encapsulated. It has the following options:
+    # encap(default):    Inter-node Pod traffic is always encapsulated and Pod to external network
+    #                    traffic is SNAT'd.
+    # noEncap:           Inter-node Pod traffic is not encapsulated; Pod to exteranl network traffic is
+    #                    SNAT'd if noSNAT is not set to true. Underlying network must be capable of
+    #                    supporting Pod traffic across IP subnets.
+    # hybrid:            noEncap if source and destination Nodes are on the same subnet, otherwise encap.
+    # networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod
+    #                    IPAM and connectivity to the primary CNI.
+    #
+    #trafficEncapMode: encap
+
+    # Whether or not to SNAT (using the Node IP) the egress traffic from a Pod to the external network.
+    # This option is for the noEncap traffic mode only, and the default value is false. In the noEncap
+    # mode, if the cluster's Pod CIDR is reachable from the external network, then the Pod traffic to
+    # the external network needs not be SNAT'd. In the networkPolicyOnly mode, antrea-agent never
+    # performs SNAT and this option will be ignored; for other modes it must be set to false.
+    #noSNAT: false
+
+    # Tunnel protocols used for encapsulating traffic across Nodes. Supported values:
     # - geneve (default)
     # - vxlan
     # - gre
@@ -1085,15 +1105,6 @@ data:
     # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
     # AntreaProxy is enabled, this parameter is not needed and will be ignored if provided.
     #serviceCIDR: 10.96.0.0/12
-
-    # Determines how traffic is encapsulated. It has the following options
-    # encap(default): Inter-node Pod traffic is always encapsulated and Pod to outbound traffic is masqueraded.
-    # noEncap: Inter-node Pod traffic is not encapsulated, but Pod to outbound traffic is masqueraded.
-    #          Underlying network must be capable of supporting Pod traffic across IP subnet.
-    # hybrid: noEncap if worker Nodes on same subnet, otherwise encap.
-    # networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod IPAM and connectivity to primary CNI.
-    #
-    #trafficEncapMode: encap
 
     # The port for the antrea-agent APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -1169,7 +1180,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-799khkd457
+  name: antrea-config-96k9447m55
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1285,7 +1296,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-799khkd457
+          name: antrea-config-96k9447m55
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1569,7 +1580,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-799khkd457
+          name: antrea-config-96k9447m55
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1044,7 +1044,8 @@ data:
     # feature that supports priorities, rule actions and externalEntities in the future.
     #  AntreaPolicy: false
 
-    # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each agent to a configured collector.
+    # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each
+    # agent to a configured collector.
     #  FlowExporter: false
 
     # Enable collecting and exposing NetworkPolicy statistics.
@@ -1065,7 +1066,26 @@ data:
     # Make sure it doesn't conflict with your existing interfaces.
     #hostGateway: antrea-gw0
 
-    # Encapsulation mode for communication between Pods across Nodes, supported values:
+    # Determines how traffic is encapsulated. It has the following options:
+    # encap(default):    Inter-node Pod traffic is always encapsulated and Pod to external network
+    #                    traffic is SNAT'd.
+    # noEncap:           Inter-node Pod traffic is not encapsulated; Pod to exteranl network traffic is
+    #                    SNAT'd if noSNAT is not set to true. Underlying network must be capable of
+    #                    supporting Pod traffic across IP subnets.
+    # hybrid:            noEncap if source and destination Nodes are on the same subnet, otherwise encap.
+    # networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod
+    #                    IPAM and connectivity to the primary CNI.
+    #
+    #trafficEncapMode: encap
+
+    # Whether or not to SNAT (using the Node IP) the egress traffic from a Pod to the external network.
+    # This option is for the noEncap traffic mode only, and the default value is false. In the noEncap
+    # mode, if the cluster's Pod CIDR is reachable from the external network, then the Pod traffic to
+    # the external network needs not be SNAT'd. In the networkPolicyOnly mode, antrea-agent never
+    # performs SNAT and this option will be ignored; for other modes it must be set to false.
+    #noSNAT: false
+
+    # Tunnel protocols used for encapsulating traffic across Nodes. Supported values:
     # - geneve (default)
     # - vxlan
     # - gre
@@ -1085,15 +1105,6 @@ data:
     # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
     # AntreaProxy is enabled, this parameter is not needed and will be ignored if provided.
     #serviceCIDR: 10.96.0.0/12
-
-    # Determines how traffic is encapsulated. It has the following options
-    # encap(default): Inter-node Pod traffic is always encapsulated and Pod to outbound traffic is masqueraded.
-    # noEncap: Inter-node Pod traffic is not encapsulated, but Pod to outbound traffic is masqueraded.
-    #          Underlying network must be capable of supporting Pod traffic across IP subnet.
-    # hybrid: noEncap if worker Nodes on same subnet, otherwise encap.
-    # networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod IPAM and connectivity to primary CNI.
-    #
-    #trafficEncapMode: encap
 
     # The port for the antrea-agent APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -1169,7 +1180,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-f4kt4bdh8t
+  name: antrea-config-75558f6fff
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1276,7 +1287,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-f4kt4bdh8t
+          name: antrea-config-75558f6fff
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1525,7 +1536,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-f4kt4bdh8t
+          name: antrea-config-75558f6fff
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -13,7 +13,8 @@ featureGates:
 # feature that supports priorities, rule actions and externalEntities in the future.
 #  AntreaPolicy: false
 
-# Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each agent to a configured collector.
+# Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each
+# agent to a configured collector.
 #  FlowExporter: false
 
 # Enable collecting and exposing NetworkPolicy statistics.
@@ -34,7 +35,26 @@ featureGates:
 # Make sure it doesn't conflict with your existing interfaces.
 #hostGateway: antrea-gw0
 
-# Encapsulation mode for communication between Pods across Nodes, supported values:
+# Determines how traffic is encapsulated. It has the following options:
+# encap(default):    Inter-node Pod traffic is always encapsulated and Pod to external network
+#                    traffic is SNAT'd.
+# noEncap:           Inter-node Pod traffic is not encapsulated; Pod to exteranl network traffic is
+#                    SNAT'd if noSNAT is not set to true. Underlying network must be capable of
+#                    supporting Pod traffic across IP subnets.
+# hybrid:            noEncap if source and destination Nodes are on the same subnet, otherwise encap.
+# networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod
+#                    IPAM and connectivity to the primary CNI.
+#
+#trafficEncapMode: encap
+
+# Whether or not to SNAT (using the Node IP) the egress traffic from a Pod to the external network.
+# This option is for the noEncap traffic mode only, and the default value is false. In the noEncap
+# mode, if the cluster's Pod CIDR is reachable from the external network, then the Pod traffic to
+# the external network needs not be SNAT'd. In the networkPolicyOnly mode, antrea-agent never
+# performs SNAT and this option will be ignored; for other modes it must be set to false.
+#noSNAT: false
+
+# Tunnel protocols used for encapsulating traffic across Nodes. Supported values:
 # - geneve (default)
 # - vxlan
 # - gre
@@ -54,15 +74,6 @@ featureGates:
 # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
 # AntreaProxy is enabled, this parameter is not needed and will be ignored if provided.
 #serviceCIDR: 10.96.0.0/12
-
-# Determines how traffic is encapsulated. It has the following options
-# encap(default): Inter-node Pod traffic is always encapsulated and Pod to outbound traffic is masqueraded.
-# noEncap: Inter-node Pod traffic is not encapsulated, but Pod to outbound traffic is masqueraded.
-#          Underlying network must be capable of supporting Pod traffic across IP subnet.
-# hybrid: noEncap if worker Nodes on same subnet, otherwise encap.
-# networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod IPAM and connectivity to primary CNI.
-#
-#trafficEncapMode: encap
 
 # The port for the antrea-agent APIServer to serve on.
 # Note that if it's set to another value, the `containerPort` of the `api` port of the

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -107,7 +107,7 @@ func run(o *Options) error {
 		TrafficEncapMode:  encapMode,
 		EnableIPSecTunnel: o.config.EnableIPSecTunnel}
 
-	routeClient, err := route.NewClient(serviceCIDRNet, encapMode)
+	routeClient, err := route.NewClient(serviceCIDRNet, encapMode, o.config.NoSNAT)
 	if err != nil {
 		return fmt.Errorf("error creating route client: %v", err)
 	}

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -48,7 +48,23 @@ type AgentConfig struct {
 	// Make sure it doesn't conflict with your existing interfaces.
 	// Defaults to antrea-gw0.
 	HostGateway string `yaml:"hostGateway,omitempty"`
-	// Encapsulation mode for communication between Pods across Nodes, supported values:
+	// Determines how traffic is encapsulated. It has the following options:
+	// encap(default):    Inter-node Pod traffic is always encapsulated and Pod to external network
+	//                    traffic is SNAT'd.
+	// noEncap:           Inter-node Pod traffic is not encapsulated; Pod to exteranl network traffic is
+	//                    SNAT'd if noSNAT is not set to true. Underlying network must be capable of
+	//                    supporting Pod traffic across IP subnets.
+	// hybrid:            noEncap if source and destination Nodes are on the same subnet, otherwise encap.
+	// networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod
+	//                    IPAM and connectivity to the primary CNI.
+	TrafficEncapMode string `yaml:"trafficEncapMode,omitempty"`
+	// Whether or not to SNAT (using the Node IP) the egress traffic from a Pod to the external network.
+	// This option is for the noEncap traffic mode only, and the default value is false. In the noEncap
+	// mode, if the cluster's Pod CIDR is reachable from the external network, then the Pod traffic to
+	// the external network needs not be SNAT'd. In the networkPolicyOnly mode, antrea-agent never
+	// performs SNAT and this option will be ignored; for other modes it must be set to false.
+	NoSNAT bool `yaml:"noSNAT,omitempty"`
+	// Tunnel protocols used for encapsulating traffic across Nodes. Supported values:
 	// - geneve (default)
 	// - vxlan
 	// - gre
@@ -74,13 +90,6 @@ type AgentConfig struct {
 	// through an environment variable: ANTREA_IPSEC_PSK.
 	// Defaults to false.
 	EnableIPSecTunnel bool `yaml:"enableIPSecTunnel,omitempty"`
-	// Determines how traffic is encapsulated. It has the following options
-	// Encap(default): Inter-node Pod traffic is always encapsulated and Pod to outbound traffic is masqueraded.
-	// NoEncap: Inter-node Pod traffic is not encapsulated, but Pod to outbound traffic is masqueraded.
-	//          Underlying network must be capable of supporting Pod traffic across IP subnet.
-	// Hybrid: noEncap if worker Nodes on same subnet, otherwise encap.
-	// NetworkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod IPAM and connectivity to primary CNI.
-	TrafficEncapMode string `yaml:"trafficEncapMode,omitempty"`
 	// APIPort is the port for the antrea-agent APIServer to serve on.
 	// Defaults to 10350.
 	APIPort int `yaml:"apiPort,omitempty"`

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -44,7 +44,7 @@ type Client struct {
 }
 
 // NewClient returns a route client.
-func NewClient(serviceCIDR *net.IPNet, encapMode config.TrafficEncapModeType) (*Client, error) {
+func NewClient(serviceCIDR *net.IPNet, encapMode config.TrafficEncapModeType, noSNAT bool) (*Client, error) {
 	nr := netroute.New()
 	return &Client{
 		nr:          nr,

--- a/pkg/agent/route/route_windows_test.go
+++ b/pkg/agent/route/route_windows_test.go
@@ -52,7 +52,7 @@ func TestRouteOperation(t *testing.T) {
 	nr := netroute.New()
 	defer nr.Exit()
 
-	client, err := NewClient(serviceCIDR, 0)
+	client, err := NewClient(serviceCIDR, 0, false)
 	require.Nil(t, err)
 	nodeConfig := &config.NodeConfig{
 		GatewayConfig: &config.GatewayConfig{


### PR DESCRIPTION
In the noEncap mode, if the cluster's Pod CIDR is routable in the Node
network, then SNAT is not required for the Pod egress traffic to the
Node or external network.

Resolves #1383