### PR TITLE
Upgrade to go-ipfix v0.2.4

### DIFF
--- a/build/yamls/elk-flow-collector/logstash/ipfix.yml
+++ b/build/yamls/elk-flow-collector/logstash/ipfix.yml
@@ -1,4 +1,4 @@
-# ipfix fields definition file. Antrea-specific fields are with Enterprise ID 55829
+# ipfix fields definition file. Antrea-specific fields are with Enterprise ID 56506
 ---
 0:
   0:
@@ -364,10 +364,10 @@
     - :uint32
     - :observationDomainId
   150:
-    - :int64
+    - :uint32
     - :flowStartSeconds
   151:
-    - :int64
+    - :uint32
     - :flowEndSeconds
   152:
     - :uint64
@@ -4027,7 +4027,7 @@
     - :ixiaThreatIPv6
 
 # Antrea
-55829:
+56506:
   100:
     - :string
     - :sourcePodNamespace
@@ -4048,10 +4048,25 @@
     - :destinationNodeName
   106:
     - :ip4_addr
-    - :destinationClusterIP
+    - :destinationClusterIPv4
   107:
+    - :ip6_addr
+    - :destinationClusterIPv6
+  108:
     - :uint16
     - :destinationServicePort
-  108:
+  109:
     - :string
     - :destinationServicePortName
+  110:
+    - :string
+    - :ingressNetworkPolicyName
+  111:
+    - :string
+    - :ingressNetworkPolicyNamespace
+  112:
+    - :string
+    - :egressNetworkPolicyName
+  113:
+    - :string
+    - :egressNetworkPolicyNamespace

--- a/docs/network-flow-visibility.md
+++ b/docs/network-flow-visibility.md
@@ -112,23 +112,23 @@ the flow. All the IEs used by the Antrea Flow Exporter are listed below:
 
 | IPFIX Information Element| Enterprise ID | Field ID | Type           |
 |--------------------------|---------------|----------|----------------|
-| packetTotalCount         | 29305         | 86       | unsigned64     |
-| octetTotalCount          | 29305         | 85       | unsigned64     |
-| packetDeltaCount         | 29305         | 2        | unsigned64     |
-| octetDeltaCount          | 29305         | 1        | unsigned64     |
+| reversePacketTotalCount  | 29305         | 86       | unsigned64     |
+| reverseOctetTotalCount   | 29305         | 85       | unsigned64     |
+| reversePacketDeltaCount  | 29305         | 2        | unsigned64     |
+| reverseOctetDeltaCount   | 29305         | 1        | unsigned64     |
 
 #### IEs from Antrea IE Registry
 
 | IPFIX Information Element | Enterprise ID | Field ID | Type        |
 |---------------------------|---------------|----------|-------------|
-| sourcePodNamespace        | 55829         | 100      | string      |
-| sourcePodName             | 55829         | 101      | string      |
-| destinationPodNamespace   | 55829         | 102      | string      |
-| destinationPodName        | 55829         | 103      | string      |
-| sourceNodeName            | 55829         | 104      | string      |
-| destinationNodeName       | 55829         | 105      | string      |
-| destinationClusterIP      | 55829         | 106      | ipv4Address |
-| destinationServicePortName| 55829         | 108      | string      |
+| sourcePodNamespace        | 56506         | 100      | string      |
+| sourcePodName             | 56506         | 101      | string      |
+| destinationPodNamespace   | 56506         | 102      | string      |
+| destinationPodName        | 56506         | 103      | string      |
+| sourceNodeName            | 56506         | 104      | string      |
+| destinationNodeName       | 56506         | 105      | string      |
+| destinationClusterIPv4    | 56506         | 106      | ipv4Address |
+| destinationServicePortName| 56506         | 109      | string      |
 
 ### Supported capabilities
 

--- a/go.mod
+++ b/go.mod
@@ -40,8 +40,8 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/ti-mo/conntrack v0.3.0
 	github.com/vishvananda/netlink v1.1.0
