### PR TITLE
[CI] Use VMware-hosted public Harbor registry in VMC CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,11 @@ docker-test-unit: $(DOCKER_CACHE)
 .PHONY: docker-test-integration
 docker-test-integration: .coverage
 	@echo "===> Building Antrea Integration Test Docker image <==="
-	@docker build --pull -t antrea/test -f build/images/test/Dockerfile .
+ifneq ($(DOCKER_REGISTRY),"")
+	docker build -t antrea/test -f build/images/test/Dockerfile .
+else
+	docker build --pull -t antrea/test -f build/images/test/Dockerfile .
+endif
 	@docker run --privileged --rm \
 		-e "GOCACHE=/tmp/gocache" \
 		-e "GOPATH=/tmp/gopath" \
@@ -253,19 +257,31 @@ ubuntu:
 .PHONY: build-ubuntu
 build-ubuntu:
 	@echo "===> Building Antrea bins and antrea/antrea-ubuntu Docker image <==="
+ifneq ($(DOCKER_REGISTRY),"")
+	docker build -t antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.ubuntu .
+else
 	docker build --pull -t antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.ubuntu .
+endif
 	docker tag antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) antrea/antrea-ubuntu
 
 .PHONY: build-windows
 build-windows:
 	@echo "===> Building Antrea bins and antrea/antrea-windows Docker image <==="
+ifneq ($(DOCKER_REGISTRY),"")
+	docker build -t antrea/antrea-windows:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.windows .
+else
 	docker build --pull -t antrea/antrea-windows:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.windows .
+endif
 	docker tag antrea/antrea-windows:$(DOCKER_IMG_VERSION) antrea/antrea-windows
 
 .PHONY: build-ubuntu-coverage
 build-ubuntu-coverage:
 	@echo "===> Building Antrea bins and antrea/antrea-ubuntu-coverage Docker image <==="
+ifneq ($(DOCKER_REGISTRY),"")
 	docker build -t antrea/antrea-ubuntu-coverage:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.coverage .
+else
+	docker build --pull -t antrea/antrea-ubuntu-coverage:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.coverage .
+endif
 	docker tag antrea/antrea-ubuntu-coverage:$(DOCKER_IMG_VERSION) antrea/antrea-ubuntu-coverage
 
 .PHONY: manifest

--- a/ci/docker-registry
+++ b/ci/docker-registry
@@ -1,0 +1,1 @@
+projects.registry.vmware.com

--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -12,7 +12,8 @@
         - shell: |-
             #!/bin/bash
             set -e
-            ./ci/jenkins/test-vmc.sh --testcase integration --coverage --codecov-token "${CODECOV_TOKEN}"
+            DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
+            ./ci/jenkins/test-vmc.sh --testcase integration --coverage --codecov-token "${CODECOV_TOKEN}" --registry ${DOCKER_REGISTRY}
 
 - builder:
     name: builder-eks-cluster-cleanup
@@ -101,7 +102,8 @@
       - shell: |-
           #!/bin/bash
           set -ex
-          ./ci/jenkins/test-vmc.sh --cluster-name "${JOB_NAME}-${BUILD_NUMBER}" --testcase e2e --coverage --codecov-token "${CODECOV_TOKEN}"
+          DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
+          ./ci/jenkins/test-vmc.sh --cluster-name "${JOB_NAME}-${BUILD_NUMBER}" --testcase e2e --coverage --codecov-token "${CODECOV_TOKEN}" --registry ${DOCKER_REGISTRY}
 
 - builder:
     name: builder-conformance
@@ -109,7 +111,8 @@
       - shell: |-
           #!/bin/bash
           set -ex
-          ./ci/jenkins/test-vmc.sh --cluster-name "${{JOB_NAME}}-${{BUILD_NUMBER}}" --testcase '{conformance_type}' --coverage --codecov-token "${{CODECOV_TOKEN}}"
+          DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
+          ./ci/jenkins/test-vmc.sh --cluster-name "${{JOB_NAME}}-${{BUILD_NUMBER}}" --testcase '{conformance_type}' --coverage --codecov-token "${{CODECOV_TOKEN}}" --registry ${{DOCKER_REGISTRY}}
 
 - builder:
     name: builder-elk-flow-collector
