### PR TITLE
Support Pod traffic shaping

### DIFF
--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends wget ca-certificates
 
 # Leading dot is required for the tar command below
-ENV CNI_PLUGINS="./host-local ./loopback ./portmap"
+ENV CNI_PLUGINS="./host-local ./loopback ./portmap ./bandwidth"
 
 RUN mkdir -p /opt/cni/bin && \
     wget -q -O - https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS

--- a/build/images/scripts/install_cni
+++ b/build/images/scripts/install_cni
@@ -27,5 +27,10 @@ if [ ! -f /host/opt/cni/bin/portmap ]; then
     install -m 755 /opt/cni/bin/portmap /host/opt/cni/bin/portmap
 fi
 
+# Install bandwidth CNI binary file
+if [ ! -f /host/opt/cni/bin/bandwidth ]; then
+    install -m 755 /opt/cni/bin/bandwidth /host/opt/cni/bin/bandwidth
+fi
+
 # Load the OVS kernel module
 modprobe openvswitch

--- a/build/images/scripts/install_cni_kind
+++ b/build/images/scripts/install_cni_kind
@@ -9,3 +9,20 @@ install -m 644 /etc/antrea/antrea-cni.conflist /host/etc/cni/net.d/10-antrea.con
 
 # Install Antrea binary file
 install -m 755 /usr/local/bin/antrea-cni /host/opt/cni/bin/antrea
+
+# Install the loopback plugin if not already present
+# It is required by kubelet on Linux when using docker as the container runtime
+
+if [ ! -f /host/opt/cni/bin/loopback ]; then
+    install -m 755 /opt/cni/bin/loopback /host/opt/cni/bin/loopback
+fi
+
+# Install PortMap CNI binary file
+if [ ! -f /host/opt/cni/bin/portmap ]; then
+    install -m 755 /opt/cni/bin/portmap /host/opt/cni/bin/portmap
+fi
+
+# Install bandwidth CNI binary file
+if [ ! -f /host/opt/cni/bin/bandwidth ]; then
+    install -m 755 /opt/cni/bin/bandwidth /host/opt/cni/bin/bandwidth
+fi

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1137,6 +1137,10 @@ data:
             {
                 "type": "portmap",
                 "capabilities": {"portMappings": true}
+            },
+            {
+                "type": "bandwidth",
+                "capabilities": {"bandwidth": true}
             }
         ]
     }
@@ -1175,7 +1179,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-8c5mfk22m2
+  name: antrea-config-c7k774f9f7
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1282,7 +1286,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-8c5mfk22m2
+          name: antrea-config-c7k774f9f7
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1531,7 +1535,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-8c5mfk22m2
+          name: antrea-config-c7k774f9f7
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1137,6 +1137,10 @@ data:
             {
                 "type": "portmap",
                 "capabilities": {"portMappings": true}
+            },
+            {
+                "type": "bandwidth",
+                "capabilities": {"bandwidth": true}
             }
         ]
     }
@@ -1175,7 +1179,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-8c5mfk22m2
+  name: antrea-config-c7k774f9f7
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1282,7 +1286,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-8c5mfk22m2
+          name: antrea-config-c7k774f9f7
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1533,7 +1537,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-8c5mfk22m2
+          name: antrea-config-c7k774f9f7
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1137,6 +1137,10 @@ data:
             {
                 "type": "portmap",
                 "capabilities": {"portMappings": true}
+            },
+            {
+                "type": "bandwidth",
+                "capabilities": {"bandwidth": true}
             }
         ]
     }
@@ -1175,7 +1179,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-78kch9fmgd
+  name: antrea-config-66hh4g7h5f
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1282,7 +1286,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-78kch9fmgd
+          name: antrea-config-66hh4g7h5f
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1531,7 +1535,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-78kch9fmgd
+          name: antrea-config-66hh4g7h5f
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1142,6 +1142,10 @@ data:
             {
                 "type": "portmap",
                 "capabilities": {"portMappings": true}
+            },
+            {
+                "type": "bandwidth",
+                "capabilities": {"bandwidth": true}
             }
         ]
     }
@@ -1180,7 +1184,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-96k9447m55
+  name: antrea-config-5t288gtgdd
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1296,7 +1300,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-96k9447m55
+          name: antrea-config-5t288gtgdd
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1580,7 +1584,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-96k9447m55
+          name: antrea-config-5t288gtgdd
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1142,6 +1142,10 @@ data:
             {
                 "type": "portmap",
                 "capabilities": {"portMappings": true}
+            },
+            {
+                "type": "bandwidth",
+                "capabilities": {"bandwidth": true}
             }
         ]
     }
