### PR TITLE
Update from go 1.13 to go 1.15

### DIFF
--- a/.github/workflows/clair.yml
+++ b/.github/workflows/clair.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
     - name: Scan Antrea Docker image for vulnerabilities
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_SES }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: [ubuntu-18.04]
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Check-out code
       uses: actions/checkout@v2
@@ -44,10 +44,10 @@ jobs:
         platform: [ubuntu-18.04, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-    - name: Set up Go 1.13
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
     - name: Check-out code
       uses: actions/checkout@v2
     - name: Run golangci-lint
@@ -58,10 +58,10 @@ jobs:
     name: Golangci-lint for netpol code
     runs-on: [ubuntu-18.04]
     steps:
-    - name: Set up Go 1.13
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
     - name: Check-out code
       uses: actions/checkout@v2
     - name: Run golangci-lint
@@ -74,10 +74,10 @@ jobs:
     runs-on: [ubuntu-18.04]
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Check-out code
       uses: actions/checkout@v2
@@ -93,10 +93,10 @@ jobs:
     runs-on: [ubuntu-18.04]
     steps:
 
-      - name: Set up Go 1.13
+      - name: Set up Go 1.15
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.15
 
       - name: Check-out code
         uses: actions/checkout@v2
@@ -110,10 +110,10 @@ jobs:
     runs-on: [ubuntu-18.04]
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Check-out code
       uses: actions/checkout@v2
@@ -127,10 +127,10 @@ jobs:
     runs-on: [ubuntu-18.04]
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Check-out code
       uses: actions/checkout@v2
@@ -144,10 +144,10 @@ jobs:
     runs-on: [ubuntu-18.04]
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Check-out code
       uses: actions/checkout@v2
@@ -160,10 +160,10 @@ jobs:
     runs-on: [ubuntu-18.04]
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Check-out code
       uses: actions/checkout@v2

--- a/.github/workflows/golicense.yml
+++ b/.github/workflows/golicense.yml
@@ -32,10 +32,10 @@ jobs:
     if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name != 'pull_request' }}
     runs-on: [ubuntu-latest]
     steps:
-    - name: Set up Go 1.13
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
     - uses: actions/checkout@v2
     - name: Cache licensing information for dependencies
       uses: actions/cache@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
     - name: Run integration tests
       run: make docker-test-integration
     - name: Code coverage

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -58,7 +58,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v1
       with:
@@ -112,7 +112,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v1
       with:
@@ -166,7 +166,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v1
       with:
@@ -220,7 +220,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v1
       with:
@@ -274,7 +274,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v1
       with:
@@ -344,7 +344,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v1
       with:
@@ -376,7 +376,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.15
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/kind_upgrade.yml
+++ b/.github/workflows/kind_upgrade.yml
@@ -58,7 +58,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v1
       with:
@@ -87,7 +87,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v1
       with:
@@ -116,7 +116,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.15
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v1
         with:
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.15
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ the `$GOPATH`.
 
 To develop locally, you can follow these steps:
 
