### PR TITLE
[IPv6] Add IPv6 support for NetworkPolicy by @wenyingd

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -212,7 +212,7 @@ spec:
                 items:
                   properties:
                     ip:
-                      format: ipv4
+                      pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                       type: string
                     name:
                       type: string
@@ -485,7 +485,7 @@ spec:
                   - ip
                 properties:
                   ip:
-                    format: ipv4
+                    pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                     type: string
                   namespace:
                     type: string
@@ -503,7 +503,7 @@ spec:
                       protocol:
                         type: integer
                       srcIP:
-                        format: ipv4
+                        pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                         type: string
                       ttl:
                         type: integer

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -212,7 +212,7 @@ spec:
                 items:
                   properties:
                     ip:
-                      format: ipv4
+                      pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                       type: string
                     name:
                       type: string
@@ -485,7 +485,7 @@ spec:
                   - ip
                 properties:
                   ip:
-                    format: ipv4
+                    pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                     type: string
                   namespace:
                     type: string
@@ -503,7 +503,7 @@ spec:
                       protocol:
                         type: integer
                       srcIP:
-                        format: ipv4
+                        pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                         type: string
                       ttl:
                         type: integer

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -212,7 +212,7 @@ spec:
                 items:
                   properties:
                     ip:
-                      format: ipv4
+                      pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                       type: string
                     name:
                       type: string
@@ -485,7 +485,7 @@ spec:
                   - ip
                 properties:
                   ip:
-                    format: ipv4
+                    pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                     type: string
                   namespace:
                     type: string
@@ -503,7 +503,7 @@ spec:
                       protocol:
                         type: integer
                       srcIP:
-                        format: ipv4
+                        pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                         type: string
                       ttl:
                         type: integer

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -212,7 +212,7 @@ spec:
                 items:
                   properties:
                     ip:
-                      format: ipv4
+                      pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                       type: string
                     name:
                       type: string
@@ -485,7 +485,7 @@ spec:
                   - ip
                 properties:
                   ip:
-                    format: ipv4
+                    pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                     type: string
                   namespace:
                     type: string
@@ -503,7 +503,7 @@ spec:
                       protocol:
                         type: integer
                       srcIP:
-                        format: ipv4
+                        pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                         type: string
                       ttl:
                         type: integer

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -212,7 +212,7 @@ spec:
                 items:
                   properties:
                     ip:
-                      format: ipv4
+                      pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                       type: string
                     name:
                       type: string
@@ -485,7 +485,7 @@ spec:
                   - ip
                 properties:
                   ip:
-                    format: ipv4
+                    pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                     type: string
                   namespace:
                     type: string
@@ -503,7 +503,7 @@ spec:
                       protocol:
                         type: integer
                       srcIP:
-                        format: ipv4
+                        pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                         type: string
                       ttl:
                         type: integer

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -109,7 +109,7 @@ spec:
                       type: string
                     ip:
                       type: string
-                      format: ipv4
+                      pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                   oneOf:
                     - required: ["pod", "namespace"]
                     - required: ["service", "namespace"]
@@ -122,7 +122,7 @@ spec:
                       properties:
                         srcIP:
                           type: string
-                          format: ipv4
+                          pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                         protocol:
                           type: integer
                         ttl:
@@ -558,7 +558,7 @@ spec:
                     properties:
                       ip:
                         type: string
-                        format: ipv4
+                        pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                       name:
                         type: string
                 ports:

--- a/pkg/agent/controller/networkpolicy/cache_test.go
+++ b/pkg/agent/controller/networkpolicy/cache_test.go
@@ -183,8 +183,12 @@ func newAppliedToGroupMember(name, namespace string, containerPorts ...v1beta2.N
 	return &v1beta2.GroupMember{Pod: &v1beta2.PodReference{Name: name, Namespace: namespace}, Ports: containerPorts}
 }
 
