### PR TITLE
Respect label selector

### DIFF
--- a/pkg/apiserver/registry/networkpolicy/addressgroup/rest_test.go
+++ b/pkg/apiserver/registry/networkpolicy/addressgroup/rest_test.go
@@ -1,0 +1,80 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package addressgroup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane"
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/vmware-tanzu/antrea/pkg/controller/networkpolicy/store"
+	"github.com/vmware-tanzu/antrea/pkg/controller/types"
+)
+
+func TestRESTList(t *testing.T) {
+	tests := []struct {
+		name          string
+		addressGroups []*types.AddressGroup
+		labelSelector labels.Selector
+		expectedObj   runtime.Object
+	}{
+		{
+			name: "label selector selecting nothing",
+			addressGroups: []*types.AddressGroup{
+				{
+					Name: "foo",
+				},
+			},
+			labelSelector: labels.Nothing(),
+			expectedObj:   &controlplane.AddressGroupList{},
+		},
+		{
+			name: "label selector selecting everything",
+			addressGroups: []*types.AddressGroup{
+				{
+					Name: "foo",
+				},
+			},
+			labelSelector: labels.Everything(),
+			expectedObj: &controlplane.AddressGroupList{
+				Items: []controlplane.AddressGroup{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "foo",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storage := store.NewAddressGroupStore()
+			for _, obj := range tt.addressGroups {
+				storage.Create(obj)
+			}
+			r := NewREST(storage)
+			actualObj, err := r.List(context.TODO(), &internalversion.ListOptions{LabelSelector: tt.labelSelector})
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tt.expectedObj.(*controlplane.AddressGroupList).Items, actualObj.(*controlplane.AddressGroupList).Items)
+		})
+	}
+}

--- a/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest_test.go
+++ b/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest_test.go
@@ -1,0 +1,80 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package appliedtogroup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane"
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/vmware-tanzu/antrea/pkg/controller/networkpolicy/store"
+	"github.com/vmware-tanzu/antrea/pkg/controller/types"
+)
+
+func TestRESTList(t *testing.T) {
+	tests := []struct {
+		name            string
+		appliedToGroups []*types.AppliedToGroup
+		labelSelector   labels.Selector
+		expectedObj     runtime.Object
+	}{
+		{
+			name: "label selector selecting nothing",
+			appliedToGroups: []*types.AppliedToGroup{
+				{
+					Name: "foo",
+				},
+			},
+			labelSelector: labels.Nothing(),
+			expectedObj:   &controlplane.AppliedToGroupList{},
+		},
+		{
+			name: "label selector selecting everything",
+			appliedToGroups: []*types.AppliedToGroup{
+				{
+					Name: "foo",
+				},
+			},
+			labelSelector: labels.Everything(),
+			expectedObj: &controlplane.AppliedToGroupList{
+				Items: []controlplane.AppliedToGroup{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "foo",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storage := store.NewAppliedToGroupStore()
+			for _, obj := range tt.appliedToGroups {
+				storage.Create(obj)
+			}
+			r := NewREST(storage)
+			actualObj, err := r.List(context.TODO(), &internalversion.ListOptions{LabelSelector: tt.labelSelector})
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tt.expectedObj.(*controlplane.AppliedToGroupList).Items, actualObj.(*controlplane.AppliedToGroupList).Items)
+		})
+	}
+}

--- a/pkg/apiserver/registry/networkpolicy/networkpolicy/rest_test.go
+++ b/pkg/apiserver/registry/networkpolicy/networkpolicy/rest_test.go
@@ -1,0 +1,80 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane"
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/vmware-tanzu/antrea/pkg/controller/networkpolicy/store"
+	"github.com/vmware-tanzu/antrea/pkg/controller/types"
+)
+
+func TestRESTList(t *testing.T) {
+	tests := []struct {
+		name            string
+		networkPolicies []*types.NetworkPolicy
+		labelSelector   labels.Selector
+		expectedObj     runtime.Object
+	}{
+		{
+			name: "label selector selecting nothing",
+			networkPolicies: []*types.NetworkPolicy{
+				{
+					Name: "foo",
+				},
+			},
+			labelSelector: labels.Nothing(),
+			expectedObj:   &controlplane.NetworkPolicyList{},
+		},
+		{
+			name: "label selector selecting everything",
+			networkPolicies: []*types.NetworkPolicy{
+				{
+					Name: "foo",
+				},
+			},
+			labelSelector: labels.Everything(),
+			expectedObj: &controlplane.NetworkPolicyList{
+				Items: []controlplane.NetworkPolicy{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "foo",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storage := store.NewNetworkPolicyStore()
+			for _, obj := range tt.networkPolicies {
+				storage.Create(obj)
+			}
+			r := NewREST(storage)
+			actualObj, err := r.List(context.TODO(), &internalversion.ListOptions{LabelSelector: tt.labelSelector})
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tt.expectedObj.(*controlplane.NetworkPolicyList).Items, actualObj.(*controlplane.NetworkPolicyList).Items)
+		})
+	}
+}

