### PR TITLE
Use DSCP instead of tun_metadata0 in Traceflow

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -37,7 +37,6 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/route"
 	"github.com/vmware-tanzu/antrea/pkg/agent/types"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"
-	"github.com/vmware-tanzu/antrea/pkg/features"
 	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 	"github.com/vmware-tanzu/antrea/pkg/util/env"
 )
@@ -291,16 +290,7 @@ func (i *Initializer) initOpenFlowPipeline() error {
 		return err
 	}
 
-	// When IPSec encyption is enabled, no flow is needed for the default tunnel interface.
 	if i.networkConfig.TrafficEncapMode.SupportsEncap() {
-		if features.DefaultFeatureGate.Enabled(features.Traceflow) {
-			// Set up Traceflow TLV map. This command is Nicira extensions to OpenFlow and require Open
-			// vSwitch 2.5 or later.
-			if err := i.ofClient.InitialTLVMap(); err != nil {
-				klog.Errorf("Error during Openflow TLV map initialization: %v", err)
-				return err
-			}
-		}
 		// Set up flow entries for the default tunnel port interface.
 		if err := i.ofClient.InstallDefaultTunnelFlows(config.DefaultTunOFPort); err != nil {
 			klog.Errorf("Failed to setup openflow entries for tunnel interface: %v", err)

--- a/pkg/agent/controller/traceflow/traceflow_controller.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller.go
@@ -324,7 +324,6 @@ func (c *Controller) injectPacket(tf *opsv1alpha1.Traceflow) error {
 	// Calculate destination MAC/IP.
 	dstMAC := ""
 	dstIP := tf.Spec.Destination.IP
-	dstNodeIP := ""
 	if dstIP != "" {
 		dstPodInterface, hasInterface := c.interfaceStore.GetInterfaceByIP(dstIP)
 		if hasInterface {
@@ -342,7 +341,6 @@ func (c *Controller) injectPacket(tf *opsv1alpha1.Traceflow) error {
 			}
 			// dstMAC is "" here, will be set to Gateway MAC in ofClient.SendTraceflowPacket
 			dstIP = dstPod.Status.PodIP
-			dstNodeIP = dstPod.Status.HostIP
 		}
 	} else if tf.Spec.Destination.Service != "" {
 		dstSvc, err := c.serviceLister.Services(tf.Spec.Destination.Namespace).Get(tf.Spec.Destination.Service)
@@ -352,17 +350,9 @@ func (c *Controller) injectPacket(tf *opsv1alpha1.Traceflow) error {
 		dstIP = dstSvc.Spec.ClusterIP
 		flagsTCP = 2
 	}
-	// Check encap status if no dstMAC found which means the destination is Service or the destination Pod/IP is not on local Node.
 	if dstMAC == "" {
-		peerIP := net.ParseIP(dstNodeIP)
-		if c.networkConfig.TunnelType == ovsconfig.GeneveTunnel && (tf.Spec.Destination.Pod == "" || c.networkConfig.TrafficEncapMode.NeedsEncapToPeer(peerIP, c.nodeConfig.NodeIPAddr)) {
-			// If the destination is Service/IP or the packet will be encapsulated to remote Node, wait a small period for other Nodes.
-			time.Sleep(time.Duration(injectPacketDelay) * time.Second)
-		} else {
-			// Inter-node traceflow is only available when the packet is encapsulated in Geneve tunnel.
-			return errors.New(fmt.Sprintf("inter-node traceflow is not available in current configuration, TunnelType: %s, EncapMode: %s, localIP: %s, peerIP: %s",
-				c.networkConfig.TunnelType, c.networkConfig.TrafficEncapMode.String(), c.nodeConfig.NodeIPAddr.String(), dstNodeIP))
-		}
+		// If the destination is Service/IP or the packet will be sent to remote Node, wait a small period for other Nodes.
+		time.Sleep(time.Duration(injectPacketDelay) * time.Second)
 	}
 
 	// Protocol is 0 (IPv6 Hop-by-Hop Option) if not set in CRD, which is not supported by Traceflow

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -677,8 +677,6 @@ func (c *client) SendTraceflowPacket(
 	inPort uint32,
 	outPort int32) error {
 
-	regName := fmt.Sprintf("%s%d", binding.NxmFieldReg, TraceflowReg)
-
 	packetOutBuilder := c.bridge.BuildPacketOut()
 	parsedSrcMAC, _ := net.ParseMAC(srcMAC)
 	parsedDstMAC, _ := net.ParseMAC(dstMAC)
@@ -723,30 +721,30 @@ func (c *client) SendTraceflowPacket(
 	if outPort != -1 {
 		packetOutBuilder = packetOutBuilder.SetOutport(uint32(outPort))
 	}
-	packetOutBuilder = packetOutBuilder.AddLoadAction(regName, uint64(dataplaneTag), OfTraceflowMarkRange)
+	packetOutBuilder = packetOutBuilder.AddLoadAction(binding.NxmFieldIPToS, uint64(dataplaneTag), traceflowTagToSRange)
 
 	packetOutObj := packetOutBuilder.Done()
 	return c.bridge.SendPacketOut(packetOutObj)
 }
 
 func (c *client) InstallTraceflowFlows(dataplaneTag uint8) error {
-	flow := c.traceflowL2ForwardOutputFlow(dataplaneTag, cookie.Default)
+	flows := c.traceflowL2ForwardOutputFlows(dataplaneTag, cookie.Default)
+	if err := c.AddAll(flows); err != nil {
+		return err
+	}
+	flow := c.traceflowConnectionTrackFlows(dataplaneTag, cookie.Default)
 	if err := c.Add(flow); err != nil {
 		return err
 	}
-	flow = c.traceflowConnectionTrackFlows(dataplaneTag, cookie.Default)
-	if err := c.Add(flow); err != nil {
-		return err
-	}
-	flows := []binding.Flow{}
 	c.conjMatchFlowLock.Lock()
 	defer c.conjMatchFlowLock.Unlock()
+	flows = []binding.Flow{}
 	for _, ctx := range c.globalConjMatchFlowCache {
 		if ctx.dropFlow != nil {
 			flows = append(
 				flows,
 				ctx.dropFlow.CopyToBuilder(priorityNormal+2, false).
-					MatchRegRange(int(TraceflowReg), uint32(dataplaneTag), OfTraceflowMarkRange).
+					MatchIPDscp(dataplaneTag).
 					SetHardTimeout(300).
 					Action().SendToController(uint8(PacketInReasonTF)).
 					Done())

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -29,7 +29,6 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/metrics"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow/cookie"
 	"github.com/vmware-tanzu/antrea/pkg/agent/types"
-	"github.com/vmware-tanzu/antrea/pkg/features"
 	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
 	"github.com/vmware-tanzu/antrea/third_party/proxy"
 )
@@ -193,7 +192,7 @@ const (
 	// marksReg stores traffic-source mark and pod-found mark.
 	// traffic-source resides in [0..15], pod-found resides in [16], Antrea Policy disposition Allow or Drop in [21]
 	marksReg        regType = 0
-	portCacheReg    regType = 1
+	PortCacheReg    regType = 1
 	swapReg         regType = 2
 	endpointIPReg   regType = 3               // Use reg3 to store endpoint IP
 	endpointPortReg regType = 4               // Use reg4[0..15] to store endpoint port
@@ -244,9 +243,7 @@ var (
 	// ofPortMarkRange takes the 16th bit of register marksReg to indicate if the ofPort number of an interface
 	// is found or not. Its value is 0x1 if yes.
 	ofPortMarkRange = binding.Range{16, 16}
-	// OfTraceflowMarkRange stores dataplaneTag at range 28-31 in marksReg.
-	OfTraceflowMarkRange = binding.Range{28, 31}
-	// ofPortRegRange takes a 32-bit range of register portCacheReg to cache the ofPort number of the interface.
+	// ofPortRegRange takes a 32-bit range of register PortCacheReg to cache the ofPort number of the interface.
 	ofPortRegRange = binding.Range{0, 31}
 	// snatMarkRange takes the 17th bit of register marksReg to indicate if the packet needs to be SNATed with Node's IP
 	// or not. Its value is 0x1 if yes.
@@ -273,6 +270,10 @@ var (
 	metricIngressRuleIDRange = binding.Range{0, 31}
 	// metricEgressRuleIDRange takes 32..63 range of ct_label to store the egress rule ID.
 	metricEgressRuleIDRange = binding.Range{32, 63}
+
+	// traceflowTagToSRange stores dataplaneTag at range 2-7 in ToS field of IP header.
+	// IPv4/v6 DSCP (bits 2-7) field supports exact match only.
+	traceflowTagToSRange = binding.Range{2, 7}
 
 	globalVirtualMAC, _ = net.ParseMAC("aa:bb:cc:dd:ee:ff")
 	hairpinIP           = net.ParseIP("169.254.169.252").To4()
@@ -451,14 +452,9 @@ func (c *client) defaultFlows() (flows []binding.Flow) {
 
 // tunnelClassifierFlow generates the flow to mark traffic comes from the tunnelOFPort.
 func (c *client) tunnelClassifierFlow(tunnelOFPort uint32, category cookie.Category) binding.Flow {
-	flowBuilder := c.pipeline[ClassifierTable].BuildFlow(priorityNormal).
-		MatchInPort(tunnelOFPort)
-	if features.DefaultFeatureGate.Enabled(features.Traceflow) {
-		regName := fmt.Sprintf("%s%d", binding.NxmFieldReg, TraceflowReg)
-		tunMetadataName := fmt.Sprintf("%s%d", binding.NxmFieldTunMetadata, 0)
-		flowBuilder = flowBuilder.Action().MoveRange(tunMetadataName, regName, OfTraceflowMarkRange, OfTraceflowMarkRange)
-	}
-	return flowBuilder.Action().LoadRegRange(int(marksReg), markTrafficFromTunnel, binding.Range{0, 15}).
+	return c.pipeline[ClassifierTable].BuildFlow(priorityNormal).
+		MatchInPort(tunnelOFPort).
+		Action().LoadRegRange(int(marksReg), markTrafficFromTunnel, binding.Range{0, 15}).
 		Action().LoadRegRange(int(marksReg), macRewriteMark, macRewriteMarkRange).
 		Action().GotoTable(conntrackTable).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
@@ -589,8 +585,9 @@ func (c *client) connectionTrackFlows(category cookie.Category) []binding.Flow {
 // avoid unexpected packet drop in Traceflow.
 func (c *client) traceflowConnectionTrackFlows(dataplaneTag uint8, category cookie.Category) binding.Flow {
 	connectionTrackStateTable := c.pipeline[conntrackStateTable]
-	flowBuilder := connectionTrackStateTable.BuildFlow(priorityLow+2).
-		MatchRegRange(int(TraceflowReg), uint32(dataplaneTag), OfTraceflowMarkRange).
+	flowBuilder := connectionTrackStateTable.BuildFlow(priorityLow + 2).
+		MatchProtocol(binding.ProtocolIP).
+		MatchIPDscp(dataplaneTag).
 		SetHardTimeout(300).
 		Cookie(c.cookieAllocator.Request(category).Raw())
 	if c.enableProxy {
@@ -650,7 +647,7 @@ func (c *client) l2ForwardCalcFlow(dstMAC net.HardwareAddr, ofPort uint32, categ
 	l2FwdCalcTable := c.pipeline[l2ForwardingCalcTable]
 	return l2FwdCalcTable.BuildFlow(priorityNormal).
 		MatchDstMAC(dstMAC).
-		Action().LoadRegRange(int(portCacheReg), ofPort, ofPortRegRange).
+		Action().LoadRegRange(int(PortCacheReg), ofPort, ofPortRegRange).
 		Action().LoadRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
 		Action().GotoTable(l2FwdCalcTable.GetNext()).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
@@ -661,26 +658,49 @@ func (c *client) l2ForwardCalcFlow(dstMAC net.HardwareAddr, ofPort uint32, categ
 func (c *client) l2ForwardOutputFlow(category cookie.Category) binding.Flow {
 	return c.pipeline[L2ForwardingOutTable].BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 		MatchRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
-		Action().OutputRegRange(int(portCacheReg), ofPortRegRange).
+		Action().OutputRegRange(int(PortCacheReg), ofPortRegRange).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
 		Done()
 }
 
-// traceflowL2ForwardOutputFlow generates Traceflow specific flow that outputs traceflow packets to OVS port and Antrea
+// traceflowL2ForwardOutputFlows generates Traceflow specific flows that outputs traceflow packets to OVS port and Antrea
 // Agent after L2forwarding calculation.
-func (c *client) traceflowL2ForwardOutputFlow(dataplaneTag uint8, category cookie.Category) binding.Flow {
-	regName := fmt.Sprintf("%s%d", binding.NxmFieldReg, TraceflowReg)
-	tunMetadataName := fmt.Sprintf("%s%d", binding.NxmFieldTunMetadata, 0)
-	return c.pipeline[L2ForwardingOutTable].BuildFlow(priorityNormal+2).
-		MatchRegRange(int(TraceflowReg), uint32(dataplaneTag), OfTraceflowMarkRange).
+func (c *client) traceflowL2ForwardOutputFlows(dataplaneTag uint8, category cookie.Category) []binding.Flow {
+	flows := []binding.Flow{}
+	// Output and SendToController if output port is tunnel or gateway port.
+	// The gw0 IP as Traceflow destination is not supported.
+	if c.encapMode.SupportsEncap() {
+		flows = append(flows, c.pipeline[L2ForwardingOutTable].BuildFlow(priorityNormal+3).
+			MatchReg(int(PortCacheReg), config.DefaultTunOFPort).
+			MatchIPDscp(dataplaneTag).
+			SetHardTimeout(300).
+			MatchProtocol(binding.ProtocolIP).
+			MatchRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
+			Action().OutputRegRange(int(PortCacheReg), ofPortRegRange).
+			Action().SendToController(uint8(PacketInReasonTF)).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done())
+	}
+	flows = append(flows, c.pipeline[L2ForwardingOutTable].BuildFlow(priorityNormal+3).
+		MatchReg(int(PortCacheReg), config.HostGatewayOFPort).
+		MatchIPDscp(dataplaneTag).
 		SetHardTimeout(300).
 		MatchProtocol(binding.ProtocolIP).
 		MatchRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
-		Action().MoveRange(regName, tunMetadataName, OfTraceflowMarkRange, OfTraceflowMarkRange).
-		Action().OutputRegRange(int(portCacheReg), ofPortRegRange).
+		Action().OutputRegRange(int(PortCacheReg), ofPortRegRange).
 		Action().SendToController(uint8(PacketInReasonTF)).
 		Cookie(c.cookieAllocator.Request(category).Raw()).
-		Done()
+		Done())
+	// Only SendToController if output port is Pod port.
+	flows = append(flows, c.pipeline[L2ForwardingOutTable].BuildFlow(priorityNormal+2).
+		MatchIPDscp(dataplaneTag).
+		SetHardTimeout(300).
+		MatchProtocol(binding.ProtocolIP).
+		MatchRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
+		Action().SendToController(uint8(PacketInReasonTF)).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
+		Done())
+	return flows
 }
 
 // l2ForwardOutputServiceHairpinFlow uses in_port action for Service
@@ -764,7 +784,7 @@ func (c *client) l3FwdFlowToRemote(
 		Action().SetSrcMAC(localGatewayMAC).
 		Action().SetDstMAC(globalVirtualMAC).
 		// Load ofport of the tunnel interface.
-		Action().LoadRegRange(int(portCacheReg), tunOFPort, ofPortRegRange).
+		Action().LoadRegRange(int(PortCacheReg), tunOFPort, ofPortRegRange).
 		// Set MAC-known.
 		Action().LoadRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
 		// Flow based tunnel. Set tunnel destination.
@@ -904,7 +924,7 @@ func (c *client) sessionAffinityReselectFlow() binding.Flow {
 func (c *client) serviceCIDRDNATFlow(serviceCIDR *net.IPNet, gatewayOFPort uint32) binding.Flow {
 	return c.pipeline[dnatTable].BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
 		MatchDstIPNet(*serviceCIDR).
-		Action().LoadRegRange(int(portCacheReg), gatewayOFPort, ofPortRegRange).
+		Action().LoadRegRange(int(PortCacheReg), gatewayOFPort, ofPortRegRange).
 		Action().LoadRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
 		Action().GotoTable(conntrackCommitTable).
 		Cookie(c.cookieAllocator.Request(cookie.Service).Raw()).
@@ -1112,7 +1132,7 @@ func (c *client) addFlowMatch(fb binding.FlowBuilder, matchType int, matchValue 
 		fb = fb.MatchProtocol(binding.ProtocolIP).MatchSrcIPNet(matchValue.(net.IPNet))
 	case MatchDstOFPort:
 		// ofport number in NXM_NX_REG1 is used in ingress rule to match packets sent to local Pod.
-		fb = fb.MatchProtocol(binding.ProtocolIP).MatchReg(int(portCacheReg), uint32(matchValue.(int32)))
+		fb = fb.MatchProtocol(binding.ProtocolIP).MatchReg(int(PortCacheReg), uint32(matchValue.(int32)))
 	case MatchSrcOFPort:
 		fb = fb.MatchProtocol(binding.ProtocolIP).MatchInPort(uint32(matchValue.(int32)))
 	case MatchTCPDstPort:

--- a/pkg/controller/traceflow/controller.go
+++ b/pkg/controller/traceflow/controller.go
@@ -48,10 +48,12 @@ const (
 	// Default number of workers processing traceflow request.
 	defaultWorkers = 4
 
-	// Min and max data plane tag for traceflow. dataplaneTag=0 means it's not a Traceflow packet.
-	// dataplaneTag=15 is reserved.
-	minTagNum uint8 = 1
-	maxTagNum uint8 = 14
+	// Min and max data plane tag for traceflow. minTagNum is 7 (0b000111), maxTagNum is 59 (0b111011).
+	// As per RFC2474, 16 different DSCP values are we reserved for Experimental or Local Use, which we use as the 16 possible data plane tag values.
+	// tagStep is 4 (0b100) to keep last 2 bits at 0b11.
+	tagStep   uint8 = 0b100
+	minTagNum uint8 = 0b1*tagStep + 0b11
+	maxTagNum uint8 = 0b1110*tagStep + 0b11
 
 	// PodIP index name for Pod cache.
 	podIPIndex = "podIP"
@@ -358,7 +360,7 @@ func (c *Controller) allocateTag(name string) (uint8, error) {
 			return 0, nil
 		}
 	}
-	for i := minTagNum; i <= maxTagNum; i++ {
+	for i := minTagNum; i <= maxTagNum; i += tagStep {
 		if _, ok := c.runningTraceflows[i]; !ok {
 			c.runningTraceflows[i] = name
 			return i, nil

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -62,6 +62,7 @@ const (
 	NxmFieldARPOp       = "NXM_OF_ARP_OP"
 	NxmFieldReg         = "NXM_NX_REG"
 	NxmFieldTunMetadata = "NXM_NX_TUN_METADATA"
+	NxmFieldIPToS       = "NXM_OF_IP_TOS"
 )
 
 const (

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/apis/ops/v1alpha1"
 )
 
@@ -44,8 +43,6 @@ func TestTraceflowIntraNode(t *testing.T) {
 		t.Fatalf("Error when setting up test: %v", err)
 	}
 	defer teardownTest(t, data)
-
-	skipIfEncapModeIs(t, data, []config.TrafficEncapModeType{config.TrafficEncapModeNoEncap, config.TrafficEncapModeNetworkPolicyOnly})
 
 	if err = data.enableTraceflow(t); err != nil {
 		t.Fatal("Error when enabling Traceflow")
@@ -325,7 +322,6 @@ func TestTraceflowIntraNode(t *testing.T) {
 
 // TestTraceflowInterNode verifies if traceflow can trace inter nodes traffic with some NetworkPolicies set.
 func TestTraceflowInterNode(t *testing.T) {
-	skipIfProviderIs(t, "kind", "Inter nodes test needs Geneve tunnel")
 	skipIfNumNodesLessThan(t, 2)
 
 	data, err := setupTest(t)

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -242,11 +242,7 @@ func testInitialize(t *testing.T, config *testConfig) {
 }
 
 func testInstallTunnelFlows(t *testing.T, config *testConfig) {
-	err := c.InitialTLVMap()
-	if err != nil {
-		t.Fatalf("Failed to install TLV Map: %v", err)
-	}
-	err = c.InstallDefaultTunnelFlows(config.tunnelOFPort)
+	err := c.InstallDefaultTunnelFlows(config.tunnelOFPort)
 	if err != nil {
 		t.Fatalf("Failed to install Openflow entries for tunnel port: %v", err)
 	}


### PR DESCRIPTION
This patch changes Traceflow dataplaneTag from tun_metadata0 to DSCP, and
removes the tunnel/encap mode restriction for inter-Node Traceflow.

This PR closes #1357