### PR TITLE
Fix golangci-lint CI and issues found by linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ fmt:
 
 .golangci-bin:
 	@echo "===> Installing Golangci-lint <==="
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $@ v1.21.0
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $@ v1.32.1
 
 .PHONY: golangci
 golangci: .golangci-bin

--- a/hack/netpol/Makefile
+++ b/hack/netpol/Makefile
@@ -23,7 +23,7 @@ push-release: build
 
 .golangci-bin:
 	@echo "===> Installing Golangci-lint <==="
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $@ v1.21.0
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $@ v1.32.1
 
 .PHONY: golangci
 golangci: .golangci-bin

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -146,7 +146,7 @@ func (i *Initializer) prepareOVSBridge() error {
 		return err
 	}
 	uplinkInterface := interfacestore.NewUplinkInterface(uplink)
-	uplinkInterface.OVSPortConfig = &interfacestore.OVSPortConfig{uplinkPortUUId, config.UplinkOFPort}
+	uplinkInterface.OVSPortConfig = &interfacestore.OVSPortConfig{uplinkPortUUId, config.UplinkOFPort} //nolint: govet
 	i.ifaceStore.AddInterface(uplinkInterface)
 	ovsCtlClient := ovsctl.NewClient(i.ovsBridge)
 

--- a/pkg/agent/apiserver/handlers/ovsflows/handler_test.go
+++ b/pkg/agent/apiserver/handlers/ovsflows/handler_test.go
@@ -94,7 +94,8 @@ func TestPodFlows(t *testing.T) {
 			expectedStatus: http.StatusNotFound,
 		},
 	}
