### PR TITLE
Delete deprecated Prometheus metrics

### DIFF
--- a/docs/prometheus-integration.md
+++ b/docs/prometheus-integration.md
@@ -153,8 +153,6 @@ errors, partitioned by operation type (add, modify and delete).
 flow operations, partitioned by operation type (add, modify and delete).
 - **antrea_agent_ovs_total_flow_count:** Total flow count of all OVS flow
 tables.
-- **antrea_agent_runtime_info:** Antrea agent runtime info (Deprecated since
-Antrea 0.10.0), defined as labels. The value of the gauge is always set to 1.
 
 ## Antrea Controller Metrics
 - **antrea_controller_address_group_processed:** The total number of
@@ -175,9 +173,6 @@ InternalNetworkPolicyQueue
 internal-networkpolicy processed
 - **antrea_controller_network_policy_sync_duration_milliseconds:** The
 duration of syncing internal-networkpolicy
-- **antrea_controller_runtime_info:** Antrea controller runtime info
-(Deprecated since Antrea 0.10.0), defined as labels. The value of the gauge
-is always set to 1.
 
 ## Common Metrics Provided by Infrastructure
 ## Apiserver Metrics

--- a/pkg/agent/metrics/prometheus.go
+++ b/pkg/agent/metrics/prometheus.go
@@ -18,8 +18,6 @@ import (
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog"
-
-	"github.com/vmware-tanzu/antrea/pkg/util/env"
 )
 
 var (
@@ -122,24 +120,6 @@ var (
 
 func InitializePrometheusMetrics() {
 	klog.Info("Initializing prometheus metrics")
-
-	nodeName, err := env.GetNodeName()
-	if err != nil {
-		klog.Errorf("Failed to retrieve agent K8S node name: %v", err)
-	}
-	deprecatedGaugeHost := metrics.NewGauge(&metrics.GaugeOpts{
-		Name:              "antrea_agent_runtime_info",
-		Help:              "Antrea agent runtime info (Deprecated since Antrea 0.10.0), defined as labels. The value of the gauge is always set to 1.",
-		ConstLabels:       metrics.Labels{"k8s_nodename": nodeName, "k8s_podname": env.GetPodName()},
-		StabilityLevel:    metrics.STABLE,
-		DeprecatedVersion: "0.10.0",
-	})
-	if err := legacyregistry.Register(deprecatedGaugeHost); err != nil {
-		klog.Error("Failed to register antrea_agent_runtime_info with Prometheus")
-	}
-	// This must be after registering the metrics.Gauge as it is lazily instantiated
-	// and will not measure anything unless the collector is first registered.
-	deprecatedGaugeHost.Set(1)
 
 	InitializePodMetrics()
 	InitializeNetworkPolicyMetrics()

--- a/pkg/controller/metrics/prometheus.go
+++ b/pkg/controller/metrics/prometheus.go
@@ -18,8 +18,6 @@ import (
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog"
-
-	"github.com/vmware-tanzu/antrea/pkg/util/env"
 )
 
 var (
@@ -73,24 +71,6 @@ var (
 // Initialize Prometheus metrics collection.
 func InitializePrometheusMetrics() {
 	klog.Info("Initializing prometheus metrics")
-
-	nodeName, err := env.GetNodeName()
-	if err != nil {
-		klog.Errorf("Failed to retrieve controller K8S node name: %v", err)
-	}
-	deprecatedGaugeHost := metrics.NewGauge(&metrics.GaugeOpts{
-		Name:              "antrea_controller_runtime_info",
-		Help:              "Antrea controller runtime info (Deprecated since Antrea 0.10.0), defined as labels. The value of the gauge is always set to 1.",
-		ConstLabels:       metrics.Labels{"k8s_nodename": nodeName, "k8s_podname": env.GetPodName()},
-		StabilityLevel:    metrics.STABLE,
-		DeprecatedVersion: "0.10.0",
-	})
-	if err = legacyregistry.Register(deprecatedGaugeHost); err != nil {
-		klog.Errorf("Failed to register antrea_controller_runtime_info with Prometheus: %s", err.Error())
-	}
-	// This must be after registering the metrics.Gauge as it is lazily instantiated
-	// and will not measure anything unless the collector is first registered.
-	deprecatedGaugeHost.Set(1)
 
 	if err := legacyregistry.Register(OpsAppliedToGroupProcessed); err != nil {
 		klog.Errorf("Failed to register antrea_controller_applied_to_group_processed with Prometheus: %s", err.Error())

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -42,7 +42,6 @@ var antreaAgentMetrics = []string{
 	"antrea_agent_ovs_flow_ops_error_count",
 	"antrea_agent_ovs_flow_ops_latency_milliseconds",
 	"antrea_agent_ovs_total_flow_count",
-	"antrea_agent_runtime_info",
 	"antrea_agent_conntrack_total_connection_count",
 	"antrea_agent_conntrack_antrea_connection_count",
 	"antrea_agent_conntrack_max_connection_count",
@@ -59,7 +58,6 @@ var antreaControllerMetrics = []string{
 	"antrea_controller_length_network_policy_queue",
 	"antrea_controller_network_policy_processed",
 	"antrea_controller_network_policy_sync_duration_milliseconds",
-	"antrea_controller_runtime_info",
 }
 
 var prometheusEnabled bool


### PR DESCRIPTION
antrea_agent_runtime_info and antrea_controller_runtime_info are
deprecated since 0.10.0 release. Deleting them from 0.11.0 release.