### PR TITLE
Add sort-by effectivePriority for antctl get networkpolicy

### DIFF
--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -172,20 +172,20 @@ antctl get appliedtogroup [name] [-o yaml]
 antctl get addressgroup [name] [-o yaml]
 ```
 
-Antrea Agent additionally supports printing NetworkPolicies applied to a
-specified local Pod using this `antctl` command:
-
-```bash
-antctl get networkpolicy -p pod -n namespace
-```
-
-Antrea Agent also supports `sort-by=effectivePriority` option, which can be used to
+NetworkPolicy also supports `sort-by=effectivePriority` option, which can be used to
 view the effective order in which the NetworkPolicies are evaluated. Antrea-native
 NetworkPolicy ordering is documented [here](
 antrea-network-policy.md#antrea-native-policy-ordering-based-on-priorities).
 
 ```bash
 antctl get networkpolicy --sort-by=effectivePriority
+```
+
+Antrea Agent additionally supports printing NetworkPolicies applied to a
+specified local Pod using this `antctl` command:
+
+```bash
+antctl get networkpolicy -p pod -n namespace
 ```
 
 #### Mapping endpoints to NetworkPolicies

--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -179,6 +179,15 @@ specified local Pod using this `antctl` command:
 antctl get networkpolicy -p pod -n namespace
 ```
 