--- a/pkg/apiserver/registry/stats/antreaclusternetworkpolicystats/rest.go
+++ b/pkg/apiserver/registry/stats/antreaclusternetworkpolicystats/rest.go
@@ -23,6 +23,7 @@ import (
 	metatable "k8s.io/apimachinery/pkg/api/meta/table"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
 
@@ -67,7 +68,17 @@ func (r *REST) List(ctx context.Context, options *internalversion.ListOptions) (
 	if !features.DefaultFeatureGate.Enabled(features.AntreaPolicy) {
 		return nil, errors.NewBadRequest("feature AntreaPolicy disabled")
 	}
-	items := r.statsProvider.ListAntreaClusterNetworkPolicyStats()
+	labelSelector := labels.Everything()
+	if options != nil && options.LabelSelector != nil {
+		labelSelector = options.LabelSelector
+	}
+	stats := r.statsProvider.ListAntreaClusterNetworkPolicyStats()
+	items := make([]statsv1alpha1.AntreaClusterNetworkPolicyStats, 0, len(stats))
+	for i := range stats {
+		if labelSelector.Matches(labels.Set(stats[i].Labels)) {
+			items = append(items, stats[i])
+		}
+	}
 	metricList := &statsv1alpha1.AntreaClusterNetworkPolicyStatsList{
 		Items: items,
 	}

--- a/pkg/apiserver/registry/stats/networkpolicystats/rest.go
+++ b/pkg/apiserver/registry/stats/networkpolicystats/rest.go
@@ -23,6 +23,7 @@ import (
 	metatable "k8s.io/apimachinery/pkg/api/meta/table"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -65,8 +66,18 @@ func (r *REST) List(ctx context.Context, options *internalversion.ListOptions) (
 	if !features.DefaultFeatureGate.Enabled(features.NetworkPolicyStats) {
 		return nil, errors.NewBadRequest("feature NetworkPolicyStats disabled")
 	}
+	labelSelector := labels.Everything()
+	if options != nil && options.LabelSelector != nil {
+		labelSelector = options.LabelSelector
+	}
 	ns, _ := request.NamespaceFrom(ctx)
-	items := r.statsProvider.ListNetworkPolicyStats(ns)
+	stats := r.statsProvider.ListNetworkPolicyStats(ns)
+	items := make([]statsv1alpha1.NetworkPolicyStats, 0, len(stats))
+	for i := range stats {
+		if labelSelector.Matches(labels.Set(stats[i].Labels)) {
+			items = append(items, stats[i])
+		}
+	}
 	metricList := &statsv1alpha1.NetworkPolicyStatsList{
 		Items: items,
 	}

--- a/pkg/apiserver/registry/system/controllerinfo/rest.go
+++ b/pkg/apiserver/registry/system/controllerinfo/rest.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
 
@@ -73,8 +74,15 @@ func (r *REST) NewList() runtime.Object {
 }
 
 func (r *REST) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
+	labelSelector := labels.Everything()
+	if options != nil && options.LabelSelector != nil {
+		labelSelector = options.LabelSelector
+	}
 	list := new(clusterinfo.AntreaControllerInfoList)
-	list.Items = []clusterinfo.AntreaControllerInfo{*r.getControllerInfo()}
+	item := r.getControllerInfo()
+	if labelSelector.Matches(labels.Set(item.Labels)) {
+		list.Items = append(list.Items, *item)
+	}
 	return list, nil
 }
 

--- a/pkg/apiserver/registry/system/controllerinfo/rest_test.go
+++ b/pkg/apiserver/registry/system/controllerinfo/rest_test.go
@@ -1,0 +1,67 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerinfo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/vmware-tanzu/antrea/pkg/apis/clusterinformation/v1beta1"
+)
+
+type fakeControllerQuerier struct{}
+
+func (q *fakeControllerQuerier) GetControllerInfo(info *v1beta1.AntreaControllerInfo, partial bool) {}
+
+func TestRESTList(t *testing.T) {
+	tests := []struct {
+		name          string
+		labelSelector labels.Selector
+		expectedObj   runtime.Object
+	}{
+		{
+			name:          "label selector selecting nothing",
+			labelSelector: labels.Nothing(),
+			expectedObj:   &v1beta1.AntreaControllerInfoList{},
+		},
+		{
+			name:          "label selector selecting everything",
+			labelSelector: labels.Everything(),
+			expectedObj: &v1beta1.AntreaControllerInfoList{
+				Items: []v1beta1.AntreaControllerInfo{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name: ControllerInfoResourceName,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewREST(&fakeControllerQuerier{})
+			actualObj, err := r.List(context.TODO(), &internalversion.ListOptions{LabelSelector: tt.labelSelector})
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tt.expectedObj.(*v1beta1.AntreaControllerInfoList).Items, actualObj.(*v1beta1.AntreaControllerInfoList).Items)
+		})
+	}
+}


### PR DESCRIPTION
This patch makes all Antrea APIs respect label selector to fix the problem that some K8s clients get unexpected resources when labelSelector is specified.

Fixes #1432