### PR TITLE
Fix flaky unit test TestLargeScaleEndpointQueryManyPolicies

### DIFF
--- a/pkg/controller/networkpolicy/endpoint_querier_test.go
+++ b/pkg/controller/networkpolicy/endpoint_querier_test.go
@@ -157,8 +157,8 @@ func makeControllerAndEndpointQuerier(objects ...runtime.Object) *endpointQuerie
 	// start informers and run controller
 	c.informerFactory.Start(stopCh)
 	go c.Run(stopCh)
-	// wait until computation is done, we assume it is done when no signal has been received on heartbeat channel for 500ms
-	idleTimeout := 500 * time.Millisecond
+	// wait until computation is done, we assume it is done when no signal has been received on heartbeat channel for 3s.
+	idleTimeout := 3 * time.Second
 	timer := time.NewTimer(idleTimeout)
 	func() {
 		for {


### PR DESCRIPTION
500ms is not long enough to ensure all computation is done.