### PR TITLE
Set tun_metadata0 for non-Traceflow traffics

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -37,7 +37,6 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/route"
 	"github.com/vmware-tanzu/antrea/pkg/agent/types"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"
-	"github.com/vmware-tanzu/antrea/pkg/features"
 	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 	"github.com/vmware-tanzu/antrea/pkg/util/env"
 )
@@ -292,14 +291,6 @@ func (i *Initializer) initOpenFlowPipeline() error {
 
 	// When IPSec encyption is enabled, no flow is needed for the default tunnel interface.
 	if i.networkConfig.TrafficEncapMode.SupportsEncap() {
-		if features.DefaultFeatureGate.Enabled(features.Traceflow) {
-			// Set up Traceflow TLV map. This command is Nicira extensions to OpenFlow and require Open
-			// vSwitch 2.5 or later.
-			if err := i.ofClient.InitialTLVMap(); err != nil {
-				klog.Errorf("Error during Openflow TLV map initialization: %v", err)
-				return err
-			}
-		}
 		// Set up flow entries for the default tunnel port interface.
 		if err := i.ofClient.InstallDefaultTunnelFlows(config.DefaultTunOFPort); err != nil {
 			klog.Errorf("Failed to setup openflow entries for tunnel interface: %v", err)

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -508,6 +508,13 @@ func (c *client) InstallBridgeUplinkFlows(uplinkPort uint32, bridgeLocalPort uin
 }
 
 func (c *client) initialize() error {
+	if c.enableTLVMap {
+		// Set up Traceflow TLV map. This command uses Nicira extensions to OpenFlow and requires Open
+		// vSwitch 2.5 or later.
+		if err := c.InitialTLVMap(); err != nil {
+			return fmt.Errorf("failed to install TLV map: %v", err)
+		}
+	}
 	if err := c.ofEntryOperations.AddAll(c.defaultFlows()); err != nil {
 		return fmt.Errorf("failed to install default flows: %v", err)
 	}

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -88,7 +88,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeNoEncap}, true, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}
@@ -116,7 +116,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeNoEncap}, true, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}
@@ -157,7 +157,7 @@ func TestFlowInstallationFailed(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeNoEncap}, true, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}
@@ -191,7 +191,7 @@ func TestConcurrentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeNoEncap}, true, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/apis/ops/v1alpha1"
 )
 
@@ -44,8 +43,6 @@ func TestTraceflowIntraNode(t *testing.T) {
 		t.Fatalf("Error when setting up test: %v", err)
 	}
 	defer teardownTest(t, data)
-
-	skipIfEncapModeIs(t, data, []config.TrafficEncapModeType{config.TrafficEncapModeNoEncap, config.TrafficEncapModeNetworkPolicyOnly})
 
 	if err = data.enableTraceflow(t); err != nil {
 		t.Fatal("Error when enabling Traceflow")


### PR DESCRIPTION
This patch is to fix "wrong tun_metadata" issue, which affects Antrea
Traceflow feature.
Currently, OVS cannot generates a megaflow which matches a field that
is not present, which caused matching wrong tun_metadata if the traffic
contains data with and without tun_metadata, and it is not clear if it
makes sense to support that (match a field that is not present). Also,
the current OpenFlow pipeline seems to assume that if tun_metadata0 is
not present, then its value is zero. But actually the value is undefined
if the tun_metadata is not present.

This PR closes #1357 