### PR TITLE
Graduate some features from Alpha to Beta

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -103,8 +103,8 @@ jobs:
         path: log.tar.gz
         retention-days: 30
 
-  test-e2e-encap-proxy:
-    name: E2e tests on a Kind cluster on Linux with proxy enabled
+  test-e2e-encap-no-proxy:
+    name: E2e tests on a Kind cluster on Linux with AntreaProxy disabled
     needs: build-antrea-coverage-image
     runs-on: [ubuntu-18.04]
     steps:
@@ -131,15 +131,15 @@ jobs:
     - name: Run e2e tests
       run: |
         mkdir log
-        mkdir test-e2e-encap-proxy-coverage
-        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-encap-proxy-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --proxy --coverage
+        mkdir test-e2e-encap-no-proxy-coverage
+        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-encap-no-proxy-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --no-proxy --coverage
     - name: Tar coverage files
-      run: tar -czf test-e2e-encap-proxy-coverage.tar.gz test-e2e-encap-proxy-coverage
-    - name: Upload coverage for test-e2e-encap-proxy-coverage
+      run: tar -czf test-e2e-encap-no-proxy-coverage.tar.gz test-e2e-encap-no-proxy-coverage
+    - name: Upload coverage for test-e2e-encap-no-proxy-coverage
       uses: actions/upload-artifact@v2
       with:
-        name: test-e2e-encap-proxy-coverage
-        path: test-e2e-encap-proxy-coverage.tar.gz
+        name: test-e2e-encap-no-proxy-coverage
+        path: test-e2e-encap-no-proxy-coverage.tar.gz
         retention-days: 30
     - name: Codecov
       uses: codecov/codecov-action@v1
@@ -147,8 +147,8 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: '*antrea*'
         flags: kind-e2e-tests
-        name: codecov-test-e2e-encap-proxy
-        directory: test-e2e-encap-proxy-coverage
+        name: codecov-test-e2e-encap-no-proxy
+        directory: test-e2e-encap-no-proxy-coverage
     - name: Tar log files
       if: ${{ failure() }}
       run: tar -czf log.tar.gz log
@@ -156,7 +156,7 @@ jobs:
       uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:
-        name: e2e-kind-encap-proxy.tar.gz
+        name: e2e-kind-encap-no-proxy.tar.gz
         path: log.tar.gz
         retention-days: 30
 
@@ -415,7 +415,7 @@ jobs:
   # yet.
   artifact-cleanup:
     name: Delete uploaded images
-    needs: [build-antrea-coverage-image, build-antrea-image, test-e2e-encap, test-e2e-encap-proxy, test-e2e-noencap, test-e2e-hybrid, test-e2e-encap-np, test-netpol-tmp, validate-prometheus-metrics-doc]
+    needs: [build-antrea-coverage-image, build-antrea-image, test-e2e-encap, test-e2e-encap-no-proxy, test-e2e-noencap, test-e2e-hybrid, test-e2e-encap-np, test-netpol-tmp, validate-prometheus-metrics-doc]
     if: ${{ always() }}
     runs-on: [ubuntu-18.04]
     steps:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1118,12 +1118,11 @@ data:
     featureGates:
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
-    # Service traffic. Antrea proxy doesn't support an IPv6 only cluster or a Dual-Stack cluster
-    # before PR #1102[https://github.com/vmware-tanzu/antrea/pull/1102] is merged.
-      AntreaProxy: true
+    # Service traffic.
+    #  AntreaProxy: true
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
-    #  Traceflow: false
+    #  Traceflow: true
 
     # Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
     # to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
@@ -1199,7 +1198,7 @@ data:
     #apiPort: 10350
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
-    #enablePrometheusMetrics: false
+    #enablePrometheusMetrics: true
 
     # Provide flow collector address as string with format <IP>:<port>[:<proto>], where proto is tcp or udp. This also enables
     # the flow exporter that sends IPFIX flow records of conntrack flows on OVS bridge. If no L4 transport proto is given,
@@ -1240,7 +1239,7 @@ data:
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
-    #  Traceflow: false
+    #  Traceflow: true
 
     # Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
     # to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