@@ -137,11 +140,12 @@
           TEST_FAIL_E2E=0
           TEST_FAIL_NP=0
           TEST_FAIL_CONFORMANCE=0
+          DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
           export JOB_NAME="matrix-${TEST_OS}-k8s-${K8S_VERSION//./-}-build-num"
           ./ci/jenkins/test-vmc.sh --cluster-name "${JOB_NAME}-${BUILD_NUMBER}" --setup-only
-          ./ci/jenkins/test-vmc.sh --cluster-name "${JOB_NAME}-${BUILD_NUMBER}" --testcase 'whole-conformance' --test-only || TEST_FAIL_CONFORMANCE=1
-          ./ci/jenkins/test-vmc.sh --cluster-name "${JOB_NAME}-${BUILD_NUMBER}" --testcase 'networkpolicy' --test-only || TEST_FAIL_NP=1
-          ./ci/jenkins/test-vmc.sh --cluster-name "${JOB_NAME}-${BUILD_NUMBER}" --testcase e2e --test-only || TEST_FAIL_E2E=1
+          ./ci/jenkins/test-vmc.sh --cluster-name "${JOB_NAME}-${BUILD_NUMBER}" --testcase 'whole-conformance' --test-only || TEST_FAIL_CONFORMANCE=1 --registry ${DOCKER_REGISTRY}
+          ./ci/jenkins/test-vmc.sh --cluster-name "${JOB_NAME}-${BUILD_NUMBER}" --testcase 'networkpolicy' --test-only || TEST_FAIL_NP=1 --registry ${DOCKER_REGISTRY}
+          ./ci/jenkins/test-vmc.sh --cluster-name "${JOB_NAME}-${BUILD_NUMBER}" --testcase e2e --test-only || TEST_FAIL_E2E=1 --registry ${DOCKER_REGISTRY}
           ./ci/jenkins/test-vmc.sh --cluster-name "${JOB_NAME}-${BUILD_NUMBER}" --cleanup-only
           if [ "${TEST_FAIL_E2E}" -eq 1 ]; then
             echo "E2E Test failed!"

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -23,11 +23,6 @@ import (
 	"time"
 )
 
