### PR TITLE
Remove peer IP check in NOTRACK rules

### DIFF
--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -1006,7 +1006,7 @@ func (c *client) conjunctionActionFlow(conjunctionID uint32, tableID binding.Tab
 			MatchConjID(conjunctionID).
 			MatchPriority(ofPriority).
 			Action().LoadRegRange(int(conjReg), conjunctionID, binding.Range{0, 31}). // Traceflow.
-			Action().CT(true, nextTable, CtZone). // CT action requires commit flag if actions other than NAT without arguments are specified.
+			Action().CT(true, nextTable, CtZone).                                     // CT action requires commit flag if actions other than NAT without arguments are specified.
 			LoadToLabelRange(uint64(conjunctionID), &labelRange).
 			CTDone().
 			Cookie(c.cookieAllocator.Request(cookie.Policy).Raw()).

--- a/pkg/agent/route/interfaces.go
+++ b/pkg/agent/route/interfaces.go
@@ -26,8 +26,8 @@ type Interface interface {
 	// It should be idempotent and can be safely called on every startup.
 	Initialize(nodeConfig *config.NodeConfig) error
 
-	// Reconcile should remove orphaned routes and related configuration based on the desired podCIDRs and remoteNodeIPs.
-	Reconcile(podCIDRs []string, remoteNodeIPs []string) error
+	// Reconcile should remove orphaned routes and related configuration based on the desired podCIDRs.
+	Reconcile(podCIDRs []string) error
 
 	// AddRoutes should add routes to the provided podCIDR.
 	// It should override the routes if they already exist, without error.
@@ -35,7 +35,7 @@ type Interface interface {
 
 	// DeleteRoutes should delete routes to the provided podCIDR.
 	// It should do nothing if the routes don't exist, without error.
-	DeleteRoutes(podCIDR *net.IPNet, peerNodeIP net.IP) error
+	DeleteRoutes(podCIDR *net.IPNet) error
 
 	// MigrateRoutesToGw should move routes from device linkname to local gateway.
 	MigrateRoutesToGw(linkName string) error

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -75,7 +75,7 @@ func (c *Client) Initialize(nodeConfig *config.NodeConfig) error {
 
 // Reconcile removes the orphaned routes and related configuration based on the desired podCIDRs. Only the route
 // entries on the host gateway interface are stored in the cache.
-func (c *Client) Reconcile(podCIDRs []string, remoteNodeIPs []string) error {
+func (c *Client) Reconcile(podCIDRs []string) error {
 	desiredPodCIDRs := sets.NewString(podCIDRs...)
 	routes, err := c.listRoutes()
 	if err != nil {
@@ -124,7 +124,7 @@ func (c *Client) AddRoutes(podCIDR *net.IPNet, peerNodeIP, peerGwIP net.IP) erro
 
 // DeleteRoutes deletes routes to the provided podCIDR.
 // It does nothing if the routes don't exist, without error.
-func (c *Client) DeleteRoutes(podCIDR *net.IPNet, peerNodeIP net.IP) error {
+func (c *Client) DeleteRoutes(podCIDR *net.IPNet) error {
 	obj, found := c.hostRoutes.Load(podCIDR.String())
 	if !found {
 		klog.V(2).Infof("Route with destination %s not exists", podCIDR.String())

--- a/pkg/agent/route/route_windows_test.go
+++ b/pkg/agent/route/route_windows_test.go
@@ -83,7 +83,7 @@ func TestRouteOperation(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, 0, len(routes3))
 
-	err = client.DeleteRoutes(destCIDR2, peerNodeIP2)
+	err = client.DeleteRoutes(destCIDR2)
 	routes4, err := nr.GetNetRoutes(gwLink, destCIDR2)
 	require.Nil(t, err)
 	assert.Equal(t, 0, len(routes4))

--- a/pkg/agent/route/testing/mock_route.go
+++ b/pkg/agent/route/testing/mock_route.go
@@ -64,17 +64,17 @@ func (mr *MockInterfaceMockRecorder) AddRoutes(arg0, arg1, arg2 interface{}) *go
 }
 
 // DeleteRoutes mocks base method
-func (m *MockInterface) DeleteRoutes(arg0 *net.IPNet, arg1 net.IP) error {
+func (m *MockInterface) DeleteRoutes(arg0 *net.IPNet) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteRoutes", arg0, arg1)
+	ret := m.ctrl.Call(m, "DeleteRoutes", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteRoutes indicates an expected call of DeleteRoutes
-func (mr *MockInterfaceMockRecorder) DeleteRoutes(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) DeleteRoutes(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRoutes", reflect.TypeOf((*MockInterface)(nil).DeleteRoutes), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRoutes", reflect.TypeOf((*MockInterface)(nil).DeleteRoutes), arg0)
 }
 
 // Initialize mocks base method
@@ -106,17 +106,17 @@ func (mr *MockInterfaceMockRecorder) MigrateRoutesToGw(arg0 interface{}) *gomock
 }
 
 // Reconcile mocks base method
-func (m *MockInterface) Reconcile(arg0, arg1 []string) error {
+func (m *MockInterface) Reconcile(arg0 []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Reconcile", arg0, arg1)
+	ret := m.ctrl.Call(m, "Reconcile", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Reconcile indicates an expected call of Reconcile
-func (mr *MockInterfaceMockRecorder) Reconcile(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) Reconcile(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockInterface)(nil).Reconcile), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockInterface)(nil).Reconcile), arg0)
 }
 
 // UnMigrateRoutesFromGw mocks base method

--- a/pkg/antctl/command_list.go
+++ b/pkg/antctl/command_list.go
@@ -49,7 +49,7 @@ func (cl *commandList) ApplyToRootCommand(root *cobra.Command) {
 	for _, groupCommand := range groupCommands {
 		root.AddCommand(groupCommand)
 	}
-	for i, _ := range cl.definitions {
+	for i := range cl.definitions {
 		def := &cl.definitions[i]
 		if (runtime.Mode == runtime.ModeAgent && def.agentEndpoint == nil) ||
 			(runtime.Mode == runtime.ModeController && def.controllerEndpoint == nil) {


### PR DESCRIPTION
For a IPv6 cluster, the ipset of Node IPs needs to be inet6, this may introduce a few more code to maintain the NOTRACK rules. This patch removes the peer IP check to make the rule simpler and applicable to both IPv4 and IPv6.

-----------
@lzhecheng reported that the ipv6 branch would crash after rebasing on master:
```
ip6tables-restore v1.8.4 (legacy): The protocol family of set ANTREA-NODE-IP is IPv4, which is not applicable.
```
One fix is to add IPv6 family ipset if Node IP's IPv6, but I guess it would make it further from @jianjuns's expectation, so this patch removes the peer IP check to simplify it, assuming the tunnel UDP port in use won't be used for other purposes.