### PR TITLE
Make iptables initialization error non fatal

### DIFF
--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"time"
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
@@ -42,6 +43,15 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane/v1beta2"
 	"github.com/vmware-tanzu/antrea/pkg/cni"
 	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
+)
+
+const (
+	// networkReadyTimeout is the maximum time the CNI server will wait for network ready when processing CNI Add
+	// requests. If timeout occurs, tryAgainLaterResponse will be returned.
+	// The default runtime request timeout of kubelet is 2 minutes.
+	// https://github.com/kubernetes/kubernetes/blob/v1.19.3/staging/src/k8s.io/kubelet/config/v1beta1/types.go#L451
+	// networkReadyTimeout is set to a shorter time so it returns a clear message to the runtime.
+	networkReadyTimeout = 30 * time.Second
 )
 
 // containerAccessArbitrator is used to ensure that concurrent goroutines cannot perfom operations
@@ -100,6 +110,8 @@ type CNIServer struct {
 	podUpdates  chan<- v1beta2.PodReference
 	isChaining  bool
 	routeClient route.Interface
+	// networkReadyCh notifies that the network is ready so new Pods can be created. Therefore, CmdAdd waits for it.
+	networkReadyCh <-chan struct{}
 }
 
 var supportedCNIVersionSet map[string]bool
@@ -184,7 +196,7 @@ func (s *CNIServer) loadNetworkConfig(request *cnipb.CniCmdRequest) (*CNIConfig,
 	if cniConfig.MTU == 0 {
 		cniConfig.MTU = s.nodeConfig.NodeMTU
 	}
-	klog.Infof("Load network configurations: %v", cniConfig)
+	klog.V(3).Infof("Load network configurations: %v", cniConfig)
 	return cniConfig, nil
 }
 
@@ -348,6 +360,13 @@ func (s *CNIServer) CmdAdd(ctx context.Context, request *cnipb.CniCmdRequest) (*
 		return response, nil
 	}
 
+	select {
+	case <-time.After(networkReadyTimeout):
+		klog.Errorf("Cannot process CmdAdd request for container %v because network is not ready", cniConfig.ContainerId)
+		return s.tryAgainLaterResponse(), nil
+	case <-s.networkReadyCh:
+	}
+
 	cniVersion := cniConfig.CNIVersion
 	result := &current.Result{CNIVersion: cniVersion}
 	netNS := s.hostNetNsPath(cniConfig.Netns)
@@ -358,12 +377,12 @@ func (s *CNIServer) CmdAdd(ctx context.Context, request *cnipb.CniCmdRequest) (*
 		// Rollback to delete configurations once ADD is failure.
 		if !success {
 			if isInfraContainer {
-				klog.Warningf("CmdAdd has failed, and try to rollback")
+				klog.Warningf("CmdAdd for container %v failed, and try to rollback", cniConfig.ContainerId)
 				if _, err := s.CmdDel(ctx, request); err != nil {
 					klog.Warningf("Failed to rollback after CNI add failure: %v", err)
 				}
 			} else {
-				klog.Warningf("CmdAdd has failed")
+				klog.Warningf("CmdAdd for container %v failed", cniConfig.ContainerId)
 			}
 		}
 	}()
@@ -392,11 +411,11 @@ func (s *CNIServer) CmdAdd(ctx context.Context, request *cnipb.CniCmdRequest) (*
 		// Request IP Address from IPAM driver.
 		ipamResult, err = ipam.ExecIPAMAdd(cniConfig.CniCmdArgs, cniConfig.IPAM.Type, infraContainer)
 		if err != nil {
-			klog.Errorf("Failed to add IP addresses from IPAM driver: %v", err)
+			klog.Errorf("Failed to request IP addresses for container %v: %v", cniConfig.ContainerId, err)
 			return s.ipamFailureResponse(err), nil
 		}
 	}
