### PR TITLE
Skip TestPodTrafficShaping on v6 clusters

### DIFF
--- a/test/e2e/bandwidth_test.go
+++ b/test/e2e/bandwidth_test.go
@@ -106,6 +106,9 @@ func TestBenchmarkBandwidthServiceRemoteAccess(t *testing.T) {
 func TestPodTrafficShaping(t *testing.T) {
 	// TODO: tc configuration succeeded, however it didn't take effect, need to understand the reason.
 	skipIfProviderIs(t, "kind", "tc does not work with Kind")
+	// Test is flaky on dual-stack clusters: https://github.com/vmware-tanzu/antrea/issues/1543.
+	// So we disable it except for IPv4 single-stack clusters for now.
+	skipIfIPv6Cluster(t)
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)


### PR DESCRIPTION
See https://github.com/vmware-tanzu/antrea/issues/1543