### PR TITLE
[IPv6] Skip TestAntctlProxy for IPv6

### DIFF
--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -221,6 +221,7 @@ func runAntctProxy(nodeName string, nodeAntctlPath string, proxyPort int, agentN
 // TestAntctlProxy validates "antctl proxy" for both the Antrea Controller and
 // Agent API.
 func TestAntctlProxy(t *testing.T) {
+	skipIfIPv6Cluster(t)
 	const proxyPort = 8001
 
 	data, err := setupTest(t)


### PR DESCRIPTION
Current implementation doesn't support this e2e test in IPv6-only setup. Will support it later.