### PR TITLE
Add baseline Tier for Antrea-Native Policies

### DIFF
--- a/pkg/agent/controller/networkpolicy/priority.go
+++ b/pkg/agent/controller/networkpolicy/priority.go
@@ -25,14 +25,18 @@ import (
 )
 
 const (
-	MaxUint16                = ^uint16(0)
-	PolicyBottomPriority     = uint16(100)
-	PolicyTopPriority        = uint16(65000)
-	zoneOffset               = uint16(5)
-	PriorityOffsetSingleTier = float64(640)
-	TierOffsetSingleTier     = uint16(0)
-	PriorityOffsetMultiTier  = float64(20)
-	TierOffsetMultiTier      = uint16(250)
+	MaxUint16                    = ^uint16(0)
+	zoneOffset                   = uint16(5)
+	DefaultTierPriority          = int32(250)
+	BaselinePolicyBottomPriority = uint16(10)
+	BaselinePolicyTopPriority    = uint16(180)
+	PolicyBottomPriority         = uint16(100)
+	PolicyTopPriority            = uint16(65000)
+	PriorityOffsetBaselineTier   = float64(10)
+	TierOffsetBaselineTier       = uint16(0)
+	PriorityOffsetMultiTier      = float64(20)
+	PriorityOffsetDefaultTier    = float64(100)
+	TierOffsetMultiTier          = uint16(200)
 )
 
 // PriorityUpdate stores the original and updated ofPriority of a Priority.
@@ -59,33 +63,6 @@ func priorityUpdatesToOFUpdates(allUpdates map[types.Priority]*PriorityUpdate) m
 	return processed
 }
 
-// InitialOFPriorityGetter is a heuristics function that will map types.Priority to a specific initial
-// OpenFlow priority in a table. It is used to space out the priorities in the OVS table and provide an
-// initial guess on the OpenFlow priority that can be assigned to the input Priority. If that OpenFlow
-// priority is not available, or if the surrounding priorities are out of place, insertConsecutivePriorities()
-// will then search for the appropriate OpenFlow priority to insert the input Priority.
-type InitialOFPriorityGetter func(p types.Priority, isSingleTier bool) uint16
-
-// InitialOFPriority is an InitialOFPriorityGetter that can be used by OVS tables handling both single
-// and multiple Antrea NetworkPolicy Tiers. It computes the initial OpenFlow priority by offsetting
-// the tier priority, policy priority and rule priority with pre determined coefficients.
-func InitialOFPriority(p types.Priority, isSingleTier bool) uint16 {
-	tierOffsetBase := TierOffsetMultiTier
-	priorityOffsetBase := PriorityOffsetMultiTier
-	if isSingleTier {
-		tierOffsetBase = TierOffsetSingleTier
-		priorityOffsetBase = PriorityOffsetSingleTier
-	}
-	tierOffset := tierOffsetBase * uint16(p.TierPriority)
-	priorityOffset := uint16(p.PolicyPriority * priorityOffsetBase)
-	offSet := tierOffset + priorityOffset + uint16(p.RulePriority)
-	// Cannot return a negative OF priority.
-	if PolicyTopPriority-PolicyBottomPriority < offSet {
-		return PolicyBottomPriority
-	}
-	return PolicyTopPriority - offSet
-}
-
 // priorityAssigner is a struct that maintains the current boundaries of
 // all ClusterNetworkPolicy categories/priorities and rule priorities, and knows
 // how to re-assign priorities if certain section overflows.
@@ -96,22 +73,58 @@ type priorityAssigner struct {
 	ofPriorityMap map[uint16]types.Priority
 	// sortedPriorities maintains a list of sorted Priorities currently registered in the table.
 	sortedPriorities types.ByPriority
-	// initialOFPriorityFunc determines the initial OpenFlow priority to be checked for input Priorities.
-	initialOFPriorityFunc InitialOFPriorityGetter
-	// isSingleTier keeps track of if the priorityAssigner is responsible for handling more than one Tier in
-	// the OVS table that it manages.
-	isSingleTier bool
+	// isBaselineTier keeps track of if the priorityAssigner is responsible for handling the baseline Tier
+	// table (which is shared with K8s NetworkPolicy default tables) or the Antrea Policy tables.
+	isBaselineTier       bool
+	// policyBottomPriority keeps track of the lowest ofPriority allowed for flow creation in the table it manages.
+	policyBottomPriority uint16
+	// policyTopPriority keeps track of the highest ofPriority allowed for flow creation in the table it manages.
+	policyTopPriority    uint16
 }
 
