### PR TITLE
Add asyncRuleCache to idAllocator in Antrea Agent

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -93,13 +93,6 @@ func run(o *Options) error {
 		features.DefaultFeatureGate.Enabled(features.AntreaProxy),
 		features.DefaultFeatureGate.Enabled(features.AntreaPolicy))
 
-	// statsCollector collects stats and reports to the antrea-controller periodically. For now it's only used for
-	// NetworkPolicy stats.
-	var statsCollector *stats.Collector
-	if features.DefaultFeatureGate.Enabled(features.NetworkPolicyStats) {
-		statsCollector = stats.NewCollector(antreaClientProvider, ofClient)
-	}
-
 	_, serviceCIDRNet, _ := net.ParseCIDR(o.config.ServiceCIDR)
 	_, encapMode := config.GetTrafficEncapModeFromStr(o.config.TrafficEncapMode)
 	networkConfig := &config.NetworkConfig{
@@ -144,21 +137,6 @@ func run(o *Options) error {
 		networkConfig,
 		nodeConfig)
 
-	var traceflowController *traceflow.Controller
-	if features.DefaultFeatureGate.Enabled(features.Traceflow) {
-		traceflowController = traceflow.NewTraceflowController(
-			k8sClient,
-			informerFactory,
-			crdClient,
-			traceflowInformer,
-			ofClient,
-			ovsBridgeClient,
-			ifaceStore,
-			networkConfig,
-			nodeConfig,
-			serviceCIDRNet)
-	}
-
 	// podUpdates is a channel for receiving Pod updates from CNIServer and
 	// notifying NetworkPolicyController to reconcile rules related to the
 	// updated Pods.
@@ -173,6 +151,14 @@ func run(o *Options) error {
 	if err != nil {
 		return fmt.Errorf("error creating new NetworkPolicy controller: %v", err)
 	}
+
+	// statsCollector collects stats and reports to the antrea-controller periodically. For now it's only used for
+	// NetworkPolicy stats.
+	var statsCollector *stats.Collector
+	if features.DefaultFeatureGate.Enabled(features.NetworkPolicyStats) {
+		statsCollector = stats.NewCollector(antreaClientProvider, ofClient, networkPolicyController)
+	}
+
 	isChaining := false
 	if networkConfig.TrafficEncapMode.IsNetworkPolicyOnly() {
 		isChaining = true
@@ -192,6 +178,22 @@ func run(o *Options) error {
 	err = cniServer.Initialize(ovsBridgeClient, ofClient, ifaceStore, o.config.OVSDatapathType)
 	if err != nil {
 		return fmt.Errorf("error initializing CNI server: %v", err)
+	}
+
+	var traceflowController *traceflow.Controller
+	if features.DefaultFeatureGate.Enabled(features.Traceflow) {
+		traceflowController = traceflow.NewTraceflowController(
+			k8sClient,
+			informerFactory,
+			crdClient,
+			traceflowInformer,
+			ofClient,
+			networkPolicyController,
+			ovsBridgeClient,
+			ifaceStore,
+			networkConfig,
+			nodeConfig,
+			serviceCIDRNet)
 	}
 
 	// TODO: we should call this after installing flows for initial node routes

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/cenkalti/hub v1.0.1 // indirect
 	github.com/cenkalti/rpc2 v0.0.0-20180727162946-9642ea02d0aa // indirect
 	github.com/cheggaaa/pb/v3 v3.0.4
-	github.com/confluentinc/bincover v0.0.0-20200910210245-839e88185831
+	github.com/confluentinc/bincover v0.1.0
 	github.com/containernetworking/cni v0.7.1
 	github.com/containernetworking/plugins v0.8.2-0.20190724153215-ded2f1757770
 	github.com/contiv/libOpenflow v0.0.0-20201014051314-c1702744526c
@@ -41,13 +41,11 @@ require (
 	github.com/ti-mo/conntrack v0.3.0
 	github.com/vishvananda/netlink v1.1.0
 	github.com/vmware/go-ipfix v0.2.1
-	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
 	golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495
-	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
-	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20200331124033-c3d80250170d
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/grpc v1.26.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.2.8

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/cheggaaa/pb/v3 v3.0.4/go.mod h1:7rgWxLrAUcFMkvJuv09+DYi7mMUYi8nO9iOWc
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa h1:OaNxuTZr7kxeODyLWsRMC+OD03aFUH+mW6r2d+MWa5Y=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
-github.com/confluentinc/bincover v0.0.0-20200910210245-839e88185831 h1:ywdQifxYw0VXYZfWtykHW785ueW1PgLrYuSdHA31gk4=
-github.com/confluentinc/bincover v0.0.0-20200910210245-839e88185831/go.mod h1:qeI1wx0RxdGTZtrJY0HVlgJ4NqC/X2Z+fHbvy87tgHE=
+github.com/confluentinc/bincover v0.1.0 h1:M4Gfj4rCXuUQVe8TqT/VXcAMjLyvN81oDRy79fjSv3o=
+github.com/confluentinc/bincover v0.1.0/go.mod h1:qeI1wx0RxdGTZtrJY0HVlgJ4NqC/X2Z+fHbvy87tgHE=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f h1:tSNMc+rJDfmYntojat8lljbt1mgKNpTxUZJsSzJ9Y1s=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
@@ -422,9 +422,8 @@ golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495 h1:I6A9Ag9FpEKOjcKrRNjQkPHawoXIhKyTGfvvjFAiiAk=
 golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -453,9 +452,8 @@ golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191007182048-72f939374954/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
-golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
@@ -465,9 +463,8 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
-golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -522,9 +519,8 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/pkg/agent/controller/networkpolicy/allocator_test.go
+++ b/pkg/agent/controller/networkpolicy/allocator_test.go
@@ -17,8 +17,18 @@ package networkpolicy
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/types"
+	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane/v1beta2"
+)
+
+const (
+	testAsyncDeleteInterval = time.Millisecond * 5
 )
 
 func TestNewIDAllocator(t *testing.T) {
@@ -61,28 +71,38 @@ func TestNewIDAllocator(t *testing.T) {
 	}
 }
 
-func TestAllocate(t *testing.T) {
+func TestAllocateForRule(t *testing.T) {
+	rule := &types.PolicyRule{
+		Direction: v1beta2.DirectionIn,
+		From:      []types.Address{},
+		To:        ofPortsToOFAddresses(sets.NewInt32(1)),
+		Service:   nil,
+	}
 	tests := []struct {
 		name        string
 		args        []uint32
+		rule        *types.PolicyRule
 		expectedID  uint32
 		expectedErr error
 	}{
 		{
 			"zero-allocated-ids",
 			nil,
+			rule,
 			1,
 			nil,
 		},
 		{
 			"consecutive-allocated-ids",
 			[]uint32{1, 2},
+			rule,
 			3,
 			nil,
 		},
 		{
 			"inconsecutive-allocated-ids",
 			[]uint32{1, 7, 5},
+			rule,
 			2,
 			nil,
 		},
@@ -90,11 +110,14 @@ func TestAllocate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := newIDAllocator(tt.args...)
-			actualID, actualErr := a.allocate()
+			actualErr := a.allocateForRule(tt.rule)
 			if actualErr != tt.expectedErr {
 				t.Fatalf("Got error %v, expected %v", actualErr, tt.expectedErr)
 			}
-			assert.Equalf(t, tt.expectedID, actualID, "Got id %v, expected %v", actualID, tt.expectedID)
+			assert.Equalf(t, tt.expectedID, tt.rule.FlowID, "Got id %v, expected %v", tt.rule.FlowID, tt.expectedID)
+			ruleFromCache, err := a.getRuleFromAsyncCache(tt.expectedID)
+			assert.Nilf(t, err, "getRuleFromAsyncCache should return valid rule with id: %v", tt.expectedID)
+			assert.Equalf(t, tt.rule, ruleFromCache, "getRuleFromAsyncCache should return expected rule")
 		})
 	}
 }
@@ -140,6 +163,57 @@ func TestRelease(t *testing.T) {
 			assert.Equalf(t, tt.expectedErr, actualErr, "Got error %v, expected %v", actualErr, tt.expectedErr)
 			assert.Equalf(t, tt.expectedAvailableSets, a.availableSet, "Got availableSet %v, expected %v", a.availableSet, tt.expectedAvailableSets)
 			assert.Equalf(t, tt.expectedAvailableSlice, a.availableSlice, "Got availableSlice %v, expected %v", a.availableSlice, tt.expectedAvailableSlice)
+		})
+	}
+}
+
+func TestWorker(t *testing.T) {
+	rule := &types.PolicyRule{
+		Direction: v1beta2.DirectionIn,
+		From:      []types.Address{},
+		To:        ofPortsToOFAddresses(sets.NewInt32(1)),
+		Service:   nil,
+	}
+	tests := []struct {
+		name        string
+		args        []uint32
+		rule        *types.PolicyRule
+		expectedID  uint32
+		expectedErr error
+	}{
+		{
+			"delete-rule-from-async-rule-cache",
+			nil,
+			rule,
+			1,
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := newIDAllocator(tt.args...)
+			actualErr := a.allocateForRule(tt.rule)
+			if actualErr != tt.expectedErr {
+				t.Fatalf("Got error %v, expected %v", actualErr, tt.expectedErr)
+			}
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			go wait.Until(a.worker, time.Millisecond, stopCh)
+
+			a.asyncRuleCache.deleteQueue.AddAfter(tt.rule.FlowID, testAsyncDeleteInterval)
+			conditionFunc := func() (bool, error) {
+				a.Lock()
+				defer a.Unlock()
+				if len(a.availableSlice) > 0 {
+					return true, nil
+				}
+				return false, nil
+			}
+			if err := wait.Poll(time.Millisecond, time.Millisecond * 10, conditionFunc); err != nil {
+				t.Fatalf("Expect the rule with id %v to be deleted from async rule cache", tt.expectedID)
+			}
+			_, err := a.getRuleFromAsyncCache(tt.expectedID)
+			assert.NotNilf(t, err, "Expect rule to be not present in asyncRuleCache")
 		})
 	}
 }

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -376,8 +376,8 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 		go wait.Until(c.worker, time.Second, stopCh)
 	}
 