@@ -1180,7 +1184,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-75558f6fff
+  name: antrea-config-f99c6dcdt8
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1287,7 +1291,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-75558f6fff
+          name: antrea-config-f99c6dcdt8
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1536,7 +1540,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-75558f6fff
+          name: antrea-config-f99c6dcdt8
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-cni.conflist
+++ b/build/yamls/base/conf/antrea-cni.conflist
@@ -11,6 +11,10 @@
         {
             "type": "portmap",
             "capabilities": {"portMappings": true}
+        },
+        {
+            "type": "bandwidth",
+            "capabilities": {"bandwidth": true}
         }
     ]
 }

--- a/build/yamls/offload/mellanox/antrea-crd.yml
+++ b/build/yamls/offload/mellanox/antrea-crd.yml
@@ -9,5 +9,5 @@ spec:
   config: '{
     "cniVersion": "0.3.1",
     "name": "antrea",
-    "plugins": [ { "type": "antrea", "ipam": { "type": "host-local" } }, { "type": "portmap", "capabilities": {"portMappings": true} }]
+    "plugins": [ { "type": "antrea", "ipam": { "type": "host-local" } }, { "type": "portmap", "capabilities": {"portMappings": true}, { "type": "bandwidth", "capabilities": {"bandwidth": true} }]
 }'

--- a/build/yamls/patches/coverage/startAgentCov.yml
+++ b/build/yamls/patches/coverage/startAgentCov.yml
@@ -5,8 +5,13 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+      - name: install-cni
+        image: antrea/antrea-ubuntu-coverage:latest
       containers:
       - name: antrea-agent
         command: ["/bin/sh"]
         args: ["-c", "sleep 2; antrea-agent-coverage -test.run=TestBincoverRunMain -test.coverprofile=antrea-agent.cov.out -args-file=/agent-arg-file; while true; do sleep 5 & wait $!; done"]
+        image: antrea/antrea-ubuntu-coverage:latest
+      - name: antrea-ovs
         image: antrea/antrea-ubuntu-coverage:latest

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,12 @@ A typical CNI configuration looks like this:
         "capabilities": {
           "portMappings": true
         }
+      },
+      {
+        "type": "bandwidth",
+        "capabilities": {
+          "bandwidth": true
+        }
       }
     ]
   }
@@ -62,9 +68,10 @@ strongly discouraged to set the `"mtu"` field in the CNI configuration to a
 value that does not match the `defaultMTU` parameter, as it may lead to
 performance degradation or packet drops.
 
-Antrea enables portmap CNI plugin by default to support `hostPort`
-functionality for Pods. In order to disable the portmap plugin, remove the
-following from Antrea CNI config:
+Antrea enables portmap and bandwidth CNI plugins by default to support `hostPort`
+and traffic shaping functionalities for Pods respectively. In order to disable
+them, remove the corresponding section from `antrea-cni.conflist` in the Antrea
+manifest. For example, removing the following section disables portmap plugin:
 ```
 {
   "type": "portmap",

--- a/docs/contributors/manual-installation.md
+++ b/docs/contributors/manual-installation.md
@@ -141,6 +141,10 @@ cat >/etc/cni/net.d/10-antrea.conflist <<EOF
     {
       "type": "portmap",
       "capabilities": {"portMappings": true}
+    },
+    {
+      "type": "bandwidth",
+      "capabilities": {"bandwidth": true}
     }
   ]
 }

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -23,9 +23,10 @@ Controller, and a DaemonSet that includes two containers to run Antrea Agent
 and OVS daemons respectively, on every Node. The DaemonSet also includes an
 init container that installs the CNI plugin - `antrea-cni` - on the Node and
 ensures that the OVS kernel module is loaded and it is chained with the portmap
-CNI plugin. All Antrea Controller, Agent, OVS daemons, and `antrea-cni` bits
-are included in a single Docker image. Antrea also has a command-line tool
-called `antctl`, and an [Octant](https://github.com/vmware-tanzu/octant) UI plugin.
+and bandwidth CNI plugins. All Antrea Controller, Agent, OVS daemons, and
+`antrea-cni` bits are included in a single Docker image. Antrea also has a
+command-line tool called `antctl`, and an [Octant](https://github.com/vmware-tanzu/octant)
+UI plugin.
 
 <img src="/docs/assets/arch.svg.png" width="600" alt="Antrea Architecture Overview">
 

--- a/docs/ovs-offload.md
+++ b/docs/ovs-offload.md
@@ -128,7 +128,7 @@ spec:
   config: '{
     "cniVersion": "0.3.1",
     "name": "antrea",
-    "plugins": [ { "type": "antrea", "ipam": { "type": "host-local" } }, { "type": "portmap", "capabilities": {"portMappings": true} }]
+    "plugins": [ { "type": "antrea", "ipam": { "type": "host-local" } }, { "type": "portmap", "capabilities": {"portMappings": true}, { "type": "bandwidth", "capabilities": {"bandwidth": true} }]
 }'
 ```
 ## Deploy Antrea Image with hw-offload enabled