+Antrea Agent also supports `sort-by=effectivePriority` option, which can be used to
+view the effective order in which the NetworkPolicies are evaluated. Antrea-native
+NetworkPolicy ordering is documented [here](
+antrea-network-policy.md#antrea-native-policy-ordering-based-on-priorities).
+
+```bash
+antctl get networkpolicy --sort-by=effectivePriority
+```
+
 #### Mapping endpoints to NetworkPolicies
 
 `antctl` supports mapping a specific Pod to the NetworkPolicies which "select"

--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -505,8 +505,9 @@ policy rules match, the packet is then enforced for rules created for K8s NP.
 If the packet still does not match any rule for K8s NP, it will then be evaluated
 against policies created in the "baseline" Tier.
 
-The [antctl command](antctl.md#networkPolicy-commands) with 'sort-by' flag can be used
-to check the order of policy enforcement on a specific Node. An example output will look like
+The [antctl command](antctl.md#networkPolicy-commands) with 'sort-by=effectivePriority'
+flag can be used to check the order of policy enforcement.
+An example output will look like the following:
 
 ```text
 antctl get netpol --sort-by=effectivePriority

--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -481,10 +481,10 @@ policies will be enforced last.
 Within a tier, Antrea-native Policy CRDs are ordered by the `priority` at the policy
 level. Thus, the policy with the highest precedence (lowest priority number
 value) is enforced first. This ordering is performed solely based on the
-`priority` assigned as opposed to the "Kind" of the resource, i.e. the relative
-ordering between a [ClusterNetworkPolicy resource](#antrea-clusternetworkpolicy) and an [Antrea NetworkPolicy
-resource](#antrea-networkpolicy) within a Tier depends only on the `priority`
-set in each of the two resources.
+`priority` assigned, as opposed to the "Kind" of the resource, i.e. the relative
+ordering between a [ClusterNetworkPolicy resource](#antrea-clusternetworkpolicy) and
+an [Antrea NetworkPolicy resource](#antrea-networkpolicy) within a Tier depends only
+on the `priority` set in each of the two resources.
 
 ### Rule enforcement based on priorities
 
@@ -504,6 +504,24 @@ Once a rule is matched, it is executed based on the action set. If none of the
 policy rules match, the packet is then enforced for rules created for K8s NP.
 If the packet still does not match any rule for K8s NP, it will then be evaluated
 against policies created in the "baseline" Tier.
+
+The [antctl command](antctl.md#networkPolicy-commands) with 'sort-by' flag can be used
+to check the order of policy enforcement on a specific Node. An example output will look like
+
+```text
+antctl get netpol --sort-by=effectivePriority
+NAME                                 APPLIED-TO                           RULES SOURCE                                 TIER-PRIORITY PRIORITY
+4c504456-9158-4838-bfab-f81665dfae12 85b88ddb-b474-5b44-93d3-c9192c09085e 1     AntreaClusterNetworkPolicy:acnp-1      250           1
+41e510e0-e430-4606-b4d9-261424184fba e36f8beb-9b0b-5b49-b1b7-5c5307cddd83 1     AntreaClusterNetworkPolicy:acnp-2      250           2
+819b8482-ede5-4423-910c-014b731fdba6 bb6711a1-87c7-5a15-9a4a-71bf49a78056 2     AntreaNetworkPolicy:anp-10             250           10
+4d18e031-f05a-48f6-bd91-0197b556ccca e216c104-770c-5731-bfd3-ff4ccbc38c39 2     K8sNetworkPolicy:default/test-1        <NONE>        <NONE>
+c547002a-d8c7-40f1-bdd1-8eb6d0217a67 e216c104-770c-5731-bfd3-ff4ccbc38c39 1     K8sNetworkPolicy:default/test-2        <NONE>        <NONE>
+aac8b8bc-f3bf-4c41-b6e0-2af1863204eb bb6711a1-87c7-5a15-9a4a-71bf49a78056 3     AntreaClusterNetworkPolicy:baseline    253           10
+```
+
+The [ovs-pipeline doc](design/ovs-pipeline.md) contains more information on how
+policy rules are realized by OpenFlow, and how the priority of flows reflects the
+order in which they are enforced.
 
 ## RBAC
 

--- a/pkg/agent/apiserver/handlers/networkpolicy/handler.go
+++ b/pkg/agent/apiserver/handlers/networkpolicy/handler.go
@@ -19,10 +19,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 
 	agentquerier "github.com/vmware-tanzu/antrea/pkg/agent/querier"
 	cpv1beta "github.com/vmware-tanzu/antrea/pkg/apis/controlplane/v1beta2"
+	"github.com/vmware-tanzu/antrea/pkg/controller/networkpolicy"
 	"github.com/vmware-tanzu/antrea/pkg/querier"
 )
 
@@ -30,7 +32,7 @@ import (
 // to query network policy rules in current agent.
 func HandleFunc(aq agentquerier.AgentQuerier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		npFilter, err := newFilterFromURLQuery(r.URL.Query())
+		npFilter, err := parseURLQuery(r.URL.Query())
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
@@ -48,12 +50,61 @@ func HandleFunc(aq agentquerier.AgentQuerier) http.HandlerFunc {
 		} else {
 			nps = npq.GetNetworkPolicies(npFilter)
 		}
-
-		obj = cpv1beta.NetworkPolicyList{Items: nps}
+		npSorter := &NPSorter{
+			networkPolicies: nps,
+			sortBy:          r.URL.Query().Get("sort-by"),
+		}
+		sort.Sort(npSorter)
+		obj = cpv1beta.NetworkPolicyList{Items: npSorter.networkPolicies}
 
 		if err := json.NewEncoder(w).Encode(obj); err != nil {
 			http.Error(w, "Failed to encode response: "+err.Error(), http.StatusInternalServerError)
 		}
+	}
+}
+
+var (
+	sortByEffectivePriority = "effectivePriority"
+	// Compute a tierPriority value in between the application tier and the baseline tier,
+	// which can be used to sort policies by tier.
+	effectiveTierPriorityK8sNP = (networkpolicy.DefaultTierPriority + networkpolicy.BaselineTierPriority) / 2
+)
+
+type NPSorter struct {
+	networkPolicies []cpv1beta.NetworkPolicy
+	sortBy          string
+}
+
+func (nps *NPSorter) Len() int { return len(nps.networkPolicies) }
+func (nps *NPSorter) Swap(i, j int) {
+	nps.networkPolicies[i], nps.networkPolicies[j] = nps.networkPolicies[j], nps.networkPolicies[i]
+}
+func (nps *NPSorter) Less(i, j int) bool {
+	switch nps.sortBy {
+	case sortByEffectivePriority:
+		var ti, tj int32
+		if nps.networkPolicies[i].TierPriority == nil {
+			ti = effectiveTierPriorityK8sNP
+		} else {
+			ti = *nps.networkPolicies[i].TierPriority
+		}
+		if nps.networkPolicies[j].TierPriority == nil {
+			tj = effectiveTierPriorityK8sNP
+		} else {
+			tj = *nps.networkPolicies[j].TierPriority
+		}
+		pi, pj := nps.networkPolicies[i].Priority, nps.networkPolicies[j].Priority
+		if ti != tj {
+			return ti < tj
+		}
+		if pi != nil && pj != nil && *pi != *pj {
+			return *pi < *pj
+		}
+		fallthrough
+	default:
+		// Do not need a tie-breaker here since NetworkPolicy names are set as UID
+		// of the source policy and will be unique.
+		return nps.networkPolicies[i].Name < nps.networkPolicies[j].Name
 	}
 }
 
@@ -66,7 +117,7 @@ var mapToNetworkPolicyType = map[string]cpv1beta.NetworkPolicyType{
 }
 
 // Create a Network Policy Filter from URL Query
-func newFilterFromURLQuery(query url.Values) (*querier.NetworkPolicyQueryFilter, error) {
+func parseURLQuery(query url.Values) (*querier.NetworkPolicyQueryFilter, error) {
 	namespace := query.Get("namespace")
 	pod := query.Get("pod")
 	if pod != "" && namespace == "" {
@@ -80,12 +131,15 @@ func newFilterFromURLQuery(query url.Values) (*querier.NetworkPolicyQueryFilter,
 	}
 
 	source := query.Get("source")
-
 	name := query.Get("name")
 	if name != "" && (source != "" || namespace != "" || pod != "" || strSourceType != "") {
 		return nil, fmt.Errorf("with a name, none of the other fields can be set")
 	}
 
+	sortBy := query.Get("sort-by")
+	if sortBy != "" && sortBy != sortByEffectivePriority {
+		return nil, fmt.Errorf("unsupported sort-by option. Supported value is %s", sortByEffectivePriority)
+	}
 	return &querier.NetworkPolicyQueryFilter{
 		Name:       name,
 		SourceName: source,

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -109,6 +109,8 @@ var CommandList = &commandList{
   $ antctl get networkpolicy 6001549b-ba63-4752-8267-30f52b4332db
   Get the list of all control plane NetworkPolicies
   $ antctl get networkpolicy
+  Get the list of all control plane NetworkPolicies, sorted by the order in which the policies are evaluated (supported by agent only)
+  $ antctl get networkpolicy --sort-by=effectivePriority
   Get the control plane NetworkPolicy with a specific source (supported by agent only)
   $ antctl get networkpolicy -S allow-http -n ns1
   Get the list of control plane NetworkPolicies whose source NetworkPolicies are in a Namespace (supported by agent only)
@@ -152,6 +154,11 @@ var CommandList = &commandList{
 							name:      "type",
 							usage:     "Get NetworkPolicies with specific type. Type means the type of its source network policy: K8sNP, ACNP, ANP",
 							shorthand: "T",
+						},
+						{
+							name:      "sort-by",
+							usage:     "Get NetworkPolicies in specific order. Current supported value is effectivePriority. If not specified, by default results are sorted by name.",
+							shorthand: "O",
 						},
 					},
 					outputType: multiple,

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -109,7 +109,7 @@ var CommandList = &commandList{
   $ antctl get networkpolicy 6001549b-ba63-4752-8267-30f52b4332db
   Get the list of all control plane NetworkPolicies
   $ antctl get networkpolicy
-  Get the list of all control plane NetworkPolicies, sorted by the order in which the policies are evaluated (supported by agent only)
+  Get the list of all control plane NetworkPolicies, sorted by the order in which the policies are evaluated.
   $ antctl get networkpolicy --sort-by=effectivePriority
   Get the control plane NetworkPolicy with a specific source (supported by agent only)
   $ antctl get networkpolicy -S allow-http -n ns1
@@ -154,11 +154,6 @@ var CommandList = &commandList{
 							name:      "type",
 							usage:     "Get NetworkPolicies with specific type. Type means the type of its source network policy: K8sNP, ACNP, ANP",
 							shorthand: "T",
-						},
-						{
-							name:      "sort-by",
-							usage:     "Get NetworkPolicies in specific order. Current supported value is effectivePriority. If not specified, by default results are sorted by name.",
-							shorthand: "O",
 						},
 					},
 					outputType: multiple,

--- a/pkg/antctl/command_definition_test.go
+++ b/pkg/antctl/command_definition_test.go
@@ -45,6 +45,11 @@ type Foobar struct {
 	Foo string `json:"foo"`
 }
 
+var (
+	AntreaPolicyTierPriority = int32(250)
+	AntreaPolicyPriority     = float64(1.0)
+)
+
 func TestCommandList_tableOutputForGetCommands(t *testing.T) {
 	for _, tc := range []struct {
 		name            string
@@ -172,6 +177,8 @@ foo2
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "880db7e8-fc2a-4030-aefe-09afc5f341ad",
 						},
+						TierPriority:    &AntreaPolicyTierPriority,
+						Priority:        &AntreaPolicyPriority,
 						AppliedToGroups: []string{"32ef631b-6817-5a18-86eb-93f4abf0467c"},
 						Rules: []cpv1beta.NetworkPolicyRule{
 							{
@@ -192,9 +199,9 @@ foo2
 					},
 				},
 			},
-			expected: `NAME                                 APPLIED-TO                                       RULES SOURCE                               
-6001549b-ba63-4752-8267-30f52b4332db 32ef631b-6817-5a18-86eb-93f4abf0467c + 1 more... 1     K8sNetworkPolicy:default/allow-all   
-880db7e8-fc2a-4030-aefe-09afc5f341ad 32ef631b-6817-5a18-86eb-93f4abf0467c             2     AntreaNetworkPolicy:default/allow-all
+			expected: `NAME                                 APPLIED-TO                                       RULES SOURCE                                TIER-PRIORITY PRIORITY
+6001549b-ba63-4752-8267-30f52b4332db 32ef631b-6817-5a18-86eb-93f4abf0467c + 1 more... 1     K8sNetworkPolicy:default/allow-all    <NONE>        <NONE>  
+880db7e8-fc2a-4030-aefe-09afc5f341ad 32ef631b-6817-5a18-86eb-93f4abf0467c             2     AntreaNetworkPolicy:default/allow-all 250           1       
 `,
 		},
 		{

--- a/pkg/antctl/command_definition_test.go
+++ b/pkg/antctl/command_definition_test.go
@@ -304,7 +304,7 @@ func TestFormat(t *testing.T) {
 	for _, tc := range []struct {
 		name            string
 		single          bool
-		transform       func(reader io.Reader, single bool) (interface{}, error)
+		transform       func(reader io.Reader, single bool, opts map[string]string) (interface{}, error)
 		rawResponseData interface{}
 		responseStruct  reflect.Type
 		expected        string
@@ -328,7 +328,7 @@ func TestFormat(t *testing.T) {
 		{
 			name:   "StructureData-Transform-Single-Yaml",
 			single: true,
-			transform: func(reader io.Reader, single bool) (i interface{}, err error) {
+			transform: func(reader io.Reader, single bool, opts map[string]string) (i interface{}, err error) {
 				foo := &Foobar{}
 				err = json.NewDecoder(reader).Decode(foo)
 				return &struct{ Bar string }{Bar: foo.Foo}, err
@@ -363,7 +363,7 @@ func TestFormat(t *testing.T) {
 			responseData, err := json.Marshal(tc.rawResponseData)
 			assert.Nil(t, err)
 			var outputBuf bytes.Buffer
-			err = opt.output(bytes.NewBuffer(responseData), &outputBuf, tc.formatter, tc.single)
+			err = opt.output(bytes.NewBuffer(responseData), &outputBuf, tc.formatter, tc.single, map[string]string{})
 			assert.Nil(t, err)
 			assert.Equal(t, tc.expected, outputBuf.String())
 		})

--- a/pkg/antctl/transform/addressgroup/transform.go
+++ b/pkg/antctl/transform/addressgroup/transform.go
@@ -28,18 +28,18 @@ type Response struct {
 	Pods []common.GroupMember `json:"pods,omitempty"`
 }
 
-func listTransform(l interface{}) (interface{}, error) {
+func listTransform(l interface{}, opts map[string]string) (interface{}, error) {
 	groups := l.(*cpv1beta.AddressGroupList)
 	result := []interface{}{}
 	for i := range groups.Items {
 		item := groups.Items[i]
-		o, _ := objectTransform(&item)
+		o, _ := objectTransform(&item, opts)
 		result = append(result, o.(Response))
 	}
 	return result, nil
 }
 
-func objectTransform(o interface{}) (interface{}, error) {
+func objectTransform(o interface{}, _ map[string]string) (interface{}, error) {
 	group := o.(*cpv1beta.AddressGroup)
 	var pods []common.GroupMember
 	for _, pod := range group.GroupMembers {
@@ -48,12 +48,13 @@ func objectTransform(o interface{}) (interface{}, error) {
 	return Response{Name: group.Name, Pods: pods}, nil
 }
 
-func Transform(reader io.Reader, single bool) (interface{}, error) {
+func Transform(reader io.Reader, single bool, opts map[string]string) (interface{}, error) {
 	return transform.GenericFactory(
 		reflect.TypeOf(cpv1beta.AddressGroup{}),
 		reflect.TypeOf(cpv1beta.AddressGroupList{}),
 		objectTransform,
 		listTransform,
+		opts,
 	)(reader, single)
 }
 

--- a/pkg/antctl/transform/appliedtogroup/transform.go
+++ b/pkg/antctl/transform/appliedtogroup/transform.go
@@ -28,18 +28,18 @@ type Response struct {
 	Pods []common.GroupMember `json:"pods,omitempty"`
 }
 
-func listTransform(l interface{}) (interface{}, error) {
+func listTransform(l interface{}, opts map[string]string) (interface{}, error) {
 	groups := l.(*cpv1beta.AppliedToGroupList)
 	result := []Response{}
 	for i := range groups.Items {
 		group := groups.Items[i]
-		o, _ := objectTransform(&group)
+		o, _ := objectTransform(&group, opts)
 		result = append(result, o.(Response))
 	}
 	return result, nil
 }
 
-func objectTransform(o interface{}) (interface{}, error) {
+func objectTransform(o interface{}, _ map[string]string) (interface{}, error) {
 	group := o.(*cpv1beta.AppliedToGroup)
 	var pods []common.GroupMember
 	for _, pod := range group.GroupMembers {
@@ -48,12 +48,13 @@ func objectTransform(o interface{}) (interface{}, error) {
 	return Response{Name: group.GetName(), Pods: pods}, nil
 }
 
-func Transform(reader io.Reader, single bool) (interface{}, error) {
+func Transform(reader io.Reader, single bool, opts map[string]string) (interface{}, error) {
 	return transform.GenericFactory(
 		reflect.TypeOf(cpv1beta.AppliedToGroup{}),
 		reflect.TypeOf(cpv1beta.AppliedToGroupList{}),
 		objectTransform,
 		listTransform,
+		opts,
 	)(reader, single)
 }
 

--- a/pkg/antctl/transform/controllerinfo/transform.go
+++ b/pkg/antctl/transform/controllerinfo/transform.go
@@ -38,7 +38,7 @@ type Response struct {
 	ControllerConditions        []clusterinfo.ControllerCondition       `json:"controllerConditions,omitempty"`        // Controller condition contains types like ControllerHealthy
 }
 
-func Transform(reader io.Reader, _ bool) (interface{}, error) {
+func Transform(reader io.Reader, _ bool, _ map[string]string) (interface{}, error) {
 	b, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return nil, err

--- a/pkg/antctl/transform/networkpolicy/transform.go
+++ b/pkg/antctl/transform/networkpolicy/transform.go
@@ -17,38 +17,94 @@ package networkpolicy
 import (
 	"io"
 	"reflect"
+	"sort"
 	"strconv"
 
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform"
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/common"
 	cpv1beta "github.com/vmware-tanzu/antrea/pkg/apis/controlplane/v1beta2"
+	"github.com/vmware-tanzu/antrea/pkg/controller/networkpolicy"
 )
 
 type Response struct {
 	*cpv1beta.NetworkPolicy
 }
 
-func objectTransform(o interface{}) (interface{}, error) {
+func objectTransform(o interface{}, _ map[string]string) (interface{}, error) {
 	return Response{o.(*cpv1beta.NetworkPolicy)}, nil
 }
 
-func listTransform(l interface{}) (interface{}, error) {
+func listTransform(l interface{}, opts map[string]string) (interface{}, error) {
 	policyList := l.(*cpv1beta.NetworkPolicyList)
+	sortBy := ""
+	if sb, ok := opts["sort-by"]; ok {
+		sortBy = sb
+	}
+	npSorter := &NPSorter{
+		networkPolicies: policyList.Items,
+		sortBy:          sortBy,
+	}
+	sort.Sort(npSorter)
 	result := make([]Response, 0, len(policyList.Items))
-	for i := range policyList.Items {
-		o, _ := objectTransform(&policyList.Items[i])
+	for i := range npSorter.networkPolicies {
+		o, _ := objectTransform(&npSorter.networkPolicies[i], opts)
 		result = append(result, o.(Response))
 	}
 	return result, nil
 }
 
-func Transform(reader io.Reader, single bool) (interface{}, error) {
+func Transform(reader io.Reader, single bool, opts map[string]string) (interface{}, error) {
 	return transform.GenericFactory(
 		reflect.TypeOf(cpv1beta.NetworkPolicy{}),
 		reflect.TypeOf(cpv1beta.NetworkPolicyList{}),
 		objectTransform,
 		listTransform,
+		opts,
 	)(reader, single)
+}
+
+const sortByEffectivePriority = "effectivePriority"
+
+// Compute a tierPriority value in between the application tier and the baseline tier,
+// which can be used to sort all policies by tier.
+var effectiveTierPriorityK8sNP = (networkpolicy.DefaultTierPriority + networkpolicy.BaselineTierPriority) / 2
+
+type NPSorter struct {
+	networkPolicies []cpv1beta.NetworkPolicy
+	sortBy          string
+}
+
+func (nps *NPSorter) Len() int { return len(nps.networkPolicies) }
+func (nps *NPSorter) Swap(i, j int) {
+	nps.networkPolicies[i], nps.networkPolicies[j] = nps.networkPolicies[j], nps.networkPolicies[i]
+}
+func (nps *NPSorter) Less(i, j int) bool {
+	switch nps.sortBy {
+	case sortByEffectivePriority:
+		var ti, tj int32
+		if nps.networkPolicies[i].TierPriority == nil {
+			ti = effectiveTierPriorityK8sNP
+		} else {
+			ti = *nps.networkPolicies[i].TierPriority
+		}
+		if nps.networkPolicies[j].TierPriority == nil {
+			tj = effectiveTierPriorityK8sNP
+		} else {
+			tj = *nps.networkPolicies[j].TierPriority
+		}
+		if ti != tj {
+			return ti < tj
+		}
+		pi, pj := nps.networkPolicies[i].Priority, nps.networkPolicies[j].Priority
+		if pi != nil && pj != nil && *pi != *pj {
+			return *pi < *pj
+		}
+		fallthrough
+	default:
+		// Do not need a tie-breaker here since NetworkPolicy names are set as UID
+		// of the source policy and will be unique.
+		return nps.networkPolicies[i].Name < nps.networkPolicies[j].Name
+	}
 }
 
 func priorityToString(p interface{}) string {

--- a/pkg/antctl/transform/networkpolicy/transform.go
+++ b/pkg/antctl/transform/networkpolicy/transform.go
@@ -51,16 +51,31 @@ func Transform(reader io.Reader, single bool) (interface{}, error) {
 	)(reader, single)
 }
 
+func priorityToString(p interface{}) string {
+	if reflect.ValueOf(p).IsNil() {
+		return ""
+	} else if pInt32, ok := p.(*int32); ok {
+		return strconv.Itoa(int(*pInt32))
+	} else {
+		pFloat64, _ := p.(*float64)
+		return strconv.FormatFloat(*pFloat64, 'f', -1, 64)
+	}
+}
+
 var _ common.TableOutput = new(Response)
 
 func (r Response) GetTableHeader() []string {
-	return []string{"NAME", "APPLIED-TO", "RULES", "SOURCE"}
+	return []string{"NAME", "APPLIED-TO", "RULES", "SOURCE", "TIER-PRIORITY", "PRIORITY"}
 }
 
 func (r Response) GetTableRow(maxColumnLength int) []string {
-	return []string{r.Name, common.GenerateTableElementWithSummary(r.AppliedToGroups, maxColumnLength), strconv.Itoa(len(r.Rules)), r.SourceRef.ToString()}
+	return []string{
+		r.Name, common.GenerateTableElementWithSummary(r.AppliedToGroups, maxColumnLength),
+		strconv.Itoa(len(r.Rules)), r.SourceRef.ToString(),
+		priorityToString(r.TierPriority), priorityToString(r.Priority),
+	}
 }
 
 func (r Response) SortRows() bool {
-	return true
+	return false
 }

--- a/pkg/antctl/transform/utils.go
+++ b/pkg/antctl/transform/utils.go
@@ -20,10 +20,10 @@ import (
 	"reflect"
 )
 
-type unary func(interface{}) (interface{}, error)
+type unary func(interface{}, map[string]string) (interface{}, error)
 type FuncType func(reader io.Reader, single bool) (interface{}, error)
 
-func GenericFactory(objType, listType reflect.Type, objTransform, listTransform unary) FuncType {
+func GenericFactory(objType, listType reflect.Type, objTransform, listTransform unary, opts map[string]string) FuncType {
 	return func(reader io.Reader, single bool) (interface{}, error) {
 		var refType reflect.Type
 		if single {
@@ -36,9 +36,9 @@ func GenericFactory(objType, listType reflect.Type, objTransform, listTransform 
 			return nil, err
 		}
 		if single && objTransform != nil {
-			return objTransform(refVal.Interface())
+			return objTransform(refVal.Interface(), opts)
 		} else if !single && listTransform != nil {
-			return listTransform(refVal.Interface())
+			return listTransform(refVal.Interface(), opts)
 		}
 		return refVal.Interface(), nil
 	}

--- a/pkg/antctl/transform/version/transform.go
+++ b/pkg/antctl/transform/version/transform.go
@@ -35,7 +35,7 @@ type Response struct {
 // AgentVersion is the AddonTransform for the version command. This function
 // will try to parse the response as a AgentVersionResponse and then populate
 // it with the version of antctl to a transformedVersionResponse object.
-func AgentTransform(reader io.Reader, _ bool) (interface{}, error) {
+func AgentTransform(reader io.Reader, _ bool, _ map[string]string) (interface{}, error) {
 	b, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func AgentTransform(reader io.Reader, _ bool) (interface{}, error) {
 	return resp, nil
 }
 
-func ControllerTransform(reader io.Reader, _ bool) (interface{}, error) {
+func ControllerTransform(reader io.Reader, _ bool, _ map[string]string) (interface{}, error) {
 	b, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/networkpolicy/antreanetworkpolicy_test.go
+++ b/pkg/controller/networkpolicy/antreanetworkpolicy_test.go
@@ -98,7 +98,7 @@ func TestProcessAntreaNetworkPolicy(t *testing.T) {
 					UID:       "uidA",
 				},
 				Priority:     &p10,
-				TierPriority: &defaultTierPriority,
+				TierPriority: &DefaultTierPriority,
 				Rules: []controlplane.NetworkPolicyRule{
 					{
 						Direction: controlplane.DirectionIn,
@@ -183,7 +183,7 @@ func TestProcessAntreaNetworkPolicy(t *testing.T) {
 					UID:       "uidB",
 				},
 				Priority:     &p10,
-				TierPriority: &defaultTierPriority,
+				TierPriority: &DefaultTierPriority,
 				Rules: []controlplane.NetworkPolicyRule{
 					{
 						Direction: controlplane.DirectionIn,
@@ -286,7 +286,7 @@ func TestAddANP(t *testing.T) {
 					UID:       "uidA",
 				},
 				Priority:     &p10,
-				TierPriority: &defaultTierPriority,
+				TierPriority: &DefaultTierPriority,
 				Rules: []controlplane.NetworkPolicyRule{
 					{
 						Direction: controlplane.DirectionIn,

--- a/pkg/controller/networkpolicy/clusternetworkpolicy_test.go
+++ b/pkg/controller/networkpolicy/clusternetworkpolicy_test.go
@@ -101,7 +101,7 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 					UID:  "uidA",
 				},
 				Priority:     &p10,
-				TierPriority: &defaultTierPriority,
+				TierPriority: &DefaultTierPriority,
 				Rules: []controlplane.NetworkPolicyRule{
 					{
 						Direction: controlplane.DirectionIn,
@@ -185,7 +185,7 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 					UID:  "uidB",
 				},
 				Priority:     &p10,
-				TierPriority: &defaultTierPriority,
+				TierPriority: &DefaultTierPriority,
 				Rules: []controlplane.NetworkPolicyRule{
 					{
 						Direction: controlplane.DirectionIn,
@@ -333,7 +333,7 @@ func TestAddCNP(t *testing.T) {
 	appTier := secv1alpha1.Tier{
 		ObjectMeta: metav1.ObjectMeta{Name: "application", UID: "tA"},
 		Spec: secv1alpha1.TierSpec{
-			Priority: defaultTierPriority,
+			Priority: DefaultTierPriority,
 		},
 	}
 	allowAction := secv1alpha1.RuleActionAllow
@@ -390,7 +390,7 @@ func TestAddCNP(t *testing.T) {
 					UID:  "uidA",
 				},
 				Priority:     &p10,
-				TierPriority: &defaultTierPriority,
+				TierPriority: &DefaultTierPriority,
 				Rules: []controlplane.NetworkPolicyRule{
 					{
 						Direction: controlplane.DirectionIn,
@@ -448,7 +448,7 @@ func TestAddCNP(t *testing.T) {
 					UID:  "uidB",
 				},
 				Priority:     &p10,
-				TierPriority: &defaultTierPriority,
+				TierPriority: &DefaultTierPriority,
 				Rules: []controlplane.NetworkPolicyRule{
 					{
 						Direction: controlplane.DirectionIn,
@@ -640,7 +640,7 @@ func TestAddCNP(t *testing.T) {
 					UID:  "uidF",
 				},
 				Priority:     &p10,
-				TierPriority: &defaultTierPriority,
+				TierPriority: &DefaultTierPriority,
 				Rules: []controlplane.NetworkPolicyRule{
 					{
 						Direction: controlplane.DirectionIn,
@@ -724,7 +724,7 @@ func TestAddCNP(t *testing.T) {
 					UID:  "uidG",
 				},
 				Priority:     &p10,
-				TierPriority: &defaultTierPriority,
+				TierPriority: &DefaultTierPriority,
 				Rules: []controlplane.NetworkPolicyRule{
 					{
 						Direction: controlplane.DirectionIn,
@@ -810,7 +810,7 @@ func TestGetTierPriority(t *testing.T) {
 		{
 			name:      "empty-tier-name",
 			inputTier: nil,
-			expPrio:   defaultTierPriority,
+			expPrio:   DefaultTierPriority,
 		},
 		{
 			name: "tier10",

--- a/pkg/controller/networkpolicy/crd_utils.go
+++ b/pkg/controller/networkpolicy/crd_utils.go
@@ -136,7 +136,7 @@ func (n *NetworkPolicyController) createAddressGroupForCRD(peer secv1alpha1.Netw
 // is returned.
 func (n *NetworkPolicyController) getTierPriority(tier string) int32 {
 	if tier == "" {
-		return defaultTierPriority
+		return DefaultTierPriority
 	}
 	// If the tier name is part of the static tier name set, we need to convert
 	// tier name to lowercase to match the corresponding Tier CRD name. This is
@@ -151,7 +151,7 @@ func (n *NetworkPolicyController) getTierPriority(tier string) int32 {
 	if err != nil {
 		// This error should ideally not occur as we perform validation.
 		klog.Errorf("Failed to retrieve Tier %s. Setting default tier priority: %v", tier, err)
-		return defaultTierPriority
+		return DefaultTierPriority
 	}
 	return t.Spec.Priority
 }

--- a/pkg/controller/networkpolicy/tier.go
+++ b/pkg/controller/networkpolicy/tier.go
@@ -34,19 +34,19 @@ var (
 	// maxSupportedTiers is the soft limit on the maximum number of supported
 	// Tiers.
 	maxSupportedTiers = 20
-	// defaultTierPriority maintains the priority for the system generated default Tier.
+	// DefaultTierPriority maintains the priority for the system generated default Tier.
 	// This is the lowest priority for tiers that will be enforced before K8s NetworkPolicies.
-	defaultTierPriority = int32(250)
-	// baselineTierPriority maintains the priority for the system generated baseline Tier.
+	DefaultTierPriority = int32(250)
+	// BaselineTierPriority maintains the priority for the system generated baseline Tier.
 	// This is the tier that will be enforced after K8s NetworkPolicies.
-	baselineTierPriority = int32(253)
+	BaselineTierPriority = int32(253)
 	// defaultTierName maintains the name of the default Tier in Antrea.
 	defaultTierName = "application"
 	// priorityMap maintains the Tier priority associated with system generated
 	// Tier names.
 	priorityMap = map[string]int32{
-		"baseline":      baselineTierPriority,
-		defaultTierName: defaultTierPriority,
+		"baseline":      BaselineTierPriority,
+		defaultTierName: DefaultTierPriority,
 		"platform":      int32(150),
 		"networkops":    int32(100),
 		"securityops":   int32(50),


### PR DESCRIPTION
This PR aims to solve #1388 
- Adds an option --sort-by=effectivePriority for `antctl get networkpolicy`, which sorts the Antrea internal controlplane NetworkPolicy objects by the order in which they are evaluated.
- `antctl get networkpolicy` displays tier priority and policy priority by default