-func newAddressGroupMember(ip string) *v1beta2.GroupMember {
-	return &v1beta2.GroupMember{IPs: []v1beta2.IPAddress{v1beta2.IPAddress(net.ParseIP(ip))}}
+func newAddressGroupMember(ips ...string) *v1beta2.GroupMember {
+	ipAddrs := make([]v1beta2.IPAddress, len(ips))
+	for idx, ip := range ips {
+		ipAddrs[idx] = v1beta2.IPAddress(net.ParseIP(ip))
+	}
+	return &v1beta2.GroupMember{IPs: ipAddrs}
 }
 
 func TestRuleCacheAddAddressGroup(t *testing.T) {

--- a/pkg/agent/controller/networkpolicy/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/reconciler.go
@@ -177,6 +177,10 @@ type reconciler struct {
 
 	// priorityAssigners provides interfaces to manage OF priorities for each OVS table.
 	priorityAssigners map[binding.TableIDType]*tablePriorityAssigner
+	// ipv4Enabled tells if IPv4 is supported on this Node or not.
+	ipv4Enabled bool
+	// ipv6Enabled tells is IPv6 is supported on this Node or not.
+	ipv6Enabled bool
 }
 
 // newReconciler returns a new *reconciler.
@@ -198,6 +202,11 @@ func newReconciler(ofClient openflow.Client, ifaceStore interfacestore.Interface
 		lastRealizeds:     sync.Map{},
 		idAllocator:       newIDAllocator(),
 		priorityAssigners: priorityAssigners,
+	}
+	// Check if ofClient is nil or not to be compatible with unit tests.
+	if ofClient != nil {
+		reconciler.ipv4Enabled = ofClient.IsIPv4Enabled()
+		reconciler.ipv6Enabled = ofClient.IsIPv6Enabled()
 	}
 	return reconciler
 }
@@ -392,7 +401,7 @@ func (r *reconciler) computeOFRulesForAdd(rule *CompletedRule, ofPriority *uint1
 		// Addresses got from source GroupMembers' IPs.
 		from1 := groupMembersToOFAddresses(rule.FromAddresses)
 		// Get addresses that in From IPBlock but not in Except IPBlocks.
-		from2 := ipBlocksToOFAddresses(rule.From.IPBlocks)
+		from2 := ipBlocksToOFAddresses(rule.From.IPBlocks, r.ipv4Enabled, r.ipv6Enabled)
 
 		podsByServicesMap, servicesMap := groupMembersByServices(rule.Services, rule.TargetMembers)
 
@@ -455,7 +464,7 @@ func (r *reconciler) computeOFRulesForAdd(rule *CompletedRule, ofPriority *uint1
 			}
 			if len(rule.To.IPBlocks) > 0 {
 				// Diff Addresses between To and Except of IPBlocks
-				to := ipBlocksToOFAddresses(rule.To.IPBlocks)
+				to := ipBlocksToOFAddresses(rule.To.IPBlocks, r.ipv4Enabled, r.ipv6Enabled)
 				ofRule.To = append(ofRule.To, to...)
 			}
 		}
@@ -517,7 +526,7 @@ func (r *reconciler) update(lastRealized *lastRealized, newRule *CompletedRule, 
 	// only happen to Group members.
 	if newRule.Direction == v1beta2.DirectionIn {
 		from1 := groupMembersToOFAddresses(newRule.FromAddresses)
-		from2 := ipBlocksToOFAddresses(newRule.From.IPBlocks)
+		from2 := ipBlocksToOFAddresses(newRule.From.IPBlocks, r.ipv4Enabled, r.ipv6Enabled)
 		addedFrom := groupMembersToOFAddresses(newRule.FromAddresses.Difference(lastRealized.FromAddresses))
 		deletedFrom := groupMembersToOFAddresses(lastRealized.FromAddresses.Difference(newRule.FromAddresses))
 
@@ -817,34 +826,38 @@ func groupMembersToOFAddresses(groupMemberSet v1beta2.GroupMemberSet) []types.Ad
 	return addresses
 }
 
-func ipBlocksToOFAddresses(ipBlocks []v1beta2.IPBlock) []types.Address {
+func ipBlocksToOFAddresses(ipBlocks []v1beta2.IPBlock, ipv4Enabled, ipv6Enabled bool) []types.Address {
 	// Must not return nil as it means not restricted by addresses in Openflow implementation.
 	addresses := make([]types.Address, 0)
 	for _, b := range ipBlocks {
-		exceptIPNet := make([]*net.IPNet, 0, len(b.Except))
-		for _, c := range b.Except {
-			exceptIPNet = append(exceptIPNet, ip.IPNetToNetIPNet(&c))
+		blockCIDR := ip.IPNetToNetIPNet(&b.CIDR)
+		if !isIPNetSupportedByAF(blockCIDR, ipv4Enabled, ipv6Enabled) {
+			klog.Infof("IPBlock %s is using unsupported address family, skip it", blockCIDR.String())
+			continue
 		}
-		diffCIDRs, err := ip.DiffFromCIDRs(ip.IPNetToNetIPNet(&b.CIDR), exceptIPNet)
+		exceptIPNets := make([]*net.IPNet, 0, len(b.Except))
+		for _, c := range b.Except {
+			except := ip.IPNetToNetIPNet(&c)
+			exceptIPNets = append(exceptIPNets, except)
+		}
+		diffCIDRs, err := ip.DiffFromCIDRs(blockCIDR, exceptIPNets)
 		if err != nil {
-			// Currently only IPv4 addresses are supported
 			klog.Errorf("Error when determining diffCIDRs: %v", err)
 			continue
 		}
 		for _, d := range diffCIDRs {
-			addresses = append(addresses, ipNetToOFAddress(*ip.NetIPNetToIPNet(d)))
+			addresses = append(addresses, openflow.NewIPNetAddress(*d))
 		}
 	}
 
 	return addresses
 }
 
-func ipNetToOFAddress(in v1beta2.IPNet) *openflow.IPNetAddress {
-	ipNet := net.IPNet{
-		IP:   net.IP(in.IP),
-		Mask: net.CIDRMask(int(in.PrefixLength), 32),
+func isIPNetSupportedByAF(ipnet *net.IPNet, ipv4Enabled, ipv6Enabled bool) bool {
+	if (ipnet.IP.To4() != nil && ipv4Enabled) || (ipnet.IP.To4() == nil && ipv6Enabled) {
+		return true
 	}
-	return openflow.NewIPNetAddress(ipNet)
+	return false
 }
 
 func ipsToOFAddresses(ips sets.String) []types.Address {

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -332,6 +332,8 @@ type client struct {
 	// packetInHandlers stores handler to process PacketIn event. Each packetin reason can have multiple handlers registered.
 	// When a packetin arrives, openflow send packet to registered handlers in this map.
 	packetInHandlers map[uint8]map[string]PacketInHandler
+	// Supported IP Protocols (IP or IPv6) on the current Node.
+	ipProtocols []binding.Protocol
 }
 
 func (c *client) GetTunnelVirtualMAC() net.HardwareAddr {
@@ -557,36 +559,29 @@ func (c *client) connectionTrackFlows(category cookie.Category) []binding.Flow {
 
 	// TODO: following flows should move to function "kubeProxyFlows". Since another PR(#1198) is trying
 	//  to polish the relevant logic, code refactoring is needed after that PR is merged.
-	if c.nodeConfig.PodIPv4CIDR != nil {
+	for _, proto := range c.ipProtocols {
+		ctZone := CtZone
+		if proto == binding.ProtocolIPv6 {
+			ctZone = CtZoneV6
+		}
 		flows = append(flows,
-			connectionTrackStateTable.BuildFlow(priorityHigh).MatchProtocol(binding.ProtocolIP).
+			// If a connection was initiated through the gateway (i.e. has gatewayCTMark) and
+			// the packet is received on the gateway port, go to the next table directly. This
+			// is to bypass the flow which is installed by ctRewriteDstMACFlow in the same
+			// table, and which will rewrite the destination MAC address for traffic with the
+			// gatewayCTMark, but which is flowing in the opposite direction.
+			connectionTrackStateTable.BuildFlow(priorityHigh).MatchProtocol(proto).
 				MatchRegRange(int(marksReg), markTrafficFromGateway, binding.Range{0, 15}).
 				MatchCTMark(gatewayCTMark, nil).
 				MatchCTStateNew(false).MatchCTStateTrk(true).
 				Action().GotoTable(connectionTrackStateTable.GetNext()).
 				Cookie(c.cookieAllocator.Request(category).Raw()).
 				Done(),
-			connectionTrackCommitTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
+			// Connections initiated through the gateway are marked with gatewayCTMark.
+			connectionTrackCommitTable.BuildFlow(priorityNormal).MatchProtocol(proto).
 				MatchRegRange(int(marksReg), markTrafficFromGateway, binding.Range{0, 15}).
 				MatchCTStateNew(true).MatchCTStateTrk(true).
-				Action().CT(true, connectionTrackCommitTable.GetNext(), CtZone).LoadToMark(gatewayCTMark).CTDone().
-				Cookie(c.cookieAllocator.Request(category).Raw()).
-				Done(),
-		)
-	}
-	if c.nodeConfig.PodIPv6CIDR != nil {
-		flows = append(flows,
-			connectionTrackStateTable.BuildFlow(priorityHigh).MatchProtocol(binding.ProtocolIPv6).
-				MatchRegRange(int(marksReg), markTrafficFromGateway, binding.Range{0, 15}).
-				MatchCTMark(gatewayCTMark, nil).
-				MatchCTStateNew(false).MatchCTStateTrk(true).
-				Action().GotoTable(connectionTrackStateTable.GetNext()).
-				Cookie(c.cookieAllocator.Request(category).Raw()).
-				Done(),
-			connectionTrackCommitTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIPv6).
-				MatchRegRange(int(marksReg), markTrafficFromGateway, binding.Range{0, 15}).
-				MatchCTStateNew(true).MatchCTStateTrk(true).
-				Action().CT(true, connectionTrackCommitTable.GetNext(), CtZoneV6).LoadToMark(gatewayCTMark).CTDone().
+				Action().CT(true, connectionTrackCommitTable.GetNext(), ctZone).LoadToMark(gatewayCTMark).CTDone().
 				Cookie(c.cookieAllocator.Request(category).Raw()).
 				Done(),
 		)
@@ -598,30 +593,20 @@ func (c *client) conntrackBasicFlows(category cookie.Category) []binding.Flow {
 	connectionTrackStateTable := c.pipeline[conntrackStateTable]
 	connectionTrackCommitTable := c.pipeline[conntrackCommitTable]
 	var flows []binding.Flow
-	if c.nodeConfig.PodIPv4CIDR != nil {
+	for _, proto := range c.ipProtocols {
+		ctZone := CtZone
+		if proto == binding.ProtocolIPv6 {
+			ctZone = CtZoneV6
+		}
 		flows = append(flows,
-			connectionTrackStateTable.BuildFlow(priorityLow).MatchProtocol(binding.ProtocolIP).
+			connectionTrackStateTable.BuildFlow(priorityLow).MatchProtocol(proto).
 				MatchCTStateInv(true).MatchCTStateTrk(true).
 				Action().Drop().
 				Cookie(c.cookieAllocator.Request(category).Raw()).
 				Done(),
-			connectionTrackCommitTable.BuildFlow(priorityLow).MatchProtocol(binding.ProtocolIP).
+			connectionTrackCommitTable.BuildFlow(priorityLow).MatchProtocol(proto).
 				MatchCTStateNew(true).MatchCTStateTrk(true).
-				Action().CT(true, connectionTrackCommitTable.GetNext(), CtZone).CTDone().
-				Cookie(c.cookieAllocator.Request(category).Raw()).
-				Done(),
-		)
-	}
-	if c.nodeConfig.PodIPv6CIDR != nil {
-		flows = append(flows,
-			connectionTrackStateTable.BuildFlow(priorityLow).MatchProtocol(binding.ProtocolIPv6).
-				MatchCTStateInv(true).MatchCTStateTrk(true).
-				Action().Drop().
-				Cookie(c.cookieAllocator.Request(category).Raw()).
-				Done(),
-			connectionTrackCommitTable.BuildFlow(priorityLow).MatchProtocol(binding.ProtocolIPv6).
-				MatchCTStateNew(true).MatchCTStateTrk(true).
-				Action().CT(true, connectionTrackCommitTable.GetNext(), CtZoneV6).CTDone().
+				Action().CT(true, connectionTrackCommitTable.GetNext(), ctZone).CTDone().
 				Cookie(c.cookieAllocator.Request(category).Raw()).
 				Done(),
 		)
@@ -632,18 +617,14 @@ func (c *client) conntrackBasicFlows(category cookie.Category) []binding.Flow {
 func (c *client) kubeProxyFlows(category cookie.Category) []binding.Flow {
 	connectionTrackTable := c.pipeline[conntrackTable]
 	var flows []binding.Flow
-	if c.nodeConfig.PodIPv4CIDR != nil {
+	for _, proto := range c.ipProtocols {
+		ctZone := CtZone
+		if proto == binding.ProtocolIPv6 {
+			ctZone = CtZoneV6
+		}
 		flows = append(flows,
-			connectionTrackTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
-				Action().CT(false, connectionTrackTable.GetNext(), CtZone).CTDone().
-				Cookie(c.cookieAllocator.Request(category).Raw()).
-				Done(),
-		)
-	}
-	if c.nodeConfig.PodIPv6CIDR != nil {
-		flows = append(flows,
-			connectionTrackTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIPv6).
-				Action().CT(false, connectionTrackTable.GetNext(), CtZoneV6).CTDone().
+			connectionTrackTable.BuildFlow(priorityNormal).MatchProtocol(proto).
+				Action().CT(false, connectionTrackTable.GetNext(), ctZone).CTDone().
 				Cookie(c.cookieAllocator.Request(category).Raw()).
 				Done(),
 		)
@@ -671,22 +652,27 @@ func (c *client) traceflowConnectionTrackFlows(dataplaneTag uint8, category cook
 	return flowBuilder.Done()
 }
 
-// ctRewriteDstMACFlow rewrites the destination MAC with local host gateway MAC if the packets has set ct_mark but not sent from the host gateway.
-func (c *client) ctRewriteDstMACFlow(gatewayMAC net.HardwareAddr, hasV4Addr, hasV6Addr bool, category cookie.Category) []binding.Flow {
+// ctRewriteDstMACFlow rewrites the destination MAC address with the local host gateway MAC if the
+// packet is marked with gatewayCTMark but was not received on the host gateway. In other words, it
+// rewrites the destination MAC address for reply traffic for connections which were initiated
+// through the gateway, to ensure that this reply traffic gets forwarded correctly (back to the host
+// network namespace, through the gateway). In particular, it is necessary in the following 2 cases:
+//  1) reply traffic for connections from a local Pod to a ClusterIP Service (when AntreaProxy is
+//  disabled and kube-proxy is used). In this case the destination IP address of the reply traffic
+//  is the Pod which initiated the connection to the Service (no SNAT). We need to make sure that
+//  these packets are sent back through the gateway so that the source IP can be rewritten (Service
+//  backend IP -> Service ClusterIP).
+//  2) when hair-pinning is involved, i.e. for connections between 2 local Pods belonging to this
+//  Node and for which NAT is performed. This applies regardless of whether AntreaProxy is enabled
+//  or not, and thus also applies to Windows Nodes (for which AntreaProxy is enabled by default).
+//  One example is a Pod accessing a NodePort Service for which externalTrafficPolicy is set to
+//  Local, using the local Node's IP address.
+func (c *client) ctRewriteDstMACFlows(gatewayMAC net.HardwareAddr, category cookie.Category) []binding.Flow {
 	connectionTrackStateTable := c.pipeline[conntrackStateTable]
 	macData, _ := strconv.ParseUint(strings.Replace(gatewayMAC.String(), ":", "", -1), 16, 64)
 	var flows []binding.Flow
-	if hasV4Addr {
-		flows = append(flows, connectionTrackStateTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
-			MatchCTMark(gatewayCTMark, nil).
-			MatchCTStateNew(false).MatchCTStateTrk(true).
-			Action().LoadRange(binding.NxmFieldDstMAC, macData, binding.Range{0, 47}).
-			Action().GotoTable(connectionTrackStateTable.GetNext()).
-			Cookie(c.cookieAllocator.Request(category).Raw()).
-			Done())
-	}
-	if hasV6Addr {
-		flows = append(flows, connectionTrackStateTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIPv6).
+	for _, proto := range c.ipProtocols {
+		flows = append(flows, connectionTrackStateTable.BuildFlow(priorityNormal).MatchProtocol(proto).
 			MatchCTMark(gatewayCTMark, nil).
 			MatchCTStateNew(false).MatchCTStateTrk(true).
 			Action().LoadRange(binding.NxmFieldDstMAC, macData, binding.Range{0, 47}).
@@ -811,14 +797,19 @@ func (c *client) l3ToPodFlow(podInterfaceIPs []net.IP, podInterfaceMAC net.Hardw
 
 // l3ToGWFlow generates the flow to rewrite MAC to gw port if the packet received is unmatched by local Pod flows.
 // This flow is used in policy only traffic mode.
-func (c *client) l3ToGWFlow(gwMAC net.HardwareAddr, category cookie.Category) binding.Flow {
+func (c *client) l3ToGWFlow(gwMAC net.HardwareAddr, category cookie.Category) []binding.Flow {
 	l3FwdTable := c.pipeline[l3ForwardingTable]
-	return l3FwdTable.BuildFlow(priorityLow).MatchProtocol(binding.ProtocolIP).
-		Action().SetDstMAC(gwMAC).
-		Action().DecTTL().
-		Action().GotoTable(l3FwdTable.GetNext()).
-		Cookie(c.cookieAllocator.Request(category).Raw()).
-		Done()
+	var flows []binding.Flow
+	for _, ipProto := range c.ipProtocols {
+		flows = append(flows, l3FwdTable.BuildFlow(priorityLow).MatchProtocol(ipProto).
+			Action().SetDstMAC(gwMAC).
+			Action().DecTTL().
+			Action().GotoTable(l3FwdTable.GetNext()).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+		)
+	}
+	return flows
 }
 
 // l3ToGatewayFlow generates flow that rewrites MAC of the packet received from tunnel port and destined to local gateway.
@@ -1005,23 +996,22 @@ func (c *client) sessionAffinityReselectFlow() binding.Flow {
 }
 
 // gatewayIPSpoofGuardFlow generates the flow to skip spoof guard checking for traffic sent from gateway interface.
-func (c *client) gatewayIPSpoofGuardFlows(gatewayOFPort uint32, hasIPv4Addr, hasIPv6Addr bool, category cookie.Category) []binding.Flow {
+func (c *client) gatewayIPSpoofGuardFlows(gatewayOFPort uint32, category cookie.Category) []binding.Flow {
 	ipPipeline := c.pipeline
 	ipSpoofGuardTable := ipPipeline[spoofGuardTable]
 	var flows []binding.Flow
-	if hasIPv4Addr {
-		flows = append(flows, ipSpoofGuardTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
-			MatchInPort(gatewayOFPort).
-			Action().GotoTable(ipSpoofGuardTable.GetNext()).
-			Cookie(c.cookieAllocator.Request(category).Raw()).
-			Done())
-	}
-	if hasIPv6Addr {
-		flows = append(flows, ipSpoofGuardTable.BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIPv6).
-			MatchInPort(gatewayOFPort).
-			Action().GotoTable(ipv6Table).
-			Cookie(c.cookieAllocator.Request(category).Raw()).
-			Done())
+	for _, proto := range c.ipProtocols {
+		nextTable := ipSpoofGuardTable.GetNext()
+		if proto == binding.ProtocolIPv6 {
+			nextTable = ipv6Table
+		}
+		flows = append(flows,
+			ipSpoofGuardTable.BuildFlow(priorityNormal).MatchProtocol(proto).
+				MatchInPort(gatewayOFPort).
+				Action().GotoTable(nextTable).
+				Cookie(c.cookieAllocator.Request(category).Raw()).
+				Done(),
+		)
 	}
 	return flows
 }
@@ -1072,26 +1062,25 @@ func (c *client) allowRulesMetricFlows(conjunctionID uint32, ingress bool) []bin
 		offset = 32
 		labelRange = metricEgressRuleIDRange
 	}
+	metricFlow := func(isCTNew bool, protocol binding.Protocol) binding.Flow {
+		return c.pipeline[metricTableID].BuildFlow(priorityNormal).
+			MatchProtocol(protocol).
+			MatchPriority(priorityNormal).
+			MatchCTStateNew(isCTNew).
+			MatchCTLabelRange(0, uint64(conjunctionID)<<offset, labelRange).
+			Action().GotoTable(c.pipeline[metricTableID].GetNext()).
+			Cookie(c.cookieAllocator.Request(cookie.Policy).Raw()).
+			Done()
+	}
+	var flows []binding.Flow
 	// These two flows track the number of sessions in addition to the packet and byte counts.
 	// The flow matching 'ct_state=+new' tracks the number of sessions and byte count of the first packet for each
 	// session.
 	// The flow matching 'ct_state=-new' tracks the byte/packet count of an established connection (both directions).
-	return []binding.Flow{
-		c.pipeline[metricTableID].BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
-			MatchPriority(priorityNormal).
-			MatchCTStateNew(true).
-			MatchCTLabelRange(0, uint64(conjunctionID)<<offset, labelRange).
-			Action().GotoTable(c.pipeline[metricTableID].GetNext()).
-			Cookie(c.cookieAllocator.Request(cookie.Policy).Raw()).
-			Done(),
-		c.pipeline[metricTableID].BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
-			MatchPriority(priorityNormal).
-			MatchCTStateNew(false).
-			MatchCTLabelRange(0, uint64(conjunctionID)<<offset, labelRange).
-			Action().GotoTable(c.pipeline[metricTableID].GetNext()).
-			Cookie(c.cookieAllocator.Request(cookie.Policy).Raw()).
-			Done(),
+	for _, proto := range c.ipProtocols {
+		flows = append(flows, metricFlow(true, proto), metricFlow(false, proto))
 	}
+	return flows
 }
 
 func (c *client) dropRuleMetricFlow(conjunctionID uint32, ingress bool) binding.Flow {
@@ -1099,7 +1088,7 @@ func (c *client) dropRuleMetricFlow(conjunctionID uint32, ingress bool) binding.
 	if !ingress {
 		metricTableID = EgressMetricTable
 	}
-	return c.pipeline[metricTableID].BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
+	return c.pipeline[metricTableID].BuildFlow(priorityNormal).
 		MatchPriority(priorityNormal).
 		MatchRegRange(int(marksReg), cnpDropMark, cnpDropMarkRange).
 		MatchReg(int(CNPDropConjunctionIDReg), conjunctionID).
@@ -1151,7 +1140,7 @@ func (c *client) ipv6Flows(category cookie.Category) []binding.Flow {
 
 // conjunctionActionFlow generates the flow to jump to a specific table if policyRuleConjunction ID is matched. Priority of
 // conjunctionActionFlow is created at priorityLow for k8s network policies, and *priority assigned by PriorityAssigner for AntreaPolicy.
-func (c *client) conjunctionActionFlow(conjunctionID uint32, tableID binding.TableIDType, nextTable binding.TableIDType, priority *uint16, enableLogging bool) binding.Flow {
+func (c *client) conjunctionActionFlow(conjunctionID uint32, tableID binding.TableIDType, nextTable binding.TableIDType, priority *uint16, enableLogging bool) []binding.Flow {
 	var ofPriority uint16
 	if priority == nil {
 		ofPriority = priorityLow
@@ -1164,29 +1153,40 @@ func (c *client) conjunctionActionFlow(conjunctionID uint32, tableID binding.Tab
 		conjReg = EgressReg
 		labelRange = metricEgressRuleIDRange
 	}
-	if enableLogging {
-		return c.pipeline[tableID].BuildFlow(ofPriority).MatchProtocol(binding.ProtocolIP).
-			MatchConjID(conjunctionID).
-			MatchPriority(ofPriority).
-			Action().LoadRegRange(int(conjReg), conjunctionID, binding.Range{0, 31}).       // Traceflow.
-			Action().LoadRegRange(int(marksReg), DispositionAllow, APDispositionMarkRange). //AntreaPolicy
-			Action().SendToController(uint8(PacketInReasonNP)).
-			Action().CT(true, nextTable, CtZone). // CT action requires commit flag if actions other than NAT without arguments are specified.
-			LoadToLabelRange(uint64(conjunctionID), &labelRange).
-			CTDone().
-			Cookie(c.cookieAllocator.Request(cookie.Policy).Raw()).
-			Done()
-	} else {
-		return c.pipeline[tableID].BuildFlow(ofPriority).MatchProtocol(binding.ProtocolIP).
-			MatchConjID(conjunctionID).
-			MatchPriority(ofPriority).
-			Action().LoadRegRange(int(conjReg), conjunctionID, binding.Range{0, 31}). // Traceflow.
-			Action().CT(true, nextTable, CtZone).                                     // CT action requires commit flag if actions other than NAT without arguments are specified.
-			LoadToLabelRange(uint64(conjunctionID), &labelRange).
-			CTDone().
-			Cookie(c.cookieAllocator.Request(cookie.Policy).Raw()).
-			Done()
+	conjActionFlow := func(proto binding.Protocol) binding.Flow {
+		ctZone := CtZone
+		if proto == binding.ProtocolIPv6 {
+			ctZone = CtZoneV6
+		}
+		if enableLogging {
+			return c.pipeline[tableID].BuildFlow(ofPriority).MatchProtocol(proto).
+				MatchConjID(conjunctionID).
+				MatchPriority(ofPriority).
+				Action().LoadRegRange(int(conjReg), conjunctionID, binding.Range{0, 31}).       // Traceflow.
+				Action().LoadRegRange(int(marksReg), DispositionAllow, APDispositionMarkRange). // AntreaPolicy
+				Action().SendToController(uint8(PacketInReasonNP)).
+				Action().CT(true, nextTable, ctZone). // CT action requires commit flag if actions other than NAT without arguments are specified.
+				LoadToLabelRange(uint64(conjunctionID), &labelRange).
+				CTDone().
+				Cookie(c.cookieAllocator.Request(cookie.Policy).Raw()).
+				Done()
+		} else {
+			return c.pipeline[tableID].BuildFlow(ofPriority).MatchProtocol(proto).
+				MatchConjID(conjunctionID).
+				MatchPriority(ofPriority).
+				Action().LoadRegRange(int(conjReg), conjunctionID, binding.Range{0, 31}). // Traceflow.
+				Action().CT(true, nextTable, ctZone).                                     // CT action requires commit flag if actions other than NAT without arguments are specified.
+				LoadToLabelRange(uint64(conjunctionID), &labelRange).
+				CTDone().
+				Cookie(c.cookieAllocator.Request(cookie.Policy).Raw()).
+				Done()
+		}
 	}
+	var flows []binding.Flow
+	for _, proto := range c.ipProtocols {
+		flows = append(flows, conjActionFlow(proto))
+	}
+	return flows
 }
 
 // conjunctionActionDropFlow generates the flow to mark the packet to be dropped if policyRuleConjunction ID is matched.
@@ -1199,7 +1199,7 @@ func (c *client) conjunctionActionDropFlow(conjunctionID uint32, tableID binding
 	}
 	// We do not drop the packet immediately but send the packet to the metric table to update the rule metrics.
 	if enableLogging {
-		return c.pipeline[tableID].BuildFlow(ofPriority).MatchProtocol(binding.ProtocolIP).
+		return c.pipeline[tableID].BuildFlow(ofPriority).
 			MatchConjID(conjunctionID).
 			MatchPriority(ofPriority).
 			Action().LoadRegRange(int(CNPDropConjunctionIDReg), conjunctionID, binding.Range{0, 31}).
@@ -1210,7 +1210,7 @@ func (c *client) conjunctionActionDropFlow(conjunctionID uint32, tableID binding
 			Cookie(c.cookieAllocator.Request(cookie.Policy).Raw()).
 			Done()
 	} else {
-		return c.pipeline[tableID].BuildFlow(ofPriority).MatchProtocol(binding.ProtocolIP).
+		return c.pipeline[tableID].BuildFlow(ofPriority).
 			MatchConjID(conjunctionID).
 			MatchPriority(ofPriority).
 			Action().LoadRegRange(int(CNPDropConjunctionIDReg), conjunctionID, binding.Range{0, 31}).
@@ -1219,7 +1219,6 @@ func (c *client) conjunctionActionDropFlow(conjunctionID uint32, tableID binding
 			Cookie(c.cookieAllocator.Request(cookie.Policy).Raw()).
 			Done()
 	}
-
 }
 
 func (c *client) Disconnect() error {
@@ -1236,74 +1235,89 @@ func (c *client) establishedConnectionFlows(category cookie.Category) (flows []b
 	// matching the NetworkPolicy rules. Packets in the established connections need not to be checked with the
 	// egressRuleTable or the egressDropTable.
 	egressDropTable := c.pipeline[EgressDefaultTable]
-	egressEstFlow := c.pipeline[EgressRuleTable].BuildFlow(priorityHigh).MatchProtocol(binding.ProtocolIP).
-		MatchCTStateNew(false).MatchCTStateEst(true).
-		Action().GotoTable(egressDropTable.GetNext()).
-		Cookie(c.cookieAllocator.Request(category).Raw()).
-		Done()
 	// ingressDropTable checks the destination address of packets, and drops packets sent to the AppliedToGroup but not
 	// matching the NetworkPolicy rules. Packets in the established connections need not to be checked with the
 	// ingressRuleTable or ingressDropTable.
 	ingressDropTable := c.pipeline[IngressDefaultTable]
-	ingressEstFlow := c.pipeline[IngressRuleTable].BuildFlow(priorityHigh).MatchProtocol(binding.ProtocolIP).
-		MatchCTStateNew(false).MatchCTStateEst(true).
-		Action().GotoTable(ingressDropTable.GetNext()).
-		Cookie(c.cookieAllocator.Request(category).Raw()).
-		Done()
-	allEstFlows := []binding.Flow{egressEstFlow, ingressEstFlow}
-	if !c.enableAntreaPolicy {
-		return allEstFlows
-	}
-	apFlows := make([]binding.Flow, len(GetAntreaPolicyEgressTables())+len(GetAntreaPolicyIngressTables()))
-	for i, tableID := range GetAntreaPolicyEgressTables() {
-		apEgressEstFlow := c.pipeline[tableID].BuildFlow(priorityTopAntreaPolicy).MatchProtocol(binding.ProtocolIP).
+	var allEstFlows []binding.Flow
+	for _, ipProto := range c.ipProtocols {
+		egressEstFlow := c.pipeline[EgressRuleTable].BuildFlow(priorityHigh).MatchProtocol(ipProto).
 			MatchCTStateNew(false).MatchCTStateEst(true).
 			Action().GotoTable(egressDropTable.GetNext()).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done()
-		apFlows[i] = apEgressEstFlow
-	}
-	for i, tableID := range GetAntreaPolicyIngressTables() {
-		apIngressEstFlow := c.pipeline[tableID].BuildFlow(priorityTopAntreaPolicy).MatchProtocol(binding.ProtocolIP).
+		ingressEstFlow := c.pipeline[IngressRuleTable].BuildFlow(priorityHigh).MatchProtocol(ipProto).
 			MatchCTStateNew(false).MatchCTStateEst(true).
 			Action().GotoTable(ingressDropTable.GetNext()).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done()
-		apFlows[i+len(GetAntreaPolicyEgressTables())] = apIngressEstFlow
+		allEstFlows = append(allEstFlows, egressEstFlow, ingressEstFlow)
+	}
+	if !c.enableAntreaPolicy {
+		return allEstFlows
+	}
+	apFlows := make([]binding.Flow, 0)
+	for _, tableID := range GetAntreaPolicyEgressTables() {
+		for _, ipProto := range c.ipProtocols {
+			apEgressEstFlow := c.pipeline[tableID].BuildFlow(priorityTopAntreaPolicy).MatchProtocol(ipProto).
+				MatchCTStateNew(false).MatchCTStateEst(true).
+				Action().GotoTable(egressDropTable.GetNext()).
+				Cookie(c.cookieAllocator.Request(category).Raw()).
+				Done()
+			apFlows = append(apFlows, apEgressEstFlow)
+		}
+
+	}
+	for _, tableID := range GetAntreaPolicyIngressTables() {
+		for _, ipProto := range c.ipProtocols {
+			apIngressEstFlow := c.pipeline[tableID].BuildFlow(priorityTopAntreaPolicy).MatchProtocol(ipProto).
+				MatchCTStateNew(false).MatchCTStateEst(true).
+				Action().GotoTable(ingressDropTable.GetNext()).
+				Cookie(c.cookieAllocator.Request(category).Raw()).
+				Done()
+			apFlows = append(apFlows, apIngressEstFlow)
+		}
+
 	}
 	allEstFlows = append(allEstFlows, apFlows...)
 	return allEstFlows
 }
 
-func (c *client) addFlowMatch(fb binding.FlowBuilder, matchType int, matchValue interface{}) binding.FlowBuilder {
-	switch matchType {
-	case MatchDstIP:
-		fb = fb.MatchProtocol(binding.ProtocolIP).MatchDstIP(matchValue.(net.IP))
-	case MatchDstIPNet:
-		fb = fb.MatchProtocol(binding.ProtocolIP).MatchDstIPNet(matchValue.(net.IPNet))
-	case MatchSrcIP:
-		fb = fb.MatchProtocol(binding.ProtocolIP).MatchSrcIP(matchValue.(net.IP))
-	case MatchSrcIPNet:
-		fb = fb.MatchProtocol(binding.ProtocolIP).MatchSrcIPNet(matchValue.(net.IPNet))
+func (c *client) addFlowMatch(fb binding.FlowBuilder, matchKey *types.MatchKey, matchValue interface{}) binding.FlowBuilder {
+	switch matchKey {
 	case MatchDstOFPort:
 		// ofport number in NXM_NX_REG1 is used in ingress rule to match packets sent to local Pod.
-		fb = fb.MatchProtocol(binding.ProtocolIP).MatchReg(int(portCacheReg), uint32(matchValue.(int32)))
+		fb = fb.MatchReg(int(portCacheReg), uint32(matchValue.(int32)))
 	case MatchSrcOFPort:
-		fb = fb.MatchProtocol(binding.ProtocolIP).MatchInPort(uint32(matchValue.(int32)))
+		fb = fb.MatchInPort(uint32(matchValue.(int32)))
+	case MatchDstIP:
+		fallthrough
+	case MatchDstIPv6:
+		fb = fb.MatchProtocol(matchKey.GetOFProtocol()).MatchDstIP(matchValue.(net.IP))
+	case MatchDstIPNet:
+		fallthrough
+	case MatchDstIPNetv6:
+		fb = fb.MatchProtocol(matchKey.GetOFProtocol()).MatchDstIPNet(matchValue.(net.IPNet))
+	case MatchSrcIP:
+		fallthrough
+	case MatchSrcIPv6:
+		fb = fb.MatchProtocol(matchKey.GetOFProtocol()).MatchSrcIP(matchValue.(net.IP))
+	case MatchSrcIPNet:
+		fallthrough
+	case MatchSrcIPNetv6:
+		fb = fb.MatchProtocol(matchKey.GetOFProtocol()).MatchSrcIPNet(matchValue.(net.IPNet))
 	case MatchTCPDstPort:
-		fb = fb.MatchProtocol(binding.ProtocolTCP)
-		portValue := matchValue.(uint16)
-		if portValue > 0 {
-			fb = fb.MatchDstPort(portValue, nil)
-		}
+		fallthrough
+	case MatchTCPv6DstPort:
+		fallthrough
 	case MatchUDPDstPort:
-		fb = fb.MatchProtocol(binding.ProtocolUDP)
-		portValue := matchValue.(uint16)
-		if portValue > 0 {
-			fb = fb.MatchDstPort(portValue, nil)
-		}
+		fallthrough
+	case MatchUDPv6DstPort:
+		fallthrough
 	case MatchSCTPDstPort:
-		fb = fb.MatchProtocol(binding.ProtocolSCTP)
+		fallthrough
+	case MatchSCTPv6DstPort:
+		fb = fb.MatchProtocol(matchKey.GetOFProtocol())
 		portValue := matchValue.(uint16)
 		if portValue > 0 {
 			fb = fb.MatchDstPort(portValue, nil)
@@ -1314,7 +1328,7 @@ func (c *client) addFlowMatch(fb binding.FlowBuilder, matchType int, matchValue 
 
 // conjunctionExceptionFlow generates the flow to jump to a specific table if both policyRuleConjunction ID and except address are matched.
 // Keeping this for reference to generic exception flow.
-func (c *client) conjunctionExceptionFlow(conjunctionID uint32, tableID binding.TableIDType, nextTable binding.TableIDType, matchKey int, matchValue interface{}) binding.Flow {
+func (c *client) conjunctionExceptionFlow(conjunctionID uint32, tableID binding.TableIDType, nextTable binding.TableIDType, matchKey *types.MatchKey, matchValue interface{}) binding.Flow {
 	conjReg := IngressReg
 	if tableID == EgressRuleTable {
 		conjReg = EgressReg
@@ -1328,7 +1342,7 @@ func (c *client) conjunctionExceptionFlow(conjunctionID uint32, tableID binding.
 }
 
 // conjunctiveMatchFlow generates the flow to set conjunctive actions if the match condition is matched.
-func (c *client) conjunctiveMatchFlow(tableID binding.TableIDType, matchKey int, matchValue interface{}, priority *uint16, actions ...*conjunctiveAction) binding.Flow {
+func (c *client) conjunctiveMatchFlow(tableID binding.TableIDType, matchKey *types.MatchKey, matchValue interface{}, priority *uint16, actions ...*conjunctiveAction) binding.Flow {
 	var ofPriority uint16
 	if priority != nil {
 		ofPriority = *priority
@@ -1344,7 +1358,7 @@ func (c *client) conjunctiveMatchFlow(tableID binding.TableIDType, matchKey int,
 }
 
 // defaultDropFlow generates the flow to drop packets if the match condition is matched.
-func (c *client) defaultDropFlow(tableID binding.TableIDType, matchKey int, matchValue interface{}) binding.Flow {
+func (c *client) defaultDropFlow(tableID binding.TableIDType, matchKey *types.MatchKey, matchValue interface{}) binding.Flow {
 	fb := c.pipeline[tableID].BuildFlow(priorityNormal)
 	return c.addFlowMatch(fb, matchKey, matchValue).
 		Action().Drop().

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -448,6 +448,34 @@ func (mr *MockClientMockRecorder) IsConnected() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsConnected", reflect.TypeOf((*MockClient)(nil).IsConnected))
 }
 
+// IsIPv4Enabled mocks base method
+func (m *MockClient) IsIPv4Enabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsIPv4Enabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsIPv4Enabled indicates an expected call of IsIPv4Enabled
+func (mr *MockClientMockRecorder) IsIPv4Enabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsIPv4Enabled", reflect.TypeOf((*MockClient)(nil).IsIPv4Enabled))
+}
+
+// IsIPv6Enabled mocks base method
+func (m *MockClient) IsIPv6Enabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsIPv6Enabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsIPv6Enabled indicates an expected call of IsIPv6Enabled
+func (mr *MockClientMockRecorder) IsIPv6Enabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsIPv6Enabled", reflect.TypeOf((*MockClient)(nil).IsIPv6Enabled))
+}
+
 // NetworkPolicyMetrics mocks base method
 func (m *MockClient) NetworkPolicyMetrics() map[uint32]*types.RuleMetric {
 	m.ctrl.T.Helper()

--- a/pkg/agent/types/networkpolicy.go
+++ b/pkg/agent/types/networkpolicy.go
@@ -20,12 +20,40 @@ import (
 	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
 )
 
+type MatchKey struct {
+	ofProtocol    binding.Protocol
+	valueCategory AddressCategory
+	keyString     string
+}
+
+func (m *MatchKey) GetOFProtocol() binding.Protocol {
+	return m.ofProtocol
+}
+
+func (m *MatchKey) GetValueCategory() AddressCategory {
+	return m.valueCategory
+}
+
+func (m *MatchKey) GetKeyString() string {
+	return m.keyString
+}
+
+func NewMatchKey(proto binding.Protocol, valueCategory AddressCategory, keyString string) *MatchKey {
+	return &MatchKey{
+		keyString:     keyString,
+		ofProtocol:    proto,
+		valueCategory: valueCategory,
+	}
+}
+
 type AddressCategory uint8
 
 const (
 	IPAddr AddressCategory = iota
 	IPNetAddr
 	OFPortAddr
+	L4PortAddr
+	UnSupported
 )
 
 type AddressType int
@@ -37,7 +65,7 @@ const (
 
 type Address interface {
 	GetMatchValue() string
-	GetMatchKey(addrType AddressType) int
+	GetMatchKey(addrType AddressType) *MatchKey
 	GetValue() interface{}
 }
 

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -132,17 +132,6 @@ func GetIPv4Addr(ips []net.IP) net.IP {
 	return nil
 }
 
-func CheckAddressFamilies(ips []net.IP) (hasV4, hasV6 bool) {
-	for _, ip := range ips {
-		if ip.To4() != nil {
-			hasV4 = true
-		} else {
-			hasV6 = true
-		}
-	}
-	return
-}
-
 func GetIPWithFamily(ips []net.IP, addrFamily uint8) (net.IP, error) {
 	if addrFamily == FamilyIPv6 {
 		for _, ip := range ips {

--- a/pkg/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_test.go
@@ -2786,6 +2786,11 @@ func getPod(name, ns, nodeName, podIP string, namedPort bool) *corev1.Pod {
 				},
 			},
 			PodIP: podIP,
+			PodIPs: []corev1.PodIP{
+				{
+					IP: podIP,
+				},
+			},
 		},
 	}
 }

--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -221,6 +221,7 @@ func runAntctProxy(nodeName string, nodeAntctlPath string, proxyPort int, agentN
 // TestAntctlProxy validates "antctl proxy" for both the Antrea Controller and
 // Agent API.
 func TestAntctlProxy(t *testing.T) {
+	skipIfIPv6Cluster(t)
 	const proxyPort = 8001
 
 	data, err := setupTest(t)

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -110,8 +110,8 @@ func (data *TestData) testHostPortPodConnectivity(t *testing.T) {
 	hpPodHostIP := hpPod.Status.HostIP
 	// Create client Pod to test connectivity.
 	clientName := randName("test-client-")
-	if err := data.createBusyboxPod(clientName); err != nil {
-		t.Fatalf("Error when creating busybox test Pod: %v", err)
+	if err := data.createBusyboxPodOnNode(clientName, ""); err != nil {
+		t.Fatalf("Error when creating test client Pod: %v", err)
 	}
 	defer deletePodWrapper(t, data, clientName)
 	if _, err := data.podWaitForIPs(defaultTimeout, clientName, testNamespace); err != nil {


### PR DESCRIPTION
1. Add enhancement in Antrea Controller and Agent to support NetworkPolicy
   in IPv6.
2. Optimize test cases to support IPv6
3. Use regex in CRD to validate IPv4 or IPv6 string

Due to absence of @wenyingd, this PR is to solve comments for PR #1272 .