### PR TITLE
Remove unused function in e2e tests

### DIFF
--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -21,8 +21,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 )
 
 const (
@@ -51,18 +49,6 @@ func skipIfNumNodesLessThan(tb testing.TB, required int) {
 func skipIfRunCoverage(tb testing.TB, reason string) {
 	if testOptions.enableCoverage {
 		tb.Skipf("Skipping test for the '%s' when run coverage: %s", tb.Name(), reason)
-	}
-}
-
-func skipIfEncapModeIs(tb testing.TB, data *TestData, encapModes []config.TrafficEncapModeType) {
-	currentEncapMode, err := data.GetEncapMode()
-	if err != nil {
-		tb.Fatalf("Failed to get encap mode: %v", err)
-	}
-	for _, encapMode := range encapModes {
-		if currentEncapMode == encapMode {
-			tb.Skipf("Skipping test for encap mode '%s'", encapMode.String())
-		}
 	}
 }
 


### PR DESCRIPTION
Which is causing CI to fail (deadcode linter)