### PR TITLE
Make controlplane NetworkPolicy cluster scoped

### DIFF
--- a/pkg/agent/apiserver/handlers/networkpolicy/handler.go
+++ b/pkg/agent/apiserver/handlers/networkpolicy/handler.go
@@ -79,8 +79,16 @@ func newFilterFromURLQuery(query url.Values) (*querier.NetworkPolicyQueryFilter,
 		return nil, fmt.Errorf("invalid reference type. It should be K8sNP, ACNP or ANP")
 	}
 
+	source := query.Get("source")
+
+	name := query.Get("name")
+	if name != "" && (source != "" || namespace != "" || pod != "" || strSourceType != "") {
+		return nil, fmt.Errorf("with a name, none of the other fields can be set")
+	}
+
 	return &querier.NetworkPolicyQueryFilter{
-		Name:       query.Get("name"),
+		Name:       name,
+		SourceName: source,
 		Namespace:  namespace,
 		Pod:        pod,
 		SourceType: npSourceType,

--- a/pkg/agent/apiserver/handlers/ovsflows/handler.go
+++ b/pkg/agent/apiserver/handlers/ovsflows/handler.go
@@ -98,7 +98,7 @@ func getPodFlows(aq agentquerier.AgentQuerier, podName, namespace string) ([]Res
 }
 
 func getNetworkPolicyFlows(aq agentquerier.AgentQuerier, npName, namespace string) ([]Response, error) {
-	if aq.GetNetworkPolicyInfoQuerier().GetNetworkPolicy(&querier.NetworkPolicyQueryFilter{Name: npName, Namespace: namespace}) == nil {
+	if len(aq.GetNetworkPolicyInfoQuerier().GetNetworkPolicies(&querier.NetworkPolicyQueryFilter{SourceName: npName, Namespace: namespace})) == 0 {
 		// NetworkPolicy not found.
 		return nil, nil
 	}

--- a/pkg/agent/apiserver/handlers/ovsflows/handler_test.go
+++ b/pkg/agent/apiserver/handlers/ovsflows/handler_test.go
@@ -147,7 +147,7 @@ func TestNetworkPolicyFlows(t *testing.T) {
 		if tc.expectedStatus != http.StatusNotFound {
 			ofc := oftest.NewMockClient(ctrl)
 			ovsctl := ovsctltest.NewMockOVSCtlClient(ctrl)
-			npq.EXPECT().GetNetworkPolicy(&querier.NetworkPolicyQueryFilter{Name: tc.name, Namespace: tc.namespace}).Return(testNetworkPolicy).Times(1)
+			npq.EXPECT().GetNetworkPolicies(&querier.NetworkPolicyQueryFilter{SourceName: tc.name, Namespace: tc.namespace}).Return([]cpv1beta.NetworkPolicy{*testNetworkPolicy}).Times(1)
 			ofc.EXPECT().GetNetworkPolicyFlowKeys(tc.name, tc.namespace).Return(testFlowKeys).Times(1)
 			q.EXPECT().GetOpenflowClient().Return(ofc).Times(1)
 			q.EXPECT().GetOVSCtlClient().Return(ovsctl).Times(len(testFlowKeys))
@@ -155,7 +155,7 @@ func TestNetworkPolicyFlows(t *testing.T) {
 				ovsctl.EXPECT().DumpMatchedFlow(testFlowKeys[i]).Return(testDumpResults[i], nil).Times(1)
 			}
 		} else {
-			npq.EXPECT().GetNetworkPolicy(&querier.NetworkPolicyQueryFilter{Name: tc.name, Namespace: tc.namespace}).Return(nil).Times(1)
+			npq.EXPECT().GetNetworkPolicies(&querier.NetworkPolicyQueryFilter{SourceName: tc.name, Namespace: tc.namespace}).Return(nil).Times(1)
 		}
 
 		runHTTPTest(t, &tc, q)

--- a/pkg/agent/controller/networkpolicy/cache_test.go
+++ b/pkg/agent/controller/networkpolicy/cache_test.go
@@ -501,7 +501,7 @@ func TestRuleCacheReplaceNetworkPolicies(t *testing.T) {
 			c, recorder, _ := newFakeRuleCache()
 			for _, rule := range tt.rules {
 				c.rules.Add(rule)
-				c.policyMap[string(rule.PolicyUID)] = rule.SourceRef
+				c.policyMap[string(rule.PolicyUID)] = &v1beta2.NetworkPolicy{}
 			}
 			c.ReplaceNetworkPolicies(tt.args)
 

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -112,7 +112,7 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 			if err != nil {
 				return nil, err
 			}
-			return antreaClient.ControlplaneV1beta2().NetworkPolicies("").Watch(context.TODO(), options)
+			return antreaClient.ControlplaneV1beta2().NetworkPolicies().Watch(context.TODO(), options)
 		},
 		AddFunc: func(obj runtime.Object) error {
 			policy, ok := obj.(*v1beta2.NetworkPolicy)
@@ -299,12 +299,6 @@ func (c *Controller) GetNetworkPolicies(npFilter *querier.NetworkPolicyQueryFilt
 // GetAppliedToNetworkPolicies returns the NetworkPolicies applied to the Pod and match the filter.
 func (c *Controller) GetAppliedNetworkPolicies(pod, namespace string, npFilter *querier.NetworkPolicyQueryFilter) []v1beta2.NetworkPolicy {
 	return c.ruleCache.getAppliedNetworkPolicies(pod, namespace, npFilter)
-}
-
-// GetNetworkPolicy looks up and returns the cached NetworkPolicy which first matches the filter.
-// nil is returned if the specified NetworkPolicy is not found.
-func (c *Controller) GetNetworkPolicy(npFilter *querier.NetworkPolicyQueryFilter) *v1beta2.NetworkPolicy {
-	return c.ruleCache.getNetworkPolicy(npFilter)
 }
 
 func (c *Controller) GetAddressGroups() []v1beta2.AddressGroup {

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -102,24 +102,24 @@ var CommandList = &commandList{
 		{
 			use:     "networkpolicy",
 			aliases: []string{"networkpolicies", "netpol"},
-			short:   "Print NetworkPolicies",
-			long:    "Print NetworkPolicies in ${component}. 'namespace' is required if 'pod' is provided.",
-			example: `  Get a specific NetworkPolicy
-  $ antctl get networkpolicy np1 -n ns1 -T acnp
-  Get the list of NetworkPolicies in a Namespace
-  $ antctl get networkpolicy -n ns1
-  Get the list of NetworkPolicies with a specific source Type
-  $ antctl get networkpolicy -T acnp
-  Get the list of all NetworkPolicies
+			short:   "Print control plane NetworkPolicies",
+			long:    "Print control plane NetworkPolicies in ${component}. 'namespace' is required if 'pod' is provided.",
+			example: `  Get a specific control plane NetworkPolicy
+  $ antctl get networkpolicy 6001549b-ba63-4752-8267-30f52b4332db
+  Get the list of all control plane NetworkPolicies
   $ antctl get networkpolicy
-  Get the list of NetworkPolicies applied to a Pod (supported by agent only)
+  Get the control plane NetworkPolicy with a specific source (supported by agent only)
+  $ antctl get networkpolicy -S allow-http -n ns1
+  Get the list of control plane NetworkPolicies whose source NetworkPolicies are in a Namespace (supported by agent only)
+  $ antctl get networkpolicy -n ns1
+  Get the list of control plane NetworkPolicies with a specific source Type (supported by agent only)
+  $ antctl get networkpolicy -T acnp
+  Get the list of control plane NetworkPolicies applied to a Pod (supported by agent only)
   $ antctl get networkpolicy -p pod1 -n ns1`,
 			commandGroup: get,
 			controllerEndpoint: &endpoint{
 				resourceEndpoint: &resourceEndpoint{
 					groupVersionResource: &cpv1beta.NetworkPolicyVersionResource,
-					resourceName:         "",
-					namespaced:           true,
 				},
 				addonTransform: networkpolicy.Transform,
 			},
@@ -129,12 +129,17 @@ var CommandList = &commandList{
 					params: []flagInfo{
 						{
 							name:  "name",
-							usage: "Get NetworkPolicy by name. If present, Namespace must be provided.",
+							usage: "Get NetworkPolicy by name.",
 							arg:   true,
 						},
 						{
+							name:      "source",
+							usage:     "Get NetworkPolicies for which the source has the provided name. The source of a control plane NetworkPolicy is the original policy resource (K8s NetworkPolicy or Antrea-native Policy) from which the control plane NetworkPolicy was derived.",
+							shorthand: "S",
+						},
+						{
 							name:      "namespace",
-							usage:     "Get Networkpolicies from specific Namespace",
+							usage:     "Get Networkpolicies from specific Namespace.",
 							shorthand: "n",
 						},
 						{

--- a/pkg/antctl/command_definition_test.go
+++ b/pkg/antctl/command_definition_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/common"
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/controllerinfo"
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/networkpolicy"
-	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/rule"
 	"github.com/vmware-tanzu/antrea/pkg/apis/clusterinformation/v1beta1"
 	cpv1beta "github.com/vmware-tanzu/antrea/pkg/apis/controlplane/v1beta2"
 )
@@ -149,37 +148,53 @@ foo2
 			name: "StructureData-NetworkPolicy-List-HasSummary-RandomFieldOrder",
 			rawResponseData: []networkpolicy.Response{
 				{
-					NameSpace:       "Namespace1",
-					Name:            "GroupName2",
-					AppliedToGroups: []string{"32ef631b-6817-5a18-86eb-93f4abf0467c", "c4c59cfe-9160-5de5-a85b-01a58d11963e"},
-					Rules: []rule.Response{
-						{
-							Direction: "In",
-							Services:  nil,
+					NetworkPolicy: &cpv1beta.NetworkPolicy{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "6001549b-ba63-4752-8267-30f52b4332db",
+						},
+						AppliedToGroups: []string{"32ef631b-6817-5a18-86eb-93f4abf0467c", "c4c59cfe-9160-5de5-a85b-01a58d11963e"},
+						Rules: []cpv1beta.NetworkPolicyRule{
+							{
+								Direction: "In",
+								Services:  nil,
+							},
+						},
+						SourceRef: &cpv1beta.NetworkPolicyReference{
+							Type:      cpv1beta.K8sNetworkPolicy,
+							Namespace: "default",
+							Name:      "allow-all",
+							UID:       "6001549b-ba63-4752-8267-30f52b4332db",
 						},
 					},
-					SourceType: cpv1beta.K8sNetworkPolicy,
 				},
 				{
-					Rules: []rule.Response{
-						{
-							Direction: "In",
-							Services:  nil,
+					NetworkPolicy: &cpv1beta.NetworkPolicy{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "880db7e8-fc2a-4030-aefe-09afc5f341ad",
 						},
-						{
-							Direction: "In",
-							Services:  nil,
+						AppliedToGroups: []string{"32ef631b-6817-5a18-86eb-93f4abf0467c"},
+						Rules: []cpv1beta.NetworkPolicyRule{
+							{
+								Direction: "In",
+								Services:  nil,
+							},
+							{
+								Direction: "In",
+								Services:  nil,
+							},
+						},
+						SourceRef: &cpv1beta.NetworkPolicyReference{
+							Type:      cpv1beta.AntreaNetworkPolicy,
+							Namespace: "default",
+							Name:      "allow-all",
+							UID:       "880db7e8-fc2a-4030-aefe-09afc5f341ad",
 						},
 					},
-					AppliedToGroups: []string{"32ef631b-6817-5a18-86eb-93f4abf0467c"},
-					Name:            "GroupName1",
-					NameSpace:       "Namespace2",
-					SourceType:      cpv1beta.AntreaNetworkPolicy,
 				},
 			},
-			expected: `NAMESPACE  NAME       APPLIED-TO                                       RULES SOURCE-TYPE        
-Namespace1 GroupName2 32ef631b-6817-5a18-86eb-93f4abf0467c + 1 more... 1     K8sNetworkPolicy   
-Namespace2 GroupName1 32ef631b-6817-5a18-86eb-93f4abf0467c             2     AntreaNetworkPolicy
+			expected: `NAME                                 APPLIED-TO                                       RULES SOURCE                               
+6001549b-ba63-4752-8267-30f52b4332db 32ef631b-6817-5a18-86eb-93f4abf0467c + 1 more... 1     K8sNetworkPolicy:default/allow-all   
+880db7e8-fc2a-4030-aefe-09afc5f341ad 32ef631b-6817-5a18-86eb-93f4abf0467c             2     AntreaNetworkPolicy:default/allow-all
 `,
 		},
 		{

--- a/pkg/antctl/transform/networkpolicy/transform.go
+++ b/pkg/antctl/transform/networkpolicy/transform.go
@@ -21,55 +21,22 @@ import (
 
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform"
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/common"
-	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/rule"
 	cpv1beta "github.com/vmware-tanzu/antrea/pkg/apis/controlplane/v1beta2"
 )
 
 type Response struct {
-	NameSpace       string                     `json:"namespace" yaml:"namespace"`
-	Name            string                     `json:"name" yaml:"name"`
-	TierPriority    int32                      `json:"tierPriority" yaml:"tierPriority"`
-	Priority        float64                    `json:"priority" yaml:"priority"`
-	Rules           []rule.Response            `json:"rules" yaml:"rules"`
-	AppliedToGroups []string                   `json:"appliedToGroups" yaml:"appliedToGroups"`
-	SourceType      cpv1beta.NetworkPolicyType `json:"sourceNetworkPolicyType" yaml:"sourceNetworkPolicyType"`
+	*cpv1beta.NetworkPolicy
 }
 
 func objectTransform(o interface{}) (interface{}, error) {
-	policy := o.(*cpv1beta.NetworkPolicy)
-	rules, _ := rule.ObjectTransform(&policy.Rules)
-	if policy.AppliedToGroups == nil {
-		policy.AppliedToGroups = []string{}
-	}
-
-	if policy.SourceRef.Type == cpv1beta.K8sNetworkPolicy {
-		return Response{
-			NameSpace:       policy.Namespace,
-			Name:            policy.Name,
-			TierPriority:    0,
-			Priority:        0,
-			Rules:           rules.([]rule.Response),
-			AppliedToGroups: policy.AppliedToGroups,
-			SourceType:      policy.SourceRef.Type,
-		}, nil
-	}
-
-	return Response{
-		NameSpace:       policy.Namespace,
-		Name:            policy.Name,
-		TierPriority:    *policy.TierPriority,
-		Priority:        *policy.Priority,
-		Rules:           rules.([]rule.Response),
-		AppliedToGroups: policy.AppliedToGroups,
-		SourceType:      policy.SourceRef.Type,
-	}, nil
+	return Response{o.(*cpv1beta.NetworkPolicy)}, nil
 }
 
 func listTransform(l interface{}) (interface{}, error) {
 	policyList := l.(*cpv1beta.NetworkPolicyList)
-	result := []Response{}
-	for _, item := range policyList.Items {
-		o, _ := objectTransform(&item)
+	result := make([]Response, 0, len(policyList.Items))
+	for i := range policyList.Items {
+		o, _ := objectTransform(&policyList.Items[i])
 		result = append(result, o.(Response))
 	}
 	return result, nil
@@ -87,11 +54,11 @@ func Transform(reader io.Reader, single bool) (interface{}, error) {
 var _ common.TableOutput = new(Response)
 
 func (r Response) GetTableHeader() []string {
-	return []string{"NAMESPACE", "NAME", "APPLIED-TO", "RULES", "SOURCE-TYPE"}
+	return []string{"NAME", "APPLIED-TO", "RULES", "SOURCE"}
 }
 
 func (r Response) GetTableRow(maxColumnLength int) []string {
-	return []string{r.NameSpace, r.Name, common.GenerateTableElementWithSummary(r.AppliedToGroups, maxColumnLength), strconv.Itoa(len(r.Rules)), string(r.SourceType)}
+	return []string{r.Name, common.GenerateTableElementWithSummary(r.AppliedToGroups, maxColumnLength), strconv.Itoa(len(r.Rules)), r.SourceRef.ToString()}
 }
 
 func (r Response) SortRows() bool {

--- a/pkg/apis/controlplane/v1beta2/generated.proto
+++ b/pkg/apis/controlplane/v1beta2/generated.proto
@@ -143,6 +143,7 @@ message NamedPort {
 }
 
 // +genclient
+// +genclient:nonNamespaced
 // +genclient:onlyVerbs=list,get,watch
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // NetworkPolicy is the message format of antrea/pkg/controller/types.NetworkPolicy in an API response.

--- a/pkg/apis/controlplane/v1beta2/types.go
+++ b/pkg/apis/controlplane/v1beta2/types.go
@@ -148,6 +148,7 @@ type NetworkPolicyReference struct {
 }
 
 // +genclient
+// +genclient:nonNamespaced
 // +genclient:onlyVerbs=list,get,watch
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // NetworkPolicy is the message format of antrea/pkg/controller/types.NetworkPolicy in an API response.

--- a/pkg/client/clientset/versioned/typed/controlplane/v1beta2/controlplane_client.go
+++ b/pkg/client/clientset/versioned/typed/controlplane/v1beta2/controlplane_client.go
@@ -43,8 +43,8 @@ func (c *ControlplaneV1beta2Client) AppliedToGroups() AppliedToGroupInterface {
 	return newAppliedToGroups(c)
 }
 
-func (c *ControlplaneV1beta2Client) NetworkPolicies(namespace string) NetworkPolicyInterface {
-	return newNetworkPolicies(c, namespace)
+func (c *ControlplaneV1beta2Client) NetworkPolicies() NetworkPolicyInterface {
+	return newNetworkPolicies(c)
 }
 
 func (c *ControlplaneV1beta2Client) NodeStatsSummaries() NodeStatsSummaryInterface {

--- a/pkg/client/clientset/versioned/typed/controlplane/v1beta2/fake/fake_controlplane_client.go
+++ b/pkg/client/clientset/versioned/typed/controlplane/v1beta2/fake/fake_controlplane_client.go
@@ -34,8 +34,8 @@ func (c *FakeControlplaneV1beta2) AppliedToGroups() v1beta2.AppliedToGroupInterf
 	return &FakeAppliedToGroups{c}
 }
 
-func (c *FakeControlplaneV1beta2) NetworkPolicies(namespace string) v1beta2.NetworkPolicyInterface {
-	return &FakeNetworkPolicies{c, namespace}
+func (c *FakeControlplaneV1beta2) NetworkPolicies() v1beta2.NetworkPolicyInterface {
+	return &FakeNetworkPolicies{c}
 }
 
 func (c *FakeControlplaneV1beta2) NodeStatsSummaries() v1beta2.NodeStatsSummaryInterface {

--- a/pkg/client/clientset/versioned/typed/controlplane/v1beta2/fake/fake_networkpolicy.go
+++ b/pkg/client/clientset/versioned/typed/controlplane/v1beta2/fake/fake_networkpolicy.go
@@ -30,7 +30,6 @@ import (
 // FakeNetworkPolicies implements NetworkPolicyInterface
 type FakeNetworkPolicies struct {
 	Fake *FakeControlplaneV1beta2
-	ns   string
 }
 
 var networkpoliciesResource = schema.GroupVersionResource{Group: "controlplane.antrea.tanzu.vmware.com", Version: "v1beta2", Resource: "networkpolicies"}
@@ -40,8 +39,7 @@ var networkpoliciesKind = schema.GroupVersionKind{Group: "controlplane.antrea.ta
 // Get takes name of the networkPolicy, and returns the corresponding networkPolicy object, and an error if there is any.
 func (c *FakeNetworkPolicies) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta2.NetworkPolicy, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(networkpoliciesResource, c.ns, name), &v1beta2.NetworkPolicy{})
-
+		Invokes(testing.NewRootGetAction(networkpoliciesResource, name), &v1beta2.NetworkPolicy{})
 	if obj == nil {
 		return nil, err
 	}
@@ -51,8 +49,7 @@ func (c *FakeNetworkPolicies) Get(ctx context.Context, name string, options v1.G
 // List takes label and field selectors, and returns the list of NetworkPolicies that match those selectors.
 func (c *FakeNetworkPolicies) List(ctx context.Context, opts v1.ListOptions) (result *v1beta2.NetworkPolicyList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(networkpoliciesResource, networkpoliciesKind, c.ns, opts), &v1beta2.NetworkPolicyList{})
-
+		Invokes(testing.NewRootListAction(networkpoliciesResource, networkpoliciesKind, opts), &v1beta2.NetworkPolicyList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -73,6 +70,5 @@ func (c *FakeNetworkPolicies) List(ctx context.Context, opts v1.ListOptions) (re
 // Watch returns a watch.Interface that watches the requested networkPolicies.
 func (c *FakeNetworkPolicies) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(networkpoliciesResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(networkpoliciesResource, opts))
 }

--- a/pkg/client/clientset/versioned/typed/controlplane/v1beta2/networkpolicy.go
+++ b/pkg/client/clientset/versioned/typed/controlplane/v1beta2/networkpolicy.go
@@ -30,7 +30,7 @@ import (
 // NetworkPoliciesGetter has a method to return a NetworkPolicyInterface.
 // A group's client should implement this interface.
 type NetworkPoliciesGetter interface {
-	NetworkPolicies(namespace string) NetworkPolicyInterface
+	NetworkPolicies() NetworkPolicyInterface
 }
 
 // NetworkPolicyInterface has methods to work with NetworkPolicy resources.
@@ -44,14 +44,12 @@ type NetworkPolicyInterface interface {
 // networkPolicies implements NetworkPolicyInterface
 type networkPolicies struct {
 	client rest.Interface
-	ns     string
 }
 
 // newNetworkPolicies returns a NetworkPolicies
-func newNetworkPolicies(c *ControlplaneV1beta2Client, namespace string) *networkPolicies {
+func newNetworkPolicies(c *ControlplaneV1beta2Client) *networkPolicies {
 	return &networkPolicies{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -59,7 +57,6 @@ func newNetworkPolicies(c *ControlplaneV1beta2Client, namespace string) *network
 func (c *networkPolicies) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta2.NetworkPolicy, err error) {
 	result = &v1beta2.NetworkPolicy{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("networkpolicies").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -76,7 +73,6 @@ func (c *networkPolicies) List(ctx context.Context, opts v1.ListOptions) (result
 	}
 	result = &v1beta2.NetworkPolicyList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("networkpolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -93,7 +89,6 @@ func (c *networkPolicies) Watch(ctx context.Context, opts v1.ListOptions) (watch
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("networkpolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/pkg/controller/networkpolicy/antreanetworkpolicy.go
+++ b/pkg/controller/networkpolicy/antreanetworkpolicy.go
@@ -32,9 +32,9 @@ func (n *NetworkPolicyController) addANP(obj interface{}) {
 	// Create an internal NetworkPolicy object corresponding to this
 	// NetworkPolicy and enqueue task to internal NetworkPolicy Workqueue.
 	internalNP := n.processAntreaNetworkPolicy(np)
-	klog.Infof("Creating new internal NetworkPolicy %#v", internalNP)
+	klog.V(2).Infof("Creating new internal NetworkPolicy %s for %s", internalNP.Name, internalNP.SourceRef.ToString())
 	n.internalNetworkPolicyStore.Create(internalNP)
-	key, _ := keyFunc(np)
+	key := internalNetworkPolicyKeyFunc(np)
 	n.enqueueInternalNetworkPolicy(key)
 }
 
@@ -47,11 +47,11 @@ func (n *NetworkPolicyController) updateANP(old, cur interface{}) {
 	// Update an internal NetworkPolicy, corresponding to this NetworkPolicy and
 	// enqueue task to internal NetworkPolicy Workqueue.
 	curInternalNP := n.processAntreaNetworkPolicy(curNP)
-	klog.V(2).Infof("Updating existing internal NetworkPolicy %s", curInternalNP.Name)
+	klog.V(2).Infof("Updating existing internal NetworkPolicy %s for %s", curInternalNP.Name, curInternalNP.SourceRef.ToString())
 	// Retrieve old secv1alpha1.NetworkPolicy object.
 	oldNP := old.(*secv1alpha1.NetworkPolicy)
 	// Old and current NetworkPolicy share the same key.
-	key, _ := keyFunc(oldNP)
+	key := internalNetworkPolicyKeyFunc(oldNP)
 	// Lock access to internal NetworkPolicy store such that concurrent access
 	// to an internal NetworkPolicy is not allowed. This will avoid the
 	// case in which an Update to an internal NetworkPolicy object may
@@ -101,10 +101,10 @@ func (n *NetworkPolicyController) deleteANP(old interface{}) {
 	}
 	defer n.heartbeat("deleteANP")
 	klog.Infof("Processing Antrea NetworkPolicy %s/%s DELETE event", np.Namespace, np.Name)
-	key, _ := keyFunc(np)
+	key := internalNetworkPolicyKeyFunc(np)
 	oldInternalNPObj, _, _ := n.internalNetworkPolicyStore.Get(key)
 	oldInternalNP := oldInternalNPObj.(*antreatypes.NetworkPolicy)
-	klog.V(4).Infof("Old internal NetworkPolicy %#v", oldInternalNP)
+	klog.V(2).Infof("Deleting internal NetworkPolicy %s for %s", oldInternalNP.Name, oldInternalNP.SourceRef.ToString())
 	err := n.internalNetworkPolicyStore.Delete(key)
 	if err != nil {
 		klog.Errorf("Error deleting internal NetworkPolicy during Antrea NetworkPolicy %s delete: %v", np.Name, err)
@@ -163,8 +163,7 @@ func (n *NetworkPolicyController) processAntreaNetworkPolicy(np *secv1alpha1.Net
 			Name:      np.Name,
 			UID:       np.UID,
 		},
-		Name:            np.Name,
-		Namespace:       np.Namespace,
+		Name:            internalNetworkPolicyKeyFunc(np),
 		UID:             np.UID,
 		AppliedToGroups: appliedToGroupNames,
 		Rules:           rules,

--- a/pkg/controller/networkpolicy/antreanetworkpolicy_test.go
+++ b/pkg/controller/networkpolicy/antreanetworkpolicy_test.go
@@ -89,9 +89,8 @@ func TestProcessAntreaNetworkPolicy(t *testing.T) {
 				},
 			},
 			expectedPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "npA",
-				Namespace: "ns1",
+				UID:  "uidA",
+				Name: "uidA",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.AntreaNetworkPolicy,
 					Namespace: "ns1",
@@ -175,9 +174,8 @@ func TestProcessAntreaNetworkPolicy(t *testing.T) {
 				},
 			},
 			expectedPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidB",
-				Name:      "npB",
-				Namespace: "ns2",
+				UID:  "uidB",
+				Name: "uidB",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.AntreaNetworkPolicy,
 					Namespace: "ns2",
@@ -279,9 +277,8 @@ func TestAddANP(t *testing.T) {
 				},
 			},
 			expPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "anpA",
-				Namespace: "nsA",
+				UID:  "uidA",
+				Name: "uidA",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.AntreaNetworkPolicy,
 					Namespace: "nsA",
@@ -316,7 +313,7 @@ func TestAddANP(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, npc := newController()
 			npc.addANP(tt.inputPolicy)
-			key, _ := keyFunc(tt.inputPolicy)
+			key := internalNetworkPolicyKeyFunc(tt.inputPolicy)
 			actualPolicyObj, _, _ := npc.internalNetworkPolicyStore.Get(key)
 			actualPolicy := actualPolicyObj.(*antreatypes.NetworkPolicy)
 
@@ -338,7 +335,7 @@ func TestDeleteANP(t *testing.T) {
 	assert.False(t, found, "expected AppliedToGroup to be deleted")
 	adgs := npc.addressGroupStore.List()
 	assert.Len(t, adgs, 0, "expected empty AddressGroup list")
-	key, _ := keyFunc(anpObj)
+	key := internalNetworkPolicyKeyFunc(anpObj)
 	_, found, _ = npc.internalNetworkPolicyStore.Get(key)
 	assert.False(t, found, "expected internal NetworkPolicy to be deleted")
 }

--- a/pkg/controller/networkpolicy/clusternetworkpolicy_test.go
+++ b/pkg/controller/networkpolicy/clusternetworkpolicy_test.go
@@ -93,9 +93,8 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 				},
 			},
 			expectedPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "cnpA",
-				Namespace: "",
+				UID:  "uidA",
+				Name: "uidA",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type: controlplane.AntreaClusterNetworkPolicy,
 					Name: "cnpA",
@@ -178,9 +177,8 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 				},
 			},
 			expectedPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidB",
-				Name:      "cnpB",
-				Namespace: "",
+				UID:  "uidB",
+				Name: "uidB",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type: controlplane.AntreaClusterNetworkPolicy,
 					Name: "cnpB",
@@ -264,9 +262,8 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 				},
 			},
 			expectedPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidC",
-				Name:      "cnpC",
-				Namespace: "",
+				UID:  "uidC",
+				Name: "uidC",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type: controlplane.AntreaClusterNetworkPolicy,
 					Name: "cnpC",
@@ -385,9 +382,8 @@ func TestAddCNP(t *testing.T) {
 				},
 			},
 			expPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "cnpA",
-				Namespace: "",
+				UID:  "uidA",
+				Name: "uidA",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type: controlplane.AntreaClusterNetworkPolicy,
 					Name: "cnpA",
@@ -445,7 +441,7 @@ func TestAddCNP(t *testing.T) {
 			},
 			expPolicy: &antreatypes.NetworkPolicy{
 				UID:  "uidB",
-				Name: "cnpB",
+				Name: "uidB",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type: controlplane.AntreaClusterNetworkPolicy,
 					Name: "cnpB",
@@ -503,9 +499,8 @@ func TestAddCNP(t *testing.T) {
 				},
 			},
 			expPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidD",
-				Name:      "cnpD",
-				Namespace: "",
+				UID:  "uidD",
+				Name: "uidD",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type: controlplane.AntreaClusterNetworkPolicy,
 					Name: "cnpD",
@@ -563,9 +558,8 @@ func TestAddCNP(t *testing.T) {
 				},
 			},
 			expPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidE",
-				Name:      "cnpE",
-				Namespace: "",
+				UID:  "uidE",
+				Name: "uidE",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type: controlplane.AntreaClusterNetworkPolicy,
 					Name: "cnpE",
@@ -638,9 +632,8 @@ func TestAddCNP(t *testing.T) {
 				},
 			},
 			expPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidF",
-				Name:      "cnpF",
-				Namespace: "",
+				UID:  "uidF",
+				Name: "uidF",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type: controlplane.AntreaClusterNetworkPolicy,
 					Name: "cnpF",
@@ -723,9 +716,8 @@ func TestAddCNP(t *testing.T) {
 				},
 			},
 			expPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidG",
-				Name:      "cnpG",
-				Namespace: "",
+				UID:  "uidG",
+				Name: "uidG",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type: controlplane.AntreaClusterNetworkPolicy,
 					Name: "cnpG",
@@ -775,7 +767,7 @@ func TestAddCNP(t *testing.T) {
 			npc.tierStore.Add(&appTier)
 			npc.tierStore.Add(&emergencyTier)
 			npc.addCNP(tt.inputPolicy)
-			key, _ := keyFunc(tt.inputPolicy)
+			key := internalNetworkPolicyKeyFunc(tt.inputPolicy)
 			actualPolicyObj, _, _ := npc.internalNetworkPolicyStore.Get(key)
 			actualPolicy := actualPolicyObj.(*antreatypes.NetworkPolicy)
 			assert.Equal(t, tt.expPolicy, actualPolicy)
@@ -803,7 +795,7 @@ func TestDeleteCNP(t *testing.T) {
 	assert.False(t, found, "expected AppliedToGroup to be deleted")
 	adgs := npc.addressGroupStore.List()
 	assert.Len(t, adgs, 0, "expected empty AddressGroup list")
-	key, _ := keyFunc(cnpObj)
+	key := internalNetworkPolicyKeyFunc(cnpObj)
 	_, found, _ = npc.internalNetworkPolicyStore.Get(key)
 	assert.False(t, found, "expected internal NetworkPolicy to be deleted")
 }

--- a/pkg/controller/networkpolicy/endpoint_querier.go
+++ b/pkg/controller/networkpolicy/endpoint_querier.go
@@ -162,9 +162,9 @@ func (eq *endpointQuerier) QueryNetworkPolicies(namespace string, podName string
 	for _, internalPolicy := range applied {
 		responsePolicy := Policy{
 			PolicyRef: PolicyRef{
-				Namespace: internalPolicy.Namespace,
-				Name:      internalPolicy.Name,
-				UID:       internalPolicy.UID,
+				Namespace: internalPolicy.SourceRef.Namespace,
+				Name:      internalPolicy.SourceRef.Name,
+				UID:       internalPolicy.SourceRef.UID,
 			},
 		}
 		responsePolicies = append(responsePolicies, responsePolicy)
@@ -174,9 +174,9 @@ func (eq *endpointQuerier) QueryNetworkPolicies(namespace string, podName string
 	for _, internalPolicy := range egress {
 		newRule := Rule{
 			PolicyRef: PolicyRef{
-				Namespace: internalPolicy.policy.Namespace,
-				Name:      internalPolicy.policy.Name,
-				UID:       internalPolicy.policy.UID,
+				Namespace: internalPolicy.policy.SourceRef.Namespace,
+				Name:      internalPolicy.policy.SourceRef.Name,
+				UID:       internalPolicy.policy.SourceRef.UID,
 			},
 			Direction: cpv1beta.DirectionOut,
 			RuleIndex: internalPolicy.index,
@@ -186,9 +186,9 @@ func (eq *endpointQuerier) QueryNetworkPolicies(namespace string, podName string
 	for _, internalPolicy := range ingress {
 		newRule := Rule{
 			PolicyRef: PolicyRef{
-				Namespace: internalPolicy.policy.Namespace,
-				Name:      internalPolicy.policy.Name,
-				UID:       internalPolicy.policy.UID,
+				Namespace: internalPolicy.policy.SourceRef.Namespace,
+				Name:      internalPolicy.policy.SourceRef.Name,
+				UID:       internalPolicy.policy.SourceRef.UID,
 			},
 			Direction: cpv1beta.DirectionIn,
 			RuleIndex: internalPolicy.index,

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -79,8 +79,6 @@ const (
 )
 
 var (
-	keyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
-
 	// uuidNamespace is a uuid.UUID type generated from a string to be
 	// used to generate uuid.UUID for internal Antrea objects like
 	// AppliedToGroup, AddressGroup etc.
@@ -674,9 +672,8 @@ func (n *NetworkPolicyController) processNetworkPolicy(np *networkingv1.NetworkP
 	}
 
 	internalNetworkPolicy := &antreatypes.NetworkPolicy{
-		Name:      np.Name,
-		Namespace: np.Namespace,
-		UID:       np.UID,
+		Name: internalNetworkPolicyKeyFunc(np),
+		UID:  np.UID,
 		SourceRef: &controlplane.NetworkPolicyReference{
 			Type:      controlplane.K8sNetworkPolicy,
 			Namespace: np.Namespace,
@@ -733,13 +730,13 @@ func (n *NetworkPolicyController) toAntreaPeer(peers []networkingv1.NetworkPolic
 func (n *NetworkPolicyController) addNetworkPolicy(obj interface{}) {
 	defer n.heartbeat("addNetworkPolicy")
 	np := obj.(*networkingv1.NetworkPolicy)
-	klog.V(2).Infof("Processing NetworkPolicy %s/%s ADD event", np.Namespace, np.Name)
+	klog.Infof("Processing K8s NetworkPolicy %s/%s ADD event", np.Namespace, np.Name)
 	// Create an internal NetworkPolicy object corresponding to this NetworkPolicy
 	// and enqueue task to internal NetworkPolicy Workqueue.
 	internalNP := n.processNetworkPolicy(np)
-	klog.Infof("Creating new internal NetworkPolicy %s/%s", internalNP.Namespace, internalNP.Name)
+	klog.V(2).Infof("Creating new internal NetworkPolicy %s for %s", internalNP.Name, internalNP.SourceRef.ToString())
 	n.internalNetworkPolicyStore.Create(internalNP)
-	key, _ := keyFunc(np)
+	key := internalNetworkPolicyKeyFunc(np)
 	n.enqueueInternalNetworkPolicy(key)
 }
 
@@ -748,15 +745,15 @@ func (n *NetworkPolicyController) addNetworkPolicy(obj interface{}) {
 func (n *NetworkPolicyController) updateNetworkPolicy(old, cur interface{}) {
 	defer n.heartbeat("updateNetworkPolicy")
 	np := cur.(*networkingv1.NetworkPolicy)
-	klog.V(2).Infof("Processing NetworkPolicy %s/%s UPDATE event", np.Namespace, np.Name)
+	klog.Infof("Processing K8s NetworkPolicy %s/%s UPDATE event", np.Namespace, np.Name)
 	// Update an internal NetworkPolicy ID, corresponding to this NetworkPolicy and
 	// enqueue task to internal NetworkPolicy Workqueue.
 	curInternalNP := n.processNetworkPolicy(np)
-	klog.V(2).Infof("Updating existing internal NetworkPolicy %s/%s", curInternalNP.Namespace, curInternalNP.Name)
+	klog.V(2).Infof("Updating existing internal NetworkPolicy %s for %s", curInternalNP.Name, curInternalNP.SourceRef.ToString())
 	// Retrieve old networkingv1.NetworkPolicy object.
 	oldNP := old.(*networkingv1.NetworkPolicy)
 	// Old and current NetworkPolicy share the same key.
-	key, _ := keyFunc(oldNP)
+	key := internalNetworkPolicyKeyFunc(oldNP)
 	// Lock access to internal NetworkPolicy store such that concurrent access
 	// to an internal NetworkPolicy is not allowed. This will avoid the
 	// case in which an Update to an internal NetworkPolicy object may
@@ -810,13 +807,13 @@ func (n *NetworkPolicyController) deleteNetworkPolicy(old interface{}) {
 	}
 	defer n.heartbeat("deleteNetworkPolicy")
 
-	klog.V(2).Infof("Processing NetworkPolicy %s/%s DELETE event", np.Namespace, np.Name)
-	key, _ := keyFunc(np)
+	klog.Infof("Processing K8s NetworkPolicy %s/%s DELETE event", np.Namespace, np.Name)
+	key := internalNetworkPolicyKeyFunc(np)
 	oldInternalNPObj, _, _ := n.internalNetworkPolicyStore.Get(key)
 	oldInternalNP := oldInternalNPObj.(*antreatypes.NetworkPolicy)
 	// AppliedToGroups currently only supports a single member.
 	oldAppliedToGroupUID := oldInternalNP.AppliedToGroups[0]
-	klog.Infof("Deleting internal NetworkPolicy %s/%s", np.Namespace, np.Name)
+	klog.Infof("Deleting internal NetworkPolicy %s for %s", oldInternalNP.Name, oldInternalNP.SourceRef.ToString())
 	// Delete corresponding internal NetworkPolicy from store.
 	err := n.internalNetworkPolicyStore.Delete(key)
 	if err != nil {
@@ -1473,7 +1470,6 @@ func (n *NetworkPolicyController) syncInternalNetworkPolicy(key string) error {
 	updatedNetworkPolicy := &antreatypes.NetworkPolicy{
 		UID:             internalNP.UID,
 		Name:            internalNP.Name,
-		Namespace:       internalNP.Namespace,
 		SourceRef:       internalNP.SourceRef,
 		Rules:           internalNP.Rules,
 		AppliedToGroups: internalNP.AppliedToGroups,
@@ -1527,4 +1523,12 @@ func cidrStrToIPNet(cidr string) (*controlplane.IPNet, error) {
 		PrefixLength: int32(prefixLen64),
 	}
 	return ipNet, nil
+}
+
+// internalNetworkPolicyKeyFunc knows how to generate the key for an internal NetworkPolicy based on the object metadata
+// of the corresponding original NetworkPolicy resource (also referred to as the "source").
+// The key must be unique across K8s NetworkPolicies, Antrea NetworkPolicies, and Antrea ClusterNetworkPolicies.
+// Currently the UID of the original NetworkPolicy is used to ensure uniqueness.
+func internalNetworkPolicyKeyFunc(obj metav1.Object) string {
+	return string(obj.GetUID())
 }

--- a/pkg/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_test.go
@@ -162,9 +162,8 @@ func TestAddNetworkPolicy(t *testing.T) {
 				},
 			},
 			expPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "npA",
-				Namespace: "nsA",
+				UID:  "uidA",
+				Name: "uidA",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.K8sNetworkPolicy,
 					Namespace: "nsA",
@@ -194,9 +193,8 @@ func TestAddNetworkPolicy(t *testing.T) {
 				},
 			},
 			expPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidB",
-				Name:      "npB",
-				Namespace: "nsA",
+				UID:  "uidB",
+				Name: "uidB",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.K8sNetworkPolicy,
 					Namespace: "nsA",
@@ -235,9 +233,8 @@ func TestAddNetworkPolicy(t *testing.T) {
 				},
 			},
 			expPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidB",
-				Name:      "npB",
-				Namespace: "nsA",
+				UID:  "uidB",
+				Name: "uidB",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.K8sNetworkPolicy,
 					Namespace: "nsA",
@@ -271,9 +268,8 @@ func TestAddNetworkPolicy(t *testing.T) {
 				},
 			},
 			expPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidC",
-				Name:      "npC",
-				Namespace: "nsA",
+				UID:  "uidC",
+				Name: "uidC",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.K8sNetworkPolicy,
 					Namespace: "nsA",
@@ -298,9 +294,8 @@ func TestAddNetworkPolicy(t *testing.T) {
 				},
 			},
 			expPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidD",
-				Name:      "npD",
-				Namespace: "nsA",
+				UID:  "uidD",
+				Name: "uidD",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.K8sNetworkPolicy,
 					Namespace: "nsA",
@@ -354,9 +349,8 @@ func TestAddNetworkPolicy(t *testing.T) {
 				},
 			},
 			expPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidE",
-				Name:      "npE",
-				Namespace: "nsA",
+				UID:  "uidE",
+				Name: "uidE",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.K8sNetworkPolicy,
 					Namespace: "nsA",
@@ -433,9 +427,8 @@ func TestAddNetworkPolicy(t *testing.T) {
 				},
 			},
 			expPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidF",
-				Name:      "npF",
-				Namespace: "nsA",
+				UID:  "uidF",
+				Name: "uidF",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.K8sNetworkPolicy,
 					Namespace: "nsA",
@@ -482,7 +475,7 @@ func TestAddNetworkPolicy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, npc := newController()
 			npc.addNetworkPolicy(tt.inputPolicy)
-			key, _ := keyFunc(tt.inputPolicy)
+			key := internalNetworkPolicyKeyFunc(tt.inputPolicy)
 			actualPolicyObj, _, _ := npc.internalNetworkPolicyStore.Get(key)
 			actualPolicy := actualPolicyObj.(*antreatypes.NetworkPolicy)
 			assert.Equal(t, tt.expPolicy, actualPolicy)
@@ -512,7 +505,7 @@ func TestDeleteNetworkPolicy(t *testing.T) {
 	assert.False(t, found, "expected AppliedToGroup to be deleted")
 	adgs := npc.addressGroupStore.List()
 	assert.Len(t, adgs, 0, "expected empty AddressGroup list")
-	key, _ := keyFunc(npObj)
+	key := internalNetworkPolicyKeyFunc(npObj)
 	_, found, _ = npc.internalNetworkPolicyStore.Get(key)
 	assert.False(t, found, "expected internal NetworkPolicy to be deleted")
 }
@@ -581,9 +574,8 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 				},
 			},
 			expNetworkPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "npA",
-				Namespace: "nsA",
+				UID:  "uidA",
+				Name: "uidA",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.K8sNetworkPolicy,
 					Namespace: "nsA",
@@ -632,9 +624,8 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 				},
 			},
 			expNetworkPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "npA",
-				Namespace: "nsA",
+				UID:  "uidA",
+				Name: "uidA",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.K8sNetworkPolicy,
 					Namespace: "nsA",
@@ -675,9 +666,8 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 				},
 			},
 			expNetworkPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "npA",
-				Namespace: "nsA",
+				UID:  "uidA",
+				Name: "uidA",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.K8sNetworkPolicy,
 					Namespace: "nsA",
@@ -708,9 +698,8 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 				},
 			},
 			expNetworkPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "npA",
-				Namespace: "nsA",
+				UID:  "uidA",
+				Name: "uidA",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.K8sNetworkPolicy,
 					Namespace: "nsA",
@@ -758,9 +747,8 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 				},
 			},
 			expNetworkPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "npA",
-				Namespace: "nsA",
+				UID:  "uidA",
+				Name: "uidA",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.K8sNetworkPolicy,
 					Namespace: "nsA",
@@ -826,9 +814,8 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 				},
 			},
 			expNetworkPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "npA",
-				Namespace: "nsA",
+				UID:  "uidA",
+				Name: "uidA",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.K8sNetworkPolicy,
 					Namespace: "nsA",
@@ -864,7 +851,7 @@ func TestUpdateNetworkPolicy(t *testing.T) {
 			_, npc := newController()
 			npc.addNetworkPolicy(oldNP)
 			npc.updateNetworkPolicy(oldNP, tt.updatedNetworkPolicy)
-			key, _ := keyFunc(oldNP)
+			key := internalNetworkPolicyKeyFunc(oldNP)
 			actualPolicyObj, _, _ := npc.internalNetworkPolicyStore.Get(key)
 			actualPolicy := actualPolicyObj.(*antreatypes.NetworkPolicy)
 			if actualAppliedToGroups := len(npc.appliedToGroupStore.List()); actualAppliedToGroups != tt.expAppliedToGroups {
@@ -2203,9 +2190,8 @@ func TestProcessNetworkPolicy(t *testing.T) {
 				},
 			},
 			expectedPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "npA",
-				Namespace: "nsA",
+				UID:  "uidA",
+				Name: "uidA",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.K8sNetworkPolicy,
 					Namespace: "nsA",
@@ -2234,9 +2220,8 @@ func TestProcessNetworkPolicy(t *testing.T) {
 				},
 			},
 			expectedPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "npA",
-				Namespace: "nsA",
+				UID:  "uidA",
+				Name: "uidA",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.K8sNetworkPolicy,
 					Namespace: "nsA",
@@ -2288,9 +2273,8 @@ func TestProcessNetworkPolicy(t *testing.T) {
 				},
 			},
 			expectedPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "npA",
-				Namespace: "nsA",
+				UID:  "uidA",
+				Name: "uidA",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.K8sNetworkPolicy,
 					Namespace: "nsA",
@@ -2367,9 +2351,8 @@ func TestProcessNetworkPolicy(t *testing.T) {
 				},
 			},
 			expectedPolicy: &antreatypes.NetworkPolicy{
-				UID:       "uidA",
-				Name:      "npA",
-				Namespace: "nsA",
+				UID:  "uidA",
+				Name: "uidA",
 				SourceRef: &controlplane.NetworkPolicyReference{
 					Type:      controlplane.K8sNetworkPolicy,
 					Namespace: "nsA",

--- a/pkg/controller/networkpolicy/store/networkpolicy.go
+++ b/pkg/controller/networkpolicy/store/networkpolicy.go
@@ -26,7 +26,6 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/apiserver/storage"
 	"github.com/vmware-tanzu/antrea/pkg/apiserver/storage/ram"
 	"github.com/vmware-tanzu/antrea/pkg/controller/types"
-	"github.com/vmware-tanzu/antrea/pkg/k8s"
 )
 
 const (
@@ -103,7 +102,6 @@ func genNetworkPolicyEvent(key string, prevObj, currObj interface{}, rv uint64) 
 // ToNetworkPolicyMsg converts the stored NetworkPolicy to its message form.
 // If includeBody is true, Rules and AppliedToGroups will be copied.
 func ToNetworkPolicyMsg(in *types.NetworkPolicy, out *controlplane.NetworkPolicy, includeBody bool) {
-	out.Namespace = in.Namespace
 	out.Name = in.Name
 	out.UID = in.UID
 	out.SourceRef = in.SourceRef
@@ -123,7 +121,7 @@ func NetworkPolicyKeyFunc(obj interface{}) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("object is not *types.NetworkPolicy: %v", obj)
 	}
-	return k8s.NamespacedName(policy.Namespace, policy.Name), nil
+	return policy.Name, nil
 }
 
 // NewNetworkPolicyStore creates a store of NetworkPolicy.

--- a/pkg/controller/networkpolicy/store/networkpolicy_test.go
+++ b/pkg/controller/networkpolicy/store/networkpolicy_test.go
@@ -39,7 +39,6 @@ func TestWatchNetworkPolicyEvent(t *testing.T) {
 		UID:       "id1",
 	}
 	policyV1 := &types.NetworkPolicy{
-		Namespace: "foo",
 		Name:      "bar",
 		SourceRef: &npRef,
 		SpanMeta:  types.SpanMeta{NodeNames: sets.NewString("node1", "node2")},
@@ -52,7 +51,6 @@ func TestWatchNetworkPolicyEvent(t *testing.T) {
 		AppliedToGroups: []string{"appliedToGroup1"},
 	}
 	policyV2 := &types.NetworkPolicy{
-		Namespace: "foo",
 		Name:      "bar",
 		SourceRef: &npRef,
 		SpanMeta:  types.SpanMeta{NodeNames: sets.NewString("node1", "node3")},
@@ -65,7 +63,6 @@ func TestWatchNetworkPolicyEvent(t *testing.T) {
 		AppliedToGroups: []string{"appliedToGroup1"},
 	}
 	policyV3 := &types.NetworkPolicy{
-		Namespace: "foo",
 		Name:      "bar",
 		SourceRef: &npRef,
 		SpanMeta:  types.SpanMeta{NodeNames: sets.NewString("node1", "node3")},
@@ -95,13 +92,13 @@ func TestWatchNetworkPolicyEvent(t *testing.T) {
 			expected: []watch.Event{
 				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{}},
 				{Type: watch.Added, Object: &controlplane.NetworkPolicy{
-					ObjectMeta:      metav1.ObjectMeta{Namespace: "foo", Name: "bar"},
+					ObjectMeta:      metav1.ObjectMeta{Name: "bar"},
 					SourceRef:       &npRef,
 					Rules:           policyV1.Rules,
 					AppliedToGroups: policyV1.AppliedToGroups,
 				}},
 				{Type: watch.Modified, Object: &controlplane.NetworkPolicy{
-					ObjectMeta:      metav1.ObjectMeta{Namespace: "foo", Name: "bar"},
+					ObjectMeta:      metav1.ObjectMeta{Name: "bar"},
 					SourceRef:       &npRef,
 					Rules:           policyV2.Rules,
 					AppliedToGroups: policyV2.AppliedToGroups,
@@ -124,19 +121,19 @@ func TestWatchNetworkPolicyEvent(t *testing.T) {
 			expected: []watch.Event{
 				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{}},
 				{Type: watch.Added, Object: &controlplane.NetworkPolicy{
-					ObjectMeta:      metav1.ObjectMeta{Namespace: "foo", Name: "bar"},
+					ObjectMeta:      metav1.ObjectMeta{Name: "bar"},
 					SourceRef:       &npRef,
 					Rules:           policyV2.Rules,
 					AppliedToGroups: policyV2.AppliedToGroups,
 				}},
 				{Type: watch.Modified, Object: &controlplane.NetworkPolicy{
-					ObjectMeta:      metav1.ObjectMeta{Namespace: "foo", Name: "bar"},
+					ObjectMeta:      metav1.ObjectMeta{Name: "bar"},
 					SourceRef:       &npRef,
 					Rules:           policyV3.Rules,
 					AppliedToGroups: policyV3.AppliedToGroups,
 				}},
 				{Type: watch.Deleted, Object: &controlplane.NetworkPolicy{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"},
+					ObjectMeta: metav1.ObjectMeta{Name: "bar"},
 					SourceRef:  &npRef,
 				}},
 			},
@@ -168,9 +165,8 @@ func TestWatchNetworkPolicyEvent(t *testing.T) {
 
 func TestGetNetworkPolicyByIndex(t *testing.T) {
 	policy1 := &types.NetworkPolicy{
-		Namespace: "foo",
-		Name:      "bar",
-		UID:       "uid-1",
+		Name: "bar",
+		UID:  "uid-1",
 		SourceRef: &controlplane.NetworkPolicyReference{
 			Type:      controlplane.K8sNetworkPolicy,
 			Namespace: "foo",
@@ -185,9 +181,8 @@ func TestGetNetworkPolicyByIndex(t *testing.T) {
 		AppliedToGroups: []string{"appliedToGroup1"},
 	}
 	policy2 := &types.NetworkPolicy{
-		Namespace: "foo2",
-		Name:      "bar2",
-		UID:       "uid-2",
+		Name: "bar2",
+		UID:  "uid-2",
 		SourceRef: &controlplane.NetworkPolicyReference{
 			Type:      controlplane.K8sNetworkPolicy,
 			Namespace: "foo2",

--- a/pkg/controller/types/networkpolicy.go
+++ b/pkg/controller/types/networkpolicy.go
@@ -95,11 +95,8 @@ type NetworkPolicy struct {
 	SpanMeta
 	// UID of the internal Network Policy.
 	UID types.UID
-	// Name of the internal Network Policy.
+	// Name of the internal Network Policy, must be unique across all Network Policy types.
 	Name string
-	// Namespace of the original K8s Network Policy.
-	// An empty value indicates that the Network Policy is Cluster scoped.
-	Namespace string
 	// Reference to the original Network Policy.
 	SourceRef *controlplane.NetworkPolicyReference
 	// Priority represents the relative priority of this Network Policy as compared to

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -34,7 +34,6 @@ type AgentNetworkPolicyInfoQuerier interface {
 	GetNetworkPolicies(npFilter *NetworkPolicyQueryFilter) []cpv1beta.NetworkPolicy
 	GetAddressGroups() []cpv1beta.AddressGroup
 	GetAppliedToGroups() []cpv1beta.AppliedToGroup
-	GetNetworkPolicy(npFilter *NetworkPolicyQueryFilter) *cpv1beta.NetworkPolicy
 	GetAppliedNetworkPolicies(pod, namespace string, npFilter *NetworkPolicyQueryFilter) []cpv1beta.NetworkPolicy
 }
 
@@ -78,9 +77,12 @@ func GetVersion() string {
 // e.g SourceType = "" means all type network policy will be retrieved
 // Can have more attributes in future if more args are required
 type NetworkPolicyQueryFilter struct {
-	// Name of the network policy.
+	// The Name of the controlplane network policy. If this field is set then
+	// none of the other fields can be.
 	Name string
-	// Namespace of the NetworkPolicy.
+	// The Name of the original network policy.
+	SourceName string
+	// The namespace of the original Namespace that the internal NetworkPolicy is created for.
 	Namespace string
 	// Name of the pod that the network policy is applied on.
 	Pod string

--- a/pkg/querier/testing/mock_querier.go
+++ b/pkg/querier/testing/mock_querier.go
@@ -147,20 +147,6 @@ func (mr *MockAgentNetworkPolicyInfoQuerierMockRecorder) GetNetworkPolicies(arg0
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkPolicies", reflect.TypeOf((*MockAgentNetworkPolicyInfoQuerier)(nil).GetNetworkPolicies), arg0)
 }
 
-// GetNetworkPolicy mocks base method
-func (m *MockAgentNetworkPolicyInfoQuerier) GetNetworkPolicy(arg0 *querier.NetworkPolicyQueryFilter) *v1beta2.NetworkPolicy {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNetworkPolicy", arg0)
-	ret0, _ := ret[0].(*v1beta2.NetworkPolicy)
-	return ret0
-}
-
-// GetNetworkPolicy indicates an expected call of GetNetworkPolicy
-func (mr *MockAgentNetworkPolicyInfoQuerierMockRecorder) GetNetworkPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkPolicy", reflect.TypeOf((*MockAgentNetworkPolicyInfoQuerier)(nil).GetNetworkPolicy), arg0)
-}
-
 // GetNetworkPolicyNum mocks base method
 func (m *MockAgentNetworkPolicyInfoQuerier) GetNetworkPolicyNum() int {
 	m.ctrl.T.Helper()

--- a/test/e2e/bandwidth_test.go
+++ b/test/e2e/bandwidth_test.go
@@ -114,7 +114,7 @@ func TestPodTrafficShaping(t *testing.T) {
 		// The bandwidths' unit is Mbits/sec.
 		clientEgressBandwidth  int
 		serverIngressBandwidth int
-		expectedBandwidth    int
+		expectedBandwidth      int
 	}{
 		{
 			name:                   "limited by egress bandwidth",

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -750,7 +750,7 @@ func (data *TestData) createNPAllowAllEgress(name string) (*networkingv1.Network
 // waitForNetworkpolicyRealized waits for the NetworkPolicy to be realized by the antrea-agent Pod.
 func (data *TestData) waitForNetworkpolicyRealized(pod string, networkpolicy string) error {
 	if err := wait.Poll(200*time.Millisecond, 5*time.Second, func() (bool, error) {
-		cmds := []string{"antctl", "get", "networkpolicy", networkpolicy, "-n", testNamespace}
+		cmds := []string{"antctl", "get", "networkpolicy", "-S", networkpolicy, "-n", testNamespace}
 		if _, stderr, err := runAntctl(pod, cmds, data); err != nil {
 			if strings.Contains(stderr, "server could not find the requested resource") {
 				return false, nil


### PR DESCRIPTION
The namespace and name of the controlplane NetworkPolicy were copied from the namespace and name of its original NetworkPolicy. If a Antrea NetworkPolicy and a K8s NetworkPolicy have the same namespace and name, they would override each other when converting to controlplane NetworkPolicy. Besides, similar to appliedToGroup and addressGroup, the controlplane NetworkPolicy should be cluster scoped.

This patch makes the controlplane NetworkPolicy cluster scoped and changes to use the UID of the original NetworkPolicy as its name to ensure uniqueness.

Fixes #1173

Another existing problem if the controlplane NetworkPolicy is namespace scoped:
For a namespace scoped API, [namespace cannot be empty if name is provided or it's a POST request](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/rest/request.go#L811-L818), which means we cannot use Create/Update/Get verb for ClusterNetworkPolicy type resources.
PR #1442 depends on this as it relies on subresource API of controlplane NetworkPolicy - "networkpolicies/status" to update status from agents.