### PR TITLE
Check features not supported on Windows Nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ antctl-release:
 .linux-test-unit: .coverage
 	@echo
 	@echo "==> Running unit tests <=="
-	$(GO) test -race -coverprofile=.coverage/coverage-unit.txt -covermode=atomic -cover github.com/vmware-tanzu/antrea/pkg/...
+	$(GO) test -race -coverprofile=.coverage/coverage-unit.txt -covermode=atomic -cover github.com/vmware-tanzu/antrea/cmd/... github.com/vmware-tanzu/antrea/pkg/...
 
 .PHONY: tidy
 tidy:

--- a/cmd/antrea-agent/options_linux.go
+++ b/cmd/antrea-agent/options_linux.go
@@ -1,0 +1,22 @@
+// +build linux
+
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+func (o *Options) checkUnsupportedFeatures() error {
+	// All features are supported on a Linux Node.
+	return nil
+}

--- a/cmd/antrea-agent/options_windows.go
+++ b/cmd/antrea-agent/options_windows.go
@@ -1,0 +1,63 @@
+// +build windows
+
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/component-base/featuregate"
+	"k8s.io/klog"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/config"
+	"github.com/vmware-tanzu/antrea/pkg/features"
+	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
+)
+
+func (o *Options) checkUnsupportedFeatures() error {
+	var unsupported []string
+
+	// First check feature gates.
+	for f, enabled := range o.config.FeatureGates {
+		if enabled && !features.SupportedOnWindows(featuregate.Feature(f)) {
+			unsupported = append(unsupported, f)
+		}
+	}
+
+	if o.config.OVSDatapathType != ovsconfig.OVSDatapathSystem {
+		unsupported = append(unsupported, "OVSDatapathType: "+o.config.OVSDatapathType)
+	}
+	_, encapMode := config.GetTrafficEncapModeFromStr(o.config.TrafficEncapMode)
+	if encapMode != config.TrafficEncapModeEncap {
+		unsupported = append(unsupported, "TrafficEncapMode: "+encapMode.String())
+	}
+	if o.config.TunnelType == ovsconfig.GRETunnel {
+		unsupported = append(unsupported, "TunnelType: "+o.config.TunnelType)
+	}
+	if o.config.EnableIPSecTunnel {
+		unsupported = append(unsupported, "IPsecTunnel")
+	}
+
+	if unsupported != nil {
+		return fmt.Errorf("unsupported features on Windows: {%s}", strings.Join(unsupported, ", "))
+	}
+
+	if !features.DefaultFeatureGate.Enabled(features.AntreaProxy) {
+		klog.Warning("AntreaProxy is not enabled. NetworkPolicies might not be enforced correctly for Service traffic!")
+	}
+	return nil
+}

--- a/cmd/antrea-agent/options_windows_test.go
+++ b/cmd/antrea-agent/options_windows_test.go
@@ -1,0 +1,92 @@
+// +build windows
+
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/config"
+	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
+)
+
+func TestCheckUnsupportedFeatures(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		config AgentConfig
+		pass   bool
+	}{
+		{
+			"default",
+			AgentConfig{},
+			true,
+		},
+		{
+			"feature gates",
+			AgentConfig{
+				FeatureGates: map[string]bool{
+					"AntreaProxy":        false,
+					"AntreaPolicy":       true,
+					"Traceflow":          false,
+					"FlowExporter":       true,
+					"NetworkPolicyStats": true,
+				},
+			},
+			true,
+		},
+		{
+			"netdev datapath",
+			AgentConfig{OVSDatapathType: ovsconfig.OVSDatapathNetdev},
+			false,
+		},
+		{
+			"noEncap mode",
+			AgentConfig{TrafficEncapMode: config.TrafficEncapModeNoEncap.String()},
+			false,
+		},
+		{
+			"GRE tunnel",
+			AgentConfig{TunnelType: ovsconfig.GRETunnel},
+			false,
+		},
+		{
+			"IPsec tunnel",
+			AgentConfig{EnableIPSecTunnel: true},
+			false,
+		},
+		{
+			"hybrid mode and GRE tunnel",
+			AgentConfig{TrafficEncapMode: config.TrafficEncapModeHybrid.String(), TunnelType: ovsconfig.GRETunnel},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			o := &Options{config: &tc.config}
+			err := o.complete(nil)
+			assert.Nil(t, err, tc.desc)
+			err = o.checkUnsupportedFeatures()
+			if tc.pass {
+				assert.Nil(t, err)
+			} else {
+				assert.NotNil(t, err)
+			}
+		})
+	}
+}

--- a/pkg/features/antrea_features.go
+++ b/pkg/features/antrea_features.go
@@ -70,8 +70,30 @@ var (
 		FlowExporter:       {Default: false, PreRelease: featuregate.Alpha},
 		NetworkPolicyStats: {Default: false, PreRelease: featuregate.Alpha},
 	}
+
+	// UnsupportedFeaturesOnWindows records the features not supported on
+	// a Windows Node. Antrea Agent on a Windows Node checks the enabled
+	// features, and fails the startup if an unsupported feature is enabled.
+	// We do not define a separate defaultAntreaFeatureGates map for
+	// Windows, because Agent code assumes all features are registered (
+	// FeatureGate.Enabled(feature) will panic if the feature is not added
+	// to the FeatureGate).
+	// In future, if a feature is supported on both Linux and Windows, but
+	// can have different FeatureSpecs between Linux and Windows, we should
+	// still define a separate defaultAntreaFeatureGates map for Windows.
+	unsupportedFeaturesOnWindows = map[featuregate.Feature]struct{}{}
 )
 
 func init() {
 	runtime.Must(DefaultMutableFeatureGate.Add(defaultAntreaFeatureGates))
+}
+
+// SupportedOnWindows checks whether a feature is supported on a Windows Node.
+func SupportedOnWindows(feature featuregate.Feature) bool {
+	_, exists := defaultAntreaFeatureGates[feature]
+	if !exists {
+		return false
+	}
+	_, exists = unsupportedFeaturesOnWindows[feature]
+	return !exists
 }


### PR DESCRIPTION
During the agent config validation, checks if the enabled features are
supported on Windows, and if not fails the validation.