@@ -1256,7 +1255,7 @@ data:
     #apiPort: 10349
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
-    #enablePrometheusMetrics: false
+    #enablePrometheusMetrics: true
 
     # Indicates whether to use auto-generated self-signed TLS certificate.
     # If false, A Secret named "antrea-controller-tls" must be provided with the following keys:
@@ -1271,7 +1270,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-hmttgfbf78
+  name: antrea-config-t4t2mdfhkc
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1378,7 +1377,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-hmttgfbf78
+          name: antrea-config-t4t2mdfhkc
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1642,7 +1641,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-hmttgfbf78
+          name: antrea-config-t4t2mdfhkc
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1118,12 +1118,11 @@ data:
     featureGates:
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
-    # Service traffic. Antrea proxy doesn't support an IPv6 only cluster or a Dual-Stack cluster
-    # before PR #1102[https://github.com/vmware-tanzu/antrea/pull/1102] is merged.
-      AntreaProxy: true
+    # Service traffic.
+    #  AntreaProxy: true
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
-    #  Traceflow: false
+    #  Traceflow: true
 
     # Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
     # to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
@@ -1199,7 +1198,7 @@ data:
     #apiPort: 10350
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
-    #enablePrometheusMetrics: false
+    #enablePrometheusMetrics: true
 
     # Provide flow collector address as string with format <IP>:<port>[:<proto>], where proto is tcp or udp. This also enables
     # the flow exporter that sends IPFIX flow records of conntrack flows on OVS bridge. If no L4 transport proto is given,
@@ -1240,7 +1239,7 @@ data:
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
-    #  Traceflow: false
+    #  Traceflow: true
 
     # Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
     # to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
@@ -1256,7 +1255,7 @@ data:
     #apiPort: 10349
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
-    #enablePrometheusMetrics: false
+    #enablePrometheusMetrics: true
 
     # Indicates whether to use auto-generated self-signed TLS certificate.
     # If false, A Secret named "antrea-controller-tls" must be provided with the following keys:
@@ -1271,7 +1270,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-hmttgfbf78
+  name: antrea-config-t4t2mdfhkc
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1378,7 +1377,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-hmttgfbf78
+          name: antrea-config-t4t2mdfhkc
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1644,7 +1643,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-hmttgfbf78
+          name: antrea-config-t4t2mdfhkc
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1118,12 +1118,11 @@ data:
     featureGates:
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
-    # Service traffic. Antrea proxy doesn't support an IPv6 only cluster or a Dual-Stack cluster
-    # before PR #1102[https://github.com/vmware-tanzu/antrea/pull/1102] is merged.
-      AntreaProxy: true
+    # Service traffic.
+    #  AntreaProxy: true
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
-    #  Traceflow: false
+    #  Traceflow: true
 
     # Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
     # to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
@@ -1199,7 +1198,7 @@ data:
     #apiPort: 10350
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
-    #enablePrometheusMetrics: false
+    #enablePrometheusMetrics: true
 
     # Provide flow collector address as string with format <IP>:<port>[:<proto>], where proto is tcp or udp. This also enables
     # the flow exporter that sends IPFIX flow records of conntrack flows on OVS bridge. If no L4 transport proto is given,
@@ -1240,7 +1239,7 @@ data:
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
-    #  Traceflow: false
+    #  Traceflow: true
 
     # Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
     # to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
@@ -1256,7 +1255,7 @@ data:
     #apiPort: 10349
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
-    #enablePrometheusMetrics: false
+    #enablePrometheusMetrics: true
 
     # Indicates whether to use auto-generated self-signed TLS certificate.
     # If false, A Secret named "antrea-controller-tls" must be provided with the following keys:
@@ -1271,7 +1270,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-8bc4m9g22g
+  name: antrea-config-gmt86d9t68
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1378,7 +1377,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-8bc4m9g22g
+          name: antrea-config-gmt86d9t68
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1642,7 +1641,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-8bc4m9g22g
+          name: antrea-config-gmt86d9t68
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1118,12 +1118,11 @@ data:
     featureGates:
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
-    # Service traffic. Antrea proxy doesn't support an IPv6 only cluster or a Dual-Stack cluster
-    # before PR #1102[https://github.com/vmware-tanzu/antrea/pull/1102] is merged.
-    #  AntreaProxy: false
+    # Service traffic.
+    #  AntreaProxy: true
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
-    #  Traceflow: false
+    #  Traceflow: true
 
     # Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
     # to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