--- a/test/e2e/bandwidth_test.go
+++ b/test/e2e/bandwidth_test.go
@@ -16,9 +16,11 @@ package e2e
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -32,13 +34,13 @@ func TestBenchmarkBandwidthIntraNode(t *testing.T) {
 		t.Fatalf("Error when setting up test: %v", err)
 	}
 	defer teardownTest(t, data)
-	if err := data.createPodOnNode("perftest-a", masterNodeName(), perftoolImage, nil, nil, nil, nil, false); err != nil {
+	if err := data.createPodOnNode("perftest-a", masterNodeName(), perftoolImage, nil, nil, nil, nil, false, nil); err != nil {
 		t.Fatalf("Error when creating the perftest client Pod: %v", err)
 	}
 	if err := data.podWaitForRunning(defaultTimeout, "perftest-a", testNamespace); err != nil {
 		t.Fatalf("Error when waiting for the perftest client Pod: %v", err)
 	}
-	if err := data.createPodOnNode("perftest-b", masterNodeName(), perftoolImage, nil, nil, nil, []v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}, false); err != nil {
+	if err := data.createPodOnNode("perftest-b", masterNodeName(), perftoolImage, nil, nil, nil, []v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
 		t.Fatalf("Error when creating the perftest server Pod: %v", err)
 	}
 	podBIP, err := data.podWaitForIP(defaultTimeout, "perftest-b", testNamespace)
@@ -64,13 +66,13 @@ func benchmarkBandwidthService(t *testing.T, endpointNode, clientNode string) {
 	if err != nil {
 		t.Fatalf("Error when creating perftest service: %v", err)
 	}
-	if err := data.createPodOnNode("perftest-a", clientNode, perftoolImage, nil, nil, nil, nil, false); err != nil {
+	if err := data.createPodOnNode("perftest-a", clientNode, perftoolImage, nil, nil, nil, nil, false, nil); err != nil {
 		t.Fatalf("Error when creating the perftest client Pod: %v", err)
 	}
 	if err := data.podWaitForRunning(defaultTimeout, "perftest-a", testNamespace); err != nil {
 		t.Fatalf("Error when waiting for the perftest client Pod: %v", err)
 	}
-	if err := data.createPodOnNode("perftest-b", endpointNode, perftoolImage, nil, nil, nil, []v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}, false); err != nil {
+	if err := data.createPodOnNode("perftest-b", endpointNode, perftoolImage, nil, nil, nil, []v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
 		t.Fatalf("Error when creating the perftest server Pod: %v", err)
 	}
 	if err := data.podWaitForRunning(defaultTimeout, "perftest-b", testNamespace); err != nil {
@@ -97,4 +99,72 @@ func TestBenchmarkBandwidthServiceRemoteAccess(t *testing.T) {
 	skipIfNotBenchmarkTest(t)
 	skipIfNumNodesLessThan(t, 2)
 	benchmarkBandwidthService(t, masterNodeName(), workerNodeName(1))
+}
+
+func TestPodTrafficShaping(t *testing.T) {
+	// TODO: tc configuration succeeded, however it didn't take effect, need to understand the reason.
+	skipIfProviderIs(t, "kind", "tc does not work with Kind")
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+	tests := []struct {
+		name string
+		// The bandwidths' unit is Mbits/sec.
+		clientEgressBandwidth  int
+		serverIngressBandwidth int
+		expectedBandwidth    int
+	}{
+		{
+			name:                   "limited by egress bandwidth",
+			clientEgressBandwidth:  100,
+			serverIngressBandwidth: 200,
+			expectedBandwidth:      100,
+		},
+		{
+			name:                   "limited by ingress bandwidth",
+			clientEgressBandwidth:  300,
+			serverIngressBandwidth: 200,
+			expectedBandwidth:      200,
+		},
+	}
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientPodName := fmt.Sprintf("client-a-%d", i)
+			serverPodName := fmt.Sprintf("server-a-%d", i)
+			if err := data.createPodOnNode(clientPodName, masterNodeName(), perftoolImage, nil, nil, nil, nil, false, func(pod *v1.Pod) {
+				pod.Annotations = map[string]string{
+					"kubernetes.io/egress-bandwidth": fmt.Sprintf("%dM", tt.clientEgressBandwidth),
+				}
+			}); err != nil {
+				t.Fatalf("Error when creating the perftest client Pod: %v", err)
+			}
+			defer deletePodWrapper(t, data, clientPodName)
+			if err := data.podWaitForRunning(defaultTimeout, clientPodName, testNamespace); err != nil {
+				t.Fatalf("Error when waiting for the perftest client Pod: %v", err)
+			}
+			if err := data.createPodOnNode(serverPodName, masterNodeName(), perftoolImage, nil, nil, nil, []v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}, false, func(pod *v1.Pod) {
+				pod.Annotations = map[string]string{
+					"kubernetes.io/ingress-bandwidth": fmt.Sprintf("%dM", tt.serverIngressBandwidth),
+				}
+			}); err != nil {
+				t.Fatalf("Error when creating the perftest server Pod: %v", err)
+			}
+			defer deletePodWrapper(t, data, serverPodName)
+			podBIP, err := data.podWaitForIP(defaultTimeout, serverPodName, testNamespace)
+			if err != nil {
+				t.Fatalf("Error when getting the perftest server Pod's IP: %v", err)
+			}
+			stdout, _, err := data.runCommandFromPod(testNamespace, clientPodName, "perftool", []string{"bash", "-c", fmt.Sprintf("iperf3 -c %s -f m -O 1|grep sender|awk '{print $7}'", podBIP)})
+			if err != nil {
+				t.Fatalf("Error when running iperf3 client: %v", err)
+			}
+			stdout = strings.TrimSpace(stdout)
+			actualBandwidth, _ := strconv.ParseFloat(strings.TrimSpace(stdout), 64)
+			t.Logf("Actual bandwidth: %v Mbits/sec", actualBandwidth)
+			// Allow a certain deviation.
+			assert.InEpsilon(t, actualBandwidth, tt.expectedBandwidth, 0.1)
+		})
+	}
 }

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -129,7 +129,7 @@ func setupTestWithIPFIXCollector(tb testing.TB) (*TestData, error) {
 		return nil, err
 	}
 	// Create pod using ipfix collector image
