### PR TITLE
Document lack of support for Pod traffic shaping on Photon OS 3

### DIFF
--- a/docs/os-issues.md
+++ b/docs/os-issues.md
@@ -62,6 +62,7 @@ notes](https://coreos.com/releases/).
 | Issues |
 | ------ |
 | [#591](https://github.com/vmware-tanzu/antrea/issues/591) |
+| [#1516](https://github.com/vmware-tanzu/antrea/issues/1516) |
 
 If your K8s Nodes are running Photon OS 3.0, you may see error messages in the
 antrea-agent logs like this one: `"Received bundle error msg: [...]"`. These
@@ -94,3 +95,21 @@ the Pod network:
 ```
 iptables -A INPUT -i antrea-gw0 -j ACCEPT
 ```
+
+### Pod Traffic Shaping
+
+Antrea provides support for Pod [Traffic Shaping](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#support-traffic-shaping)
+by leveraging the open-source [bandwidth plugin](https://github.com/containernetworking/plugins/tree/master/plugins/meta/bandwidth)
+maintained by the CNI project. This plugin requires the following Kernel
+modules: `ifb`, `sch_tbf` and `sch_ingress`. It seems that at the moment Photon
+OS 3.0 is built without the `ifb` Kernel module, which you can confirm by
+running `modprobe --dry-run ifb`: an error would indicate that the module is
+indeed missing. Without this module, Pods with the
+`kubernetes.io/egress-bandwidth` annotation cannot be created successfully. Pods
+with no traffic shaping annotation, or which only use the
+`kubernetes.io/ingress-bandwidth` annotation, can still be created successfully
+as they do not require the creation of an `ifb` device.
+
+If Photon OS is patched to enable `ifb`, we will update this documentation to
+reflect this change, and include information about which Photon OS version can
+support egress traffic shaping.

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -70,6 +70,21 @@ func skipIfNotIPv6Cluster(tb testing.TB) {
 	}
 }
 
+func skipIfMissingKernelModule(tb testing.TB, nodeName string, requiredModules []string) {
+	for _, module := range requiredModules {
+		// modprobe with "--dry-run" does not require root privileges
+		cmd := fmt.Sprintf("modprobe --dry-run %s", module)
+		rc, stdout, stderr, err := RunCommandOnNode(nodeName, cmd)
+		if err != nil {
+			tb.Skipf("Skipping test as modprobe could not be run to confirm the presence of module '%s': %v", module, err)
+		}
+		if rc != 0 {
+			tb.Skipf("Skipping test as modprobe exited with an error when trying to confirm the presence of module '%s' - stdout: %s - stderr: %s", module, stdout, stderr)
+		}
+	}
+	tb.Logf("The following modules have been found on Node '%s': %v", nodeName, requiredModules)
+}
+
 func ensureAntreaRunning(tb testing.TB, data *TestData) error {
 	tb.Logf("Applying Antrea YAML")
 	if err := data.deployAntrea(); err != nil {


### PR DESCRIPTION
Egress traffic shaping is not supported because of a missing Kernel
module (ifb), which is required by the bandwitdh CNI plugin.

This change also updates TestPodTrafficShaping to skip the test if some
of the required Kernel modules for traffic shaping are missing.

Fixes #1516