### PR TITLE
Bump up portmap version to v0.8.7

### DIFF
--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
 ENV CNI_PLUGINS="./host-local ./loopback ./portmap ./bandwidth"
 
 RUN mkdir -p /opt/cni/bin && \
-    wget -q -O - https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
+    wget -q -O - https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
 
 
 FROM antrea/openvswitch:${OVS_VERSION}

--- a/build/images/scripts/install_cni
+++ b/build/images/scripts/install_cni
@@ -15,22 +15,17 @@ install -m 755 /usr/local/bin/antrea-cni /host/opt/cni/bin/antrea
 # Hence, delete older 10-antrea.conf file.
 rm -f /host/etc/cni/net.d/10-antrea.conf
 
-# Install the loopback plugin if not already present
-# It is required by kubelet on Linux when using docker as the container runtime
+# Install the loopback plugin.
+# It is required by kubelet on Linux when using docker as the container runtime.
+# We replace the binary files even they are already present on the Node to make
+# sure expected versions are used.
+install -m 755 /opt/cni/bin/loopback /host/opt/cni/bin/loopback
 
-if [ ! -f /host/opt/cni/bin/loopback ]; then
-    install -m 755 /opt/cni/bin/loopback /host/opt/cni/bin/loopback
-fi
+# Install PortMap CNI binary file. It is required to support hostPort.
+install -m 755 /opt/cni/bin/portmap /host/opt/cni/bin/portmap
 
-# Install PortMap CNI binary file
-if [ ! -f /host/opt/cni/bin/portmap ]; then
-    install -m 755 /opt/cni/bin/portmap /host/opt/cni/bin/portmap
-fi
-
-# Install bandwidth CNI binary file
-if [ ! -f /host/opt/cni/bin/bandwidth ]; then
-    install -m 755 /opt/cni/bin/bandwidth /host/opt/cni/bin/bandwidth
-fi
+# Install bandwidth CNI binary file, It is required to support traffic shaping.
+install -m 755 /opt/cni/bin/bandwidth /host/opt/cni/bin/bandwidth
 
 # Load the OVS kernel module
 modprobe openvswitch

--- a/build/images/scripts/install_cni_kind
+++ b/build/images/scripts/install_cni_kind
@@ -10,19 +10,14 @@ install -m 644 /etc/antrea/antrea-cni.conflist /host/etc/cni/net.d/10-antrea.con
 # Install Antrea binary file
 install -m 755 /usr/local/bin/antrea-cni /host/opt/cni/bin/antrea
 
-# Install the loopback plugin if not already present
-# It is required by kubelet on Linux when using docker as the container runtime
+# Install the loopback plugin.
+# It is required by kubelet on Linux when using docker as the container runtime.
+# We replace the binary files even they are already present on the Node to make
+# sure expected versions are used.
+install -m 755 /opt/cni/bin/loopback /host/opt/cni/bin/loopback
 
-if [ ! -f /host/opt/cni/bin/loopback ]; then
-    install -m 755 /opt/cni/bin/loopback /host/opt/cni/bin/loopback
-fi
+# Install PortMap CNI binary file. It is required to support hostPort.
+install -m 755 /opt/cni/bin/portmap /host/opt/cni/bin/portmap
 
-# Install PortMap CNI binary file
-if [ ! -f /host/opt/cni/bin/portmap ]; then
-    install -m 755 /opt/cni/bin/portmap /host/opt/cni/bin/portmap
-fi
-
-# Install bandwidth CNI binary file
-if [ ! -f /host/opt/cni/bin/bandwidth ]; then
-    install -m 755 /opt/cni/bin/bandwidth /host/opt/cni/bin/bandwidth
-fi
+# Install bandwidth CNI binary file, It is required to support traffic shaping.
+install -m 755 /opt/cni/bin/bandwidth /host/opt/cni/bin/bandwidth


### PR DESCRIPTION
To fix a performance issue that portmap performs expensive iptables
operations even no portMappings are configured.

Upstream fix: https://github.com/containernetworking/plugins/pull/509/commits/877602d6276eaabac480f589deccb41b2faccb20

Fixes #1499