-	if err := data.createPodOnNode("ipfix-collector", masterNodeName(), ipfixCollectorImage, nil, nil, nil, nil, true); err != nil {
+	if err := data.createPodOnNode("ipfix-collector", masterNodeName(), ipfixCollectorImage, nil, nil, nil, nil, true, nil); err != nil {
 		tb.Fatalf("Error when creating the ipfix collector Pod: %v", err)
 	}
 	ipfixCollectorIP, err := data.podWaitForIP(defaultTimeout, "ipfix-collector", testNamespace)

--- a/test/e2e/flowexporter_test.go
+++ b/test/e2e/flowexporter_test.go
@@ -37,14 +37,14 @@ func TestFlowExporter(t *testing.T) {
 	}
 	defer teardownTest(t, data)
 
-	if err := data.createPodOnNode("perftest-a", masterNodeName(), perftoolImage, nil, nil, nil, nil, false); err != nil {
+	if err := data.createPodOnNode("perftest-a", masterNodeName(), perftoolImage, nil, nil, nil, nil, false, nil); err != nil {
 		t.Fatalf("Error when creating the perftest client Pod: %v", err)
 	}
 	podAIP, err := data.podWaitForIP(defaultTimeout, "perftest-a", testNamespace)
 	if err != nil {
 		t.Fatalf("Error when waiting for the perftest client Pod: %v", err)
 	}
-	if err := data.createPodOnNode("perftest-b", masterNodeName(), perftoolImage, nil, nil, nil, []v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}, false); err != nil {
+	if err := data.createPodOnNode("perftest-b", masterNodeName(), perftoolImage, nil, nil, nil, []v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
 		t.Fatalf("Error when creating the perftest server Pod: %v", err)
 	}
 	podBIP, err := data.podWaitForIP(defaultTimeout, "perftest-b", testNamespace)

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -91,7 +91,7 @@ func TestProxyHairpin(t *testing.T) {
 	skipIfProxyDisabled(t, data)
 
 	nodeName := nodeName(1)
-	err = data.createPodOnNode("busybox", nodeName, "busybox", []string{"nc", "-lk", "-p", "80"}, nil, nil, []corev1.ContainerPort{{ContainerPort: 80, Protocol: corev1.ProtocolTCP}}, false)
+	err = data.createPodOnNode("busybox", nodeName, "busybox", []string{"nc", "-lk", "-p", "80"}, nil, nil, []corev1.ContainerPort{{ContainerPort: 80, Protocol: corev1.ProtocolTCP}}, false, nil)
 	require.NoError(t, err)
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, "busybox", testNamespace))
 	svc, err := data.createService("busybox", 80, 80, map[string]string{"antrea-e2e": "busybox"}, false, corev1.ServiceTypeClusterIP)


### PR DESCRIPTION
The bandwidth plugin offered by the CNI plugin team can be used to
support ingress and egress traffic shaping for Kubernetes Pod, and
kubelet reads the bandwidth annotations on Pods and passes them as
parameters of CNI requests. To support traffic shaping in Antrea, the
bandwidth plugin should be appended to the chaining list of antrea cni
conf and its binary should be installed.

This patch does the above and adds an e2e test to ensure the integration
work as expected.

Closes #1413