### PR TITLE
[Windows] Provide scripts/guide to prepare env needed by antrea-agent

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -173,8 +173,9 @@ curl.exe -LO https://github.com/kubernetes-sigs/sig-windows-tools/releases/lates
 
 4. Prepare node environment needed by antrea-agent
 
-Run following commands to prepare node environment needed by antrea-agent:
-```
+Run the following commands to prepare the Node environment needed by antrea-agent:
+
+```powershell
 mkdir c:\k\antrea
 cd c:\k\antrea
 curl.exe -LO https://raw.githubusercontent.com/vmware-tanzu/antrea/master/hack/windows/Clean-AntreaNetwork.ps1
@@ -182,37 +183,39 @@ curl.exe -LO https://raw.githubusercontent.com/vmware-tanzu/antrea/master/hack/w
 curl.exe -LO https://raw.githubusercontent.com/vmware-tanzu/antrea/master/hack/windows/Prepare-AntreaAgent.ps1
 .\Prepare-AntreaAgent.ps1
 ```
-The script `Prepare-AntreaAgent.ps1` completes following tasks:
+
+The script `Prepare-AntreaAgent.ps1` performs following tasks:
+
 - Prepare network adapter for kube-proxy.
 
     kube-proxy needs a network adapter to configure Kubernetes Service IPs and
     uses the adapter for proxying connections to Service. Use following script
     to create the network adapter. The adapter will be deleted automatically by
-    Windows after Windows Node reboots.
+    Windows after the Windows Node reboots.
 
 - Remove stale network resources created by antrea-agent.
 
-    After Windows Node reboots, there will be stale network resources which
+    After the Windows Node reboots, there will be stale network resources which
     need to be cleaned before starting antrea-agent.
-
-> Note: The script must be executed evey time the node is restarted.
 
 As you know from the task details from above, the script must be executed every
 time you restart the Node to prepare the environment for antrea-agent.
 
 You could make the script be executed automatically after Windows startup by
-some methods. Here're two examples for your reference:
+using different methods. Here're two examples for your reference:
 
 - Example1: Update kubelet service.
 
 Insert following line in kubelet service script `c:\k\StartKubelet.ps1` to invoke
 `Prepare-AntreaAgent.ps1` when starting kubelet service:
-```
+
+```powershell
 & C:\k\Prepare-AntreaAgent.ps1
 ```
 
 - Example2: Create a ScheduledJob that runs at startup.
