### PR TITLE
Introducing NodePortLocal in Antrea Agent

### DIFF
--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1047,6 +1047,9 @@ data:
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: false
 
+    # Enable NodePortLocal feature to make the pod reachable externally through nodeport
+    #  NodePortLocal: false
+
     # Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
     # to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
     # feature that supports priorities, rule actions and externalEntities in the future.

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -36,6 +36,7 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/flowexporter/flowrecords"
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
 	"github.com/vmware-tanzu/antrea/pkg/agent/metrics"
+	npl "github.com/vmware-tanzu/antrea/pkg/agent/nplagent/bootstrap"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
 	"github.com/vmware-tanzu/antrea/pkg/agent/proxy"
 	"github.com/vmware-tanzu/antrea/pkg/agent/querier"
@@ -205,6 +206,11 @@ func run(o *Options) error {
 	// cause the stopCh channel to be closed; if another signal is received before the program
 	// exits, we will force exit.
 	stopCh := signals.RegisterSignalHandlers()
+
+	// Start the NPL agent.
+	if features.DefaultFeatureGate.Enabled(features.NodePortLocal) {
+		npl.InitializeNPLAgent(k8sClient, informerFactory)
+	}
 
 	log.StartLogFileNumberMonitor(stopCh)
 

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/google/uuid v1.1.1
 	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd
+	github.com/onsi/gomega v1.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/common v0.4.1
 	github.com/rakelkar/gonetsh v0.0.0-20190930180311-e5c5ffe4bdf0

--- a/pkg/agent/nplagent/bootstrap/npl_agent_init.go
+++ b/pkg/agent/nplagent/bootstrap/npl_agent_init.go
@@ -1,0 +1,41 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrap
+
+import (
+	"github.com/vmware-tanzu/antrea/pkg/agent/nplagent/k8s"
+	"github.com/vmware-tanzu/antrea/pkg/agent/nplagent/lib"
+	"github.com/vmware-tanzu/antrea/pkg/agent/nplagent/portcache"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+)
+
+// InitializeNPLAgent : start NodePortLocal (NPL) agent
+// Initialize port table cache to keep a track of node ports available for use of NPL
+// SetupEventHandlers to handle pod add, update and delete events
+// When a Pod gets created, a free node port is obtained from the port table cache and a DNAT rule is added to send traffic to the pod ip:port
+func InitializeNPLAgent(kubeClient clientset.Interface, informerFactory informers.SharedInformerFactory) error {
+	c := k8s.NewNPLController(kubeClient)
+	start, end, err := lib.GetPortsRange()
+	if err != nil {
+		klog.Errorf("Something went wrong while fetching port range: %s", err.Error())
+		return err
+	}
+	c.PortTable = portcache.NewPortTable(start, end)
+	c.RemoveNPLAnnotationFromPods()
+	c.SetupEventHandlers(informerFactory)
+	return nil
+}

--- a/pkg/agent/nplagent/k8s/annotations.go
+++ b/pkg/agent/nplagent/k8s/annotations.go
@@ -1,0 +1,150 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+
+	nplutils "github.com/vmware-tanzu/antrea/pkg/agent/nplagent/lib"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+)
+
+type NPLEPAnnotation struct {
+	PodPort  string `json:"Podport"`
+	NodeIP   string `json:"Nodeip"`
+	NodePort string `json:"Nodeport"`
+}
+
+func IsNodePortInAnnotation(s []NPLEPAnnotation, nodeport string) bool {
+	for _, i := range s {
+		if i.NodePort == nodeport {
+			return true
+		}
+	}
+	return false
+}
+
+func assignPodAnnotation(pod *corev1.Pod, containerPort, nodeIP, nodePort string) {
+	var err error
+	current := make(map[string]string)
+	if pod.Annotations != nil {
+		current = pod.Annotations
+	}
+
+	klog.Infof("Building annotation for pod: %s\tport: %s --> %s:%s", pod.Name, containerPort, nodeIP, nodePort)
+
+	var annotations []NPLEPAnnotation
+	// nplEP annotation exists
+	if current[nplutils.NPLEPAnnotation] != "" {
+		if err = json.Unmarshal([]byte(current[nplutils.NPLEPAnnotation]), &annotations); err != nil {
+			klog.Warningf("Unable to unmarshal NPLEP annotation")
+		}
+
+		if !IsNodePortInAnnotation(annotations, nodePort) {
+			annotations = append(annotations, NPLEPAnnotation{
+				PodPort:  containerPort,
+				NodeIP:   nodeIP,
+				NodePort: nodePort,
+			})
+		} else {
+			// mapping for the containerPort already exists
+			// TODO
+		}
+	} else {
+		annotations = []NPLEPAnnotation{NPLEPAnnotation{
+			PodPort:  containerPort,
+			NodeIP:   nodeIP,
+			NodePort: nodePort,
+		}}
+	}
+
+	current[nplutils.NPLEPAnnotation] = nplutils.Stringify(annotations)
+	pod.Annotations = current
+}
+
+func removeFromPodAnnotation(pod *corev1.Pod, containerPort string) {
+	var err error
+	current := pod.Annotations
+
+	klog.Infof("Removing annotation from pod: %s\tport: %s", pod.Name, containerPort)
+	var annotations []NPLEPAnnotation
+	if err = json.Unmarshal([]byte(current[nplutils.NPLEPAnnotation]), &annotations); err != nil {
+		klog.Warningf("Unable to unmarshal NPLEP annotation")
+		return
+	}
+
+	for i, ann := range annotations {
+		if ann.PodPort == containerPort {
+			annotations = append(annotations[:i], annotations[i+1:]...)
+			break
+		}
+	}
+
+	current[nplutils.NPLEPAnnotation] = nplutils.Stringify(annotations)
+	pod.Annotations = current
+}
+
+// RemoveNPLAnnotationFromPods : Removes npl annotations from all pods
+func (c *Controller) RemoveNPLAnnotationFromPods() {
+	podList, err := c.KubeClient.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		klog.Warningf("Unable to list Pods")
+		return
+	}
+	for _, pod := range podList.Items {
+		if nplutils.GetHostname() != pod.Spec.NodeName {
+			continue
+		}
+		podAnnotation := pod.GetAnnotations()
+		if podAnnotation == nil {
+			continue
+		}
+		klog.Infof("Removing all NPL annotation from pod: %s, ns: %s", pod.Name, pod.Namespace)
+		delete(podAnnotation, nplutils.NPLEPAnnotation)
+		pod.Annotations = podAnnotation
+		c.KubeClient.CoreV1().Pods(pod.Namespace).Update(context.TODO(), &pod, metav1.UpdateOptions{})
+	}
+}
+
+func (c *Controller) updatePodAnnotation(pod *corev1.Pod) error {
+	if _, err := c.KubeClient.CoreV1().Pods(pod.Namespace).Update(context.TODO(), pod, metav1.UpdateOptions{}); err != nil {
+		klog.Warningf("Unable to update pod %s with annotation: %+v", pod.Name, err)
+		return err
+	}
+	klog.Infof("Successfuly updated pod %s %s annotation", pod.Name, pod.Namespace)
+	return nil
+}
+
+// returns nodeport for podport
+func getNodeportFromPodAnnotation(pod *corev1.Pod, port string) string {
+	current := pod.Annotations
+	var annotations []NPLEPAnnotation
+	if err := json.Unmarshal([]byte(current[nplutils.NPLEPAnnotation]), &annotations); err != nil {
+		klog.Warningf("Unable to unmarshal NPLEP annotation")
+		return ""
+	}
+
+	for _, i := range annotations {
+		if i.PodPort == port {
+			return i.NodePort
+		}
+	}
+
+	klog.Warningf("Corresponding nodeport for pod: %s port: %s Not found", pod.Name, port)
+	return ""
+}