-const (
-	ipfixCollectorImage = "antrea/ipfix-collector:10282020.1"
-	ipfixCollectorPort  = "4739"
-)
-
 func skipIfNotBenchmarkTest(tb testing.TB) {
 	if !testOptions.withBench {
 		tb.Skipf("Skipping benchmark test: %s", tb.Name())

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -81,6 +81,13 @@ const (
 	antreaControllerConfName string = "antrea-controller.conf"
 
 	nameSuffixLength int = 8
+
+	agnhostImage        = "gcr.io/kubernetes-e2e-test-images/agnhost:2.8"
+	busyboxImage        = "projects.registry.vmware.com/library/busybox"
+	nginxImage          = "projects.registry.vmware.com/antrea/nginx"
+	perftoolImage       = "projects.registry.vmware.com/antrea/perftool"
+	ipfixCollectorImage = "projects.registry.vmware.com/antrea/ipfix-collector:10282020.1"
+	ipfixCollectorPort  = "4739"
 )
 
 type ClusterNode struct {
@@ -674,7 +681,7 @@ func (data *TestData) createPodOnNode(name string, nodeName string, image string
 // Pod will be scheduled on the specified Node (if nodeName is not empty).
 func (data *TestData) createBusyboxPodOnNode(name string, nodeName string) error {
 	sleepDuration := 3600 // seconds
-	return data.createPodOnNode(name, nodeName, "busybox", []string{"sleep", strconv.Itoa(sleepDuration)}, nil, nil, nil, false, nil)
+	return data.createPodOnNode(name, nodeName, busyboxImage, []string{"sleep", strconv.Itoa(sleepDuration)}, nil, nil, nil, false, nil)
 }
 
 // createBusyboxPod creates a Pod in the test namespace with a single busybox container.
@@ -685,7 +692,7 @@ func (data *TestData) createBusyboxPod(name string) error {
 // createNginxPodOnNode creates a Pod in the test namespace with a single nginx container. The
 // Pod will be scheduled on the specified Node (if nodeName is not empty).
 func (data *TestData) createNginxPodOnNode(name string, nodeName string) error {
-	return data.createPodOnNode(name, nodeName, "nginx", []string{}, nil, nil, []corev1.ContainerPort{
+	return data.createPodOnNode(name, nodeName, nginxImage, []string{}, nil, nil, []corev1.ContainerPort{
 		{
 			Name:          "http",
 			ContainerPort: 80,
@@ -702,7 +709,6 @@ func (data *TestData) createNginxPod(name, nodeName string) error {
 // createServerPod creates a Pod that can listen to specified port and have named port set.
 func (data *TestData) createServerPod(name string, portName string, portNum int, setHostPort bool) error {
 	// See https://github.com/kubernetes/kubernetes/blob/master/test/images/agnhost/porter/porter.go#L17 for the image's detail.
-	image := "gcr.io/kubernetes-e2e-test-images/agnhost:2.8"
 	cmd := "porter"
 	env := corev1.EnvVar{Name: fmt.Sprintf("SERVE_PORT_%d", portNum), Value: "foo"}
 	port := corev1.ContainerPort{Name: portName, ContainerPort: int32(portNum)}
@@ -710,7 +716,7 @@ func (data *TestData) createServerPod(name string, portName string, portNum int,
 		// If hostPort is to be set, it must match the container port number.
 		port.HostPort = int32(portNum)
 	}
-	return data.createPodOnNode(name, "", image, nil, []string{cmd}, []corev1.EnvVar{env}, []corev1.ContainerPort{port}, false, nil)
+	return data.createPodOnNode(name, "", agnhostImage, nil, []string{cmd}, []corev1.EnvVar{env}, []corev1.ContainerPort{port}, false, nil)
 }
 
 // deletePod deletes a Pod in the test namespace.

--- a/test/e2e/performance_test.go
+++ b/test/e2e/performance_test.go
@@ -36,8 +36,6 @@ const (
 	perfTestAppLabel                = "antrea-perf-test"
 	podsConnectionNetworkPolicyName = "pods.ingress"
 	workloadNetworkPolicyName       = "workloads.ingress"
-	perftoolImage                   = "antrea/perftool"
-	nginxImage                      = "nginx"
 	perftoolContainerName           = "perftool"
 	nginxContainerName              = "nginx"
 )

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -98,7 +98,7 @@ func TestProxyHairpin(t *testing.T) {
 	skipIfProxyDisabled(t, data)
 
 	nodeName := nodeName(1)
-	err = data.createPodOnNode("busybox", nodeName, "busybox", []string{"nc", "-lk", "-p", "80"}, nil, nil, []corev1.ContainerPort{{ContainerPort: 80, Protocol: corev1.ProtocolTCP}}, false, nil)
+	err = data.createPodOnNode("busybox", nodeName, busyboxImage, []string{"nc", "-lk", "-p", "80"}, nil, nil, []corev1.ContainerPort{{ContainerPort: 80, Protocol: corev1.ProtocolTCP}}, false, nil)
 	require.NoError(t, err)
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, "busybox", testNamespace))
 	svc, err := data.createService("busybox", 80, 80, map[string]string{"antrea-e2e": "busybox"}, false, corev1.ServiceTypeClusterIP)


### PR DESCRIPTION
Due to rate limit of dockerhub, it is necessary to use VMware-hosted public Harbor registry (projects.registry.vmware.com) in CI. Also Use registry in e2e tests.