@@ -1204,7 +1203,7 @@ data:
     #apiPort: 10350
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
-    #enablePrometheusMetrics: false
+    #enablePrometheusMetrics: true
 
     # Provide flow collector address as string with format <IP>:<port>[:<proto>], where proto is tcp or udp. This also enables
     # the flow exporter that sends IPFIX flow records of conntrack flows on OVS bridge. If no L4 transport proto is given,
@@ -1245,7 +1244,7 @@ data:
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
-    #  Traceflow: false
+    #  Traceflow: true
 
     # Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
     # to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
@@ -1261,7 +1260,7 @@ data:
     #apiPort: 10349
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
-    #enablePrometheusMetrics: false
+    #enablePrometheusMetrics: true
 
     # Indicates whether to use auto-generated self-signed TLS certificate.
     # If false, A Secret named "antrea-controller-tls" must be provided with the following keys:
@@ -1276,7 +1275,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-kgd27dftgd
+  name: antrea-config-2k6g59bdkg
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1392,7 +1391,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-kgd27dftgd
+          name: antrea-config-2k6g59bdkg
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1691,7 +1690,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-kgd27dftgd
+          name: antrea-config-2k6g59bdkg
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -21,7 +21,7 @@ data:
     # Enable antrea proxy which provides ServiceLB for in-cluster services in antrea agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
     # Service traffic.
-      AntreaProxy: true
+    #  AntreaProxy: true
 
     # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each agent to a configured collector.
     #  FlowExporter: false
@@ -54,7 +54,7 @@ data:
     #apiPort: 10350
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
-    #enablePrometheusMetrics: false
+    #enablePrometheusMetrics: true
 
     # Provide flow collector address as string with format <IP>:<port>[:<proto>], where proto is tcp or udp. This also enables
     # the flow exporter that sends IPFIX flow records of conntrack flows on OVS bridge. If no L4 transport proto is given,
@@ -88,7 +88,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-windows-config-5ht8dmf8tk
+  name: antrea-windows-config-6d4gc5kdc8
   namespace: kube-system
 ---
 apiVersion: apps/v1
@@ -176,7 +176,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-windows-config-5ht8dmf8tk
+          name: antrea-windows-config-6d4gc5kdc8
         name: antrea-windows-config
       - configMap:
           defaultMode: 420

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1118,12 +1118,11 @@ data:
     featureGates:
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
-    # Service traffic. Antrea proxy doesn't support an IPv6 only cluster or a Dual-Stack cluster
-    # before PR #1102[https://github.com/vmware-tanzu/antrea/pull/1102] is merged.
-    #  AntreaProxy: false
+    # Service traffic.
+    #  AntreaProxy: true
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
-    #  Traceflow: false
+    #  Traceflow: true
 
     # Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
     # to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
@@ -1204,7 +1203,7 @@ data:
     #apiPort: 10350
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
-    #enablePrometheusMetrics: false
+    #enablePrometheusMetrics: true
 
     # Provide flow collector address as string with format <IP>:<port>[:<proto>], where proto is tcp or udp. This also enables
     # the flow exporter that sends IPFIX flow records of conntrack flows on OVS bridge. If no L4 transport proto is given,
@@ -1245,7 +1244,7 @@ data:
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
-    #  Traceflow: false
+    #  Traceflow: true
 
     # Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
     # to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
@@ -1261,7 +1260,7 @@ data:
     #apiPort: 10349
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
-    #enablePrometheusMetrics: false
+    #enablePrometheusMetrics: true
 
     # Indicates whether to use auto-generated self-signed TLS certificate.
     # If false, A Secret named "antrea-controller-tls" must be provided with the following keys:
@@ -1276,7 +1275,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-2hk276fdf4
+  name: antrea-config-9c7h568bgf
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1383,7 +1382,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-2hk276fdf4
+          name: antrea-config-9c7h568bgf
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1647,7 +1646,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-2hk276fdf4
+          name: antrea-config-9c7h568bgf
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -2,12 +2,11 @@
 featureGates:
 # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
 # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
