### PR TITLE
[CI] Fix TEST_FAILURE judgement

### DIFF
--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -356,12 +356,12 @@ function run_e2e {
     test_rc=$?
     set -e
 
-    if [ "$test_rc" == "1" ]
-    then
+    if [[ "$test_rc" != "0" ]]; then
         echo "=== TEST FAILURE !!! ==="
         TEST_FAILURE=true
+    else
+        echo "=== TEST SUCCESS !!! ==="
     fi
-    echo "=== TEST SUCCESS !!! ==="
 
     tar -zcf ${GIT_CHECKOUT_DIR}/antrea-test-logs.tar.gz ${GIT_CHECKOUT_DIR}/antrea-test-logs
 


### PR DESCRIPTION
* "TEST SUCCESS" should appear only when test succeeds
* test_rc can be other than 0 and 1. Such result should be considered as failure.