-func newPriorityAssigner(initialOFPriorityFunc InitialOFPriorityGetter, isSingleTier bool) *priorityAssigner {
+func newPriorityAssigner(isBaselineTier bool) *priorityAssigner {
+	bottomPriority := PolicyBottomPriority
+	topPriority := PolicyTopPriority
+	if isBaselineTier {
+		bottomPriority = BaselinePolicyBottomPriority
+		topPriority = BaselinePolicyTopPriority
+	}
 	pa := &priorityAssigner{
-		priorityMap:           map[types.Priority]uint16{},
-		ofPriorityMap:         map[uint16]types.Priority{},
-		sortedPriorities:      []types.Priority{},
-		initialOFPriorityFunc: initialOFPriorityFunc,
-		isSingleTier:          isSingleTier,
+		priorityMap:          map[types.Priority]uint16{},
+		ofPriorityMap:        map[uint16]types.Priority{},
+		sortedPriorities:     []types.Priority{},
+		isBaselineTier:       isBaselineTier,
+		policyBottomPriority: bottomPriority,
+		policyTopPriority:    topPriority,
 	}
 	return pa
+}
+
+// initialOFPriority is a heuristic function that will map types.Priority to a specific initial
+// OpenFlow priority in a table. It is used to space out the priorities in the OVS table and provide an
+// initial guess on the OpenFlow priority that can be assigned to the input Priority. If that OpenFlow
+// priority is not available, or if the surrounding priorities are out of place, insertConsecutivePriorities()
+// will then search for the appropriate OpenFlow priority to insert the input Priority.
+// It computes the initial OpenFlow priority by offsetting the tier priority, policy priority and rule priority
+// with pre-determined coefficients.
+func (pa *priorityAssigner) initialOFPriority(p types.Priority, isBaselineTier bool) uint16 {
+	tierOffsetBase := TierOffsetMultiTier
+	priorityOffsetBase := PriorityOffsetMultiTier
+	if p.TierPriority == DefaultTierPriority {
+		priorityOffsetBase = PriorityOffsetDefaultTier
+	}
+	if isBaselineTier {
+		tierOffsetBase = TierOffsetBaselineTier
+		priorityOffsetBase = PriorityOffsetBaselineTier
+	}
+	tierOffset := tierOffsetBase * uint16(p.TierPriority)
+	priorityOffset := uint16(p.PolicyPriority * priorityOffsetBase)
+	offSet := tierOffset + priorityOffset + uint16(p.RulePriority)
+	// Cannot return a negative OF priority.
+	if pa.policyTopPriority-pa.policyBottomPriority < offSet {
+		return pa.policyBottomPriority
+	}
+	return pa.policyTopPriority - offSet
 }
 
 // updatePriorityAssignment updates all the local maps to correlate input ofPriority and Priority.
@@ -142,7 +155,7 @@ func (pa *priorityAssigner) findReassignBoundaries(lowerBound, upperBound uint16
 	costMap := map[int]*reassignCost{}
 	reassignBoundLow, reassignBoundHigh := lowerBound, upperBound
 	costSiftDown, costSiftUp, emptiedSlotsLow, emptiedSlotsHigh := 0, 0, 0, 0
-	for reassignBoundLow >= PolicyBottomPriority && emptiedSlotsLow < target {
+	for reassignBoundLow >= pa.policyBottomPriority && emptiedSlotsLow < target {
 		if _, exists := pa.ofPriorityMap[reassignBoundLow]; exists {
 			costSiftDown++
 		} else {
@@ -151,7 +164,7 @@ func (pa *priorityAssigner) findReassignBoundaries(lowerBound, upperBound uint16
 		}
 		reassignBoundLow--
 	}
-	for reassignBoundHigh <= PolicyTopPriority && emptiedSlotsHigh < target {
+	for reassignBoundHigh <= pa.policyTopPriority && emptiedSlotsHigh < target {
 		if _, exists := pa.ofPriorityMap[reassignBoundHigh]; exists {
 			costSiftUp++
 		} else {
@@ -256,7 +269,7 @@ func (pa *priorityAssigner) RegisterPriorities(priorities []types.Priority) (map
 	numPriorityToRegister := len(prioritiesToRegister)
 	if numPriorityToRegister == 0 {
 		return nil, nil, nil
-	} else if uint16(numPriorityToRegister+len(pa.sortedPriorities)) > PolicyTopPriority-PolicyBottomPriority+1 {
+	} else if uint16(numPriorityToRegister+len(pa.sortedPriorities)) > pa.policyTopPriority-pa.policyBottomPriority+1 {
 		return nil, nil, fmt.Errorf("number of priorities to be registered is greater than available openflow priorities")
 	}
 	sort.Sort(types.ByPriority(prioritiesToRegister))
@@ -310,11 +323,11 @@ func (pa *priorityAssigner) registerConsecutivePriorities(consecutivePriorities 
 func (pa *priorityAssigner) insertConsecutivePriorities(priorities types.ByPriority, updates map[types.Priority]*PriorityUpdate) error {
 	numPriorities := len(priorities)
 	pLow, pHigh := priorities[0], priorities[numPriorities-1]
-	insertionPointLow := pa.initialOFPriorityFunc(pLow, pa.isSingleTier)
-	insertionPointHigh := pa.initialOFPriorityFunc(pHigh, pa.isSingleTier)
+	insertionPointLow := pa.initialOFPriority(pLow, pa.isBaselineTier)
+	insertionPointHigh := pa.initialOFPriority(pHigh, pa.isBaselineTier)
 	// get the index for inserting the lowest Priority into the registered Priorities.
 	insertionIdx := sort.Search(len(pa.sortedPriorities), func(i int) bool { return pLow.Less(pa.sortedPriorities[i]) })
-	upperBound, lowerBound := PolicyTopPriority, PolicyBottomPriority
+	upperBound, lowerBound := pa.policyTopPriority, pa.policyBottomPriority
 	if insertionIdx > 0 {
 		// set lowerBound to the ofPriority of the registered Priority that is immediately lower than the inserting Priorities.
 		lowerBound = pa.priorityMap[pa.sortedPriorities[insertionIdx-1]]

--- a/pkg/agent/controller/networkpolicy/priority.go
+++ b/pkg/agent/controller/networkpolicy/priority.go
@@ -107,13 +107,13 @@ func newPriorityAssigner(isBaselineTier bool) *priorityAssigner {
 // will then search for the appropriate OpenFlow priority to insert the input Priority.
 // It computes the initial OpenFlow priority by offsetting the tier priority, policy priority and rule priority
 // with pre-determined coefficients.
-func (pa *priorityAssigner) initialOFPriority(p types.Priority, isBaselineTier bool) uint16 {
+func (pa *priorityAssigner) initialOFPriority(p types.Priority) uint16 {
 	tierOffsetBase := TierOffsetMultiTier
 	priorityOffsetBase := PriorityOffsetMultiTier
 	if p.TierPriority == DefaultTierPriority {
 		priorityOffsetBase = PriorityOffsetDefaultTier
 	}
-	if isBaselineTier {
+	if pa.isBaselineTier {
 		tierOffsetBase = TierOffsetBaselineTier
 		priorityOffsetBase = PriorityOffsetBaselineTier
 	}
@@ -324,8 +324,8 @@ func (pa *priorityAssigner) registerConsecutivePriorities(consecutivePriorities 
 func (pa *priorityAssigner) insertConsecutivePriorities(priorities types.ByPriority, updates map[types.Priority]*PriorityUpdate) error {
 	numPriorities := len(priorities)
 	pLow, pHigh := priorities[0], priorities[numPriorities-1]
-	insertionPointLow := pa.initialOFPriority(pLow, pa.isBaselineTier)
-	insertionPointHigh := pa.initialOFPriority(pHigh, pa.isBaselineTier)
+	insertionPointLow := pa.initialOFPriority(pLow)
+	insertionPointHigh := pa.initialOFPriority(pHigh)
 	// get the index for inserting the lowest Priority into the registered Priorities.
 	insertionIdx := sort.Search(len(pa.sortedPriorities), func(i int) bool { return pLow.Less(pa.sortedPriorities[i]) })
 	upperBound, lowerBound := pa.policyTopPriority, pa.policyBottomPriority

--- a/pkg/agent/controller/networkpolicy/priority_test.go
+++ b/pkg/agent/controller/networkpolicy/priority_test.go
@@ -67,7 +67,7 @@ func TestUpdatePriorityAssignment(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pa := newPriorityAssigner(InitialOFPriority, true)
+			pa := newPriorityAssigner(false)
 			for i := 0; i < len(tt.argsPriorities); i++ {
 				pa.updatePriorityAssignment(tt.argsOFPriorities[i], tt.argsPriorities[i])
 			}
@@ -156,7 +156,7 @@ func TestReassignBoundaryPriorities(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pa := newPriorityAssigner(InitialOFPriority, true)
+			pa := newPriorityAssigner(false)
 			for i, p := range tt.originalOfPriorities {
 				pa.updatePriorityAssignment(p, tt.originalPriorities[i])
 			}
@@ -171,8 +171,9 @@ func TestReassignBoundaryPriorities(t *testing.T) {
 
 func TestInsertConsecutivePriorities(t *testing.T) {
 	prioritiesToRegister := []types.Priority{p1133, p1132, p1131, p1130}
-	insertionLow := InitialOFPriority(prioritiesToRegister[0], true)
-	insertionHigh := InitialOFPriority(prioritiesToRegister[3], true)
+	pa := newPriorityAssigner(false)
+	insertionLow := pa.initialOFPriority(prioritiesToRegister[0], false)
+	insertionHigh := pa.initialOFPriority(prioritiesToRegister[3], false)
 	tests := []struct {
 		name                  string
 		originalPriorities    []types.Priority
@@ -248,7 +249,7 @@ func TestInsertConsecutivePriorities(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pa := newPriorityAssigner(InitialOFPriority, true)
+			pa := newPriorityAssigner(false)
 			for i, p := range tt.originalOfPriorities {
 				pa.updatePriorityAssignment(p, tt.originalPriorities[i])
 			}
@@ -261,10 +262,10 @@ func TestInsertConsecutivePriorities(t *testing.T) {
 }
 
 func TestRegisterPrioritiesAndRevert(t *testing.T) {
-	pa := newPriorityAssigner(InitialOFPriority, false)
+	pa := newPriorityAssigner(false)
 	prioritiesToRegister := []types.Priority{p1132, p1131, p1130, p190, p191}
-	insertionPoint1132 := InitialOFPriority(p1132, false)
-	insertionPoint191 := InitialOFPriority(p191, false)
+	insertionPoint1132 := pa.initialOFPriority(p1132, false)
+	insertionPoint191 := pa.initialOFPriority(p191, false)
 	pa.updatePriorityAssignment(insertionPoint1132-1, p1140)
 	pa.updatePriorityAssignment(insertionPoint1132+2, p1121)
 	pa.updatePriorityAssignment(insertionPoint1132+3, p1120)
@@ -295,20 +296,20 @@ func generatePriorities(tierPriority, start, end int32, policyPriority float64) 
 }
 
 func TestRegisterAllOFPriorities(t *testing.T) {
-	pa := newPriorityAssigner(InitialOFPriority, true)
-	maxPriorities := generatePriorities(250, int32(PolicyBottomPriority), int32(PolicyTopPriority), 5)
+	pa := newPriorityAssigner(true)
+	maxPriorities := generatePriorities(253, int32(BaselinePolicyBottomPriority), int32(BaselinePolicyTopPriority), 5)
 	_, _, err := pa.RegisterPriorities(maxPriorities)
-	assert.Equalf(t, nil, err, "Error occurred in registering max number of allowed priorities")
+	assert.Equalf(t, nil, err, "Error occurred in registering max number of allowed priorities in baseline tier")
 
 	extraPriority := types.Priority{
-		TierPriority:   1,
+		TierPriority:   253,
 		PolicyPriority: 5,
-		RulePriority:   int32(PolicyTopPriority) - int32(PolicyBottomPriority) + 1,
+		RulePriority:   int32(BaselinePolicyTopPriority) - int32(BaselinePolicyBottomPriority) + 1,
 	}
 	_, _, err = pa.RegisterPriorities([]types.Priority{extraPriority})
-	assert.Errorf(t, err, "Error should be raised after max number of priorities are registered")
+	assert.Errorf(t, err, "Error should be raised after max number of priorities are registered in baseline tier")
 
-	pa = newPriorityAssigner(InitialOFPriority, false)
+	pa = newPriorityAssigner(false)
 	consecPriorities1 := generatePriorities(5, int32(PolicyBottomPriority), 10000, 5)
 	_, _, err = pa.RegisterPriorities(consecPriorities1)
 

--- a/pkg/agent/controller/networkpolicy/priority_test.go
+++ b/pkg/agent/controller/networkpolicy/priority_test.go
@@ -172,8 +172,8 @@ func TestReassignBoundaryPriorities(t *testing.T) {
 func TestInsertConsecutivePriorities(t *testing.T) {
 	prioritiesToRegister := []types.Priority{p1133, p1132, p1131, p1130}
 	pa := newPriorityAssigner(false)
-	insertionLow := pa.initialOFPriority(prioritiesToRegister[0], false)
-	insertionHigh := pa.initialOFPriority(prioritiesToRegister[3], false)
+	insertionLow := pa.initialOFPriority(prioritiesToRegister[0])
+	insertionHigh := pa.initialOFPriority(prioritiesToRegister[3])
 	tests := []struct {
 		name                  string
 		originalPriorities    []types.Priority
@@ -246,6 +246,16 @@ func TestInsertConsecutivePriorities(t *testing.T) {
 				insertionLow + 9: p1121, insertionLow + 10: p1120,
 			},
 		},
+		{
+			"gap-just-enough-for-insertion",
+			[]types.Priority{p1141, p1140, p1121, p1120},
+			[]uint16{insertionLow - 1, insertionLow, insertionLow + 5, insertionLow + 6},
+			map[uint16]types.Priority{
+				insertionLow - 1: p1141, insertionLow: p1140,
+				insertionLow + 1: p1133, insertionLow + 2: p1132, insertionLow + 3: p1131, insertionLow + 4: p1130,
+				insertionLow + 5: p1121, insertionLow + 6: p1120,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -264,8 +274,8 @@ func TestInsertConsecutivePriorities(t *testing.T) {
 func TestRegisterPrioritiesAndRevert(t *testing.T) {
 	pa := newPriorityAssigner(false)
 	prioritiesToRegister := []types.Priority{p1132, p1131, p1130, p190, p191}
-	insertionPoint1132 := pa.initialOFPriority(p1132, false)
-	insertionPoint191 := pa.initialOFPriority(p191, false)
+	insertionPoint1132 := pa.initialOFPriority(p1132)
+	insertionPoint191 := pa.initialOFPriority(p191)
 	pa.updatePriorityAssignment(insertionPoint1132-1, p1140)
 	pa.updatePriorityAssignment(insertionPoint1132+2, p1121)
 	pa.updatePriorityAssignment(insertionPoint1132+3, p1120)

--- a/pkg/agent/controller/networkpolicy/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/reconciler.go
@@ -35,7 +35,7 @@ import (
 )
 
 var (
-	defaultTierPriority int32 = 250
+	baselineTierPriority int32 = 253
 )
 
 // Reconciler is an interface that knows how to reconcile the desired state of
@@ -182,14 +182,14 @@ type reconciler struct {
 // newReconciler returns a new *reconciler.
 func newReconciler(ofClient openflow.Client, ifaceStore interfacestore.InterfaceStore) *reconciler {
 	priorityAssigners := map[binding.TableIDType]*tablePriorityAssigner{}
-	for _, table := range openflow.GetAntreaPolicySingleTierTables() {
+	for _, table := range openflow.GetAntreaPolicyBaselineTierTables() {
 		priorityAssigners[table] = &tablePriorityAssigner{
-			assigner: newPriorityAssigner(InitialOFPriority, true),
+			assigner: newPriorityAssigner(true),
 		}
 	}
 	for _, table := range openflow.GetAntreaPolicyMultiTierTables() {
 		priorityAssigners[table] = &tablePriorityAssigner{
-			assigner: newPriorityAssigner(InitialOFPriority, false),
+			assigner: newPriorityAssigner(false),
 		}
 	}
 	reconciler := &reconciler{
@@ -252,7 +252,7 @@ func (r *reconciler) getOFRuleTable(rule *CompletedRule) binding.TableIDType {
 	} else {
 		ruleTables = openflow.GetAntreaPolicyEgressTables()
 	}
-	if *rule.TierPriority != defaultTierPriority {
+	if *rule.TierPriority != baselineTierPriority {
 		return ruleTables[0]
 	}
 	return ruleTables[1]

--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -303,7 +303,7 @@ func TestBatchInstallPolicyRuleFlows(t *testing.T) {
 		Priority:  &priorityRule2,
 		To:        parseAddresses([]string{"192.168.1.70"}),
 		FlowID:    ruleID2,
-		TableID:   DefaultTierEgressRuleTable,
+		TableID:   AntreaPolicyEgressRuleTable,
 		PolicyRef: &v1beta2.NetworkPolicyReference{
 			Type:      v1beta2.AntreaNetworkPolicy,
 			Namespace: "ns1",
@@ -588,18 +588,18 @@ func prepareClient(ctrl *gomock.Controller) *client {
 	)
 	bridge := mocks.NewMockBridge(ctrl)
 	bridge.EXPECT().AddFlowsInBundle(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	cnpOutTable = createMockTable(ctrl, DefaultTierEgressRuleTable, EgressRuleTable, binding.TableMissActionNext)
+	cnpOutTable = createMockTable(ctrl, AntreaPolicyEgressRuleTable, EgressRuleTable, binding.TableMissActionNext)
 	outTable = createMockTable(ctrl, EgressRuleTable, EgressDefaultTable, binding.TableMissActionNext)
 	outDropTable = createMockTable(ctrl, EgressDefaultTable, EgressMetricTable, binding.TableMissActionNext)
 	metricTable = createMockTable(ctrl, EgressMetricTable, l3ForwardingTable, binding.TableMissActionNext)
 	outAllowTable = createMockTable(ctrl, l3ForwardingTable, l2ForwardingCalcTable, binding.TableMissActionNext)
 	c = &client{
 		pipeline: map[binding.TableIDType]binding.Table{
-			DefaultTierEgressRuleTable: cnpOutTable,
-			EgressRuleTable:            outTable,
-			EgressDefaultTable:         outDropTable,
-			EgressMetricTable:          metricTable,
-			l3ForwardingTable:          outAllowTable,
+			AntreaPolicyEgressRuleTable: cnpOutTable,
+			EgressRuleTable:             outTable,
+			EgressDefaultTable:          outDropTable,
+			EgressMetricTable:           metricTable,
+			l3ForwardingTable:           outAllowTable,
 		},
 		policyCache:              policyCache,
 		globalConjMatchFlowCache: map[string]*conjMatchFlowContext{},

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -36,32 +36,30 @@ import (
 
 const (
 	// Flow table id index
-	ClassifierTable             binding.TableIDType = 0
-	uplinkTable                 binding.TableIDType = 5
-	spoofGuardTable             binding.TableIDType = 10
-	arpResponderTable           binding.TableIDType = 20
-	serviceHairpinTable         binding.TableIDType = 29
-	conntrackTable              binding.TableIDType = 30
-	conntrackStateTable         binding.TableIDType = 31
-	sessionAffinityTable        binding.TableIDType = 40
-	dnatTable                   binding.TableIDType = 40
-	serviceLBTable              binding.TableIDType = 41
-	endpointDNATTable           binding.TableIDType = 42
-	MultiTierEgressRuleTable    binding.TableIDType = 45
-	DefaultTierEgressRuleTable  binding.TableIDType = 49
-	EgressRuleTable             binding.TableIDType = 50
-	EgressDefaultTable          binding.TableIDType = 60
-	EgressMetricTable           binding.TableIDType = 61
-	l3ForwardingTable           binding.TableIDType = 70
-	l2ForwardingCalcTable       binding.TableIDType = 80
-	MultiTierIngressRuleTable   binding.TableIDType = 85
-	DefaultTierIngressRuleTable binding.TableIDType = 89
-	IngressRuleTable            binding.TableIDType = 90
-	IngressDefaultTable         binding.TableIDType = 100
-	IngressMetricTable          binding.TableIDType = 101
-	conntrackCommitTable        binding.TableIDType = 105
-	hairpinSNATTable            binding.TableIDType = 106
-	L2ForwardingOutTable        binding.TableIDType = 110
+	ClassifierTable              binding.TableIDType = 0
+	uplinkTable                  binding.TableIDType = 5
+	spoofGuardTable              binding.TableIDType = 10
+	arpResponderTable            binding.TableIDType = 20
+	serviceHairpinTable          binding.TableIDType = 29
+	conntrackTable               binding.TableIDType = 30
+	conntrackStateTable          binding.TableIDType = 31
+	sessionAffinityTable         binding.TableIDType = 40
+	dnatTable                    binding.TableIDType = 40
+	serviceLBTable               binding.TableIDType = 41
+	endpointDNATTable            binding.TableIDType = 42
+	AntreaPolicyEgressRuleTable  binding.TableIDType = 45
+	EgressRuleTable              binding.TableIDType = 50
+	EgressDefaultTable           binding.TableIDType = 60
+	EgressMetricTable            binding.TableIDType = 61
+	l3ForwardingTable            binding.TableIDType = 70
+	l2ForwardingCalcTable        binding.TableIDType = 80
+	AntreaPolicyIngressRuleTable binding.TableIDType = 85
+	IngressRuleTable             binding.TableIDType = 90
+	IngressDefaultTable          binding.TableIDType = 100
+	IngressMetricTable           binding.TableIDType = 101
+	conntrackCommitTable         binding.TableIDType = 105
+	hairpinSNATTable             binding.TableIDType = 106
+	L2ForwardingOutTable         binding.TableIDType = 110
 
 	// Flow priority level
 	priorityHigh            = uint16(210)
@@ -85,10 +83,9 @@ var (
 	// egressTables map records all IDs of tables related to
 	// egress rules.
 	egressTables = map[binding.TableIDType]struct{}{
-		MultiTierEgressRuleTable:   {},
-		DefaultTierEgressRuleTable: {},
-		EgressRuleTable:            {},
-		EgressDefaultTable:         {},
+		AntreaPolicyEgressRuleTable: {},
+		EgressRuleTable:             {},
+		EgressDefaultTable:          {},
 	}
 
 	FlowTables = []struct {
@@ -106,15 +103,13 @@ var (
 		{sessionAffinityTable, "SessionAffinity"},
 		{serviceLBTable, "ServiceLB"},
 		{endpointDNATTable, "EndpointDNAT"},
-		{MultiTierEgressRuleTable, "AntreaPolicyMultiTierEgressRule"},
-		{DefaultTierEgressRuleTable, "AntreaPolicyAppTierEgressRule"},
+		{AntreaPolicyEgressRuleTable, "AntreaPolicyEgressRule"},
 		{EgressRuleTable, "EgressRule"},
 		{EgressDefaultTable, "EgressDefaultRule"},
 		{EgressMetricTable, "EgressMetric"},
 		{l3ForwardingTable, "l3Forwarding"},
 		{l2ForwardingCalcTable, "L2Forwarding"},
-		{MultiTierIngressRuleTable, "AntreaPolicyMultiTierIngressRule"},
-		{DefaultTierIngressRuleTable, "AntreaPolicyAppTierIngressRule"},
+		{AntreaPolicyIngressRuleTable, "AntreaPolicyIngressRule"},
 		{IngressRuleTable, "IngressRule"},
 		{IngressDefaultTable, "IngressDefaultRule"},
 		{IngressMetricTable, "IngressMetric"},
@@ -149,29 +144,29 @@ func GetFlowTableNumber(tableName string) binding.TableIDType {
 
 func GetAntreaPolicyEgressTables() []binding.TableIDType {
 	return []binding.TableIDType{
-		MultiTierEgressRuleTable,
-		DefaultTierEgressRuleTable,
+		AntreaPolicyEgressRuleTable,
+		EgressDefaultTable,
 	}
 }
 
 func GetAntreaPolicyIngressTables() []binding.TableIDType {
 	return []binding.TableIDType{
-		MultiTierIngressRuleTable,
-		DefaultTierIngressRuleTable,
+		AntreaPolicyIngressRuleTable,
+		IngressDefaultTable,
 	}
 }
 
-func GetAntreaPolicySingleTierTables() []binding.TableIDType {
+func GetAntreaPolicyBaselineTierTables() []binding.TableIDType {
 	return []binding.TableIDType{
-		DefaultTierEgressRuleTable,
-		DefaultTierIngressRuleTable,
+		EgressDefaultTable,
+		IngressDefaultTable,
 	}
 }
 
 func GetAntreaPolicyMultiTierTables() []binding.TableIDType {
 	return []binding.TableIDType{
-		MultiTierEgressRuleTable,
-		MultiTierIngressRuleTable,
+		AntreaPolicyEgressRuleTable,
+		AntreaPolicyIngressRuleTable,
 	}
 }
 
@@ -1455,7 +1450,7 @@ func priorityIndexFunc(obj interface{}) ([]string, error) {
 func generatePipeline(bridge binding.Bridge, enableProxy, enableAntreaNP bool) map[binding.TableIDType]binding.Table {
 	var egressEntryTable, IngressEntryTable binding.TableIDType
 	if enableAntreaNP {
-		egressEntryTable, IngressEntryTable = MultiTierEgressRuleTable, MultiTierIngressRuleTable
+		egressEntryTable, IngressEntryTable = AntreaPolicyEgressRuleTable, AntreaPolicyIngressRuleTable
 	} else {
 		egressEntryTable, IngressEntryTable = EgressRuleTable, IngressRuleTable
 	}
@@ -1506,10 +1501,8 @@ func generatePipeline(bridge binding.Bridge, enableProxy, enableAntreaNP bool) m
 	if !enableAntreaNP {
 		return pipeline
 	}
-	pipeline[MultiTierEgressRuleTable] = bridge.CreateTable(MultiTierEgressRuleTable, DefaultTierEgressRuleTable, binding.TableMissActionNext)
-	pipeline[DefaultTierEgressRuleTable] = bridge.CreateTable(DefaultTierEgressRuleTable, EgressRuleTable, binding.TableMissActionNext)
-	pipeline[MultiTierIngressRuleTable] = bridge.CreateTable(MultiTierIngressRuleTable, DefaultTierIngressRuleTable, binding.TableMissActionNext)
-	pipeline[DefaultTierIngressRuleTable] = bridge.CreateTable(DefaultTierIngressRuleTable, IngressRuleTable, binding.TableMissActionNext)
+	pipeline[AntreaPolicyEgressRuleTable] = bridge.CreateTable(AntreaPolicyEgressRuleTable, EgressRuleTable, binding.TableMissActionNext)
+	pipeline[AntreaPolicyIngressRuleTable] = bridge.CreateTable(AntreaPolicyIngressRuleTable, IngressRuleTable, binding.TableMissActionNext)
 	return pipeline
 }
 

--- a/pkg/controller/networkpolicy/tier.go
+++ b/pkg/controller/networkpolicy/tier.go
@@ -34,12 +34,16 @@ var (
 	// maxSupportedTiers is the soft limit on the maximum number of supported
 	// Tiers.
 	maxSupportedTiers = 20
-	// defaultTierPriority maintains the lowest priority for the system generated
-	// default Tier.
+	// defaultTierPriority maintains the priority for the system generated default Tier.
+	// This is the lowest priority for tiers that will be enforced before K8s NetworkPolicies.
 	defaultTierPriority = int32(250)
+	// baselineTierPriority maintains the priority for the system generated baseline Tier.
+	// This is the tier that will be enforced after K8s NetworkPolicies.
+	baselineTierPriority = int32(253)
 	// priorityMap maintains the Tier priority associated with system generated
 	// Tier names.
 	priorityMap = map[string]int32{
+		"baseline":    baselineTierPriority,
 		"application": defaultTierPriority,
 		"platform":    int32(150),
 		"networkops":  int32(100),
@@ -48,9 +52,18 @@ var (
 	}
 	// staticTierSet maintains the names of the static tiers such that they can
 	// be converted to corresponding Tier CRD names.
-	staticTierSet = sets.NewString("Emergency", "SecurityOps", "NetworkOps", "Platform", "Application")
+	staticTierSet = sets.NewString("Emergency", "SecurityOps", "NetworkOps", "Platform", "Application", "Baseline")
 	// systemGeneratedTiers are the Tier CRs to be created at init.
 	systemGeneratedTiers = []*secv1alpha1.Tier{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "baseline",
+			},
+			Spec: secv1alpha1.TierSpec{
+				Priority:    priorityMap["baseline"],
+				Description: "[READ-ONLY]: System generated Baseline Tier",
+			},
+		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "application",

--- a/pkg/controller/networkpolicy/validate.go
+++ b/pkg/controller/networkpolicy/validate.go
@@ -28,13 +28,14 @@ import (
 )
 
 var (
-	// reservedTierPriorities stores the reserved priority range from 251-255.
-	// The priority 250 is reserved for default Tier but not part of this set in
-	// order to be able to create the Tier by Antrea.
-	reservedTierPriorities = sets.NewInt32(int32(251), int32(252), int32(253), int32(254), int32(255))
+	// reservedTierPriorities stores the reserved priority range from 251, 252, 254 and 255.
+	// The priority 250 is reserved for default Tier but not part of this set in order to be
+	// able to create the Tier by Antrea. Same for priority 253 which is reserved for the
+	// baseline tier.
+	reservedTierPriorities = sets.NewInt32(int32(251), int32(252), int32(254), int32(255))
 	// reservedTierNames stores the set of Tier names which cannot be deleted
 	// since they are created by Antrea.
-	reservedTierNames = sets.NewString("application", "platform", "networkops", "securityops", "emergency")
+	reservedTierNames = sets.NewString("baseline", "application", "platform", "networkops", "securityops", "emergency")
 )
 
 type NetworkPolicyValidator struct {

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -318,7 +318,7 @@ func testCNPDropEgress(t *testing.T) {
 
 // testBaselineNamespaceIsolation tests that a CNP in the baseline Tier is able to enforce default namespace isolation,
 // which can be later overridden by developer K8s NetworkPolicies.
-func testCNPBaselineNamespaceIsolation(t *testing.T) {
+func testBaselineNamespaceIsolation(t *testing.T) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	nsExpOtherThanX := metav1.LabelSelectorRequirement{
 		Key:      "ns",
@@ -332,9 +332,10 @@ func testCNPBaselineNamespaceIsolation(t *testing.T) {
 	builder.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, nil,
 		nil, &[]metav1.LabelSelectorRequirement{nsExpOtherThanX}, secv1alpha1.RuleActionDrop)
 
-	// create a K8s NetworkPolicy to allow ingress from pods in it's own ns and y/a to connect to pods in namespace x.
+	// create a K8s NetworkPolicy for Pods in namespace x to allow ingress traffic from Pods in the same namespace,
+	// as well as from the y/a Pod. It should open up ingress from y/a since it's evaluated before the baseline tier.
 	k8sNPBuilder := &NetworkPolicySpecBuilder{}
-	k8sNPBuilder = k8sNPBuilder.SetName("x", "default-deny-namespace").
+	k8sNPBuilder = k8sNPBuilder.SetName("x", "allow-ns-x-and-y-a").
 		SetTypeIngress().
 		AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil,
 			nil, map[string]string{"ns": "x"}, nil, nil).
@@ -865,7 +866,7 @@ func TestAntreaPolicy(t *testing.T) {
 		// testcases below do not depend on underlying k8s NetworkPolicies
 		t.Run("Case=CNPAllowNoDefaultIsolation", func(t *testing.T) { testCNPAllowNoDefaultIsolation(t) })
 		t.Run("Case=CNPDropEgress", func(t *testing.T) { testCNPDropEgress(t) })
-		t.Run("Case=CNPBaselinePolicy", func(t *testing.T) { testCNPBaselineNamespaceIsolation(t) })
+		t.Run("Case=CNPBaselinePolicy", func(t *testing.T) { testBaselineNamespaceIsolation(t) })
 		t.Run("Case=CNPPrioirtyOverride", func(t *testing.T) { testCNPPriorityOverride(t) })
 		t.Run("Case=CNPTierOverride", func(t *testing.T) { testCNPTierOverride(t) })
 		t.Run("Case=CNPCustomTiers", func(t *testing.T) { testCNPCustomTiers(t) })


### PR DESCRIPTION
This PR partially addresses #1362.
Scope of change:
- Add a new Tier named `baseline` which is generated by Antrea as an addition to the existing 5 pre-created tiers.
- Ensure that policy rules in the `baseline` tier will be enforced after K8s NetworkPolicies. This is done by creating the flows in the K8s Ingress/Egress default tables, below K8s default drop flow priority.
- Instead of splitting flows for default tier and other tiers in different tables, all flows in the 5 tiers enforced before K8s NetworkPolicies will be created in single table (45 for egress and 85 for ingress). This will address the performance concerns raised in https://github.com/vmware-tanzu/antrea/pull/1237#discussion_r492872510.
- Refactor the priorityAssigner to handle K8s default ingress/egress tables for the baseline tier.
- Fix a bug in priorityAssigner where it would try to re-arrange existing priorities when not necessary.
- Add E2E testcase for baseline tier policy.