### PR TITLE
Fix missing routes caused by Node events coming out of order

### DIFF
--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -17,7 +17,6 @@ package noderoute
 import (
 	"fmt"
 	"net"
-	"sync"
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ip"
@@ -45,12 +44,14 @@ const (
 	// Interval of reprocessing every node.
 	nodeResyncPeriod = 60 * time.Second
 	// How long to wait before retrying the processing of a node change
-	minRetryDelay = 5 * time.Second
-	maxRetryDelay = 300 * time.Second
+	minRetryDelay = 2 * time.Second
+	maxRetryDelay = 120 * time.Second
 	// Default number of workers processing a node change
 	defaultWorkers = 4
 
 	ovsExternalIDNodeName = "node-name"
+
+	nodeRouteInfoPodCIDRIndexName = "podCIDR"
 )
 
 // Controller is responsible for setting up necessary IP routes and Openflow entries for inter-node traffic.
@@ -69,7 +70,7 @@ type Controller struct {
 	// installedNodes records routes and flows installation states of Nodes.
 	// The key is the host name of the Node, the value is the nodeRouteInfo of the Node.
 	// A node will be in the map after its flows and routes are installed successfully.
-	installedNodes *sync.Map
+	installedNodes cache.Indexer
 }
 
 // NewNodeRouteController instantiates a new Controller object which will process Node events
@@ -96,7 +97,7 @@ func NewNodeRouteController(
 		nodeLister:       nodeInformer.Lister(),
 		nodeListerSynced: nodeInformer.Informer().HasSynced,
 		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "noderoute"),
-		installedNodes:   &sync.Map{}}
+		installedNodes:   cache.NewIndexer(nodeRouteInfoKeyFunc, cache.Indexers{nodeRouteInfoPodCIDRIndexName: nodeRouteInfoPodCIDRIndexFunc})}
 	nodeInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(cur interface{}) {
@@ -114,8 +115,17 @@ func NewNodeRouteController(
 	return controller
 }
 
+func nodeRouteInfoKeyFunc(obj interface{}) (string, error) {
+	return obj.(*nodeRouteInfo).nodeName, nil
+}
+
+func nodeRouteInfoPodCIDRIndexFunc(obj interface{}) ([]string, error) {
+	return []string{obj.(*nodeRouteInfo).podCIDR.String()}, nil
+}
+
 // nodeRouteInfo is the route related information extracted from corev1.Node.
 type nodeRouteInfo struct {
+	nodeName  string
 	podCIDR   *net.IPNet
 	nodeIP    net.IP
 	gatewayIP net.IP
@@ -360,7 +370,7 @@ func (c *Controller) syncNodeRoute(nodeName string) error {
 func (c *Controller) deleteNodeRoute(nodeName string) error {
 	klog.Infof("Deleting routes and flows to Node %s", nodeName)
 
-	obj, installed := c.installedNodes.Load(nodeName)
+	obj, installed, _ := c.installedNodes.GetByKey(nodeName)
 	if !installed {
 		// Route is not added for this Node.
 		return nil
@@ -373,7 +383,7 @@ func (c *Controller) deleteNodeRoute(nodeName string) error {
 	if err := c.ofClient.UninstallNodeFlows(nodeName); err != nil {
 		return fmt.Errorf("failed to uninstall flows to Node %s: %v", nodeName, err)
 	}
-	c.installedNodes.Delete(nodeName)
+	c.installedNodes.Delete(obj)
 
 	if c.networkConfig.EnableIPSecTunnel {
 		interfaceConfig, ok := c.interfaceStore.GetNodeTunnelInterface(nodeName)
@@ -392,7 +402,7 @@ func (c *Controller) deleteNodeRoute(nodeName string) error {
 }
 
 func (c *Controller) addNodeRoute(nodeName string, node *corev1.Node) error {
-	if _, installed := c.installedNodes.Load(nodeName); installed {
+	if _, installed, _ := c.installedNodes.GetByKey(nodeName); installed {
 		// Route is already added for this Node.
 		return nil
 	}
@@ -405,6 +415,22 @@ func (c *Controller) addNodeRoute(nodeName string, node *corev1.Node) error {
 		// Does not help to return an error and trigger controller retries.
 		return nil
 	}
+
+	nodesHaveSamePodCIDR, _ := c.installedNodes.ByIndex(nodeRouteInfoPodCIDRIndexName, node.Spec.PodCIDR)
+	// PodCIDRs can be released from deleted Nodes and allocated to new Nodes. For server side, it won't happen that a
+	// PodCIDR is allocated to more than one Node at any point. However, for client side, if a resync happens to occur
+	// when there are Node creation and deletion events, the informer will generate the events in a way that all
+	// creation events come before deletion ones even they actually happen in the opposite order on the server side.
+	// See https://github.com/kubernetes/kubernetes/blob/v1.18.2/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go#L503-L512
+	// Therefore, a PodCIDR may appear in a new Node before the Node that previously owns it is removed. To ensure the
+	// stale routes, flows, and relevant cache of this podCIDR are removed appropriately, we wait for the Node deletion
+	// event to be processed before proceeding, or the route installation and uninstallation operations may override or
+	// conflict with each other.
+	if len(nodesHaveSamePodCIDR) > 0 {
+		// Return an error so that the Node will be put back to the workqueue and will be retried later.
+		return fmt.Errorf("skipping addNodeRoute for Node %s because podCIDR %s is duplicate with Node %s, will retry later", nodeName, node.Spec.PodCIDR, nodesHaveSamePodCIDR[0].(*nodeRouteInfo).nodeName)
+	}
+
 	peerPodCIDRAddr, peerPodCIDR, err := net.ParseCIDR(node.Spec.PodCIDR)
 	if err != nil {
 		klog.Errorf("Failed to parse PodCIDR %s for Node %s", node.Spec.PodCIDR, nodeName)
@@ -442,7 +468,8 @@ func (c *Controller) addNodeRoute(nodeName string, node *corev1.Node) error {
 	if err := c.routeClient.AddRoutes(peerPodCIDR, peerNodeIP, peerGatewayIP); err != nil {
 		return err
 	}
-	c.installedNodes.Store(nodeName, &nodeRouteInfo{
+	c.installedNodes.Add(&nodeRouteInfo{
+		nodeName:  nodeName,
 		podCIDR:   peerPodCIDR,
 		nodeIP:    peerNodeIP,
 		gatewayIP: peerGatewayIP,

--- a/pkg/agent/controller/noderoute/node_route_controller_test.go
+++ b/pkg/agent/controller/noderoute/node_route_controller_test.go
@@ -1,0 +1,152 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package noderoute
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/containernetworking/plugins/pkg/ip"
+	"github.com/golang/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/config"
+	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
+	oftest "github.com/vmware-tanzu/antrea/pkg/agent/openflow/testing"
+	routetest "github.com/vmware-tanzu/antrea/pkg/agent/route/testing"
+	ovsconfigtest "github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig/testing"
+)
+
+var (
+	gatewayMAC, _  = net.ParseMAC("00:00:00:00:00:01")
+	_, podCIDR, _  = net.ParseCIDR("1.1.1.0/24")
+	podCIDRGateway = ip.NextIP(podCIDR.IP)
+	nodeIP1        = net.ParseIP("10.10.10.10")
+	nodeIP2        = net.ParseIP("10.10.10.11")
+)
+
+type fakeController struct {
+	*Controller
+	clientset       *fake.Clientset
+	informerFactory informers.SharedInformerFactory
+	ofClient        *oftest.MockClient
+	ovsClient       *ovsconfigtest.MockOVSBridgeClient
+	routeClient     *routetest.MockInterface
+	interfaceStore  interfacestore.InterfaceStore
+}
+
+func newController(t *testing.T) (*fakeController, func()) {
+	clientset := fake.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(clientset, 12*time.Hour)
+	ctrl := gomock.NewController(t)
+	ofClient := oftest.NewMockClient(ctrl)
+	ovsClient := ovsconfigtest.NewMockOVSBridgeClient(ctrl)
+	routeClient := routetest.NewMockInterface(ctrl)
+	interfaceStore := interfacestore.NewInterfaceStore()
+	c := NewNodeRouteController(clientset, informerFactory, ofClient, ovsClient, routeClient, interfaceStore, &config.NetworkConfig{}, &config.NodeConfig{GatewayConfig: &config.GatewayConfig{
+		IP:  nil,
+		MAC: gatewayMAC,
+	}})
+	return &fakeController{
+		Controller:      c,
+		clientset:       clientset,
+		informerFactory: informerFactory,
+		ofClient:        ofClient,
+		ovsClient:       ovsClient,
+		routeClient:     routeClient,
+		interfaceStore:  interfaceStore,
+	}, ctrl.Finish
+}
+
+func TestControllerWithDuplicatePodCIDR(t *testing.T) {
+	c, closeFn := newController(t)
+	defer closeFn()
+	defer c.queue.ShutDown()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	c.informerFactory.Start(stopCh)
+
+	node1 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+		},
+		Spec: corev1.NodeSpec{
+			PodCIDR:  podCIDR.String(),
+			PodCIDRs: []string{podCIDR.String()},
+		},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{
+					Type:    corev1.NodeInternalIP,
+					Address: nodeIP1.String(),
+				},
+			},
+		},
+	}
+	node2 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node2",
+		},
+		Spec: corev1.NodeSpec{
+			PodCIDR:  podCIDR.String(),
+			PodCIDRs: []string{podCIDR.String()},
+		},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{
+					Type:    corev1.NodeInternalIP,
+					Address: nodeIP2.String(),
+				},
+			},
+		},
+	}
+
+	finishCh := make(chan struct{})
+	go func() {
+		defer close(finishCh)
+
+		c.clientset.CoreV1().Nodes().Create(context.TODO(), node1, metav1.CreateOptions{})
+		c.ofClient.EXPECT().InstallNodeFlows("node1", gatewayMAC, *podCIDR, podCIDRGateway, nodeIP1, uint32(config.DefaultTunOFPort), uint32(0)).Times(1)
+		c.routeClient.EXPECT().AddRoutes(podCIDR, nodeIP1, podCIDRGateway).Times(1)
+		c.processNextWorkItem()
+
+		// Since node1 is not deleted yet, routes and flows for node2 shouldn't be installed as its PodCIDR is duplicate.
+		c.clientset.CoreV1().Nodes().Create(context.TODO(), node2, metav1.CreateOptions{})
+		c.processNextWorkItem()
+
+		// node1 is deleted, its routes and flows should be deleted.
+		c.clientset.CoreV1().Nodes().Delete(context.TODO(), node1.Name, metav1.DeleteOptions{})
+		c.ofClient.EXPECT().UninstallNodeFlows("node1").Times(1)
+		c.routeClient.EXPECT().DeleteRoutes(podCIDR).Times(1)
+		c.processNextWorkItem()
+
+		// After node1 is deleted, routes and flows should be installed for node2 successfully.
+		c.ofClient.EXPECT().InstallNodeFlows("node2", gatewayMAC, *podCIDR, podCIDRGateway, nodeIP2, uint32(config.DefaultTunOFPort), uint32(0)).Times(1)
+		c.routeClient.EXPECT().AddRoutes(podCIDR, nodeIP2, podCIDRGateway).Times(1)
+		c.processNextWorkItem()
+	}()
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Errorf("Test didn't finish in time")
+	case <-finishCh:
+	}
+}


### PR DESCRIPTION
PodCIDRs can be released from deleted Nodes and allocated to new Nodes.
For server side, it won't happen that a PodCIDR is allocated to more
than one Node at any point. However, for client side, if a resync
happens to occur when there are Node creation and deletion events, the
informer will generate the events in a way that all creation events come
before deletion ones even they actually happen in the opposite order on
the server side. Therefore, a PodCIDR may appear in a new Node before
the Node that previously owns it is removed.

To ensure the stale routes, flows, and relevant cache of this podCIDR
are removed appropriately, we wait for the Node deletion event to be
processed before proceeding, or the route installation and
uninstallation operations may override or conflict with each other.

Fixes #1527