-	for _, tc := range testcases {
+	for i := range testcases {
+		tc := testcases[i]
 		i := interfacestoretest.NewMockInterfaceStore(ctrl)
 		q := aqtest.NewMockAgentQuerier(ctrl)
 		q.EXPECT().GetInterfaceStore().Return(i).Times(1)
@@ -139,7 +140,8 @@ func TestNetworkPolicyFlows(t *testing.T) {
 			expectedStatus: http.StatusNotFound,
 		},
 	}
-	for _, tc := range testcases {
+	for i := range testcases {
+		tc := testcases[i]
 		npq := queriertest.NewMockAgentNetworkPolicyInfoQuerier(ctrl)
 		q := aqtest.NewMockAgentQuerier(ctrl)
 		q.EXPECT().GetNetworkPolicyInfoQuerier().Return(npq).Times(1)
@@ -179,7 +181,8 @@ func TestTableFlows(t *testing.T) {
 			expectedStatus: http.StatusOK,
 		},
 	}
-	for _, tc := range testcases {
+	for i := range testcases {
+		tc := testcases[i]
 		ovsctl := ovsctltest.NewMockOVSCtlClient(ctrl)
 		q := aqtest.NewMockAgentQuerier(ctrl)
 		q.EXPECT().GetOVSCtlClient().Return(ovsctl).Times(1)

--- a/pkg/agent/apiserver/handlers/ovstracing/handler_test.go
+++ b/pkg/agent/apiserver/handlers/ovstracing/handler_test.go
@@ -175,7 +175,8 @@ func TestPodFlows(t *testing.T) {
 			expectedStatus: http.StatusOK,
 		},
 	}
-	for _, tc := range testcases {
+	for i := range testcases {
+		tc := testcases[i]
 		q := aqtest.NewMockAgentQuerier(ctrl)
 		i := interfacestoretest.NewMockInterfaceStore(ctrl)
 		ofc := oftest.NewMockClient(ctrl)

--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -56,7 +56,7 @@ const (
 )
 
 const (
-	defaultOVSInterfaceType int = iota
+	defaultOVSInterfaceType int = iota //nolint suppress deadcode check for windows
 	internalOVSInterfaceType
 )
 

--- a/pkg/agent/controller/networkpolicy/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/reconciler.go
@@ -818,7 +818,8 @@ func ipBlocksToOFAddresses(ipBlocks []v1beta2.IPBlock) []types.Address {
 	addresses := make([]types.Address, 0)
 	for _, b := range ipBlocks {
 		exceptIPNet := make([]*net.IPNet, 0, len(b.Except))
-		for _, c := range b.Except {
+		for i := range b.Except {
+			c := b.Except[i]
 			exceptIPNet = append(exceptIPNet, ip.IPNetToNetIPNet(&c))
 		}
 		diffCIDRs, err := ip.DiffFromCIDRs(ip.IPNetToNetIPNet(&b.CIDR), exceptIPNet)

--- a/pkg/agent/flowexporter/connections/conntrack_linux.go
+++ b/pkg/agent/flowexporter/connections/conntrack_linux.go
@@ -99,7 +99,8 @@ func (nfct *netFilterConnTrack) DumpFlowsInCtZone(zoneFilter uint16) ([]*flowexp
 		return nil, err
 	}
 	antreaConns := make([]*flowexporter.Connection, len(conns))
-	for i, conn := range conns {
+	for i := range conns {
+		conn := conns[i]
 		antreaConns[i] = netlinkFlowToAntreaConnection(&conn)
 	}
 

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -708,6 +708,7 @@ func (c *client) SendTraceflowPacket(
 	case 6:
 		packetOutBuilder = packetOutBuilder.SetIPProtocol(binding.ProtocolTCP)
 		if TCPSrcPort == 0 {
+			// #nosec G404: random number generator not used for security purposes
 			TCPSrcPort = uint16(rand.Uint32())
 		}
 		packetOutBuilder = packetOutBuilder.SetTCPSrcPort(TCPSrcPort)

--- a/pkg/agent/openflow/cookie/allocator_test.go
+++ b/pkg/agent/openflow/cookie/allocator_test.go
@@ -38,6 +38,7 @@ func TestConcurrentAllocate(t *testing.T) {
 	concurrentNum := 8
 
 	rand.Seed(time.Now().UnixNano())
+	// #nosec G404: random number generator not used for security purposes
 	round := rand.Uint64() >> (64 - BitwidthRound)
 	a := NewAllocator(round)
 

--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -560,6 +560,7 @@ func parseAddresses(addrs []string) []types.Address {
 	var addresses = make([]types.Address, 0)
 	for _, addr := range addrs {
 		if !strings.Contains(addr, ".") {
+			// #nosec G109: parseAddresses is only called on constant test inputs, no potential integer overflow
 			ofPort, _ := strconv.Atoi(addr)
 			addresses = append(addresses, NewOFPortAddress(int32(ofPort)))
 		} else if strings.Contains(addr, "/") {

--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -293,7 +293,8 @@ func (c *Client) Reconcile(podCIDRs []string) error {
 	if err != nil {
 		return fmt.Errorf("error listing ip routes: %v", err)
 	}
-	for _, route := range routes {
+	for i := range routes {
+		route := routes[i]
 		if reflect.DeepEqual(route.Dst, c.nodeConfig.PodCIDR) {
 			continue
 		}
@@ -392,7 +393,8 @@ func (c *Client) MigrateRoutesToGw(linkName string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get routes for link %s: %w", linkName, err)
 	}
-	for _, route := range routes {
+	for i := range routes {
+		route := routes[i]
 		route.LinkIndex = gwLink.Attrs().Index
 		if err = netlink.RouteReplace(&route); err != nil {
 			return fmt.Errorf("failed to add route %v to link %s: %w", &route, gwLink.Attrs().Name, err)
@@ -404,7 +406,8 @@ func (c *Client) MigrateRoutesToGw(linkName string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get addresses for %s: %w", linkName, err)
 	}
-	for _, addr := range addrs {
+	for i := range addrs {
+		addr := addrs[i]
 		if err = netlink.AddrDel(link, &addr); err != nil {
 			klog.Errorf("failed to delete addr %v from %s: %v", addr, link, err)
 		}
@@ -431,7 +434,8 @@ func (c *Client) UnMigrateRoutesFromGw(route *net.IPNet, linkName string) error 
 	if err != nil {
 		return fmt.Errorf("failed to get routes for link %s: %w", gwLink.Attrs().Name, err)
 	}
-	for _, rt := range routes {
+	for i := range routes {
+		rt := routes[i]
 		if route.String() == rt.Dst.String() {
 			if link != nil {
 				rt.LinkIndex = link.Attrs().Index

--- a/pkg/agent/route/route_windows_test.go
+++ b/pkg/agent/route/route_windows_test.go
@@ -77,13 +77,14 @@ func TestRouteOperation(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(routes2))
 
-	err = client.Reconcile([]string{dest2}, []string{peerNodeIP2.String()})
+	err = client.Reconcile([]string{dest2})
 	require.Nil(t, err)
 	routes3, err := nr.GetNetRoutes(gwLink, destCIDR1)
 	require.Nil(t, err)
 	assert.Equal(t, 0, len(routes3))
 
 	err = client.DeleteRoutes(destCIDR2)
+	require.Nil(t, err)
 	routes4, err := nr.GetNetRoutes(gwLink, destCIDR2)
 	require.Nil(t, err)
 	assert.Equal(t, 0, len(routes4))

--- a/pkg/agent/util/iptables/iptables.go
+++ b/pkg/agent/util/iptables/iptables.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 // Copyright 2020 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/agent/util/iptables/lock.go
+++ b/pkg/agent/util/iptables/lock.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 // Copyright 2020 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/agent/util/iptables/lock_test.go
+++ b/pkg/agent/util/iptables/lock_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 // Copyright 2020 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/agent/util/net_windows.go
+++ b/pkg/agent/util/net_windows.go
@@ -244,7 +244,7 @@ func ConfigureLinkAddress(idx int, gwIPNet *net.IPNet) error {
 
 	klog.V(2).Infof("Adding address %v to gateway interface %s", gwIP, name)
 	if err := ConfigureInterfaceAddress(iface.Name, gwIPNet); err != nil {
-		klog.Errorf("Failed to set gateway interface %s with address %v: %v", iface, gwIP, err)
+		klog.Errorf("Failed to set gateway interface %v with address %v: %v", iface, gwIP, err)
 		return err
 	}
 	return nil

--- a/pkg/agent/util/net_windows_test.go
+++ b/pkg/agent/util/net_windows_test.go
@@ -46,7 +46,9 @@ func TestCreateHNSNetwork(t *testing.T) {
 	_, subnet, _ := net.ParseCIDR("172.16.1.0/24")
 	nodeIP, err := getAdapterIPv4Addr("Ethernet0")
 	require.Nil(t, err)
-	hnsNet, err = CreateHNSNetwork(testNet, subnet, nodeIP)
+	adapter, err := net.InterfaceByName("Ethernet0")
+	require.Nil(t, err)
+	hnsNet, err = CreateHNSNetwork(testNet, subnet, nodeIP, adapter)
 	require.Nil(t, err, "No error expected when creating HNSNetwork")
 	defer hnsNet.Delete()
 

--- a/pkg/agent/util/sysctl/sysctl_linux.go
+++ b/pkg/agent/util/sysctl/sysctl_linux.go
@@ -44,6 +44,7 @@ func GetSysctlNet(sysctl string) (int, error) {
 
 // SetSysctlNet sets the specified sysctl net.* parameter to the new value.
 func SetSysctlNet(sysctl string, newVal int) error {
+	// #nosec G306: provided permissions match /proc/sys file permissions
 	return ioutil.WriteFile(path.Join(sysctlNet, sysctl), []byte(strconv.Itoa(newVal)), 0640)
 }
 

--- a/pkg/agent/util/winfirewall/winfirewall.go
+++ b/pkg/agent/util/winfirewall/winfirewall.go
@@ -44,8 +44,8 @@ type fwRuleProtocol string
 
 const (
 	fwRuleIPProtocol  fwRuleProtocol = "Any"
-	fwRuleTCPProtocol fwRuleProtocol = "TCP"
-	fwRuleUDPProtocol fwRuleProtocol = "UDP"
+	fwRuleTCPProtocol fwRuleProtocol = "TCP" //nolint: deadcode
+	fwRuleUDPProtocol fwRuleProtocol = "UDP" //nolint: deadcode
 )
 
 const (

--- a/pkg/agent/util/winfirewall/winfirewall_test.go
+++ b/pkg/agent/util/winfirewall/winfirewall_test.go
@@ -44,6 +44,7 @@ func TestWinFirewallRules(t *testing.T) {
 	err := client.AddRuleAllowIP(inRule, FWRuleIn, podCIDR)
 	require.Nil(t, err)
 	err = client.AddRuleAllowIP(outRule, FWRuleOut, podCIDR)
+	require.Nil(t, err)
 	checkExistence(expectedRules, true)
 
 	err = client.DelFirewallRuleByName(inRule)

--- a/pkg/antctl/raw/proxy/command.go
+++ b/pkg/antctl/raw/proxy/command.go
@@ -174,7 +174,8 @@ func createAgentClientCfg(k8sClientset kubernetes.Interface, antreaClientset ant
 		return nil, err
 	}
 	var agentInfo *clusterinformationv1beta1.AntreaAgentInfo
-	for _, ai := range agentInfoList.Items {
+	for i := range agentInfoList.Items {
+		ai := agentInfoList.Items[i]
 		if ai.NodeRef.Name == nodeName {
 			agentInfo = &ai
 			break

--- a/pkg/antctl/raw/supportbundle/command.go
+++ b/pkg/antctl/raw/supportbundle/command.go
@@ -317,7 +317,8 @@ func createAgentClients(k8sClientset kubernetes.Interface, antreaClientset antre
 			return hit
 		}
 	}
-	for _, node := range nodeList.Items {
+	for i := range nodeList.Items {
+		node := nodeList.Items[i]
 		if !matcher(node.Name) {
 			continue
 		}

--- a/pkg/antctl/transform/addressgroup/transform.go
+++ b/pkg/antctl/transform/addressgroup/transform.go
@@ -31,7 +31,8 @@ type Response struct {
 func listTransform(l interface{}) (interface{}, error) {
 	groups := l.(*cpv1beta.AddressGroupList)
 	result := []interface{}{}
-	for _, item := range groups.Items {
+	for i := range groups.Items {
+		item := groups.Items[i]
 		o, _ := objectTransform(&item)
 		result = append(result, o.(Response))
 	}

--- a/pkg/antctl/transform/appliedtogroup/transform.go
+++ b/pkg/antctl/transform/appliedtogroup/transform.go
@@ -31,7 +31,8 @@ type Response struct {
 func listTransform(l interface{}) (interface{}, error) {
 	groups := l.(*cpv1beta.AppliedToGroupList)
 	result := []Response{}
-	for _, group := range groups.Items {
+	for i := range groups.Items {
+		group := groups.Items[i]
 		o, _ := objectTransform(&group)
 		result = append(result, o.(Response))
 	}

--- a/pkg/apis/controlplane/v1beta1/conversion.go
+++ b/pkg/apis/controlplane/v1beta1/conversion.go
@@ -148,12 +148,14 @@ func Convert_controlplane_GroupMember_To_v1beta1_GroupMemberPod(in *controlplane
 func Convert_v1beta1_AddressGroup_To_controlplane_AddressGroup(in *AddressGroup, out *controlplane.AddressGroup, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
 	var groupMembers []controlplane.GroupMember
-	for _, p := range in.Pods {
+	for i := range in.Pods {
+		p := in.Pods[i]
 		var podMember controlplane.GroupMember
 		Convert_v1beta1_GroupMemberPod_To_controlplane_GroupMember(&p, &podMember, nil)
 		groupMembers = append(groupMembers, podMember)
 	}
-	for _, m := range in.GroupMembers {
+	for i := range in.GroupMembers {
+		m := in.GroupMembers[i]
 		var member controlplane.GroupMember
 		Convert_v1beta1_GroupMember_To_controlplane_GroupMember(&m, &member, nil)
 		groupMembers = append(groupMembers, member)
@@ -166,7 +168,8 @@ func Convert_controlplane_AddressGroup_To_v1beta1_AddressGroup(in *controlplane.
 	out.ObjectMeta = in.ObjectMeta
 	var groupMembers []GroupMember
 	var pods []GroupMemberPod
-	for _, m := range in.GroupMembers {
+	for i := range in.GroupMembers {
+		m := in.GroupMembers[i]
 		if m.Pod != nil {
 			var pod GroupMemberPod
 			if err := Convert_controlplane_GroupMember_To_v1beta1_GroupMemberPod(&m, &pod, nil); err != nil {
@@ -187,22 +190,26 @@ func Convert_controlplane_AddressGroup_To_v1beta1_AddressGroup(in *controlplane.
 func Convert_v1beta1_AddressGroupPatch_To_controlplane_AddressGroupPatch(in *AddressGroupPatch, out *controlplane.AddressGroupPatch, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
 	var addedMembers, removedMembers []controlplane.GroupMember
-	for _, p := range in.AddedPods {
+	for i := range in.AddedPods {
+		p := in.AddedPods[i]
 		var podMember controlplane.GroupMember
 		Convert_v1beta1_GroupMemberPod_To_controlplane_GroupMember(&p, &podMember, nil)
 		addedMembers = append(addedMembers, podMember)
 	}
-	for _, p := range in.RemovedPods {
+	for i := range in.RemovedPods {
+		p := in.RemovedPods[i]
 		var podMember controlplane.GroupMember
 		Convert_v1beta1_GroupMemberPod_To_controlplane_GroupMember(&p, &podMember, nil)
 		removedMembers = append(removedMembers, podMember)
 	}
-	for _, m := range in.AddedGroupMembers {
+	for i := range in.AddedGroupMembers {
+		m := in.AddedGroupMembers[i]
 		var member controlplane.GroupMember
 		Convert_v1beta1_GroupMember_To_controlplane_GroupMember(&m, &member, nil)
 		addedMembers = append(addedMembers, member)
 	}
-	for _, m := range in.RemovedGroupMembers {
+	for i := range in.RemovedGroupMembers {
+		m := in.RemovedGroupMembers[i]
 		var member controlplane.GroupMember
 		Convert_v1beta1_GroupMember_To_controlplane_GroupMember(&m, &member, nil)
 		removedMembers = append(removedMembers, member)
@@ -216,7 +223,8 @@ func Convert_controlplane_AddressGroupPatch_To_v1beta1_AddressGroupPatch(in *con
 	out.ObjectMeta = in.ObjectMeta
 	var addedPods, removedPods []GroupMemberPod
 	var addedMembers, removedMembers []GroupMember
-	for _, m := range in.AddedGroupMembers {
+	for i := range in.AddedGroupMembers {
+		m := in.AddedGroupMembers[i]
 		if m.Pod != nil {
 			var pod GroupMemberPod
 			if err := Convert_controlplane_GroupMember_To_v1beta1_GroupMemberPod(&m, &pod, nil); err != nil {
@@ -229,7 +237,8 @@ func Convert_controlplane_AddressGroupPatch_To_v1beta1_AddressGroupPatch(in *con
 			addedMembers = append(addedMembers, ee)
 		}
 	}
-	for _, m := range in.RemovedGroupMembers {
+	for i := range in.RemovedGroupMembers {
+		m := in.RemovedGroupMembers[i]
 		if m.Pod != nil {
 			var pod GroupMemberPod
 			if err := Convert_controlplane_GroupMember_To_v1beta1_GroupMemberPod(&m, &pod, nil); err != nil {
@@ -252,12 +261,14 @@ func Convert_controlplane_AddressGroupPatch_To_v1beta1_AddressGroupPatch(in *con
 func Convert_v1beta1_AppliedToGroup_To_controlplane_AppliedToGroup(in *AppliedToGroup, out *controlplane.AppliedToGroup, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
 	var groupMembers []controlplane.GroupMember
-	for _, p := range in.Pods {
+	for i := range in.Pods {
+		p := in.Pods[i]
 		var podMember controlplane.GroupMember
 		Convert_v1beta1_GroupMemberPod_To_controlplane_GroupMember(&p, &podMember, nil)
 		groupMembers = append(groupMembers, podMember)
 	}
-	for _, m := range in.GroupMembers {
+	for i := range in.GroupMembers {
+		m := in.GroupMembers[i]
 		var member controlplane.GroupMember
 		Convert_v1beta1_GroupMember_To_controlplane_GroupMember(&m, &member, nil)
 		groupMembers = append(groupMembers, member)
@@ -270,7 +281,8 @@ func Convert_controlplane_AppliedToGroup_To_v1beta1_AppliedToGroup(in *controlpl
 	out.ObjectMeta = in.ObjectMeta
 	var groupMembers []GroupMember
 	var pods []GroupMemberPod
-	for _, m := range in.GroupMembers {
+	for i := range in.GroupMembers {
+		m := in.GroupMembers[i]
 		if m.Pod != nil {
 			var pod GroupMemberPod
 			if err := Convert_controlplane_GroupMember_To_v1beta1_GroupMemberPod(&m, &pod, nil); err != nil {
@@ -292,22 +304,26 @@ func Convert_v1beta1_AppliedToGroupPatch_To_controlplane_AppliedToGroupPatch(in 
 	out.ObjectMeta = in.ObjectMeta
 	var addedMembers []controlplane.GroupMember
 	var removedMembers []controlplane.GroupMember
-	for _, p := range in.AddedPods {
+	for i := range in.AddedPods {
+		p := in.AddedPods[i]
 		var podMember controlplane.GroupMember
 		Convert_v1beta1_GroupMemberPod_To_controlplane_GroupMember(&p, &podMember, nil)
 		addedMembers = append(addedMembers, podMember)
 	}
-	for _, p := range in.RemovedPods {
+	for i := range in.RemovedPods {
+		p := in.RemovedPods[i]
 		var podMember controlplane.GroupMember
 		Convert_v1beta1_GroupMemberPod_To_controlplane_GroupMember(&p, &podMember, nil)
 		removedMembers = append(removedMembers, podMember)
 	}
-	for _, m := range in.AddedGroupMembers {
+	for i := range in.AddedGroupMembers {
+		m := in.AddedGroupMembers[i]
 		var member controlplane.GroupMember
 		Convert_v1beta1_GroupMember_To_controlplane_GroupMember(&m, &member, nil)
 		addedMembers = append(addedMembers, member)
 	}
-	for _, m := range in.RemovedGroupMembers {
+	for i := range in.RemovedGroupMembers {
+		m := in.RemovedGroupMembers[i]
 		var member controlplane.GroupMember
 		Convert_v1beta1_GroupMember_To_controlplane_GroupMember(&m, &member, nil)
 		removedMembers = append(removedMembers, member)
@@ -321,7 +337,8 @@ func Convert_controlplane_AppliedToGroupPatch_To_v1beta1_AppliedToGroupPatch(in 
 	out.ObjectMeta = in.ObjectMeta
 	var addedPods, removedPods []GroupMemberPod
 	var addedMembers, removedMembers []GroupMember
-	for _, m := range in.AddedGroupMembers {
+	for i := range in.AddedGroupMembers {
+		m := in.AddedGroupMembers[i]
 		if m.Pod != nil {
 			var pod GroupMemberPod
 			if err := Convert_controlplane_GroupMember_To_v1beta1_GroupMemberPod(&m, &pod, nil); err != nil {
@@ -334,7 +351,8 @@ func Convert_controlplane_AppliedToGroupPatch_To_v1beta1_AppliedToGroupPatch(in 
 			addedMembers = append(addedMembers, ee)
 		}
 	}
-	for _, m := range in.RemovedGroupMembers {
+	for i := range in.RemovedGroupMembers {
+		m := in.RemovedGroupMembers[i]
 		if m.Pod != nil {
 			var pod GroupMemberPod
 			if err := Convert_controlplane_GroupMember_To_v1beta1_GroupMemberPod(&m, &pod, nil); err != nil {

--- a/pkg/apiserver/registry/networkpolicy/addressgroup/rest_test.go
+++ b/pkg/apiserver/registry/networkpolicy/addressgroup/rest_test.go
@@ -19,12 +19,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane"
 	"github.com/vmware-tanzu/antrea/pkg/controller/networkpolicy/store"
 	"github.com/vmware-tanzu/antrea/pkg/controller/types"
 )

--- a/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest_test.go
+++ b/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest_test.go
@@ -19,12 +19,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane"
 	"github.com/vmware-tanzu/antrea/pkg/controller/networkpolicy/store"
 	"github.com/vmware-tanzu/antrea/pkg/controller/types"
 )

--- a/pkg/apiserver/registry/networkpolicy/networkpolicy/rest_test.go
+++ b/pkg/apiserver/registry/networkpolicy/networkpolicy/rest_test.go
@@ -19,12 +19,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane"
 	"github.com/vmware-tanzu/antrea/pkg/controller/networkpolicy/store"
 	"github.com/vmware-tanzu/antrea/pkg/controller/types"
 )

--- a/pkg/graphviz/traceflow.go
+++ b/pkg/graphviz/traceflow.go
@@ -138,7 +138,8 @@ func getWrappedStr(str string) string {
 }
 
 func getNodeResult(tf *opsv1alpha1.Traceflow, fn func(result *opsv1alpha1.NodeResult) bool) *opsv1alpha1.NodeResult {
-	for _, result := range tf.Status.Results {
+	for i := range tf.Status.Results {
+		result := tf.Status.Results[i]
 		if fn(&result) {
 			return &result
 		}
@@ -271,7 +272,8 @@ func genSubGraph(graph *gographviz.Graph, cluster *gographviz.SubGraph, result *
 	}
 
 	// Draw the actual observations of traceflow.
-	for _, o := range obs {
+	for i := range obs {
+		o := obs[i]
 		// Construct node and edge.
 		nodeName := fmt.Sprintf("%s_%d", cluster.Name, len(nodes))
 		node, err := createNodeWithDefaultStyle(graph, cluster.Name, nodeName)

--- a/pkg/ovs/openflow/ofctrl_packetout.go
+++ b/pkg/ovs/openflow/ofctrl_packetout.go
@@ -205,7 +205,9 @@ func (b *ofPacketOutBuilder) Done() *ofctrl.PacketOut {
 		b.pktOut.IPHeader.Length = 20 + b.pktOut.ICMPHeader.Len()
 	} else if b.pktOut.TCPHeader != nil {
 		b.pktOut.TCPHeader.HdrLen = 5
+		// #nosec G404: random number generator not used for security purposes
 		b.pktOut.TCPHeader.SeqNum = rand.Uint32()
+		// #nosec G404: random number generator not used for security purposes
 		b.pktOut.TCPHeader.AckNum = rand.Uint32()
 		b.pktOut.TCPHeader.Checksum = b.tcpHeaderChecksum()
 		b.pktOut.IPHeader.Length = 20 + b.pktOut.TCPHeader.Len()
@@ -214,6 +216,7 @@ func (b *ofPacketOutBuilder) Done() *ofctrl.PacketOut {
 		b.pktOut.UDPHeader.Checksum = b.udpHeaderChecksum()
 		b.pktOut.IPHeader.Length = 20 + b.pktOut.UDPHeader.Len()
 	}
+	// #nosec G404: random number generator not used for security purposes
 	b.pktOut.IPHeader.Id = uint16(rand.Uint32())
 	// Set IP version in the IP Header.
 	if b.pktOut.IPHeader.NWSrc.To4() != nil {

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -45,8 +45,8 @@ const (
 	// provide enough time for policies to be enforced & deleted by the CNI plugin.
 	networkPolicyDelay = 2 * time.Second
 	// audit log directory on Antrea Agent
-	logDir             = "/var/log/antrea/networkpolicy/"
-	logfileName        = "np.log"
+	logDir      = "/var/log/antrea/networkpolicy/"
+	logfileName = "np.log"
 )
 
 func failOnError(err error, t *testing.T) {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -999,6 +999,7 @@ var lettersAndDigits = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
 func randSeq(n int) string {
 	b := make([]rune, n)
 	for i := range b {
+		// #nosec G404: random number generator not used for security purposes
 		randIdx := rand.Intn(len(lettersAndDigits))
 		b[i] = lettersAndDigits[randIdx]
 	}

--- a/test/integration/agent/flowexporter_test.go
+++ b/test/integration/agent/flowexporter_test.go
@@ -1,3 +1,19 @@
+// +build !windows
+
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package agent
 
 import (


### PR DESCRIPTION
1. Golangci linters do not work after we upgrade golang to 1.15,
this patch upgrades golangci-lint version to fix the issue.

2. Fix gosec issues, change code by declaring a
separate varialbe inside loop to fix issue G601: Implicit memory aliasing in for loop,
for other gosec issues, use annotations to skip them.

3. Fix multiple windows golangci-lint issues including test code paramerters mismatch,
conditional compilation issues, temporarily get rid of flow exporter integration test
for windows and other minor fixes for windows.

4. Fix gofmt issues.