-	github.com/vmware/go-ipfix v0.2.1
-	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
+	github.com/vmware/go-ipfix v0.2.4
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20200331124033-c3d80250170d

--- a/go.sum
+++ b/go.sum
@@ -393,8 +393,8 @@ github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYp
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/vmware/go-ipfix v0.2.1 h1:6Sj4/A7LPlhCiJMRsjSyn8zjkk+ZBONXMgBKZ+epFgA=
-github.com/vmware/go-ipfix v0.2.1/go.mod h1:8suqePBGCX20vEh/4/ekuRjX4BsZ2zYWcD22NpAWHVU=
+github.com/vmware/go-ipfix v0.2.4 h1:zlf+GTDh/Q+t0z5dkUQBr/7bU0fxR9WjtX0WopU3GSg=
+github.com/vmware/go-ipfix v0.2.4/go.mod h1:8suqePBGCX20vEh/4/ekuRjX4BsZ2zYWcD22NpAWHVU=
 github.com/wenyingd/ofnet v0.0.0-20201109024835-6fd225d8c8d1 h1:jBQJP2829C09r07Rc5EWS0+LefZhY51BJG0v3pLlGGA=
 github.com/wenyingd/ofnet v0.0.0-20201109024835-6fd225d8c8d1/go.mod h1:8mMMWAYBNUeTGXYKizOLETfN3WIbu3P5DgvS2jiXKdI=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
@@ -421,8 +421,9 @@ golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495 h1:I6A9Ag9FpEKOjcKrRNjQkPHawoXIhKyTGfvvjFAiiAk=
 golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/pkg/agent/flowexporter/exporter/exporter_test.go