-	klog.Infof("Starting IDAllocator worker now to maintain async rule cache.")
-	go wait.Until(c.reconciler.GetIDAllocatorWorker(), time.Second, stopCh)
+	klog.Infof("Start IDAllocator worker to maintain the async rule cache.")
+	go c.reconciler.RunIDAllocatorWorker(stopCh)
 
 	<-stopCh
 }

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -106,8 +106,8 @@ func (r *mockReconciler) RunIDAllocatorWorker(_ <-chan struct{}) {
 	return
 }
 
-func (r *mockReconciler) GetRuleByFlowID(_ uint32) (*agenttypes.PolicyRule, error) {
-	return nil, nil
+func (r *mockReconciler) GetRuleByFlowID(_ uint32) (*agenttypes.PolicyRule, bool, error) {
+	return nil, false, nil
 }
 
 func (r *mockReconciler) getLastRealized(ruleID string) (*CompletedRule, bool) {

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -102,10 +102,8 @@ func (r *mockReconciler) Forget(ruleID string) error {
 	return nil
 }
 
-func (r *mockReconciler) GetIDAllocatorWorker() func() {
-	return func() {
-		return
-	}
+func (r *mockReconciler) RunIDAllocatorWorker(_ <-chan struct{}) {
+	return
 }
 
 func (r *mockReconciler) GetRuleByFlowID(_ uint32) (*agenttypes.PolicyRule, error) {

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/component-base/metrics/testutil"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/metrics"
+	agenttypes "github.com/vmware-tanzu/antrea/pkg/agent/types"
 	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane/v1beta2"
 	"github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned"
 	"github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned/fake"
@@ -99,6 +100,16 @@ func (r *mockReconciler) Forget(ruleID string) error {
 	delete(r.lastRealized, ruleID)
 	r.deleted <- ruleID
 	return nil
+}
+
+func (r *mockReconciler) GetIDAllocatorWorker() func() {
+	return func() {
+		return
+	}
+}
+
+func (r *mockReconciler) GetRuleByFlowID(_ uint32) (*agenttypes.PolicyRule, error) {
+	return nil, nil
 }
 
 func (r *mockReconciler) getLastRealized(ruleID string) (*CompletedRule, bool) {

--- a/pkg/agent/controller/networkpolicy/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/reconciler.go
@@ -52,6 +52,12 @@ type Reconciler interface {
 
 	// Forget cleanups the actual state of Openflow entries of the specified ruleID.
 	Forget(ruleID string) error
+
+	// GetIDAllocatorWorker returns the idAllocator worker
+	GetIDAllocatorWorker() func()
+
+	// GetRuleByFlowID return the rule from async rule cache in idAllocator
+	GetRuleByFlowID(ruleID uint32) (*types.PolicyRule, error)
 }
 
 // servicesKey is used to identify Services based on their numbered ports.
@@ -172,7 +178,7 @@ type reconciler struct {
 	// It's a mapping from ruleID to *lastRealized.
 	lastRealizeds sync.Map
 
-	// idAllocator provides interfaces to allocate and release uint32 id.
+	// idAllocator provides interfaces to allocateForRule and release uint32 id.
 	idAllocator *idAllocator
 
 	// priorityAssigners provides interfaces to manage OF priorities for each OVS table.
@@ -366,16 +372,15 @@ func (r *reconciler) add(rule *CompletedRule, ofPriority *uint16, table binding.
 	ofRuleByServicesMap, lastRealized := r.computeOFRulesForAdd(rule, ofPriority, table)
 	for svcKey, ofRule := range ofRuleByServicesMap {
 		// Each pod group gets an Openflow ID.
-		ofID, err := r.idAllocator.allocate()
+		err := r.idAllocator.allocateForRule(ofRule)
 		if err != nil {
 			return fmt.Errorf("error allocating Openflow ID")
 		}
-		ofRule.FlowID = ofID
 		if err = r.installOFRule(ofRule); err != nil {
 			return err
 		}
 		// Record ofID only if its Openflow is installed successfully.
-		lastRealized.ofIDs[svcKey] = ofID
+		lastRealized.ofIDs[svcKey] = ofRule.FlowID
 	}
 	return nil
 }
@@ -475,21 +480,20 @@ func (r *reconciler) batchAdd(rules []*CompletedRule, ofPriorities []*uint16) er
 		ofRuleByServicesMap, lastRealized := r.computeOFRulesForAdd(rule, ofPriorities[idx], ruleTable)
 		lastRealizeds[idx] = lastRealized
 		for svcKey, ofRule := range ofRuleByServicesMap {
-			ofID, err := r.idAllocator.allocate()
+			err := r.idAllocator.allocateForRule(ofRule)
 			if err != nil {
 				return fmt.Errorf("error allocating Openflow ID")
 			}
-			ofRule.FlowID = ofID
 			allOFRules = append(allOFRules, ofRule)
 			if ofIDUpdateMaps[idx] == nil {
 				ofIDUpdateMaps[idx] = make(map[servicesKey]uint32)
 			}
-			ofIDUpdateMaps[idx][svcKey] = ofID
+			ofIDUpdateMaps[idx][svcKey] = ofRule.FlowID
 		}
 	}
 	if err := r.ofClient.BatchInstallPolicyRuleFlows(allOFRules); err != nil {
 		for _, rule := range allOFRules {
-			r.idAllocator.release(rule.FlowID)
+			r.idAllocator.forgetRule(rule.FlowID)
 		}
 		return err
 	}
@@ -527,10 +531,6 @@ func (r *reconciler) update(lastRealized *lastRealized, newRule *CompletedRule, 
 			ofID, exists := lastRealized.ofIDs[svcKey]
 			// Install a new Openflow rule if this group doesn't exist, otherwise do incremental update.
 			if !exists {
-				ofID, err := r.idAllocator.allocate()
-				if err != nil {
-					return fmt.Errorf("error allocating Openflow ID")
-				}
 				ofRule := &types.PolicyRule{
 					Direction:     v1beta2.DirectionIn,
 					From:          append(from1, from2...),
@@ -543,10 +543,14 @@ func (r *reconciler) update(lastRealized *lastRealized, newRule *CompletedRule, 
 					PolicyRef:     newRule.SourceRef,
 					EnableLogging: newRule.EnableLogging,
 				}
+				err := r.idAllocator.allocateForRule(ofRule)
+				if err != nil {
+					return fmt.Errorf("error allocating Openflow ID")
+				}
 				if err = r.installOFRule(ofRule); err != nil {
 					return err
 				}
-				lastRealized.ofIDs[svcKey] = ofID
+				lastRealized.ofIDs[svcKey] = ofRule.FlowID
 			} else {
 				addedTo := ofPortsToOFAddresses(newOFPorts.Difference(lastRealized.podOFPorts[svcKey]))
 				deletedTo := ofPortsToOFAddresses(lastRealized.podOFPorts[svcKey].Difference(newOFPorts))
@@ -576,10 +580,6 @@ func (r *reconciler) update(lastRealized *lastRealized, newRule *CompletedRule, 
 		for svcKey, members := range memberByServicesMap {
 			ofID, exists := lastRealized.ofIDs[svcKey]
 			if !exists {
-				ofID, err := r.idAllocator.allocate()
-				if err != nil {
-					return fmt.Errorf("error allocating Openflow ID")
-				}
 				ofRule := &types.PolicyRule{
 					Direction:     v1beta2.DirectionOut,
 					From:          from,
@@ -592,10 +592,14 @@ func (r *reconciler) update(lastRealized *lastRealized, newRule *CompletedRule, 
 					PolicyRef:     newRule.SourceRef,
 					EnableLogging: newRule.EnableLogging,
 				}
+				err := r.idAllocator.allocateForRule(ofRule)
+				if err != nil {
+					return fmt.Errorf("error allocating Openflow ID")
+				}
 				if err = r.installOFRule(ofRule); err != nil {
 					return err
 				}
-				lastRealized.ofIDs[svcKey] = ofID
+				lastRealized.ofIDs[svcKey] = ofRule.FlowID
 			} else {
 				addedTo := groupMembersToOFAddresses(members.Difference(prevMembersByServicesMap[svcKey]))
 				deletedTo := groupMembersToOFAddresses(prevMembersByServicesMap[svcKey].Difference(members))
@@ -624,7 +628,7 @@ func (r *reconciler) installOFRule(ofRule *types.PolicyRule) error {
 	klog.V(2).Infof("Installing ofRule %d (Direction: %v, From: %d, To: %d, Service: %d)",
 		ofRule.FlowID, ofRule.Direction, len(ofRule.From), len(ofRule.To), len(ofRule.Service))
 	if err := r.ofClient.InstallPolicyRuleFlows(ofRule); err != nil {
-		r.idAllocator.release(ofRule.FlowID)
+		r.idAllocator.forgetRule(ofRule.FlowID)
 		return fmt.Errorf("error installing ofRule %v: %v", ofRule.FlowID, err)
 	}
 	return nil
@@ -676,10 +680,7 @@ func (r *reconciler) uninstallOFRule(ofID uint32, table binding.TableIDType) err
 			priorityAssigner.assigner.Release(uint16(priorityNum))
 		}
 	}
-	if err := r.idAllocator.release(ofID); err != nil {
-		// This should never happen. If it does, it is a programming error.
-		klog.Errorf("Error releasing Openflow ID for ofRule %v: %v", ofID, err)
-	}
+	r.idAllocator.forgetRule(ofID)
 	return nil
 }
 
@@ -711,6 +712,14 @@ func (r *reconciler) Forget(ruleID string) error {
 
 	r.lastRealizeds.Delete(ruleID)
 	return nil
+}
+
+func (r *reconciler) GetIDAllocatorWorker() func() {
+	return r.idAllocator.worker
+}
+
+func (r *reconciler) GetRuleByFlowID(ruleFlowID uint32) (*types.PolicyRule, error) {
+	return r.idAllocator.getRuleFromAsyncCache(ruleFlowID)
 }
 
 func (r *reconciler) getPodOFPorts(members v1beta2.GroupMemberSet) sets.Int32 {

--- a/pkg/agent/controller/traceflow/packetin.go
+++ b/pkg/agent/controller/traceflow/packetin.go
@@ -137,7 +137,7 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*opsv1alpha1.Tracefl
 		ob.Component = opsv1alpha1.NetworkPolicy
 		ob.ComponentInfo = openflow.GetFlowTableName(openflow.EgressRuleTable)
 		ob.Action = opsv1alpha1.Forwarded
-		npRef := c.ofClient.GetPolicyFromConjunction(egressInfo)
+		npRef := c.networkPolicyQuerier.GetNetworkPolicyByRuleFlowID(egressInfo)
 		if npRef != nil {
 			ob.NetworkPolicy = npRef.ToString()
 		}
@@ -154,7 +154,7 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*opsv1alpha1.Tracefl
 		ob.Component = opsv1alpha1.NetworkPolicy
 		ob.ComponentInfo = openflow.GetFlowTableName(openflow.IngressRuleTable)
 		ob.Action = opsv1alpha1.Forwarded
-		npRef := c.ofClient.GetPolicyFromConjunction(ingressInfo)
+		npRef := c.networkPolicyQuerier.GetNetworkPolicyByRuleFlowID(ingressInfo)
 		if npRef != nil {
 			ob.NetworkPolicy = npRef.ToString()
 		}

--- a/pkg/agent/controller/traceflow/traceflow_controller.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller.go
@@ -42,6 +42,7 @@ import (
 	opslisters "github.com/vmware-tanzu/antrea/pkg/client/listers/ops/v1alpha1"
 	"github.com/vmware-tanzu/antrea/pkg/features"
 	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
+	"github.com/vmware-tanzu/antrea/pkg/querier"
 )
 
 type icmpType uint8
@@ -76,6 +77,7 @@ type Controller struct {
 	traceflowListerSynced  cache.InformerSynced
 	ovsBridgeClient        ovsconfig.OVSBridgeClient
 	ofClient               openflow.Client
+	networkPolicyQuerier   querier.AgentNetworkPolicyInfoQuerier
 	interfaceStore         interfacestore.InterfaceStore
 	networkConfig          *config.NetworkConfig
 	nodeConfig             *config.NodeConfig
@@ -95,6 +97,7 @@ func NewTraceflowController(
 	traceflowClient clientsetversioned.Interface,
 	traceflowInformer opsinformers.TraceflowInformer,
 	client openflow.Client,
+	npQuerier querier.AgentNetworkPolicyInfoQuerier,
 	ovsBridgeClient ovsconfig.OVSBridgeClient,
 	interfaceStore interfacestore.InterfaceStore,
 	networkConfig *config.NetworkConfig,
@@ -108,6 +111,7 @@ func NewTraceflowController(
 		traceflowListerSynced: traceflowInformer.Informer().HasSynced,
 		ovsBridgeClient:       ovsBridgeClient,
 		ofClient:              client,
+		networkPolicyQuerier:  npQuerier,
 		interfaceStore:        interfaceStore,
 		networkConfig:         networkConfig,
 		nodeConfig:            nodeConfig,

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -25,7 +25,6 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow/cookie"
 	"github.com/vmware-tanzu/antrea/pkg/agent/types"
-	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane/v1beta2"
 	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
 	"github.com/vmware-tanzu/antrea/third_party/proxy"
 )
@@ -216,9 +215,6 @@ type Client interface {
 
 	// Initial tun_metadata0 in TLV map for Traceflow.
 	InitialTLVMap() error
-
-	// Find network policy and namespace by conjunction ID.
-	GetPolicyFromConjunction(ruleID uint32) *v1beta2.NetworkPolicyReference
 
 	// Find Network Policy reference and OFpriority by conjunction ID.
 	GetPolicyInfoFromConjunction(ruleID uint32) (string, string)

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -24,7 +24,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	config "github.com/vmware-tanzu/antrea/pkg/agent/config"
 	types "github.com/vmware-tanzu/antrea/pkg/agent/types"
-	v1beta2 "github.com/vmware-tanzu/antrea/pkg/apis/controlplane/v1beta2"
 	openflow "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
 	proxy "github.com/vmware-tanzu/antrea/third_party/proxy"
 	net "net"
@@ -164,20 +163,6 @@ func (m *MockClient) GetPodFlowKeys(arg0 string) []string {
 func (mr *MockClientMockRecorder) GetPodFlowKeys(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodFlowKeys", reflect.TypeOf((*MockClient)(nil).GetPodFlowKeys), arg0)
-}
-
-// GetPolicyFromConjunction mocks base method
-func (m *MockClient) GetPolicyFromConjunction(arg0 uint32) *v1beta2.NetworkPolicyReference {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPolicyFromConjunction", arg0)
-	ret0, _ := ret[0].(*v1beta2.NetworkPolicyReference)
-	return ret0
-}
-
-// GetPolicyFromConjunction indicates an expected call of GetPolicyFromConjunction
-func (mr *MockClientMockRecorder) GetPolicyFromConjunction(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPolicyFromConjunction", reflect.TypeOf((*MockClient)(nil).GetPolicyFromConjunction), arg0)
 }
 
 // GetPolicyInfoFromConjunction mocks base method

--- a/pkg/agent/stats/collector.go
+++ b/pkg/agent/stats/collector.go
@@ -109,7 +109,9 @@ func (m *Collector) collect() *statsCollection {
 	for ofID, ruleStats := range ruleStatsMap {
 		policyRef := m.networkPolicyQuerier.GetNetworkPolicyByRuleFlowID(ofID)
 		if policyRef == nil {
-			klog.Infof("Cannot find NetworkPolicy that has ofID %v", ofID)
+			// This should not happen because the rule flow ID to rule mapping is
+			// preserved for 5 seconds even after the rule deletion.
+			klog.Warningf("Cannot find NetworkPolicy that has ofID %v", ofID)
 			continue
 		}
 		klog.V(4).Infof("Converting ofID %v to policy %s", ofID, policyRef.ToString())

--- a/pkg/agent/stats/collector_test.go
+++ b/pkg/agent/stats/collector_test.go
@@ -25,6 +25,7 @@ import (
 	agenttypes "github.com/vmware-tanzu/antrea/pkg/agent/types"
 	cpv1beta "github.com/vmware-tanzu/antrea/pkg/apis/controlplane/v1beta2"
 	statsv1alpha1 "github.com/vmware-tanzu/antrea/pkg/apis/stats/v1alpha1"
+	queriertest "github.com/vmware-tanzu/antrea/pkg/querier/testing"
 )
 
 var (
@@ -187,12 +188,13 @@ func TestCollect(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ofClient := oftest.NewMockClient(ctrl)
+			npQuerier := queriertest.NewMockAgentNetworkPolicyInfoQuerier(ctrl)
 			ofClient.EXPECT().NetworkPolicyMetrics().Return(tt.ruleStats).Times(1)
 			for ofID, policy := range tt.ofIDToPolicyMap {
-				ofClient.EXPECT().GetPolicyFromConjunction(ofID).Return(policy)
+				npQuerier.EXPECT().GetNetworkPolicyByRuleFlowID(ofID).Return(policy)
 			}
 
-			m := &Collector{ofClient: ofClient}
+			m := &Collector{ofClient: ofClient, networkPolicyQuerier: npQuerier}
 			actualPolicyStats := m.collect()
 			assert.Equal(t, tt.expectedStatsCollection, actualPolicyStats)
 		})

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -35,6 +35,7 @@ type AgentNetworkPolicyInfoQuerier interface {
 	GetAddressGroups() []cpv1beta.AddressGroup
 	GetAppliedToGroups() []cpv1beta.AppliedToGroup
 	GetAppliedNetworkPolicies(pod, namespace string, npFilter *NetworkPolicyQueryFilter) []cpv1beta.NetworkPolicy
+	GetNetworkPolicyByRuleFlowID(ruleFlowID uint32) *cpv1beta.NetworkPolicyReference
 }
 
 type ControllerNetworkPolicyInfoQuerier interface {

--- a/pkg/querier/testing/mock_querier.go
+++ b/pkg/querier/testing/mock_querier.go
@@ -147,6 +147,20 @@ func (mr *MockAgentNetworkPolicyInfoQuerierMockRecorder) GetNetworkPolicies(arg0
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkPolicies", reflect.TypeOf((*MockAgentNetworkPolicyInfoQuerier)(nil).GetNetworkPolicies), arg0)
 }
 
+// GetNetworkPolicyByRuleFlowID mocks base method
+func (m *MockAgentNetworkPolicyInfoQuerier) GetNetworkPolicyByRuleFlowID(arg0 uint32) *v1beta2.NetworkPolicyReference {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNetworkPolicyByRuleFlowID", arg0)
+	ret0, _ := ret[0].(*v1beta2.NetworkPolicyReference)
+	return ret0
+}
+
+// GetNetworkPolicyByRuleFlowID indicates an expected call of GetNetworkPolicyByRuleFlowID
+func (mr *MockAgentNetworkPolicyInfoQuerierMockRecorder) GetNetworkPolicyByRuleFlowID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkPolicyByRuleFlowID", reflect.TypeOf((*MockAgentNetworkPolicyInfoQuerier)(nil).GetNetworkPolicyByRuleFlowID), arg0)
+}
+
 // GetNetworkPolicyNum mocks base method
 func (m *MockAgentNetworkPolicyInfoQuerier) GetNetworkPolicyNum() int {
 	m.ctrl.T.Helper()

--- a/plugins/octant/go.sum
+++ b/plugins/octant/go.sum
@@ -106,7 +106,7 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
-github.com/confluentinc/bincover v0.0.0-20200910210245-839e88185831/go.mod h1:qeI1wx0RxdGTZtrJY0HVlgJ4NqC/X2Z+fHbvy87tgHE=
+github.com/confluentinc/bincover v0.1.0/go.mod h1:qeI1wx0RxdGTZtrJY0HVlgJ4NqC/X2Z+fHbvy87tgHE=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.3.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -700,9 +700,8 @@ golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200222125558-5a598a2470a0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
-golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -819,9 +818,8 @@ golang.org/x/tools v0.0.0-20200716134326-a8f9df4c9543 h1:onHykNOjYYTQ3AMcREXdnzW
 golang.org/x/tools v0.0.0-20200716134326-a8f9df4c9543/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=


### PR DESCRIPTION
This is for services such as networkPolicy stats, flow exporter,
traceflow etc. to query networkPolicy/networkPolicyRule using
rule flow ID (also tagged as ruleOfID in pkg/agent/openflow).

We delete the rules asynchronously after a delay as the above mentioned
services would need the info of network policy rule even after its
deletion. The allocated ID (allocator.go) will not be released until the rule is deleted
from asyncRuleCache.

We provide the interface to this query in AgentNetworkPolicyInfoQuerier.

Fixes #1270 