--- a/pkg/agent/nplagent/k8s/handlers.go
+++ b/pkg/agent/nplagent/k8s/handlers.go
@@ -1,0 +1,111 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"fmt"
+
+	nplutils "github.com/vmware-tanzu/antrea/pkg/agent/nplagent/lib"
+	"github.com/vmware-tanzu/antrea/pkg/agent/nplagent/portcache"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
+)
+
+var portTable *portcache.PortTable
+
+func (c *Controller) addRuleForPod(pod *corev1.Pod) {
+	podIP, nodeIP := pod.Status.PodIP, pod.Status.HostIP
+	if podIP == "" || nodeIP == "" {
+		return
+	}
+	podContainers := pod.Spec.Containers
+
+	for _, container := range podContainers {
+		for _, cport := range container.Ports {
+			port := fmt.Sprint(cport.ContainerPort)
+			nodePort, ok := c.PortTable.AddRule(podIP, int(cport.ContainerPort))
+			if !ok {
+				klog.Warningf("failed to add rule for podIP: %s, port: %d", podIP, cport.ContainerPort)
+				continue
+			}
+			assignPodAnnotation(pod, port, nodeIP, fmt.Sprint(nodePort))
+		}
+	}
+}
+
+// HandleAddPod handles pod annotations in NPL for an added pod
+func (c *Controller) HandleAddPod(pod *corev1.Pod) {
+	klog.Infof("Got add event for pod: %s/%s", pod.Namespace, pod.Name)
+	c.addRuleForPod(pod)
+	c.updatePodAnnotation(pod)
+}
+
+// HandleDeletePod handles pod annotations for a deleted pod
+func (c *Controller) HandleDeletePod(pod *corev1.Pod) {
+	klog.Infof("Got delete event for pod: %s/%s", pod.Namespace, pod.Name)
+	podIP := pod.Status.PodIP
+
+	for _, container := range pod.Spec.Containers {
+		for _, cport := range container.Ports {
+			c.PortTable.DeleteRule(podIP, int(cport.ContainerPort))
+		}
+	}
+}
+
+// HandleUpdatePod handles pod annotations for a updated pod
+func (c *Controller) HandleUpdatePod(old, newp *corev1.Pod) {
+	klog.Infof("Got update for pod: %s/%s", newp.Namespace, newp.Name)
+	podIP := newp.Status.PodIP
+
+	// if the namespace of the pod has changed and has gone out of our scope, we need to delete it
+	if old.Namespace != newp.Namespace {
+		c.HandleDeletePod(newp)
+		return
+	}
+
+	var newPodPorts []string
+	newPodContainers := newp.Spec.Containers
+	for _, container := range newPodContainers {
+		for _, cport := range container.Ports {
+			port := fmt.Sprint(cport.ContainerPort)
+			newPodPorts = append(newPodPorts, port)
+			if !c.PortTable.RuleExists(podIP, int(cport.ContainerPort)) {
+				c.addRuleForPod(newp)
+			}
+		}
+	}
+
+	// oldPodPorts: [8080, 8081] newPodPorts: [8082, 8081] portsToRemove should have: [8080]
+	oldPodContainers := old.Spec.Containers
+	oldPodIP := old.Status.PodIP
+	for _, container := range oldPodContainers {
+		for _, cport := range container.Ports {
+			port := fmt.Sprint(cport.ContainerPort)
+			if !nplutils.HasElem(newPodPorts, port) {
+				// removed port
+				nodePort := getNodeportFromPodAnnotation(newp, port)
+				if nodePort == "" && c.PortTable.GetEntryByPodIPPort(oldPodIP, int(cport.ContainerPort)) == nil {
+					break
+				}
+				ok, _ := c.PortTable.DeleteRule(podIP, int(cport.ContainerPort))
+				if ok {
+					removeFromPodAnnotation(newp, port)
+				}
+			}
+		}
+	}
+	c.updatePodAnnotation(newp)
+}