- ```
+
+```powershell
 $trigger = New-JobTrigger -AtStartup
 $options = New-ScheduledJobOption -RunElevated
 Register-ScheduledJob -Name PrepareAntreaAgent -Trigger $trigger  -ScriptBlock { Invoke-Expression C:\k\antrea\Prepare-AntreaAgent.ps1 } -ScheduledJobOption $options

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -171,7 +171,7 @@ curl.exe -LO https://github.com/kubernetes-sigs/sig-windows-tools/releases/lates
 .\PrepareNode.ps1 -KubernetesVersion v1.18.0
 ```
 
-4. Prepare node environment needed by antrea-agent
+4. Prepare Node environment needed by antrea-agent
 
 Run the following commands to prepare the Node environment needed by antrea-agent:
 
@@ -188,7 +188,7 @@ The script `Prepare-AntreaAgent.ps1` performs following tasks:
 
 - Prepare network adapter for kube-proxy.
 
-    kube-proxy needs a network adapter to configure Kubernetes Service IPs and
+    kube-proxy needs a network adapter to configure Kubernetes Services IPs and
     uses the adapter for proxying connections to Service. Use following script
     to create the network adapter. The adapter will be deleted automatically by
     Windows after the Windows Node reboots.

--- a/hack/windows/Clean-AntreaNetwork.ps1
+++ b/hack/windows/Clean-AntreaNetwork.ps1
@@ -18,7 +18,7 @@ function GetHnsnetworkId($NetName) {
 $AntreaHnsNetworkName = "antrea-hnsnetwork"
 
 Write-Host "Delete OVS bridge: br-int"
-ovs-vsctl.exe --no-wait del-br br-int
+ovs-vsctl.exe --no-wait --if-exists del-br br-int
 $MaxRetryCount = 10
 $RetryCountRange = 1..$MaxRetryCount
 $BrIntDeleted = $false

--- a/hack/windows/Prepare-AntreaAgent.ps1
+++ b/hack/windows/Prepare-AntreaAgent.ps1
@@ -4,8 +4,8 @@ Prepare environment for antrea-agent.
 
 .DESCRIPTION
 This script prepares environment needed by antrea-agent which includes:
-- Cleaning stale Antrea network resources if exist.
-- Prepare a service network interface which is needed by kube-proxy. Without the interface, kube-proxy can not
+- Cleaning stale Antrea network resources if they exist.
+- Prepare a service network interface which is needed by kube-proxy. Without the interface, kube-proxy cannot
   provide the proxy for Kubernetes services.
 #>
 
@@ -24,7 +24,7 @@ if ($AntreaHnsNetwork) {
     }
 }
 if ($NeedCleanNetwork) {
-    Write-Host "Cleaning stale Antrea network resources if exist..."
+    Write-Host "Cleaning stale Antrea network resources if they exist..."
     & $CleanAntreaNetworkScript
 }
 # Enure OVS services are running.

--- a/hack/windows/Prepare-AntreaAgent.ps1
+++ b/hack/windows/Prepare-AntreaAgent.ps1
@@ -1,0 +1,37 @@
+<#
+.SYNOPSIS
+Prepare environment for antrea-agent.
+
+.DESCRIPTION
+This script prepares environment needed by antrea-agent which includes:
+- Cleaning stale Antrea network resources if exist.
+- Prepare a service network interface which is needed by kube-proxy. Without the interface, kube-proxy can not
+  provide the proxy for Kubernetes services.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDirectory = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
+$CleanAntreaNetworkScript = Join-Path $ScriptDirectory "Clean-AntreaNetwork.ps1"
+$PrepareServiceInterfaceScript = Join-Path $ScriptDirectory "Prepare-ServiceInterface.ps1"
+# Clean stale Antrea HNSNetwork and OVS bridge.
+$NeedCleanNetwork = $true
+$AntreaHnsNetwork = Get-HnsNetwork | Where-Object {$_.Name -eq "antrea-hnsnetwork"}
+if ($AntreaHnsNetwork) {
+    $OVSExtension = $AntreaHnsNetwork.Extensions | Where-Object {$_.Name -eq "Open vSwitch Extension"}
+    if ($OVSExtension.IsEnabled) {
+        $NeedCleanNetwork = $false
+    }
+}
+if ($NeedCleanNetwork) {
+    Write-Host "Cleaning stale Antrea network resources if exist..."
+    & $CleanAntreaNetworkScript
+}
+# Enure OVS services are running.
+Write-Host "Starting ovsdb-server service..."
+Start-Service ovsdb-server
+Write-Host "Starting ovs-vswitchd service..."
+Start-Service ovs-vswitchd
+# Prepare service network interface for kube-proxy.
+Write-Host "Preparing service network interface for kube-proxy..."
+& $PrepareServiceInterfaceScript

--- a/hack/windows/Prepare-AntreaAgent.ps1
+++ b/hack/windows/Prepare-AntreaAgent.ps1
@@ -5,8 +5,8 @@ Prepare environment for antrea-agent.
 .DESCRIPTION
 This script prepares environment needed by antrea-agent which includes:
 - Cleaning stale Antrea network resources if they exist.
-- Prepare a service network interface which is needed by kube-proxy. Without the interface, kube-proxy cannot
-  provide the proxy for Kubernetes services.
+- Prepare a network interface which is needed by kube-proxy. Without the interface, kube-proxy cannot
+  provide the proxy for Kubernetes Services.
 #>
 
 $ErrorActionPreference = 'Stop'

--- a/hack/windows/Prepare-ServiceInterface.ps1
+++ b/hack/windows/Prepare-ServiceInterface.ps1
@@ -3,7 +3,7 @@
 Create virtual netadapter for kube-proxy. The default full name of the virtual adapter is "vEthernet (HNS Internal NIC)"
 
 .DESCRIPTION
-This script creates virtual netadapter for kube-proxy. The created virtual adapter is used by kube-proxy to configure service IPs on it.
+This script creates virtual netadapter for kube-proxy. The created virtual adapter is used by kube-proxy to configure kubernetes Services IPs on it.
 
 .PARAMETER KubernetesVersion
 Kubernetes version to download and use
@@ -13,7 +13,7 @@ PS> .\PrepareServiceInterface.ps1 -InterfaceAlias "HNS Internal NIC"
 
 #>
 Param(
-    [parameter(Mandatory = $false, HelpMessage="Interface to be added service IPs by kube-proxy")] [string] $InterfaceAlias="HNS Internal NIC",
+    [parameter(Mandatory = $false, HelpMessage="Interface to be added Services IPs by kube-proxy")] [string] $InterfaceAlias="HNS Internal NIC",
     [parameter(Mandatory = $false, HelpMessage="Stop existing kube-proxy process after creating interface")] [bool] $StopKubeProxyOnCreation=$true
 )
 $ErrorActionPreference = 'Stop'

--- a/hack/windows/Prepare-ServiceInterface.ps1
+++ b/hack/windows/Prepare-ServiceInterface.ps1
@@ -30,8 +30,8 @@ Add-VMNetworkAdapter -ManagementOS -Name $InterfaceAlias -SwitchName $hnsSwitchN
 Set-NetIPInterface -ifAlias $INTERFACE_TO_ADD_SERVICE_IP -Forwarding Enabled
 
 if ($StopKubeProxyOnCreation) {
-  # Restart kube-proxy to make new created inteface can be used.
-  # Kill kube-proxy and the process will be recreated by kube-proxy pod.
+  # Restart kube-proxy to ensure that the newly created interface can be used.
+  # Kill kube-proxy and the process will be automatically restarted by the kube-proxy Pod.
   Write-Host "killing running kube-proxy process if exists..."
   taskkill /im rancher-wins-kube-proxy.exe /f
 }


### PR DESCRIPTION
1. Add a script `Prepare-AntreaAgent.ps1` to prepare env needed by
  antrea-agent:
    - Create network adapter needed by kube-proxy.
    - Clean stale network resources created by antrea-agent.
2. Update Windows doc to guide how to use the script and highlight
   that the script must be executed after a Windows Node is restarted.

Fixes: #1455

Signed-off-by: Rui Cao <rcao@vmware.com>