### PR TITLE
[NOT FOR REVIEW][CI] Verify ovstest patch

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,10 +13,12 @@ jobs:
     name: Integration tests
     runs-on: [ubuntu-18.04]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.3.3
     - uses: actions/setup-go@v1
       with:
         go-version: 1.13
+    - name: show git-show
+      run: git show --numstat
     - name: Run integration tests
       run: make docker-test-integration
     - name: Code coverage

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -89,9 +89,11 @@ func run(o *Options) error {
 
 	ovsBridgeClient := ovsconfig.NewOVSBridge(o.config.OVSBridge, o.config.OVSDatapathType, ovsdbConnection)
 	ovsBridgeMgmtAddr := ofconfig.GetMgmtAddress(o.config.OVSRunDir, o.config.OVSBridge)
+	enableTLVMap := features.DefaultFeatureGate.Enabled(features.Traceflow)
 	ofClient := openflow.NewClient(o.config.OVSBridge, ovsBridgeMgmtAddr,
 		features.DefaultFeatureGate.Enabled(features.AntreaProxy),
-		features.DefaultFeatureGate.Enabled(features.AntreaPolicy))
+		features.DefaultFeatureGate.Enabled(features.AntreaPolicy),
+		enableTLVMap)
 
 	// statsCollector collects stats and reports to the antrea-controller periodically. For now it's only used for
 	// NetworkPolicy stats.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -37,7 +37,6 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/route"
 	"github.com/vmware-tanzu/antrea/pkg/agent/types"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"
-	"github.com/vmware-tanzu/antrea/pkg/features"
 	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 	"github.com/vmware-tanzu/antrea/pkg/util/env"
 )
@@ -292,14 +291,6 @@ func (i *Initializer) initOpenFlowPipeline() error {
 
 	// When IPSec encyption is enabled, no flow is needed for the default tunnel interface.
 	if i.networkConfig.TrafficEncapMode.SupportsEncap() {
-		if features.DefaultFeatureGate.Enabled(features.Traceflow) {
-			// Set up Traceflow TLV map. This command is Nicira extensions to OpenFlow and require Open
-			// vSwitch 2.5 or later.
-			if err := i.ofClient.InitialTLVMap(); err != nil {
-				klog.Errorf("Error during Openflow TLV map initialization: %v", err)
-				return err
-			}
-		}
 		// Set up flow entries for the default tunnel port interface.
 		if err := i.ofClient.InstallDefaultTunnelFlows(config.DefaultTunOFPort); err != nil {
 			klog.Errorf("Failed to setup openflow entries for tunnel interface: %v", err)

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -508,6 +508,13 @@ func (c *client) InstallBridgeUplinkFlows(uplinkPort uint32, bridgeLocalPort uin
 }
 
 func (c *client) initialize() error {
+	if c.enableTLVMap {
+		// Set up Traceflow TLV map. This command is Nicira extensions to OpenFlow and require Open
+		// vSwitch 2.5 or later.
+		if err := c.InitialTLVMap(); err != nil {
+			return fmt.Errorf("failed to install TLV map: %v", err)
+		}
+	}
 	if err := c.ofEntryOperations.AddAll(c.defaultFlows()); err != nil {
 		return fmt.Errorf("failed to install default flows: %v", err)
 	}

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -88,7 +88,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}
@@ -116,7 +116,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}
@@ -157,7 +157,7 @@ func TestFlowInstallationFailed(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}
@@ -191,7 +191,7 @@ func TestConcurrentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.nodeConfig = &config.NodeConfig{}

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -94,7 +94,7 @@ func TestConnectivityFlows(t *testing.T) {
 	// Initialize ovs metrics (Prometheus) to test them
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 	defer func() {
@@ -121,7 +121,7 @@ func TestConnectivityFlows(t *testing.T) {
 }
 
 func TestReplayFlowsConnectivityFlows(t *testing.T) {
-	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -148,7 +148,7 @@ func TestReplayFlowsConnectivityFlows(t *testing.T) {
 }
 
 func TestReplayFlowsNetworkPolicyFlows(t *testing.T) {
-	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -317,7 +317,7 @@ func TestNetworkPolicyFlows(t *testing.T) {
 	// Initialize ovs metrics (Prometheus) to test them
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 


### PR DESCRIPTION
This patch is to fix "wrong tun_metadata" issue, which affect Antrea
Traceflow feature.
Currently, OVS can not generates a megaflow that matches a field that
is not present, which caused matching wrong tun_metadata if the traffic
contains data with and without tun)metadata, and it is not sure if it
makes sense to support that (match a field that is not present). Also,
the current OpenFlow pipeline seems to assume that if tun_metadata0 is
not present, then the value of it is zero. But actually it is undefined
if the tun_metadata is not present.