### PR TITLE
Fix issues in E2E test for audit logging feature

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -726,22 +726,6 @@ func (data *TestData) podWaitForIP(timeout time.Duration, name, namespace string
 	return pod.Status.PodIP, nil
 }
 
-// podWaitForNode polls the K8s apiserver until the specified Pod is in the "running" state (or until
-// the provided timeout expires). The function then returns the node which the Pod is scheduled on.
-func (data *TestData) podWaitForNode(timeout time.Duration, name, namespace string) (string, error) {
-	pod, err := data.podWaitFor(timeout, name, namespace, func(pod *corev1.Pod) (bool, error) {
-		return pod.Status.Phase == corev1.PodRunning, nil
-	})
-	if err != nil {
-		return "", err
-	}
-	// If not specified at creation, nodeName in spec will be filled by the K8s scheduler.
-	if pod.Spec.NodeName == "" {
-		return "", fmt.Errorf("pod is running but not scheduled on any node, which should never happen")
-	}
-	return pod.Spec.NodeName, nil
-}
-
 // deleteAntreaAgentOnNode deletes the antrea-agent Pod on a specific Node and measure how long it
 // takes for the Pod not to be visible to the client any more. It also waits for a new antrea-agent
 // Pod to be running on the Node.

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -726,6 +726,22 @@ func (data *TestData) podWaitForIP(timeout time.Duration, name, namespace string
 	return pod.Status.PodIP, nil
 }
 
+// podWaitForNode polls the K8s apiserver until the specified Pod is in the "running" state (or until
+// the provided timeout expires). The function then returns the node which the Pod is scheduled on.
+func (data *TestData) podWaitForNode(timeout time.Duration, name, namespace string) (string, error) {
+	pod, err := data.podWaitFor(timeout, name, namespace, func(pod *corev1.Pod) (bool, error) {
+		return pod.Status.Phase == corev1.PodRunning, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	// If not specified at creation, nodeName in spec will be filled by the K8s scheduler.
+	if pod.Spec.NodeName == "" {
+		return "", fmt.Errorf("pod is running but not scheduled on any node, which should never happen")
+	}
+	return pod.Spec.NodeName, nil
+}
+
 // deleteAntreaAgentOnNode deletes the antrea-agent Pod on a specific Node and measure how long it
 // takes for the Pod not to be visible to the client any more. It also waits for a new antrea-agent
 // Pod to be running on the Node.

--- a/test/e2e/utils/anpspecbuilder.go
+++ b/test/e2e/utils/anpspecbuilder.go
@@ -186,3 +186,11 @@ func (b *AntreaNetworkPolicySpecBuilder) AddEgress(protoc v1.Protocol,
 	})
 	return b
 }
+
+func (b *AntreaNetworkPolicySpecBuilder) AddEgressLogging() *AntreaNetworkPolicySpecBuilder {
+	for i, e := range b.Spec.Egress {
+		e.EnableLogging = true
+		b.Spec.Egress[i] = e
+	}
+	return b
+}

--- a/test/e2e/utils/cnpspecbuilder.go
+++ b/test/e2e/utils/cnpspecbuilder.go
@@ -211,15 +211,17 @@ func (b *ClusterNetworkPolicySpecBuilder) WithEgressDNS() *ClusterNetworkPolicyS
 		Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 53},
 	}
 
-	for _, e := range b.Spec.Egress {
+	for i, e := range b.Spec.Egress {
 		e.Ports = append(e.Ports, route53)
+		b.Spec.Egress[i] = e
 	}
 	return b
 }
 
 func (b *ClusterNetworkPolicySpecBuilder) AddEgressLogging() *ClusterNetworkPolicySpecBuilder {
-	for _, e := range b.Spec.Egress {
+	for i, e := range b.Spec.Egress {
 		e.EnableLogging = true
+		b.Spec.Egress[i] = e
 	}
 	return b
 }

--- a/test/e2e/utils/networkpolicyspecbuilder.go
+++ b/test/e2e/utils/networkpolicyspecbuilder.go
@@ -143,8 +143,9 @@ func (n *NetworkPolicySpecBuilder) WithEgressDNS() *NetworkPolicySpecBuilder {
 		Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 53},
 	}
 
-	for _, e := range n.Spec.Egress {
+	for i, e := range n.Spec.Egress {
 		e.Ports = append(e.Ports, route53)
+		n.Spec.Egress[i] = e
 	}
 	return n
 }


### PR DESCRIPTION
- Fixed logic flaws in policy builders, which cause logging to never actually be enabled in E2E tests
- Check the log dir on Antrea agent of the node where the ACNP appliedTo pod is scheduled on
- Moved audit logging testcase into its own subtest