+++ b/pkg/agent/flowexporter/exporter/exporter_test.go
@@ -56,7 +56,7 @@ func TestFlowExporter_sendTemplateRecord(t *testing.T) {
 		elemList = append(elemList, ipfixentities.NewInfoElement(ie, 0, 0, ipfixregistry.IANAEnterpriseID, 0))
 	}
 	for _, ie := range IANAReverseInfoElements {
-		elemList = append(elemList, ipfixentities.NewInfoElement(ie, 0, 0, ipfixregistry.ReverseEnterpriseID, 0))
+		elemList = append(elemList, ipfixentities.NewInfoElement(ie, 0, 0, ipfixregistry.IANAReversedEnterpriseID, 0))
 	}
 	for _, ie := range AntreaInfoElements {
 		elemList = append(elemList, ipfixentities.NewInfoElement(ie, 0, 0, ipfixregistry.AntreaEnterpriseID, 0))
@@ -71,7 +71,7 @@ func TestFlowExporter_sendTemplateRecord(t *testing.T) {
 		mockTempRec.EXPECT().AddInfoElement(elemList[i], nil).Return(tempBytes, nil)
 	}
 	for i, ie := range IANAReverseInfoElements {
-		mockIPFIXRegistry.EXPECT().GetInfoElement(ie, ipfixregistry.ReverseEnterpriseID).Return(elemList[i+len(IANAInfoElements)], nil)
+		mockIPFIXRegistry.EXPECT().GetInfoElement(ie, ipfixregistry.IANAReversedEnterpriseID).Return(elemList[i+len(IANAInfoElements)], nil)
 		mockTempRec.EXPECT().AddInfoElement(elemList[i+len(IANAInfoElements)], nil).Return(tempBytes, nil)
 	}
 	for i, ie := range AntreaInfoElements {
@@ -139,7 +139,7 @@ func TestFlowExporter_sendDataRecord(t *testing.T) {
 		elemList[i] = ipfixentities.NewInfoElement(ie, 0, 0, 0, 0)
 	}
 	for i, ie := range IANAReverseInfoElements {
-		elemList[i+len(IANAInfoElements)] = ipfixentities.NewInfoElement(ie, 0, 0, ipfixregistry.ReverseEnterpriseID, 0)
+		elemList[i+len(IANAInfoElements)] = ipfixentities.NewInfoElement(ie, 0, 0, ipfixregistry.IANAReversedEnterpriseID, 0)
 	}
 	for i, ie := range AntreaInfoElements {
 		elemList[i+len(IANAInfoElements)+len(IANAReverseInfoElements)] = ipfixentities.NewInfoElement(ie, 0, 0, 0, 0)
@@ -163,16 +163,16 @@ func TestFlowExporter_sendDataRecord(t *testing.T) {
 	for _, ie := range flowExp.elementsList {
 		switch ieName := ie.Name; ieName {
 		case "flowStartSeconds", "flowEndSeconds":
-			mockDataRec.EXPECT().AddInfoElement(ie, time.Time{}.Unix()).Return(tempBytes, nil)
+			mockDataRec.EXPECT().AddInfoElement(ie, uint32(time.Time{}.Unix())).Return(tempBytes, nil)
 		case "sourceIPv4Address", "destinationIPv4Address":
 			mockDataRec.EXPECT().AddInfoElement(ie, nil).Return(tempBytes, nil)
-		case "destinationClusterIP":
+		case "destinationClusterIPv4":
 			mockDataRec.EXPECT().AddInfoElement(ie, net.IP{0, 0, 0, 0}).Return(tempBytes, nil)
 		case "sourceTransportPort", "destinationTransportPort":
 			mockDataRec.EXPECT().AddInfoElement(ie, uint16(0)).Return(tempBytes, nil)
 		case "protocolIdentifier":
 			mockDataRec.EXPECT().AddInfoElement(ie, uint8(0)).Return(tempBytes, nil)
-		case "packetTotalCount", "octetTotalCount", "packetDeltaCount", "octetDeltaCount", "reverse_PacketTotalCount", "reverse_OctetTotalCount", "reverse_PacketDeltaCount", "reverse_OctetDeltaCount":
+		case "packetTotalCount", "octetTotalCount", "packetDeltaCount", "octetDeltaCount", "reversePacketTotalCount", "reverseOctetTotalCount", "reversePacketDeltaCount", "reverseOctetDeltaCount":
 			mockDataRec.EXPECT().AddInfoElement(ie, uint64(0)).Return(tempBytes, nil)
 		case "sourcePodName", "sourcePodNamespace", "sourceNodeName", "destinationPodName", "destinationPodNamespace", "destinationNodeName", "destinationServicePortName":
 			mockDataRec.EXPECT().AddInfoElement(ie, "").Return(tempBytes, nil)

--- a/plugins/octant/go.sum
+++ b/plugins/octant/go.sum
@@ -586,7 +586,7 @@ github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmF
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vmware-tanzu/octant v0.16.1 h1:fkofB9oZ4yTqOaKf0JEhdibnIGBEOJ4OYOZL4Kli74A=
 github.com/vmware-tanzu/octant v0.16.1/go.mod h1:FhWXp2v0bgOQEwuOMOE49DXUu+uwWt8lXh7aOHtrA8A=
-github.com/vmware/go-ipfix v0.2.1/go.mod h1:8suqePBGCX20vEh/4/ekuRjX4BsZ2zYWcD22NpAWHVU=
+github.com/vmware/go-ipfix v0.2.4/go.mod h1:8suqePBGCX20vEh/4/ekuRjX4BsZ2zYWcD22NpAWHVU=
 github.com/wenyingd/ofnet v0.0.0-20201109024835-6fd225d8c8d1/go.mod h1:8mMMWAYBNUeTGXYKizOLETfN3WIbu3P5DgvS2jiXKdI=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSfTONNIgpN5RA8prR7fF8nkF6cTWTcNerRO8=


### PR DESCRIPTION
This PR will update Antrea according to go-ipfix v0.2.4 release.

Fixes #1448 and #1417 