-	klog.Infof("Added ip addresses from IPAM driver, %v", ipamResult)
+	klog.Infof("Requested ip addresses for container %v: %v", cniConfig.ContainerId, ipamResult)
 	result.IPs = ipamResult.IPs
 	result.Routes = ipamResult.Routes
 	// Ensure interface gateway setting and mapping relations between result.Interfaces and result.IPs
@@ -425,7 +444,7 @@ func (s *CNIServer) CmdAdd(ctx context.Context, request *cnipb.CniCmdRequest) (*
 
 	var resultBytes bytes.Buffer
 	_ = result.PrintTo(&resultBytes)
-	klog.Infof("CmdAdd succeeded")
+	klog.Infof("CmdAdd for container %v succeeded", cniConfig.ContainerId)
 	// mark success as true to avoid rollback
 	success = true
 	return &cnipb.CniCmdResponse{CniResult: resultBytes.Bytes()}, nil
@@ -449,15 +468,16 @@ func (s *CNIServer) CmdDel(_ context.Context, request *cnipb.CniCmdRequest) (
 	}
 	// Release IP to IPAM driver
 	if err := ipam.ExecIPAMDelete(cniConfig.CniCmdArgs, cniConfig.IPAM.Type, infraContainer); err != nil {
-		klog.Errorf("Failed to delete IP addresses by IPAM driver: %v", err)
+		klog.Errorf("Failed to delete IP addresses for container %v: %v", cniConfig.ContainerId, err)
 		return s.ipamFailureResponse(err), nil
 	}
-	klog.Info("Deleted IP addresses by IPAM driver")
+	klog.Infof("Deleted IP addresses for container %v", cniConfig.ContainerId)
 	// Remove host interface and OVS configuration
 	if err := s.podConfigurator.removeInterfaces(cniConfig.ContainerId); err != nil {
 		klog.Errorf("Failed to remove interfaces for container %s: %v", cniConfig.ContainerId, err)
 		return s.configInterfaceFailureResponse(err), nil
 	}
+	klog.Infof("CmdDel for container %v succeeded", cniConfig.ContainerId)
 	return &cnipb.CniCmdResponse{CniResult: []byte("")}, nil
 }
 
@@ -479,7 +499,7 @@ func (s *CNIServer) CmdCheck(_ context.Context, request *cnipb.CniCmdRequest) (
 	}
 
 	if err := ipam.ExecIPAMCheck(cniConfig.CniCmdArgs, cniConfig.IPAM.Type); err != nil {
-		klog.Errorf("Failed to check IPAM configuration: %v", err)
+		klog.Errorf("Failed to check IPAM configuration for container %v: %v", cniConfig.ContainerId, err)
 		return s.ipamFailureResponse(err), nil
 	}
 
@@ -491,7 +511,7 @@ func (s *CNIServer) CmdCheck(_ context.Context, request *cnipb.CniCmdRequest) (
 			return response, nil
 		}
 	}
-	klog.Info("Succeed to check network configuration")
+	klog.Infof("CmdCheck for container %v succeeded", cniConfig.ContainerId)
 	return &cnipb.CniCmdResponse{CniResult: []byte("")}, nil
 }
 