-# Service traffic. Antrea proxy doesn't support an IPv6 only cluster or a Dual-Stack cluster
-# before PR #1102[https://github.com/vmware-tanzu/antrea/pull/1102] is merged.
-#  AntreaProxy: false
+# Service traffic.
+#  AntreaProxy: true
 
 # Enable traceflow which provides packet tracing feature to diagnose network issue.
-#  Traceflow: false
+#  Traceflow: true
 
 # Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
 # to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
@@ -88,7 +87,7 @@ featureGates:
 #apiPort: 10350
 
 # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
-#enablePrometheusMetrics: false
+#enablePrometheusMetrics: true
 
 # Provide flow collector address as string with format <IP>:<port>[:<proto>], where proto is tcp or udp. This also enables
 # the flow exporter that sends IPFIX flow records of conntrack flows on OVS bridge. If no L4 transport proto is given,

--- a/build/yamls/base/conf/antrea-controller.conf
+++ b/build/yamls/base/conf/antrea-controller.conf
@@ -1,7 +1,7 @@
 # FeatureGates is a map of feature names to bools that enable or disable experimental features.
 featureGates:
 # Enable traceflow which provides packet tracing feature to diagnose network issue.
-#  Traceflow: false
+#  Traceflow: true
 
 # Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
 # to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
@@ -17,7 +17,7 @@ featureGates:
 #apiPort: 10349
 
 # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
-#enablePrometheusMetrics: false
+#enablePrometheusMetrics: true
 
 # Indicates whether to use auto-generated self-signed TLS certificate.
 # If false, A Secret named "antrea-controller-tls" must be provided with the following keys:

--- a/build/yamls/windows/base/conf/antrea-agent.conf
+++ b/build/yamls/windows/base/conf/antrea-agent.conf
@@ -3,7 +3,7 @@ featureGates:
 # Enable antrea proxy which provides ServiceLB for in-cluster services in antrea agent.
 # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
 # Service traffic.
-  AntreaProxy: true
+#  AntreaProxy: true
 
 # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each agent to a configured collector.
 #  FlowExporter: false
@@ -36,7 +36,7 @@ featureGates:
 #apiPort: 10350
 
 # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
-#enablePrometheusMetrics: false
+#enablePrometheusMetrics: true
 
 # Provide flow collector address as string with format <IP>:<port>[:<proto>], where proto is tcp or udp. This also enables
 # the flow exporter that sends IPFIX flow records of conntrack flows on OVS bridge. If no L4 transport proto is given,

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -276,8 +276,7 @@ function deliver_antrea {
 
     sed -i "s|#serviceCIDR: 10.96.0.0/12|serviceCIDR: 100.64.0.0/13|g" $GIT_CHECKOUT_DIR/build/yamls/$antrea_yml
 
-    # Configure and append antrea-prometheus.yml to antrea.yml
-    sed -i "s|#enablePrometheusMetrics: false|enablePrometheusMetrics: true|g" $GIT_CHECKOUT_DIR/build/yamls/$antrea_yml
+    # Append antrea-prometheus.yml to antrea.yml
     echo "---" >> $GIT_CHECKOUT_DIR/build/yamls/$antrea_yml
     cat $GIT_CHECKOUT_DIR/build/yamls/antrea-prometheus.yml >> $GIT_CHECKOUT_DIR/build/yamls/$antrea_yml
 

--- a/ci/kind/kind-setup.sh
+++ b/ci/kind/kind-setup.sh
@@ -26,7 +26,7 @@ POD_CIDR="10.10.0.0/16"
 NUM_WORKERS=2
 SUBNETS=""
 ENCAP_MODE=""
-PROXY=false
+PROXY=true
 PROMETHEUS=false
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
@@ -47,9 +47,9 @@ where:
   modify-node: modify kind node with name NODE_NAME
   --pod-cidr: specifies pod cidr used in kind cluster, default is $POD_CIDR
   --encap-mode: inter-node pod traffic encap mode, default is encap
-  --proxy: enable Antrea proxy, default is false
-  --antrea-cni: specifies install Antrea CNI in kind cluster, default is true.
-  --prometheus: enable Prometheus metrics listener for Antrea Controller and Agents, default is false
+  --no-proxy: disable Antrea proxy
+  --antrea-cni: specifies install Antrea CNI in kind cluster, default is true
+  --prometheus: create RBAC resources for Prometheus, default is false
   --num-workers: specifies number of worker nodes in kind cluster, default is $NUM_WORKERS
   --images: specifies images loaded to kind cluster, default is $IMAGES
   --subnets: a subnet creates a separate docker bridge network (named 'antrea-<idx>') with assigned subnet that worker nodes may connect to. Default is empty: all worker
@@ -271,11 +271,8 @@ EOF
   if [[ $ANTREA_CNI == true ]]; then
     cmd=$(dirname $0)
     cmd+="/../../hack/generate-manifest.sh"
-    if [[ $PROXY == true ]]; then
-      cmd+=" --proxy"
-    fi
-    if [[ $PROMETHEUS == true ]]; then
-      cmd+=" --prometheus"
+    if [[ $PROXY == false ]]; then
+      cmd+=" --no-proxy"
     fi
     echo "$cmd --kind $(get_encap_mode) | kubectl apply --context kind-$CLUSTER_NAME -f -"
     eval "$cmd --kind $(get_encap_mode) | kubectl apply --context kind-$CLUSTER_NAME -f -"
@@ -327,8 +324,8 @@ while [[ $# -gt 0 ]]
       ENCAP_MODE="$2"
       shift 2
       ;;
-    --proxy)
-      PROXY=true
+    --no-proxy)
+      PROXY=false
       shift
       ;;
     --prometheus)

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -22,9 +22,9 @@ function echoerr {
     >&2 echo "$@"
 }
 