- 1. [Install Go 1.13](https://golang.org/doc/install)
+ 1. [Install Go 1.15](https://golang.org/doc/install)
  2. Checkout your feature branch and `cd` into it.
  3. To build all Go files and install them under `bin`, run `make bin`
  4. To run all Go unit tests, run `make test-unit`

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ DOCKER_ENV := \
 		-v $(DOCKER_CACHE)/gopath:/tmp/gopath \
 		-v $(DOCKER_CACHE)/gocache:/tmp/gocache \
 		-v $(CURDIR):/usr/src/github.com/vmware-tanzu/antrea \
-		golang:1.13
+		golang:1.15
 
 .PHONY: docker-bin
 docker-bin: $(DOCKER_CACHE)

--- a/build/images/Dockerfile.build.coverage
+++ b/build/images/Dockerfile.build.coverage
@@ -1,4 +1,4 @@
-FROM golang:1.13 as antrea-build
+FROM golang:1.15 as antrea-build
 
 WORKDIR /antrea
 

--- a/build/images/Dockerfile.build.ubuntu
+++ b/build/images/Dockerfile.build.ubuntu
@@ -1,4 +1,4 @@
-FROM golang:1.13 as antrea-build
+FROM golang:1.15 as antrea-build
 
 WORKDIR /antrea
 

--- a/build/images/Dockerfile.build.windows
+++ b/build/images/Dockerfile.build.windows
@@ -10,7 +10,7 @@ RUN curl.exe -LO https://github.com/containernetworking/plugins/releases/downloa
     rm cni-plugins-windows-amd64-v0.8.1.tgz
 
 
-FROM golang:1.13 as antrea-build-windows
+FROM golang:1.15 as antrea-build-windows
 
 WORKDIR /
 

--- a/build/images/Dockerfile.octant.ubuntu
+++ b/build/images/Dockerfile.octant.ubuntu
@@ -1,4 +1,4 @@
-FROM golang:1.13 as antrea-build
+FROM golang:1.15 as antrea-build
 
 COPY . /antrea
 

--- a/build/images/codegen/Dockerfile
+++ b/build/images/codegen/Dockerfile
@@ -10,10 +10,10 @@ RUN PROTOBUF_VERSION=3.0.2; ZIPNAME="protoc-${PROTOBUF_VERSION}-linux-x86_64.zip
   chmod -R +rX /tmp/protoc
 
 
-FROM golang:1.13
+FROM golang:1.15
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
-LABEL description="A Docker image based on golang 1.13 which includes codegen tools."
+LABEL description="A Docker image based on golang 1.15 which includes codegen tools."
 
 ENV GO111MODULE=on
 

--- a/build/images/codegen/README.md
+++ b/build/images/codegen/README.md
@@ -1,6 +1,6 @@
 # images/codegen
 
-This Docker image is a very lightweight image based on golang 1.13 which
+This Docker image is a very lightweight image based on golang 1.15 which
 includes codegen tools.
 
 If you need to build a new version of the image and push it to Dockerhub, you
@@ -8,8 +8,8 @@ can run the following:
 
 ```bash
 cd build/images/codegen
-docker build -t antrea/codegen:latest .
-docker push antrea/codegen:latest
+docker build -t antrea/codegen:<TAG> .
+docker push antrea/codegen:<TAG>
 ```
 
 The `docker push` command will fail if you do not have permission to push to the

--- a/build/images/test/Dockerfile
+++ b/build/images/test/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends iproute2 iptables ipset make wget gcc libc6-dev ca-certificates git && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
-ENV GO_VERSION=1.13.12
+ENV GO_VERSION=1.15.3
 ENV GOPATH /go
 
 RUN wget -q -O - https://golang.org/dl/go$GO_VERSION.linux-amd64.tar.gz | tar xz -C /usr/local/ && \

--- a/ci/clair-scan/go.mod
+++ b/ci/clair-scan/go.mod
@@ -1,9 +1,10 @@
 module github.com/vmware-tanzu/antrea/ci/clair
 
-go 1.13
+go 1.15
 
 require (
 	github.com/aws/aws-sdk-go v1.30.23
+	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 	k8s.io/klog v1.0.0
 )

--- a/ci/clair-scan/go.sum
+++ b/ci/clair-scan/go.sum
@@ -18,6 +18,8 @@ golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc h1:2gGKlE2+asNV9m7xrywl36YYNnBG5ZQ0r/BOOxqPpmk=
+gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc/go.mod h1:m7x9LTH6d71AHyAX77c9yqWCCa3UKHcVEj9y7hAtKDk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df h1:n7WqCuqOuCbNr617RXOY0AWRXxgwEyPp2z+p0+hgMuE=

--- a/docs/contributors/manual-installation.md
+++ b/docs/contributors/manual-installation.md
@@ -16,7 +16,7 @@ There are four components which need to be deployed in order to run Antrea:
 
 Prior to bringing up the individual components, follow the common steps:
 
-* Ensure Go v1.13 is [installed](https://golang.org/doc/install)
+* Ensure Go v1.15 is [installed](https://golang.org/doc/install)
 
 * Git clone your forked Antrea repository and `cd` into the `antrea` directory
     ```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/antrea
 
-go 1.13
+go 1.15
 
 require (
 	github.com/Mellanox/sriovnet v1.0.1

--- a/hack/netpol/Makefile
+++ b/hack/netpol/Makefile
@@ -1,5 +1,5 @@
 # TODO: use kustomize if the code stays in the Antrea repo for a long time.
-VERSION ?= alpha6
+VERSION ?= alpha7
 
 .PHONY: all
 all: build

--- a/hack/netpol/go.mod
+++ b/hack/netpol/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/antrea/hack/netpol
 
-go 1.13
+go 1.15
 
 require (
 	github.com/imdario/mergo v0.3.8 // indirect

--- a/hack/netpol/go.sum
+++ b/hack/netpol/go.sum
@@ -10,6 +10,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v0.0.0-20160705203006-01aeca54ebda/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
+github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e h1:p1yVGRW3nmb85p1Sh1ZJSDm4A4iKLS5QNbvUHMgGu/M=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -30,6 +31,7 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v0.0.0-20160524151835-7d79101e329e/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
@@ -53,9 +55,12 @@ github.com/json-iterator/go v1.1.8 h1:QiWkFLKq0T7mpzwOTu6BzNDbfTE8OLrYhVKYMLF46O
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -77,6 +82,7 @@ github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -90,6 +96,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20181025213731-e84da0312774/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
@@ -125,8 +132,10 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20181011042414-1f849cf54d09/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.5.0 h1:KxkO13IPW4Lslp2bz+KHP2E3gtFlrIGNThxkZQ3g+4c=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/hack/netpol/install.yml
+++ b/hack/netpol/install.yml
@@ -13,5 +13,5 @@ spec:
       containers:
         - name: netpol
           imagePullPolicy: Always
-          image: antrea/netpol:alpha6
+          image: antrea/netpol:alpha7
       serviceAccount: netpol

--- a/hack/tidy-check.sh
+++ b/hack/tidy-check.sh
@@ -30,7 +30,7 @@ SUM_FILE="$PROJECT_DIR/go.sum"
 TMP_DIR="$THIS_DIR/.tmp.tidy-check"
 TMP_MOD_FILE="$TMP_DIR/go.mod"
 TMP_SUM_FILE="$TMP_DIR/go.sum"
-TARGET_GO_VERSION="1.13"
+TARGET_GO_VERSION="1.15"
 TARGET_GO_VERSION_PATTERN="go$TARGET_GO_VERSION*"
 
 # if Go environment variable is set, use it as it is, otherwise default to "go"

--- a/hack/windows/Install-DevTools.ps1
+++ b/hack/windows/Install-DevTools.ps1
@@ -70,7 +70,7 @@ function InstallMingw() {
 }
 
 function InstallGolang() {
-    $GOLANG_VERSION = "1.13.10"
+    $GOLANG_VERSION = "1.15.3"
     Write-Host "Installing Golang $GOLANG_VERSION"
     Write-Host "=============="
     if (CommandExists("go")) {

--- a/plugins/octant/go.mod
+++ b/plugins/octant/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/antrea/plugins/octant
 
-go 1.13
+go 1.15
 
 require (
 	github.com/vmware-tanzu/antrea v0.0.0


### PR DESCRIPTION
This is long overdue since go 1.13 is no longer maintained.

I have already updated antrea/codegen:kubernetes-1.18.4 and the
generated code is not impacted by this change. No other Docker image
needs to be updated manually, they are all built / tested / pushed as
part of CI.

Not updating hack/netpol/ intentionally as this is still supposed to be
moved out of the repo in the medium-term.

Interestingly, Antrea Linux binaries are now smaller by a few MB, which
will reduce the Docker image size:

```bash
abas-a01:antrea abas$ GO=go-1.15 make bin
GOOS=linux go-1.15 build -o /Users/abas/vmware/antrea/bin  -ldflags ' -X github.com/vmware-tanzu/antrea/pkg/version.Version=v0.11.0-dev -X github.com/vmware-tanzu/antrea/pkg/version.GitSHA=fbb856fe -X github.com/vmware-tanzu/antrea/pkg/version.GitTreeState=clean -X github.com/vmware-tanzu/antrea/pkg/version.ReleaseStatus=unreleased' github.com/vmware-tanzu/antrea/cmd/...
abas-a01:antrea abas$ ls -l bin/
total 343656
-rwxr-xr-x  1 abas  staff  49431998 Oct 20 15:49 antctl
-rwxr-xr-x  1 abas  staff  59662411 Oct 20 15:49 antrea-agent
-rwxr-xr-x  1 abas  staff   9946421 Oct 20 15:49 antrea-cni
-rwxr-xr-x  1 abas  staff  56901466 Oct 20 15:49 antrea-controller
abas-a01:antrea abas$ GO=go-1.13 make bin
GOOS=linux go-1.13 build -o /Users/abas/vmware/antrea/bin  -ldflags ' -X github.com/vmware-tanzu/antrea/pkg/version.Version=v0.11.0-dev -X github.com/vmware-tanzu/antrea/pkg/version.GitSHA=fbb856fe -X github.com/vmware-tanzu/antrea/pkg/version.GitTreeState=clean -X github.com/vmware-tanzu/antrea/pkg/version.ReleaseStatus=unreleased' github.com/vmware-tanzu/antrea/cmd/...
abas-a01:antrea abas$ ls -l bin/
total 368032
-rwxr-xr-x  1 abas  staff  51922089 Oct 20 15:49 antctl
-rwxr-xr-x  1 abas  staff  63649324 Oct 20 15:49 antrea-agent
-rwxr-xr-x  1 abas  staff  12602341 Oct 20 15:49 antrea-cni
-rwxr-xr-x  1 abas  staff  60018304 Oct 20 15:49 antrea-controller
```

Fixes #437