--- a/pkg/agent/nplagent/k8s/k8s_controller.go
+++ b/pkg/agent/nplagent/k8s/k8s_controller.go
@@ -1,0 +1,82 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"sync"
+	"time"
+
+	nplutils "github.com/vmware-tanzu/antrea/pkg/agent/nplagent/lib"
+	"github.com/vmware-tanzu/antrea/pkg/agent/nplagent/portcache"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+var ctrlonce sync.Once
+
+const podResyncPeriod = 60 * time.Minute
+
+type Controller struct {
+	PortTable  *portcache.PortTable
+	KubeClient clientset.Interface
+}
+
+func NewNPLController(kubeClient clientset.Interface) *Controller {
+	return &Controller{KubeClient: kubeClient}
+}
+
+func (c *Controller) SetupEventHandlers(k8sinfo informers.SharedInformerFactory) {
+	podEventHandler := cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			addPod := obj.(*corev1.Pod)
+			if nplutils.GetHostname() == addPod.Spec.NodeName {
+				c.HandleAddPod(addPod)
+			}
+		},
+
+		DeleteFunc: func(obj interface{}) {
+			deletePod, ok := obj.(*corev1.Pod)
+			if !ok {
+				// Pod was deleted but its final state is unrecorded.
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if !ok {
+					klog.Warningf("couldn't get object from tombstone %#v", obj)
+					return
+				}
+				deletePod, ok = tombstone.Obj.(*corev1.Pod)
+				if !ok {
+					klog.Warningf("Tombstone contained object that is not a Pod: %#v", obj)
+					return
+				}
+			}
+			if nplutils.GetHostname() == deletePod.Spec.NodeName {
+				c.HandleDeletePod(deletePod)
+			}
+		},
+
+		UpdateFunc: func(old, cur interface{}) {
+			oldPod, newPod := old.(*corev1.Pod), cur.(*corev1.Pod)
+			if oldPod.ResourceVersion != newPod.ResourceVersion &&
+				nplutils.GetHostname() == newPod.Spec.NodeName {
+				c.HandleUpdatePod(oldPod, newPod)
+			}
+		},
+	}
+	podInformer := k8sinfo.Core().V1().Pods()
+	podInformer.Informer().AddEventHandlerWithResyncPeriod(podEventHandler, podResyncPeriod)
+}

