### PR TITLE
Do not track UDP encapsulation packets in host network

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -107,7 +107,7 @@ func run(o *Options) error {
 		TrafficEncapMode:  encapMode,
 		EnableIPSecTunnel: o.config.EnableIPSecTunnel}
 
-	routeClient, err := route.NewClient(serviceCIDRNet, encapMode, o.config.NoSNAT)
+	routeClient, err := route.NewClient(serviceCIDRNet, networkConfig, o.config.NoSNAT)
 	if err != nil {
 		return fmt.Errorf("error creating route client: %v", err)
 	}

--- a/pkg/agent/route/interfaces.go
+++ b/pkg/agent/route/interfaces.go
@@ -26,8 +26,8 @@ type Interface interface {
 	// It should be idempotent and can be safely called on every startup.
 	Initialize(nodeConfig *config.NodeConfig) error
 
-	// Reconcile should remove orphaned routes and related configuration based on the desired podCIDRs.
-	Reconcile(podCIDRs []string) error
+	// Reconcile should remove orphaned routes and related configuration based on the desired podCIDRs and remoteNodeIPs.
+	Reconcile(podCIDRs []string, remoteNodeIPs []string) error
 
 	// AddRoutes should add routes to the provided podCIDR.
 	// It should override the routes if they already exist, without error.
@@ -35,7 +35,7 @@ type Interface interface {
 
 	// DeleteRoutes should delete routes to the provided podCIDR.
 	// It should do nothing if the routes don't exist, without error.
-	DeleteRoutes(podCIDR *net.IPNet) error
+	DeleteRoutes(podCIDR *net.IPNet, peerNodeIP net.IP) error
 
 	// MigrateRoutesToGw should move routes from device linkname to local gateway.
 	MigrateRoutesToGw(linkName string) error

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -44,7 +44,7 @@ type Client struct {
 }
 
 // NewClient returns a route client.
-func NewClient(serviceCIDR *net.IPNet, encapMode config.TrafficEncapModeType, noSNAT bool) (*Client, error) {
+func NewClient(serviceCIDR *net.IPNet, networkConfig *config.NetworkConfig, noSNAT bool) (*Client, error) {
 	nr := netroute.New()
 	return &Client{
 		nr:          nr,
@@ -75,7 +75,7 @@ func (c *Client) Initialize(nodeConfig *config.NodeConfig) error {
 
 // Reconcile removes the orphaned routes and related configuration based on the desired podCIDRs. Only the route
 // entries on the host gateway interface are stored in the cache.
-func (c *Client) Reconcile(podCIDRs []string) error {
+func (c *Client) Reconcile(podCIDRs []string, remoteNodeIPs []string) error {
 	desiredPodCIDRs := sets.NewString(podCIDRs...)
 	routes, err := c.listRoutes()
 	if err != nil {
@@ -124,7 +124,7 @@ func (c *Client) AddRoutes(podCIDR *net.IPNet, peerNodeIP, peerGwIP net.IP) erro
 
 // DeleteRoutes deletes routes to the provided podCIDR.
 // It does nothing if the routes don't exist, without error.
-func (c *Client) DeleteRoutes(podCIDR *net.IPNet) error {
+func (c *Client) DeleteRoutes(podCIDR *net.IPNet, peerNodeIP net.IP) error {
 	obj, found := c.hostRoutes.Load(podCIDR.String())
 	if !found {
 		klog.V(2).Infof("Route with destination %s not exists", podCIDR.String())

--- a/pkg/agent/route/testing/mock_route.go
+++ b/pkg/agent/route/testing/mock_route.go
@@ -64,17 +64,17 @@ func (mr *MockInterfaceMockRecorder) AddRoutes(arg0, arg1, arg2 interface{}) *go
 }
 
 // DeleteRoutes mocks base method
-func (m *MockInterface) DeleteRoutes(arg0 *net.IPNet) error {
+func (m *MockInterface) DeleteRoutes(arg0 *net.IPNet, arg1 net.IP) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteRoutes", arg0)
+	ret := m.ctrl.Call(m, "DeleteRoutes", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteRoutes indicates an expected call of DeleteRoutes
-func (mr *MockInterfaceMockRecorder) DeleteRoutes(arg0 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) DeleteRoutes(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRoutes", reflect.TypeOf((*MockInterface)(nil).DeleteRoutes), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRoutes", reflect.TypeOf((*MockInterface)(nil).DeleteRoutes), arg0, arg1)
 }
 
 // Initialize mocks base method
@@ -106,17 +106,17 @@ func (mr *MockInterfaceMockRecorder) MigrateRoutesToGw(arg0 interface{}) *gomock
 }
 
 // Reconcile mocks base method
-func (m *MockInterface) Reconcile(arg0 []string) error {
+func (m *MockInterface) Reconcile(arg0, arg1 []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Reconcile", arg0)
+	ret := m.ctrl.Call(m, "Reconcile", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Reconcile indicates an expected call of Reconcile
-func (mr *MockInterfaceMockRecorder) Reconcile(arg0 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) Reconcile(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockInterface)(nil).Reconcile), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockInterface)(nil).Reconcile), arg0, arg1)
 }
 
 // UnMigrateRoutesFromGw mocks base method

--- a/pkg/agent/util/ipset/ipset.go
+++ b/pkg/agent/util/ipset/ipset.go
@@ -27,6 +27,7 @@ const (
 	// The hash:net set type uses a hash to store different sized IP network addresses.
 	// The lookup time grows linearly with the number of the different prefix values added to the set.
 	HashNet SetType = "hash:net"
+	HashIP  SetType = "hash:ip"
 )
 
 // memberPattern is used to match the members part of ipset list result.

--- a/pkg/agent/util/iptables/iptables.go
+++ b/pkg/agent/util/iptables/iptables.go
@@ -36,10 +36,12 @@ const (
 	MasqueradeTarget = "MASQUERADE"
 	MarkTarget       = "MARK"
 	ConnTrackTarget  = "CT"
+	NoTrackTarget    = "NOTRACK"
 
 	PreRoutingChain  = "PREROUTING"
 	ForwardChain     = "FORWARD"
 	PostRoutingChain = "POSTROUTING"
+	OutputChain      = "OUTPUT"
 
 	waitSeconds              = 10
 	waitIntervalMicroSeconds = 200000


### PR DESCRIPTION
For Geneve and VXLAN encapsulation packets, the request and response packets don't belong to a UDP connection so tracking them doesn't give the normal benefits of conntrack. Besides, kube-proxy may install great number of iptables rules in nat table. The first encapsulation packets of connections would have to go through all of the rules which wastes CPU and increases packet latency.

This patch installs iptables rules in raw table to skip tracking UDP encapsulation packets. The improvement is as below (tested with kube-proxy iptables mode):

- When no extra services are created, the Inter-Node Pod-to-Pod TCP_CRR can be increased from ~2600 to ~2800 TPS.

- When 4,000 services are created, the Inter-Node Pod-to-Pod TCP_CRR can be increased from ~1140 to ~2800 TPS, and the CPU usage of "ipt_do_table" function can be reduced from 30.35% to 2.35%.

Fixes #1133