@@ -502,6 +522,7 @@ func New(
 	podUpdates chan<- v1beta2.PodReference,
 	isChaining bool,
 	routeClient route.Interface,
+	networkReadyCh <-chan struct{},
 ) *CNIServer {
 	return &CNIServer{
 		cniSocket:            cniSocket,
@@ -514,6 +535,7 @@ func New(
 		podUpdates:           podUpdates,
 		isChaining:           isChaining,
 		routeClient:          routeClient,
+		networkReadyCh:       networkReadyCh,
 	}
 }
 

--- a/pkg/agent/cniserver/server_test.go
+++ b/pkg/agent/cniserver/server_test.go
@@ -517,12 +517,15 @@ func translateRawPrevResult(prevResult *current.Result, cniVersion string) (map[
 }
 
 func newCNIServer(t *testing.T) *CNIServer {
+	networkReadyCh := make(chan struct{})
 	cniServer := &CNIServer{
 		cniSocket:       testSocket,
 		nodeConfig:      testNodeConfig,
 		serverVersion:   cni.AntreaCNIVersion,
 		containerAccess: newContainerAccessArbitrator(),
+		networkReadyCh:  networkReadyCh,
 	}
+	close(networkReadyCh)
 	cniServer.supportedCNIVersions = buildVersionSet()
 	return cniServer
 }

--- a/pkg/agent/route/interfaces.go
+++ b/pkg/agent/route/interfaces.go
@@ -24,7 +24,7 @@ import (
 type Interface interface {
 	// Initialize should initialize all infrastructures required to route container packets in host network.
 	// It should be idempotent and can be safely called on every startup.
-	Initialize(nodeConfig *config.NodeConfig) error
+	Initialize(nodeConfig *config.NodeConfig, done func()) error
 
 	// Reconcile should remove orphaned routes and related configuration based on the desired podCIDRs.
 	Reconcile(podCIDRs []string) error

--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -82,7 +83,7 @@ func NewClient(serviceCIDR *net.IPNet, networkConfig *config.NetworkConfig, noSN
 
 // Initialize initializes all infrastructures required to route container packets in host network.
 // It is idempotent and can be safely called on every startup.
-func (c *Client) Initialize(nodeConfig *config.NodeConfig) error {
+func (c *Client) Initialize(nodeConfig *config.NodeConfig, done func()) error {
 	c.nodeConfig = nodeConfig
 
 	// Sets up the ipset that will be used in iptables.
@@ -91,9 +92,8 @@ func (c *Client) Initialize(nodeConfig *config.NodeConfig) error {
 	}
 
 	// Sets up the iptables infrastructure required to route packets in host network.
-	if err := c.initIPTables(); err != nil {
-		return fmt.Errorf("failed to initialize iptables: %v", err)
-	}
+	// It's called in a goroutine because xtables lock may not be acquired immediately.
+	go c.initIPTablesOnce(done)
 
 	// Sets up the IP routes and IP rule required to route packets in host network.
 	if err := c.initIPRoutes(); err != nil {
@@ -101,6 +101,22 @@ func (c *Client) Initialize(nodeConfig *config.NodeConfig) error {
 	}
 
 	return nil
+}
+
+// initIPTablesOnce starts a loop that initializes the iptables infrastructure.
+// It returns after one successful execution.
+func (c *Client) initIPTablesOnce(done func()) {
+	defer done()
+	backoffTime := 2 * time.Second
+	for {
+		if err := c.initIPTables(); err != nil {
+			klog.Errorf("Failed to initialize iptables: %v - will retry in %v", err, backoffTime)
+			time.Sleep(backoffTime)
+			continue
+		}
+		klog.Info("Initialized iptables")
+		return
+	}
 }
 
 // initIPSet ensures that the required ipset exists and it has the initial members.

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -56,7 +56,7 @@ func NewClient(serviceCIDR *net.IPNet, networkConfig *config.NetworkConfig, noSN
 
 // Initialize sets nodeConfig on Window.
 // Service LoadBalancing is provided by OpenFlow.
-func (c *Client) Initialize(nodeConfig *config.NodeConfig) error {
+func (c *Client) Initialize(nodeConfig *config.NodeConfig, done func()) error {
 	c.nodeConfig = nodeConfig
 	if err := c.initFwRules(); err != nil {
 		return err
@@ -70,6 +70,7 @@ func (c *Client) Initialize(nodeConfig *config.NodeConfig) error {
 	if err := util.EnableIPForwarding(nodeConfig.GatewayConfig.Name); err != nil {
 		return err
 	}
+	done()
 	return nil
 }
 

--- a/pkg/agent/route/route_windows_test.go
+++ b/pkg/agent/route/route_windows_test.go
@@ -61,8 +61,10 @@ func TestRouteOperation(t *testing.T) {
 			LinkIndex: gwLink,
 		},
 	}
-	err = client.Initialize(nodeConfig)
+	called := false
+	err = client.Initialize(nodeConfig, func() { called = true })
 	require.Nil(t, err)
+	require.True(t, called)
 
 	// Add initial routes.
 	err = client.AddRoutes(destCIDR1, peerNodeIP1, gwIP1)

--- a/pkg/agent/route/testing/mock_route.go
+++ b/pkg/agent/route/testing/mock_route.go
@@ -78,17 +78,17 @@ func (mr *MockInterfaceMockRecorder) DeleteRoutes(arg0 interface{}) *gomock.Call
 }
 
 // Initialize mocks base method
-func (m *MockInterface) Initialize(arg0 *config.NodeConfig) error {
+func (m *MockInterface) Initialize(arg0 *config.NodeConfig, arg1 func()) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Initialize", arg0)
+	ret := m.ctrl.Call(m, "Initialize", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Initialize indicates an expected call of Initialize
-func (mr *MockInterfaceMockRecorder) Initialize(arg0 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) Initialize(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockInterface)(nil).Initialize), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockInterface)(nil).Initialize), arg0, arg1)
 }
 
 // MigrateRoutesToGw mocks base method

--- a/pkg/agent/util/iptables/iptables.go
+++ b/pkg/agent/util/iptables/iptables.go
@@ -128,7 +128,7 @@ func (c *Client) Restore(data []byte, flush bool) error {
 	if c.restoreWaitSupported {
 		cmd.Args = append(cmd.Args, "-w", strconv.Itoa(waitSeconds), "-W", strconv.Itoa(waitIntervalMicroSeconds))
 	} else {
-		unlockFunc, err := lock(xtablesLockFilePath, waitSeconds*time.Second)
+		unlockFunc, err := Lock(XtablesLockFilePath, waitSeconds*time.Second)
 		if err != nil {
 			return err
 		}

--- a/pkg/agent/util/iptables/lock.go
+++ b/pkg/agent/util/iptables/lock.go
@@ -26,13 +26,13 @@ import (
 )
 
 const (
-	xtablesLockFilePath       = "/var/run/xtables.lock"
+	XtablesLockFilePath       = "/var/run/xtables.lock"
 	xtablesLockFilePermission = 0600
 )
 
-// lock acquires the provided file lock. It's thread-safe.
+// Lock acquires the provided file lock. It's thread-safe.
 // It will block until the lock is acquired or the timeout is reached.
-func lock(lockFilePath string, timeout time.Duration) (func() error, error) {
+func Lock(lockFilePath string, timeout time.Duration) (func() error, error) {
 	lockFile, err := os.OpenFile(lockFilePath, os.O_CREATE, xtablesLockFilePermission)
 	if err != nil {
 		return nil, fmt.Errorf("error opening xtables lock file: %v", err)

--- a/pkg/agent/util/iptables/lock_test.go
+++ b/pkg/agent/util/iptables/lock_test.go
@@ -44,7 +44,7 @@ func TestLock(t *testing.T) {
 			name:         "lock-already-acquired",
 			lockFilePath: filePath2,
 			prepareFunc: func(filePath string) {
-				lock(filePath, 2*time.Second)
+				Lock(filePath, 2*time.Second)
 			},
 			wantErr: true,
 		},
@@ -52,7 +52,7 @@ func TestLock(t *testing.T) {
 			name:         "lock-already-released",
 			lockFilePath: filePath3,
 			prepareFunc: func(filePath string) {
-				unlockFunc, _ := lock(filePath, 2*time.Second)
+				unlockFunc, _ := Lock(filePath, 2*time.Second)
 				unlockFunc()
 			},
 			wantErr: false,
@@ -61,7 +61,7 @@ func TestLock(t *testing.T) {
 			name:         "lock-released-in-one-second",
 			lockFilePath: filePath4,
 			prepareFunc: func(filePath string) {
-				unlockFunc, _ := lock(filePath, 2*time.Second)
+				unlockFunc, _ := Lock(filePath, 2*time.Second)
 				go func() {
 					time.Sleep(1 * time.Second)
 					unlockFunc()
@@ -76,7 +76,7 @@ func TestLock(t *testing.T) {
 			if tt.prepareFunc != nil {
 				tt.prepareFunc(tt.lockFilePath)
 			}
-			unlockFunc, err := lock(tt.lockFilePath, 2*time.Second)
+			unlockFunc, err := Lock(tt.lockFilePath, 2*time.Second)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("lock() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -287,12 +287,13 @@ func ipVersion(ip net.IP) string {
 }
 
 type cmdAddDelTester struct {
-	server   *cniserver.CNIServer
-	ctx      context.Context
-	testNS   ns.NetNS
-	targetNS ns.NetNS
-	request  *cnimsg.CniCmdRequest
-	vethName string
+	server         *cniserver.CNIServer
+	ctx            context.Context
+	testNS         ns.NetNS
+	targetNS       ns.NetNS
+	request        *cnimsg.CniCmdRequest
+	vethName       string
+	networkReadyCh chan struct{}
 }
 
 func (tester *cmdAddDelTester) setNS(testNS ns.NetNS, targetNS ns.NetNS) {
@@ -564,13 +565,15 @@ func newTester() *cmdAddDelTester {
 	tester := &cmdAddDelTester{}
 	ifaceStore := interfacestore.NewInterfaceStore()
 	testNodeConfig.NodeMTU = 1450
+	tester.networkReadyCh = make(chan struct{})
 	tester.server = cniserver.New(testSock,
 		"",
 		testNodeConfig,
 		k8sFake.NewSimpleClientset(),
 		make(chan v1beta2.PodReference, 100),
 		false,
-		nil)
+		nil,
+		tester.networkReadyCh)
 	tester.server.Initialize(ovsServiceMock, ofServiceMock, ifaceStore, "")
 	ctx := context.Background()
 	tester.ctx = ctx
@@ -606,6 +609,7 @@ func cmdAddDelCheckTest(testNS ns.NetNS, tc testCase, dataDir string) {
 	ovsServiceMock.EXPECT().GetOFPort(ovsPortname).Return(int32(10), nil).AnyTimes()
 	ofServiceMock.EXPECT().InstallPodFlows(ovsPortname, mock.Any(), mock.Any(), mock.Any(), mock.Any()).Return(nil)
 
+	close(tester.networkReadyCh)
 	// Test ip allocation
 	prevResult, err := tester.cmdAddTest(tc, dataDir)
 	testRequire.Nil(err)
@@ -720,13 +724,16 @@ func setupChainTest(
 
 	if newServer {
 		routeMock = routetest.NewMockInterface(controller)
+		networkReadyCh := make(chan struct{})
+		close(networkReadyCh)
 		server = cniserver.New(testSock,
 			"",
 			testNodeConfig,
 			k8sFake.NewSimpleClientset(),
 			make(chan v1beta2.PodReference, 100),
 			true,
-			routeMock)
+			routeMock,
+			networkReadyCh)
 	} else {
 		server = inServer
 	}


### PR DESCRIPTION
In large scale clusters, xtables lock may be hold by kubelet/
kube-proxy/ portmap for a long time, especially when there are many
service rules in nat table. antrea-agent may not be able to acquire the
lock in short time. If the agent blocks on the lock or quit itself, the
CNI server won't be running, causing all CNI requests to fail.  If the
Pods' restart policy is Always and there are dead Pods, container
runtime will keep retrying calling CNIs, during which portmap is called
first, leading to more xtables lock contention.

This patch makes iptables initialization error non fatal and uses a
goroutine to retry it until success. The agent will start the CNI server
anyway and handle the CNI Del requests but won't handle CNI Add requests
until the network is ready.

Fixes #1499