--- a/pkg/agent/nplagent/k8s/store.go
+++ b/pkg/agent/nplagent/k8s/store.go
@@ -1,0 +1,71 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package k8s
+
+import (
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+type ObjectStore struct {
+	podPortsMap map[string][]int32
+	sync.RWMutex
+}
+
+var objOnce sync.Once
+var objStore ObjectStore
+
+func NewObjectStore() *ObjectStore {
+	objOnce.Do(func() {
+		objStore = ObjectStore{}
+	})
+	return &objStore
+}
+
+func (o *ObjectStore) AddUpdatePodToSync(pod *corev1.Pod) {
+	o.Lock()
+	defer o.Unlock()
+	ports := []int32{}
+	if !o.IsPodInStore(pod.Name) {
+		o.podPortsMap[pod.Name] = ports
+	}
+
+	for _, container := range pod.Spec.Containers {
+		for _, cport := range container.Ports {
+			if !o.IsPortInPodMapping(pod.Name, cport.ContainerPort) {
+				ports = append(ports, cport.ContainerPort)
+			}
+		}
+	}
+	o.podPortsMap[pod.Name] = ports
+}
+
+func (o *ObjectStore) IsPodInStore(podname string) bool {
+	o.Lock()
+	defer o.Unlock()
+	_, found := o.podPortsMap[podname]
+	return found
+}
+
+func (o *ObjectStore) IsPortInPodMapping(podname string, port int32) bool {
+	o.Lock()
+	defer o.Unlock()
+	for _, p := range o.podPortsMap[podname] {
+		if p == port {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/agent/nplagent/lib/constants.go
+++ b/pkg/agent/nplagent/lib/constants.go
@@ -1,0 +1,20 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lib
+
+const (
+	NPLEPAnnotation = "npl.k8s.io/endpoints"
+	IPTableRule     = "IPTABLE"
+)

--- a/pkg/agent/nplagent/lib/utils.go
+++ b/pkg/agent/nplagent/lib/utils.go
@@ -1,0 +1,93 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lib
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+	"k8s.io/klog"
+)
+
+func Stringify(serialize interface{}) string {
+	json_marshalled, _ := json.Marshal(serialize)
+	return string(json_marshalled)
+}
+
+func HasElem(s interface{}, elem interface{}) bool {
+	arrV := reflect.ValueOf(s)
+
+	if arrV.Kind() == reflect.Slice {
+		for i := 0; i < arrV.Len(); i++ {
+			// panics if slice element points to an unexported struct field
+			// see https://golang.org/pkg/reflect/#Value.Interface
+			if arrV.Index(i).Interface() == elem {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func GetPortsRange() (start, end int, err error) {
+	// required field
+	envConst := os.Getenv("NPL_PORT_RANGE")
+	portsRange := strings.Split(envConst, "-")
+	if len(portsRange) != 2 {
+		klog.Warningf("Wrong port range format: %s", envConst)
+		return 0, 0, errors.New("Wrong port range format")
+	}
+
+	if start, err = strconv.Atoi(portsRange[0]); err != nil {
+		return 0, 0, err
+	}
+
+	if end, err = strconv.Atoi(portsRange[1]); err != nil {
+		return 0, 0, err
+	}
+
+	return start, end, nil
+}
+
+func GetHostname() string {
+	envConst := os.Getenv("HOSTNAME")
+	return envConst
+}
+
+func IsPortAvailable(mPort int) bool {
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_STREAM, unix.IPPROTO_TCP)
+	if err != nil {
+		klog.Warningf("unix socket creation failed with error: %v", err)
+		return false
+	}
+	defer unix.Close(fd)
+
+	err = unix.Bind(fd, &unix.SockaddrInet4{
+		Port: mPort,
+		Addr: [4]byte{0, 0, 0, 0},
+	})
+
+	if err != nil {
+		return false
+	}
+
+	return true
+}

--- a/pkg/agent/nplagent/nplagent_test.go
+++ b/pkg/agent/nplagent/nplagent_test.go
@@ -1,0 +1,322 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nplagent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/vmware-tanzu/antrea/pkg/agent/nplagent/k8s"
+	"github.com/vmware-tanzu/antrea/pkg/agent/nplagent/lib"
+	"github.com/vmware-tanzu/antrea/pkg/agent/nplagent/portcache"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// Mock PortPortRule for tests to simulate IPTable
+// Currently the functions always return true to adhere to the interface requirement
+type PPRTest struct {
+}
+
+func (PPRTest) Init() (bool, error) {
+	return true, nil
+}
+
+func (PPRTest) AddRule(port int, podip string) (bool, error) {
+	return true, nil
+}
+
+func (PPRTest) DeleteRule(port int, podip string) (bool, error) {
+	return true, nil
+}
+
+func (PPRTest) SyncState(podPort map[int]string) bool {
+	return true
+}
+
+func (PPRTest) GetAllRules(podPort map[int]string) (bool, error) {
+	return true, nil
+}
+
+func (PPRTest) DeleteAllRules() (bool, error) {
+	return true, nil
+}
+
+type nplAnnotation struct {
+	Podport  string
+	Nodeip   string
+	Nodeport string
+}
+
+func NewPortTable() *portcache.PortTable {
+	ptable := portcache.PortTable{StartPort: 40000, EndPort: 45000}
+	ptable.Table = make(map[int]portcache.NodePortData)
+	ptable.PodPortRules = &PPRTest{}
+	return &ptable
+}
+
+var defaultPodName = "test-pod"
+var defaultNS = "default"
+var defaultNodeName = "test-node"
+var defaultHostIP = "10.10.10.10"
+var defaultPodIP = "192.168.32.10"
+var defaultPort = 80
+
+var kubeClient *k8sfake.Clientset
+var c *k8s.Controller
+
+func getTestPod() corev1.Pod {
+
+	testPod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultPodName,
+			Namespace: defaultNS,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: defaultNodeName,
+			Containers: []corev1.Container{
+				{
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: int32(defaultPort),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			HostIP: defaultHostIP,
+			PodIP:  defaultPodIP,
+		},
+	}
+	return testPod
+}
+
+func TestMain(t *testing.T) {
+	os.Setenv("HOSTNAME", defaultNodeName)
+	kubeClient = k8sfake.NewSimpleClientset()
+
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, 5*time.Second)
+	c = k8s.NewNPLController(kubeClient)
+
+	c.PortTable = NewPortTable()
+	c.SetupEventHandlers(informerFactory)
+	stopCh := make(chan struct{})
+	informerFactory.Start(stopCh)
+}
+
+// Add a new Pod with fake k8s client and verify that npl annotation gets updated
+// and an entry gets added in the local port cache
+func TestPodAdd(t *testing.T) {
+	var ann map[string]string
+	var data string
+	var found bool
+
+	g := gomega.NewGomegaWithT(t)
+
+	testPod := getTestPod()
+	p, err := c.KubeClient.CoreV1().Pods(defaultNS).Create(context.TODO(), &testPod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Pod creation failed with err: %v", err)
+	}
+	t.Logf("successfully created Pod: %v", p)
+
+	g.Eventually(func() bool {
+		updatedPod, err := c.KubeClient.CoreV1().Pods(defaultNS).Get(context.TODO(), defaultPodName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Failed to update pod: %v", err)
+		}
+		ann = updatedPod.GetAnnotations()
+		data, found = ann[lib.NPLEPAnnotation]
+		return found
+	}, 20*time.Second).Should(gomega.Equal(true))
+
+	var nplData []nplAnnotation
+	json.Unmarshal([]byte(data), &nplData)
+
+	if len(nplData) != 1 {
+		t.Fatalf("Expected npl annotation of length: 1, got: %d", len(nplData))
+	}
+
+	g.Expect(nplData[0].Nodeip).To(gomega.Equal(defaultHostIP))
+	g.Expect(nplData[0].Podport).To(gomega.Equal(fmt.Sprint(defaultPort)))
+	g.Expect(c.PortTable.RuleExists(defaultPodIP, defaultPort)).To(gomega.Equal(true))
+}
+
+// Test that any update in the Pod container port is reflected in pod annotation and local port cache
+func TestPodUpdate(t *testing.T) {
+	var ann map[string]string
+	var nplData []nplAnnotation
+	var data string
+
+	g := gomega.NewGomegaWithT(t)
+
+	testPod := getTestPod()
+	testPod.Spec.Containers[0].Ports[0].ContainerPort = 8080
+	testPod.ResourceVersion = "2"
+	p, err := c.KubeClient.CoreV1().Pods(defaultNS).Update(context.TODO(), &testPod, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Pod creation failed with err: %v", err)
+	}
+	t.Logf("successfully created Pod: %v", p)
+
+	g.Eventually(func() string {
+		updatedPod, err := c.KubeClient.CoreV1().Pods(defaultNS).Get(context.TODO(), defaultPodName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Failed to update pod: %v", err)
+		}
+		ann = updatedPod.GetAnnotations()
+		data, _ = ann[lib.NPLEPAnnotation]
+		json.Unmarshal([]byte(data), &nplData)
+		if len(nplData) != 1 {
+			return ""
+		}
+		return nplData[0].Podport
+	}, 20*time.Second).Should(gomega.Equal("8080"))
+	g.Expect(c.PortTable.RuleExists(defaultPodIP, defaultPort)).To(gomega.Equal(false))
+	g.Expect(c.PortTable.RuleExists(defaultPodIP, 8080)).To(gomega.Equal(true))
+}
+
+// Make sure that when a pod gets deleted, corresponding entry gets deleted from local port cache also
+func TestPodDel(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	err := c.KubeClient.CoreV1().Pods(defaultNS).Delete(context.TODO(), defaultPodName, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Pod deletion failed with err: %v", err)
+	}
+	t.Logf("successfully deleted Pod: %s", defaultPodName)
+
+	g.Eventually(func() bool {
+		return c.PortTable.RuleExists(defaultPodIP, 8080)
+	}, 20*time.Second).Should(gomega.Equal(false))
+}
+
+// Create a pod with multiple ports and verify that pod annotation and local port cache are updated correctly
+func TestPodAddMultiPort(t *testing.T) {
+	var ann map[string]string
+	var data string
+	var found bool
+
+	g := gomega.NewGomegaWithT(t)
+
+	testPod := getTestPod()
+	newPort := corev1.ContainerPort{ContainerPort: 90}
+	testPod.Spec.Containers[0].Ports = append(testPod.Spec.Containers[0].Ports, newPort)
+	p, err := c.KubeClient.CoreV1().Pods(defaultNS).Create(context.TODO(), &testPod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Pod creation failed with err: %v", err)
+	}
+	t.Logf("successfully created Pod: %v", p)
+
+	g.Eventually(func() bool {
+		updatedPod, err := c.KubeClient.CoreV1().Pods(defaultNS).Get(context.TODO(), defaultPodName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Failed to update pod: %v", err)
+		}
+		ann = updatedPod.GetAnnotations()
+		data, found = ann[lib.NPLEPAnnotation]
+		return found
+	}, 20*time.Second).Should(gomega.Equal(true))
+
+	var nplData []nplAnnotation
+	json.Unmarshal([]byte(data), &nplData)
+
+	if len(nplData) != 2 {
+		t.Fatalf("Expected npl annotation of length: 2, got: %d", len(nplData))
+	}
+
+	g.Expect(nplData[0].Nodeip).To(gomega.Equal(defaultHostIP))
+	g.Expect(nplData[0].Podport).To(gomega.Equal(fmt.Sprint(defaultPort)))
+	g.Expect(c.PortTable.RuleExists(defaultPodIP, defaultPort)).To(gomega.Equal(true))
+
+	g.Expect(nplData[1].Nodeip).To(gomega.Equal(defaultHostIP))
+	g.Expect(nplData[1].Podport).To(gomega.Equal("90"))
+	g.Expect(c.PortTable.RuleExists(defaultPodIP, 90)).To(gomega.Equal(true))
+}
+
+// Create Multiple Pods and test that annotations for both te pods are updated correctly
+// and local port cache is updated accordingly
+func TestAddMultiplePods(t *testing.T) {
+	var ann map[string]string
+	var data string
+	var found bool
+
+	g := gomega.NewGomegaWithT(t)
+
+	testPod1 := getTestPod()
+	testPod1.Name = "pod1"
+	testPod1.Status.PodIP = "10.10.10.1"
+	p, err := c.KubeClient.CoreV1().Pods(defaultNS).Create(context.TODO(), &testPod1, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Pod creation failed with err: %v", err)
+	}
+	t.Logf("successfully created Pod: %v", p)
+
+	testPod2 := getTestPod()
+	testPod2.Name = "pod2"
+	testPod2.Status.PodIP = "10.10.10.2"
+	p, err = c.KubeClient.CoreV1().Pods(defaultNS).Create(context.TODO(), &testPod2, metav1.CreateOptions{})
+	if err != nil {
+		t.Errorf("Pod creation failed with err: %v", err)
+	}
+	t.Logf("successfully created Pod: %v", p)
+
+	g.Eventually(func() bool {
+		updatedPod, err := c.KubeClient.CoreV1().Pods(defaultNS).Get(context.TODO(), testPod1.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Failed to update pod: %v", err)
+		}
+		ann = updatedPod.GetAnnotations()
+		data, found = ann[lib.NPLEPAnnotation]
+		return found
+	}, 20*time.Second).Should(gomega.Equal(true))
+
+	var nplData []nplAnnotation
+	json.Unmarshal([]byte(data), &nplData)
+
+	if len(nplData) != 1 {
+		t.Fatalf("Expected npl annotation of length: 1, got: %d", len(nplData))
+	}
+
+	g.Expect(nplData[0].Nodeip).To(gomega.Equal(defaultHostIP))
+	g.Expect(nplData[0].Podport).To(gomega.Equal(fmt.Sprint(defaultPort)))
+	g.Expect(c.PortTable.RuleExists(testPod1.Status.PodIP, defaultPort)).To(gomega.Equal(true))
+
+	g.Eventually(func() bool {
+		updatedPod, err := c.KubeClient.CoreV1().Pods(defaultNS).Get(context.TODO(), testPod2.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Failed to update pod: %v", err)
+		}
+		ann = updatedPod.GetAnnotations()
+		data, found = ann[lib.NPLEPAnnotation]
+		return found
+	}, 20*time.Second).Should(gomega.Equal(true))
+	json.Unmarshal([]byte(data), &nplData)
+
+	if len(nplData) != 1 {
+		t.Fatalf("Expected npl annotation of length: 1, got: %d", len(nplData))
+	}
+
+	g.Expect(nplData[0].Nodeip).To(gomega.Equal(defaultHostIP))
+	g.Expect(nplData[0].Podport).To(gomega.Equal(fmt.Sprint(defaultPort)))
+	g.Expect(c.PortTable.RuleExists(testPod2.Status.PodIP, defaultPort)).To(gomega.Equal(true))
+}

--- a/pkg/agent/nplagent/portcache/port_table.go
+++ b/pkg/agent/nplagent/portcache/port_table.go
@@ -1,0 +1,178 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package portcache
+
+import (
+	"fmt"
+	"sync"
+
+	nplutils "github.com/vmware-tanzu/antrea/pkg/agent/nplagent/lib"
+	"github.com/vmware-tanzu/antrea/pkg/agent/nplagent/rules"
+	"k8s.io/klog"
+)
+
+const (
+	successStatus = 0
+	pendingStatus = 1
+	failStatus    = 2
+)
+
+type NodePortData struct {
+	Nodeport int
+	Podport  int
+	Podip    string
+	Status   int
+	//podname  string
+}
+
+type PortTable struct {
+	Table        map[int]NodePortData
+	StartPort    int
+	EndPort      int
+	PodPortRules rules.PodPortRules
+	tableLock    sync.RWMutex
+}
+
+var once sync.Once
+var ptable PortTable
+
+func NewPortTable(start, end int) *PortTable {
+	once.Do(func() {
+		ptable = PortTable{StartPort: start, EndPort: end}
+		ptable.Table = make(map[int]NodePortData)
+		ptable.PodPortRules = rules.Initrules()
+	})
+	return &ptable
+}
+
+func GetPortTable() *PortTable {
+	return &ptable
+}
+
+func (pt *PortTable) PopulatePortTable(r rules.PodPortRules) {
+	portMap := make(map[int]string)
+	ok, err := r.GetAllRules(portMap)
+	if !ok {
+		klog.Warningf("Could not populate port table cache due to error: %v", err)
+		return
+	}
+	table := make(map[int]NodePortData)
+	for nodeport, podip := range portMap {
+		entry := NodePortData{
+			Nodeport: nodeport,
+			Podip:    podip,
+		}
+		table[nodeport] = entry
+	}
+	pt.tableLock.Lock()
+	defer pt.tableLock.Unlock()
+	pt.Table = table
+}
+
+func (pt *PortTable) AddUpdateEntry(nodeport, podport int, podip string) {
+	pt.tableLock.Lock()
+	defer pt.tableLock.Unlock()
+	data := NodePortData{Nodeport: nodeport, Podport: podport, Podip: podip}
+	pt.Table[nodeport] = data
+}
+
+func (pt *PortTable) DeleteEntry(nodeport int) {
+	pt.tableLock.Lock()
+	defer pt.tableLock.Unlock()
+	delete(pt.Table, nodeport)
+}
+
+func (pt *PortTable) DeleteEntryByPodIP(ip string) {
+	pt.tableLock.Lock()
+	defer pt.tableLock.Unlock()
+	for i, data := range pt.Table {
+		if data.Podip == ip {
+			delete(pt.Table, i)
+		}
+	}
+}
+
+func (pt *PortTable) DeleteEntryByPodIPPort(ip string, port int) {
+	pt.tableLock.Lock()
+	defer pt.tableLock.Unlock()
+	for i, data := range pt.Table {
+		if data.Podip == ip && data.Podport == port {
+			delete(pt.Table, i)
+		}
+	}
+}
+
+func (pt *PortTable) GetEntry(nodeport int) *NodePortData {
+	pt.tableLock.RLock()
+	defer pt.tableLock.RUnlock()
+	data, _ := pt.Table[nodeport]
+	return &data
+}
+
+func (pt *PortTable) GetEntryByPodIPPort(ip string, port int) *NodePortData {
+	pt.tableLock.RLock()
+	defer pt.tableLock.RUnlock()
+	for _, data := range pt.Table {
+		if data.Podip == ip && data.Podport == port {
+			return &data
+		}
+	}
+	return nil
+}
+
+func (pt *PortTable) getFreePort() int {
+	pt.tableLock.RLock()
+	defer pt.tableLock.RUnlock()
+	for i := pt.StartPort; i <= pt.EndPort; i++ {
+		if _, ok := pt.Table[i]; !ok && nplutils.IsPortAvailable(i) {
+			return i
+		}
+	}
+	return -1
+}
+
+func (pt *PortTable) AddRule(podip string, podport int) (int, bool) {
+	nodeport := pt.getFreePort()
+	if nodeport < 0 {
+		return 0, false
+	}
+	if pt == nil {
+		return 0, false
+	}
+	ok, _ := pt.PodPortRules.AddRule(nodeport, fmt.Sprintf("%s:%d", podip, podport))
+	if !ok {
+		return 0, false
+	}
+	pt.AddUpdateEntry(nodeport, podport, podip)
+	return nodeport, true
+}
+
+func (pt *PortTable) DeleteRule(podip string, podport int) (bool, error) {
+	data := pt.GetEntryByPodIPPort(podip, podport)
+	ok, err := pt.PodPortRules.DeleteRule(data.Nodeport, fmt.Sprintf("%s:%d", podip, podport))
+	if !ok {
+		return false, err
+	}
+	pt.DeleteEntry(data.Nodeport)
+	return true, nil
+}
+
+func (pt *PortTable) RuleExists(podip string, podport int) bool {
+	data := pt.GetEntryByPodIPPort(podip, podport)
+	if data != nil {
+		return true
+	}
+	return false
+}

--- a/pkg/agent/nplagent/rules/iptable_rule.go
+++ b/pkg/agent/nplagent/rules/iptable_rule.go
@@ -1,0 +1,175 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/coreos/go-iptables/iptables"
+	"k8s.io/klog"
+)
+
+type IPTableRule struct {
+	name  string
+	table *iptables.IPTables
+}
+
+var once sync.Once
+
+func (ipt *IPTableRule) Init() (bool, error) {
+	_, err := iptables.New()
+	if err != nil {
+		klog.Infof("init iptable for NPL failed: %v\n", err)
+		return false, errors.New("iptable init failed")
+	}
+	return true, nil
+}
+
+// CreateChains : Create the chain NODE-PORT-LOCAL in NAT table
+// All DNAT rules for NPL would be added in this chain
+func (ipt *IPTableRule) CreateChains() error {
+	exists, err := ipt.table.Exists("nat", "NODE-PORT-LOCAL")
+	if err != nil {
+		klog.Warningf("check for NODE-PORT-LOCAL chain in iptable failed with error: %v", err)
+		return err
+	}
+	if !exists {
+		err = ipt.table.NewChain("nat", "NODE-PORT-LOCAL")
+		if err != nil {
+			klog.Warningf("IPtable chain creation failed for NPL with error: %v", err)
+			return err
+		}
+	}
+
+	exists, err = ipt.table.Exists("nat", "PREROUTING", "-p", "tcp", "-j", "NODE-PORT-LOCAL")
+	if err != nil {
+		klog.Warningf("check for NODE-PORT-LOCAL chain in iptable failed with error: %v", err)
+		return err
+	}
+	if !exists {
+		err = ipt.table.Append("nat", "PREROUTING", "-p", "tcp", "-j", "NODE-PORT-LOCAL")
+		if err != nil {
+			klog.Warningf("IPtable rule creation in PREROUTING chain failed for NPL with error: %v", err)
+			return err
+		}
+	}
+	return nil
+}
+
+// AddRule : Appends a DNAT rule in NODE-PORT-LOCAL chain of NAT table
+func (ipt *IPTableRule) AddRule(port int, podip string) (bool, error) {
+	exists, err := ipt.table.Exists("nat", "NODE-PORT-LOCAL", "-p", "tcp", "-m", "tcp", "--dport",
+		fmt.Sprint(port), "-j", "DNAT", "--to-destination", podip)
+	if err != nil {
+		klog.Warningf("check for NODE-PORT-LOCAL chain in iptable failed with error: %v", err)
+		return false, err
+	}
+	if !exists {
+		err := ipt.table.Append("nat", "NODE-PORT-LOCAL", "-p", "tcp", "-m", "tcp", "--dport",
+			fmt.Sprint(port), "-j", "DNAT", "--to-destination", podip)
+
+		if err != nil {
+			klog.Warningf("IPtable rule creation in failed for NPL with error: %v", err)
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+// DeleteRule : Delete a specific NPL rule from NODE-PORT-LOCAL chain
+func (ipt *IPTableRule) DeleteRule(port int, podip string) (bool, error) {
+	klog.Infof("Deleting rule with port %v and podip %v", port, podip)
+	err := ipt.table.Delete("nat", "NODE-PORT-LOCAL", "-p", "tcp", "-m", "tcp", "--dport",
+		fmt.Sprint(port), "-j", "DNAT", "--to-destination", podip)
+
+	if err != nil {
+		klog.Infof("%v", err)
+		return false, err
+	}
+	return true, nil
+}
+
+// SyncState : To Do - Compare existing rules with expected rules for all pods
+// and make sure that correct rules are programmed correctly
+func (ipt *IPTableRule) SyncState(podPort map[int]string) bool {
+	m := make(map[int]string)
+	var success = false
+	for port, node := range podPort {
+		success, _ = ipt.AddRule(port, node)
+		if success == false {
+			m[port] = node
+			klog.Warningf("Adding iptables failed for port %d and node %s", port, node)
+			return false
+		}
+	}
+	podPort = m
+	return true
+}
+
+// GetAllRules : Get list of all NPL rules progammed in the node
+func (ipt *IPTableRule) GetAllRules(podPort map[int]string) (bool, error) {
+	rules, err := ipt.table.List("nat", "NODE-PORT-LOCAL")
+	if err != nil {
+		klog.Warningf("Failed to list IPtable rules for NPL: %v", err)
+		return false, err
+	}
+	m := make(map[int]string)
+	for i := range rules {
+		splitRule := strings.Fields(rules[i])
+		// A rule has details about the node port, port ip and port number.
+		// e.g.:  -A NODE-PORT-LOCAL -p tcp -m tcp --dport 45000 -j DNAT --to-destination 10.244.0.43:8080
+		if len(splitRule) != 12 {
+			continue
+		}
+		port, err := strconv.Atoi(splitRule[7])
+		if err != nil {
+			klog.Warningf("Failed to convert port string to int: %v", err)
+			continue
+		}
+		nodeipPort := strings.Split(splitRule[11], ":")
+		if len(nodeipPort) != 2 {
+			continue
+		}
+		//TODO: Need to check whether it's a proper ip:port combination
+		m[port] = splitRule[11]
+	}
+	podPort = m
+	return true, nil
+}
+
+// DeleteAllRules : Delete all NPL rules progammed in the node
+func (ipt *IPTableRule) DeleteAllRules() (bool, error) {
+	err := ipt.table.Delete("nat", "PREROUTING", "-p", "tcp", "-j", "NODE-PORT-LOCAL")
+	if err != nil {
+		klog.Warningf("Failed to delete rule from PREROUTING chain for NPL: %v\n", err)
+		return false, err
+	}
+	err = ipt.table.ClearChain("nat", "NODE-PORT-LOCAL")
+	if err != nil {
+		klog.Warningf("Failed to clear chain for NPL: %v\n", err)
+		return false, err
+	}
+	err = ipt.table.DeleteChain("nat", "NODE-PORT-LOCAL")
+	if err != nil {
+		klog.Warningf("Failed to delete chain for NPL: %v\n", err)
+		return false, err
+	}
+	return true, nil
+}

--- a/pkg/agent/nplagent/rules/rules.go
+++ b/pkg/agent/nplagent/rules/rules.go
@@ -1,0 +1,55 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"github.com/coreos/go-iptables/iptables"
+	nplutils "github.com/vmware-tanzu/antrea/pkg/agent/nplagent/lib"
+)
+
+type PodPortRules interface {
+	Init() (bool, error)
+	AddRule(port int, podip string) (bool, error)
+	DeleteRule(port int, podip string) (bool, error)
+	SyncState(podPort map[int]string) bool
+	GetAllRules(podPort map[int]string) (bool, error)
+	DeleteAllRules() (bool, error)
+}
+
+func Initrules(args ...string) PodPortRules {
+	var ruletype string
+	if len(args) == 0 {
+		// By default use iptable
+		ruletype = nplutils.IPTableRule
+	} else {
+		ruletype = args[0]
+	}
+	switch ruletype {
+	case "IPTABLE":
+		ipt, err := iptables.New()
+		if err != nil {
+			return nil
+		}
+		iptRule := IPTableRule{
+			name:  "NPL",
+			table: ipt,
+		}
+
+		iptRule.DeleteAllRules()
+		iptRule.CreateChains()
+		return &iptRule
+	}
+	return nil
+}

--- a/pkg/features/antrea_features.go
+++ b/pkg/features/antrea_features.go
@@ -50,6 +50,10 @@ const (
 	// alpha: v0.10
 	// Enable collecting and exposing NetworkPolicy statistics.
 	NetworkPolicyStats featuregate.Feature = "NetworkPolicyStats"
+
+	// alpha: v0.1
+	// Expose Pod IPs through nodeport
+	NodePortLocal featuregate.Feature = "NodePortLocal"
 )
 
 var (
@@ -69,6 +73,7 @@ var (
 		Traceflow:          {Default: false, PreRelease: featuregate.Alpha},
 		FlowExporter:       {Default: false, PreRelease: featuregate.Alpha},
 		NetworkPolicyStats: {Default: false, PreRelease: featuregate.Alpha},
+		NodePortLocal:      {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 


### PR DESCRIPTION
This commit introduces NodePortLocal (NPL) in Antrea agent.
With NPL, a pod pod port can be directly reached from external network through a port of the node on which the pod is running.
NPL programs IPTABLE rules to send incoming traffic on a specific port of a node to a POD port.
This information is exposed through annotation of the POD for consumption of other agents. An example of the pod annotation is given bellow.
metadata:
  annotations:
    npl.k8s.io/endpoints: '[{"podport":"8080","nodeip":"10.102.47.229","nodeport":"40002"}]'

More details about Node-Port-Local can be found in the design document: https://docs.google.com/document/d/1SoAKBvbbt2QMnGmt53E8ja0ZxCv_T4r1zLVnMzpykTg

To use this feature, following changes are required in Antrea configuration:
- Set NodePortLocal: true under featureGates in antrea-agent.conf in Antrea Configmap.
- In the Antrea Agent DaemonSet configure the port range for NPL (NPL_PORT_RANGE) in the env.  e.g.
        - name: NPL_PORT_RANGE
          value: 40000-46000
- Add capability for pod update in antrea-agent cluster role

Upcoming changes in future commits:
- Label based service filtering to select backend pods for NPL
- Option to select port range for NPL though Configmap
- Bootup sync : Compare programmed IPtable rules with pod annotation during bootup and add/delete new rules in iptable only if required.
    - Currently we are deleting all the rules and adding new rules for all the pods while booting up Antrea agent.

Signed-off-by: Hemant Shaw <hemant.shaw@avinetworks.com>
Signed-off-by: Manu Dilip Shah <manu.shah@avinetworks.com>
Signed-off-by: Monotosh Das <monotosh.das@avinetworks.com>
Signed-off-by: Shubham Chauhan <shubham@avinetworks.com>
Signed-off-by: Sudipta Biswas <sudipto@avinetworks.com>