-_usage="Usage: $0 [--encap-mode <mode>] [--proxy] [--np] [--coverage] [--help|-h]
+_usage="Usage: $0 [--encap-mode <mode>] [--no-proxy] [--np] [--coverage] [--help|-h]
         --encap-mode                  Traffic encapsulation mode. (default is 'encap')
-        --proxy                       Enables Antrea proxy.
+        --no-proxy                    Disables Antrea proxy.
         --np                          Enables Namespaced Antrea NetworkPolicy CRDs and ClusterNetworkPolicy related CRDs.
         --coverage                    Enables measure Antrea code coverage when run e2e tests on kind.
         --help, -h                    Print this message and exit
@@ -48,7 +48,7 @@ function quit {
 trap "quit" INT EXIT
 
 mode=""
-proxy=false
+proxy=true
 np=false
 coverage=false
 while [[ $# -gt 0 ]]
@@ -56,8 +56,8 @@ do
 key="$1"
 
 case $key in
-    --proxy)
-    proxy=true
+    --no-proxy)
+    proxy=false
     shift
     ;;
     --np)
@@ -84,8 +84,8 @@ esac
 done
 
 manifest_args=""
-if $proxy; then
-    manifest_args="$manifest_args --proxy"
+if ! $proxy; then
+    manifest_args="$manifest_args --no-proxy"
 fi
 if $np; then
     # See https://github.com/vmware-tanzu/antrea/issues/897

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -99,7 +99,7 @@ type AgentConfig struct {
 	// Defaults to 10350.
 	APIPort int `yaml:"apiPort,omitempty"`
 	// Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener
-	// Defaults to false.
+	// Defaults to true.
 	EnablePrometheusMetrics bool `yaml:"enablePrometheusMetrics,omitempty"`
 	// Provide the flow collector address as string with format <IP>:<port>[:<proto>], where proto is tcp or udp. This also
 	// enables the flow exporter that sends IPFIX flow records of conntrack flows on OVS bridge. If no L4 transport proto

--- a/cmd/antrea-controller/config.go
+++ b/cmd/antrea-controller/config.go
@@ -28,7 +28,7 @@ type ControllerConfig struct {
 	// Defaults to 10349.
 	APIPort int `yaml:"apiPort,omitempty"`
 	// Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener
-	// Defaults to false.
+	// Defaults to true.
 	EnablePrometheusMetrics bool `yaml:"enablePrometheusMetrics,omitempty"`
 	// Indicates whether to use auto-generated self-signed TLS certificate.
 	// If false, A Secret named "antrea-controller-tls" must be provided with the following keys:

--- a/cmd/antrea-controller/options.go
+++ b/cmd/antrea-controller/options.go
@@ -34,7 +34,10 @@ type Options struct {
 
 func newOptions() *Options {
 	return &Options{
-		config: new(ControllerConfig),
+		config: &ControllerConfig{
+			EnablePrometheusMetrics: true,
+			SelfSignedCert:          true,
+		},
 	}
 }
 
@@ -46,11 +49,9 @@ func (o *Options) addFlags(fs *pflag.FlagSet) {
 // complete completes all the required options.
 func (o *Options) complete(args []string) error {
 	if len(o.configFile) > 0 {
-		c, err := o.loadConfigFromFile(o.configFile)
-		if err != nil {
+		if err := o.loadConfigFromFile(); err != nil {
 			return err
 		}
-		o.config = c
 	}
 	o.setDefaults()
 	return features.DefaultMutableFeatureGate.SetFromMap(o.config.FeatureGates)
@@ -64,20 +65,13 @@ func (o *Options) validate(args []string) error {
 	return nil
 }
 
-func (o *Options) loadConfigFromFile(file string) (*ControllerConfig, error) {
-	data, err := ioutil.ReadFile(file)
+func (o *Options) loadConfigFromFile() error {
+	data, err := ioutil.ReadFile(o.configFile)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	c := ControllerConfig{
-		SelfSignedCert: true,
-	}
-	err = yaml.UnmarshalStrict(data, &c)
-	if err != nil {
-		return nil, err
-	}
-	return &c, nil
+	return yaml.UnmarshalStrict(data, &o.config)
 }
 
 func (o *Options) setDefaults() {

--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -33,11 +33,11 @@ example, to enable `AntreaProxy` on Linux, edit the Agent configuration in the
 
 | Feature Name            | Component          | Default | Stage | Alpha Release | Beta Release | GA Release | Extra Requirements | Notes |
 | ----------------------- | ------------------ | ------- | ----- | ------------- | ------------ | ---------- | ------------------ | ----- |
-| `AntreaProxy`           | Agent              | `false` | Alpha | v0.8.0        | N/A          | N/A        | Yes                | Must be enabled for Windows. |
-| `AntreaPolicy`          | Agent + Controller | `false` | Alpha | v0.8.0        | N/A          | N/A        | No                 | Agent side config required from v0.9.0+. |
-| `Traceflow`             | Agent + Controller | `false` | Alpha | v0.8.0        | N/A          | N/A        | Yes                |       |
-| `FlowExporter`          | Agent              | `false` | Alpha | v0.9.0        | N/A          | N/A        | Yes                |       |
-| `NetworkPolicyStats`    | Agent + Controller | `false` | Alpha | v0.10.0       | N/A          | N/A        | No                 |       |
+| `AntreaProxy`           | Agent              | `false` | Alpha | v0.8          | v0.11        | N/A        | Yes                | Must be enabled for Windows. |
+| `AntreaPolicy`          | Agent + Controller | `false` | Alpha | v0.8          | N/A          | N/A        | No                 | Agent side config required from v0.9.0+. |
+| `Traceflow`             | Agent + Controller | `false` | Alpha | v0.8          | v0.11        | N/A        | Yes                |       |
+| `FlowExporter`          | Agent              | `false` | Alpha | v0.9          | N/A          | N/A        | Yes                |       |
+| `NetworkPolicyStats`    | Agent + Controller | `false` | Alpha | v0.10         | N/A          | N/A        | No                 |       |
 
 ## Description and Requirements of Features
 
@@ -81,11 +81,14 @@ this [document](traceflow-guide.md) for more information.
 
 #### Requirements for this Feature
 
-This feature can only be used in "encap" mode when the Geneve tunnel type is
-being used. Note that this is the default configuration for both Linux and
-Windows. In order to support cluster Services as the destination for tracing
-requests, `AntreaProxy` should be enabled (it is not enabled by default for
-Linux Nodes in "encap" mode)..
+Until Antrea v0.11, this feature could only be used in "encap" mode, with the
+Geneve tunnel type (default configuration for both Linux and Windows). In v0.11,
+this feature was graduated to Beta (enabled by default) and this requirement was
+lifted.
+
+In order to support cluster Services as the destination for tracing requests,
+`AntreaProxy` should be enabled, which is the default starting with Antrea
+v0.11.
 
 ### Flow Exporter
 

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -1653,16 +1653,18 @@ func (c *client) endpointDNATFlow(endpointIP net.IP, endpointPort uint16, protoc
 		Cookie(c.cookieAllocator.Request(cookie.Service).Raw()).
 		MatchRegRange(int(endpointPortReg), unionVal, binding.Range{0, 18}).
 		MatchProtocol(protocol)
+	ctZone := CtZone
 	if ipProtocol == binding.ProtocolIP {
 		ipVal := binary.BigEndian.Uint32(endpointIP.To4())
 		flowBuilder = flowBuilder.MatchReg(int(endpointIPReg), ipVal).
 			MatchRegRange(int(endpointPortReg), unionVal, binding.Range{0, 18})
 	} else {
+		ctZone = CtZoneV6
 		ipVal := []byte(endpointIP)
 		flowBuilder = flowBuilder.MatchXXReg(int(endpointIPv6XXReg), ipVal).
 			MatchRegRange(int(endpointPortReg), unionVal, binding.Range{0, 18})
 	}
-	return flowBuilder.Action().CT(true, table.GetNext(), CtZone).
+	return flowBuilder.Action().CT(true, table.GetNext(), ctZone).
 		DNAT(
 			&binding.IPRange{StartIP: endpointIP, EndIP: endpointIP},
 			&binding.PortRange{StartPort: endpointPort, EndPort: endpointPort},

--- a/pkg/features/antrea_features.go
+++ b/pkg/features/antrea_features.go
@@ -34,12 +34,14 @@ const (
 	AntreaPolicy featuregate.Feature = "AntreaPolicy"
 
 	// alpha: v0.8
+	// beta: v0.11
 	// Enable antrea proxy which provides ServiceLB for in-cluster services in antrea agent.
 	// It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
 	// Service traffic.
 	AntreaProxy featuregate.Feature = "AntreaProxy"
 
 	// alpha: v0.8
+	// beta: v0.11
 	// Allows to trace path from a generated packet.
 	Traceflow featuregate.Feature = "Traceflow"
 
@@ -65,8 +67,8 @@ var (
 	// available throughout Antrea binaries.
 	defaultAntreaFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 		AntreaPolicy:       {Default: false, PreRelease: featuregate.Alpha},
-		AntreaProxy:        {Default: false, PreRelease: featuregate.Alpha},
-		Traceflow:          {Default: false, PreRelease: featuregate.Alpha},
+		AntreaProxy:        {Default: true, PreRelease: featuregate.Beta},
+		Traceflow:          {Default: true, PreRelease: featuregate.Beta},
 		FlowExporter:       {Default: false, PreRelease: featuregate.Alpha},
 		NetworkPolicyStats: {Default: false, PreRelease: featuregate.Alpha},
 	}

--- a/test/e2e/infra/vagrant/push_antrea.sh
+++ b/test/e2e/infra/vagrant/push_antrea.sh
@@ -39,7 +39,6 @@ cp "${ANTREA_BASE_YML}" "${ANTREA_YML}"
 
 if [ "$RUN_PROMETHEUS" == "true" ]; then
     # Prepare Antrea yamls
-    sed -i.bak -E 's|#enablePrometheusMetrics: false|enablePrometheusMetrics: true|g' "${ANTREA_YML}"
     echo "---" >> "${ANTREA_YML}"
     cat "${ANTREA_PROMETHEUS_YML}" >> "${ANTREA_YML}"
 fi

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -37,7 +37,7 @@ func skipIfProxyDisabled(t *testing.T, data *TestData) {
 	if featureGate, err := data.GetAgentFeatures(antreaNamespace); err != nil {
 		t.Fatalf("Error when detecting proxy: %v", err)
 	} else if !featureGate.Enabled(features.AntreaProxy) {
-		t.Skip()
+		t.Skip("Skipping test because AntreaProxy is not enabled")
 	}
 }
 

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane/v1beta2"
 	"github.com/vmware-tanzu/antrea/pkg/apis/ops/v1alpha1"
+	"github.com/vmware-tanzu/antrea/pkg/features"
 )
 
 type testcase struct {
@@ -35,6 +36,19 @@ type testcase struct {
 	tf              *v1alpha1.Traceflow
 	expectedPhase   v1alpha1.TraceflowPhase
 	expectedResults []v1alpha1.NodeResult
+}
+
+func skipIfTraceflowDisabled(t *testing.T, data *TestData) {
+	if featureGate, err := data.GetAgentFeatures(antreaNamespace); err != nil {
+		t.Fatalf("Error when detecting traceflow: %v", err)
+	} else if !featureGate.Enabled(features.AntreaProxy) {
+		t.Skip("Skipping test because Traceflow is not enabled in the Agent")
+	}
+	if featureGate, err := data.GetControllerFeatures(antreaNamespace); err != nil {
+		t.Fatalf("Error when detecting traceflow: %v", err)
+	} else if !featureGate.Enabled(features.AntreaProxy) {
+		t.Skip("Skipping test because Traceflow is not enabled in the Controller")
+	}
 }
 
 // TestTraceflowIntraNode verifies if traceflow can trace intra node traffic with some NetworkPolicies set.
@@ -46,9 +60,7 @@ func TestTraceflowIntraNode(t *testing.T) {
 	}
 	defer teardownTest(t, data)
 
-	if err = data.enableTraceflow(t); err != nil {
-		t.Fatal("Error when enabling Traceflow")
-	}
+	skipIfTraceflowDisabled(t, data)
 
 	node1 := nodeName(0)
 
@@ -333,9 +345,7 @@ func TestTraceflowInterNode(t *testing.T) {
 	}
 	defer teardownTest(t, data)
 
-	if err = data.enableTraceflow(t); err != nil {
-		t.Fatal("Error when enabling Traceflow")
-	}
+	skipIfTraceflowDisabled(t, data)
 
 	node1 := nodeName(0)
 	node2 := nodeName(1)
@@ -685,21 +695,6 @@ func (data *TestData) waitForTraceflow(t *testing.T, name string, phase v1alpha1
 		return nil, err
 	}
 	return tf, nil
-}
-
-func (data *TestData) enableTraceflow(t *testing.T) error {
-	// Enable Traceflow in antrea-controller and antrea-agent ConfigMap.
-	// Use Geneve tunnel.
-	return data.mutateAntreaConfigMap(func(data map[string]string) {
-		antreaControllerConf, _ := data["antrea-controller.conf"]
-		antreaControllerConf = strings.Replace(antreaControllerConf, "#  Traceflow: false", "  Traceflow: true", 1)
-		data["antrea-controller.conf"] = antreaControllerConf
-		antreaAgentConf, _ := data["antrea-agent.conf"]
-		antreaAgentConf = strings.Replace(antreaAgentConf, "#  Traceflow: false", "  Traceflow: true", 1)
-		antreaAgentConf = strings.Replace(antreaAgentConf, "#  AntreaProxy: false", "  AntreaProxy: true", 1)
-		antreaAgentConf = strings.Replace(antreaAgentConf, "#tunnelType: geneve", "tunnelType: geneve", 1)
-		data["antrea-agent.conf"] = antreaAgentConf
-	}, true, true)
 }
 
 // compareObservations compares expected results and actual results.

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane/v1beta2"
 	"github.com/vmware-tanzu/antrea/pkg/apis/ops/v1alpha1"
 	"github.com/vmware-tanzu/antrea/pkg/features"
@@ -61,6 +62,14 @@ func TestTraceflowIntraNode(t *testing.T) {
 	defer teardownTest(t, data)
 
 	skipIfTraceflowDisabled(t, data)
+	encapMode, err := data.GetEncapMode()
+	if err != nil {
+		t.Fatalf("Failed to retrieve encap mode: %v", err)
+	}
+	if encapMode != config.TrafficEncapModeNoEncap {
+		// https://github.com/vmware-tanzu/antrea/issues/897
+		skipIfProviderIs(t, "kind", "Skipping inter-Node Traceflow test for Kind because of #897")
+	}
 
 	node1 := nodeName(0)
 


### PR DESCRIPTION
 * AntreaProxy
 * Traceflow
 * Prometheus metrics (not controlled by a feature gate but by a boolean
   config parameter, which now defaults to 'true')

This change required a few modifications to some of our test scripts.