### PR TITLE
[IPv6] Add 2 Network Policy tests

### DIFF
--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -64,6 +64,12 @@ func skipIfIPv6Cluster(tb testing.TB) {
 	}
 }
 
+func skipIfNotIPv6Cluster(tb testing.TB) {
+	if clusterInfo.podV6NetworkCIDR == "" {
+		tb.Skipf("Skipping test as it is not needed in IPv4 cluster")
+	}
+}
+
 func ensureAntreaRunning(tb testing.TB, data *TestData) error {
 	tb.Logf("Applying Antrea YAML")
 	if err := data.deployAntrea(); err != nil {


### PR DESCRIPTION
2 upstream Network Policy tests didn't consider netmask for IPv6, this patch
is to add correct tests. When bug is fixed in latest release, these 2 tests can be deleted.
Kubernetes PR:
https://github.com/kubernetes/kubernetes/pull/93583
2 testcases
https://github.com/kubernetes/kubernetes/blob/v1.20.0-alpha.0/test/e2e/network/network_policy.go#L1365
https://github.com/kubernetes/kubernetes/blob/v1.20.0-alpha.0/test/e2e/network/network_policy.go#L1444