### PR TITLE
Remove unnecessary arguments of Openflow client funcs

### DIFF
--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -181,7 +181,7 @@ func (i *Initializer) prepareOVSBridge() error {
 // initHostNetworkFlows installs Openflow flows between bridge local port and uplink port to support
 // host networking.
 func (i *Initializer) initHostNetworkFlows() error {
-	if err := i.ofClient.InstallBridgeUplinkFlows(config.UplinkOFPort, config.BridgeOFPort); err != nil {
+	if err := i.ofClient.InstallBridgeUplinkFlows(); err != nil {
 		return err
 	}
 	return nil
@@ -190,13 +190,11 @@ func (i *Initializer) initHostNetworkFlows() error {
 // initExternalConnectivityFlows installs OpenFlow entries to SNAT Pod traffic
 // using Node IP, and then Pod could communicate to the external IP addresses.
 func (i *Initializer) initExternalConnectivityFlows() error {
-	subnetCIDR := i.nodeConfig.PodIPv4CIDR
-	if subnetCIDR == nil {
+	if i.nodeConfig.PodIPv4CIDR == nil {
 		return fmt.Errorf("Failed to find valid IPv4 PodCIDR")
 	}
-	nodeIP := i.nodeConfig.NodeIPAddr.IP
 	// Install OpenFlow entries on the OVS to enable Pod traffic to communicate to external IP addresses.
-	if err := i.ofClient.InstallExternalFlows(nodeIP, *subnetCIDR); err != nil {
+	if err := i.ofClient.InstallExternalFlows(); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -432,7 +432,6 @@ func (pc *podConfigurator) reconcile(pods []corev1.Pod) error {
 				containerConfig.InterfaceName,
 				containerConfig.IPs,
 				containerConfig.MAC,
-				pc.gatewayMAC,
 				uint32(containerConfig.OFPort),
 			); err != nil {
 				klog.Errorf("Error when re-installing flows for Pod %s", namespacedName)
@@ -496,7 +495,7 @@ func (pc *podConfigurator) connectInterfaceToOVS(
 	}
 
 	klog.V(2).Infof("Setting up Openflow entries for container %s", containerID)
-	err = pc.ofClient.InstallPodFlows(ovsPortName, containerConfig.IPs, containerConfig.MAC, pc.gatewayMAC, uint32(ofPort))
+	err = pc.ofClient.InstallPodFlows(ovsPortName, containerConfig.IPs, containerConfig.MAC, uint32(ofPort))
 	if err != nil {
 		return nil, fmt.Errorf("failed to add Openflow entries for container %s: %v", containerID, err)
 	}

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -475,11 +475,8 @@ func (c *Controller) addNodeRoute(nodeName string, node *corev1.Node) error {
 
 	err = c.ofClient.InstallNodeFlows(
 		nodeName,
-		c.nodeConfig.GatewayConfig.MAC,
 		peerConfig,
 		peerNodeIP,
-		config.DefaultTunOFPort,
-		config.HostGatewayOFPort,
 		uint32(ipsecTunOFPort))
 	if err != nil {
 		return fmt.Errorf("failed to install flows to Node %s: %v", nodeName, err)

--- a/pkg/agent/controller/noderoute/node_route_controller_test.go
+++ b/pkg/agent/controller/noderoute/node_route_controller_test.go
@@ -126,7 +126,7 @@ func TestControllerWithDuplicatePodCIDR(t *testing.T) {
 		c.clientset.CoreV1().Nodes().Create(context.TODO(), node1, metav1.CreateOptions{})
 		// The 2nd argument is Any() because the argument is unpredictable when it uses pointer as the key of map.
 		// The argument type is map[*net.IPNet]net.IP.
-		c.ofClient.EXPECT().InstallNodeFlows("node1", gatewayMAC, gomock.Any(), nodeIP1, uint32(config.DefaultTunOFPort), uint32(config.HostGatewayOFPort), uint32(0)).Times(1)
+		c.ofClient.EXPECT().InstallNodeFlows("node1", gomock.Any(), nodeIP1, uint32(0)).Times(1)
 		c.routeClient.EXPECT().AddRoutes(podCIDR, nodeIP1, podCIDRGateway).Times(1)
 		c.processNextWorkItem()
 
@@ -143,7 +143,7 @@ func TestControllerWithDuplicatePodCIDR(t *testing.T) {
 		// After node1 is deleted, routes and flows should be installed for node2 successfully.
 		// The 2nd argument is Any() because the argument is unpredictable when it uses pointer as the key of map.
 		// The argument type is map[*net.IPNet]net.IP.
-		c.ofClient.EXPECT().InstallNodeFlows("node2", gatewayMAC, gomock.Any(), nodeIP2, uint32(config.DefaultTunOFPort), uint32(config.HostGatewayOFPort), uint32(0)).Times(1)
+		c.ofClient.EXPECT().InstallNodeFlows("node2", gomock.Any(), nodeIP2, uint32(0)).Times(1)
 		c.routeClient.EXPECT().AddRoutes(podCIDR, nodeIP2, podCIDRGateway).Times(1)
 		c.processNextWorkItem()
 	}()

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -42,13 +42,12 @@ var bridgeMgmtAddr = ofconfig.GetMgmtAddress(ovsconfig.DefaultOVSRunDir, bridgeN
 
 func installNodeFlows(ofClient Client, cacheKey string) (int, error) {
 	hostName := cacheKey
-	gwMAC, _ := net.ParseMAC("AA:BB:CC:DD:EE:FF")
 	gwIP, ipNet, _ := net.ParseCIDR("10.0.1.1/24")
 	peerNodeIP := net.ParseIP("192.168.1.1")
 	peerConfig := map[*net.IPNet]net.IP{
 		ipNet: gwIP,
 	}
-	err := ofClient.InstallNodeFlows(hostName, gwMAC, peerConfig, peerNodeIP, config.DefaultTunOFPort, config.HostGatewayOFPort, 0)
+	err := ofClient.InstallNodeFlows(hostName, peerConfig, peerNodeIP, 0)
 	client := ofClient.(*client)
 	fCacheI, ok := client.nodeFlowCache.Load(hostName)
 	if ok {
@@ -60,11 +59,10 @@ func installNodeFlows(ofClient Client, cacheKey string) (int, error) {
 
 func installPodFlows(ofClient Client, cacheKey string) (int, error) {
 	containerID := cacheKey
-	gwMAC, _ := net.ParseMAC("AA:BB:CC:DD:EE:FF")
 	podMAC, _ := net.ParseMAC("AA:BB:CC:DD:EE:EE")
 	podIP := net.ParseIP("10.0.0.2")
 	ofPort := uint32(10)
-	err := ofClient.InstallPodFlows(containerID, []net.IP{podIP}, podMAC, gwMAC, ofPort)
+	err := ofClient.InstallPodFlows(containerID, []net.IP{podIP}, podMAC, ofPort)
 	client := ofClient.(*client)
 	fCacheI, ok := client.podFlowCache.Load(containerID)
 	if ok {
@@ -96,8 +94,11 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
-			client.nodeConfig = &config.NodeConfig{}
 			client.ofEntryOperations = m
+
+			gwMAC, _ := net.ParseMAC("AA:BB:CC:DD:EE:EE")
+			gatewayConfig := &config.GatewayConfig{MAC: gwMAC}
+			client.nodeConfig = &config.NodeConfig{GatewayConfig: gatewayConfig}
 
 			m.EXPECT().AddAll(gomock.Any()).Return(nil).Times(1)
 			// Installing the flows should succeed, and all the flows should be added into the cache.
@@ -124,8 +125,11 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
-			client.nodeConfig = &config.NodeConfig{}
 			client.ofEntryOperations = m
+
+			gwMAC, _ := net.ParseMAC("AA:BB:CC:DD:EE:EE")
+			gatewayConfig := &config.GatewayConfig{MAC: gwMAC}
+			client.nodeConfig = &config.NodeConfig{GatewayConfig: gatewayConfig}
 
 			errorCall := m.EXPECT().AddAll(gomock.Any()).Return(errors.New("Bundle error")).Times(1)
 			m.EXPECT().AddAll(gomock.Any()).Return(nil).After(errorCall)
@@ -165,8 +169,11 @@ func TestFlowInstallationFailed(t *testing.T) {
 			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
-			client.nodeConfig = &config.NodeConfig{}
 			client.ofEntryOperations = m
+
+			gwMAC, _ := net.ParseMAC("AA:BB:CC:DD:EE:EE")
+			gatewayConfig := &config.GatewayConfig{MAC: gwMAC}
+			client.nodeConfig = &config.NodeConfig{GatewayConfig: gatewayConfig}
 
 			// We generate an error for AddAll call.
 			m.EXPECT().AddAll(gomock.Any()).Return(errors.New("Bundle error"))
@@ -199,8 +206,11 @@ func TestConcurrentFlowInstallation(t *testing.T) {
 			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
-			client.nodeConfig = &config.NodeConfig{}
 			client.ofEntryOperations = m
+
+			gwMAC, _ := net.ParseMAC("AA:BB:CC:DD:EE:EE")
+			gatewayConfig := &config.GatewayConfig{MAC: gwMAC}
+			client.nodeConfig = &config.NodeConfig{GatewayConfig: gatewayConfig}
 
 			var concurrentCalls atomic.Value // set to true if we observe concurrent calls
 			timeoutCh := make(chan struct{})

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -209,74 +209,74 @@ func (mr *MockClientMockRecorder) InitialTLVMap() *gomock.Call {
 }
 
 // Initialize mocks base method
-func (m *MockClient) Initialize(arg0 types.RoundInfo, arg1 *config.NodeConfig, arg2 config.TrafficEncapModeType, arg3 uint32) (<-chan struct{}, error) {
+func (m *MockClient) Initialize(arg0 types.RoundInfo, arg1 *config.NodeConfig, arg2 config.TrafficEncapModeType) (<-chan struct{}, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Initialize", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Initialize", arg0, arg1, arg2)
 	ret0, _ := ret[0].(<-chan struct{})
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Initialize indicates an expected call of Initialize
-func (mr *MockClientMockRecorder) Initialize(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) Initialize(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockClient)(nil).Initialize), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockClient)(nil).Initialize), arg0, arg1, arg2)
 }
 
 // InstallBridgeUplinkFlows mocks base method
-func (m *MockClient) InstallBridgeUplinkFlows(arg0, arg1 uint32) error {
+func (m *MockClient) InstallBridgeUplinkFlows() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallBridgeUplinkFlows", arg0, arg1)
+	ret := m.ctrl.Call(m, "InstallBridgeUplinkFlows")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallBridgeUplinkFlows indicates an expected call of InstallBridgeUplinkFlows
-func (mr *MockClientMockRecorder) InstallBridgeUplinkFlows(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallBridgeUplinkFlows() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallBridgeUplinkFlows", reflect.TypeOf((*MockClient)(nil).InstallBridgeUplinkFlows), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallBridgeUplinkFlows", reflect.TypeOf((*MockClient)(nil).InstallBridgeUplinkFlows))
 }
 
 // InstallClusterServiceCIDRFlows mocks base method
-func (m *MockClient) InstallClusterServiceCIDRFlows(arg0 []*net.IPNet, arg1 uint32) error {
+func (m *MockClient) InstallClusterServiceCIDRFlows(arg0 []*net.IPNet) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallClusterServiceCIDRFlows", arg0, arg1)
+	ret := m.ctrl.Call(m, "InstallClusterServiceCIDRFlows", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallClusterServiceCIDRFlows indicates an expected call of InstallClusterServiceCIDRFlows
-func (mr *MockClientMockRecorder) InstallClusterServiceCIDRFlows(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallClusterServiceCIDRFlows(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallClusterServiceCIDRFlows", reflect.TypeOf((*MockClient)(nil).InstallClusterServiceCIDRFlows), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallClusterServiceCIDRFlows", reflect.TypeOf((*MockClient)(nil).InstallClusterServiceCIDRFlows), arg0)
 }
 
 // InstallClusterServiceFlows mocks base method
-func (m *MockClient) InstallClusterServiceFlows(arg0, arg1 bool) error {
+func (m *MockClient) InstallClusterServiceFlows() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallClusterServiceFlows", arg0, arg1)
+	ret := m.ctrl.Call(m, "InstallClusterServiceFlows")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallClusterServiceFlows indicates an expected call of InstallClusterServiceFlows
-func (mr *MockClientMockRecorder) InstallClusterServiceFlows(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallClusterServiceFlows() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallClusterServiceFlows", reflect.TypeOf((*MockClient)(nil).InstallClusterServiceFlows), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallClusterServiceFlows", reflect.TypeOf((*MockClient)(nil).InstallClusterServiceFlows))
 }
 
 // InstallDefaultTunnelFlows mocks base method
-func (m *MockClient) InstallDefaultTunnelFlows(arg0 uint32) error {
+func (m *MockClient) InstallDefaultTunnelFlows() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallDefaultTunnelFlows", arg0)
+	ret := m.ctrl.Call(m, "InstallDefaultTunnelFlows")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallDefaultTunnelFlows indicates an expected call of InstallDefaultTunnelFlows
-func (mr *MockClientMockRecorder) InstallDefaultTunnelFlows(arg0 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallDefaultTunnelFlows() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallDefaultTunnelFlows", reflect.TypeOf((*MockClient)(nil).InstallDefaultTunnelFlows), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallDefaultTunnelFlows", reflect.TypeOf((*MockClient)(nil).InstallDefaultTunnelFlows))
 }
 
 // InstallEndpointFlows mocks base method
@@ -294,31 +294,31 @@ func (mr *MockClientMockRecorder) InstallEndpointFlows(arg0, arg1, arg2 interfac
 }
 
 // InstallExternalFlows mocks base method
-func (m *MockClient) InstallExternalFlows(arg0 net.IP, arg1 net.IPNet) error {
+func (m *MockClient) InstallExternalFlows() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallExternalFlows", arg0, arg1)
+	ret := m.ctrl.Call(m, "InstallExternalFlows")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallExternalFlows indicates an expected call of InstallExternalFlows
-func (mr *MockClientMockRecorder) InstallExternalFlows(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallExternalFlows() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallExternalFlows", reflect.TypeOf((*MockClient)(nil).InstallExternalFlows), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallExternalFlows", reflect.TypeOf((*MockClient)(nil).InstallExternalFlows))
 }
 
 // InstallGatewayFlows mocks base method
-func (m *MockClient) InstallGatewayFlows(arg0 []net.IP, arg1 net.HardwareAddr, arg2 uint32) error {
+func (m *MockClient) InstallGatewayFlows() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallGatewayFlows", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "InstallGatewayFlows")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallGatewayFlows indicates an expected call of InstallGatewayFlows
-func (mr *MockClientMockRecorder) InstallGatewayFlows(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallGatewayFlows() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallGatewayFlows", reflect.TypeOf((*MockClient)(nil).InstallGatewayFlows), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallGatewayFlows", reflect.TypeOf((*MockClient)(nil).InstallGatewayFlows))
 }
 
 // InstallLoadBalancerServiceFromOutsideFlows mocks base method
@@ -336,31 +336,31 @@ func (mr *MockClientMockRecorder) InstallLoadBalancerServiceFromOutsideFlows(arg
 }
 
 // InstallNodeFlows mocks base method
-func (m *MockClient) InstallNodeFlows(arg0 string, arg1 net.HardwareAddr, arg2 map[*net.IPNet]net.IP, arg3 net.IP, arg4, arg5, arg6 uint32) error {
+func (m *MockClient) InstallNodeFlows(arg0 string, arg1 map[*net.IPNet]net.IP, arg2 net.IP, arg3 uint32) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallNodeFlows", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret := m.ctrl.Call(m, "InstallNodeFlows", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallNodeFlows indicates an expected call of InstallNodeFlows
-func (mr *MockClientMockRecorder) InstallNodeFlows(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallNodeFlows(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallNodeFlows", reflect.TypeOf((*MockClient)(nil).InstallNodeFlows), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallNodeFlows", reflect.TypeOf((*MockClient)(nil).InstallNodeFlows), arg0, arg1, arg2, arg3)
 }
 
 // InstallPodFlows mocks base method
-func (m *MockClient) InstallPodFlows(arg0 string, arg1 []net.IP, arg2, arg3 net.HardwareAddr, arg4 uint32) error {
+func (m *MockClient) InstallPodFlows(arg0 string, arg1 []net.IP, arg2 net.HardwareAddr, arg3 uint32) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallPodFlows", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "InstallPodFlows", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallPodFlows indicates an expected call of InstallPodFlows
-func (mr *MockClientMockRecorder) InstallPodFlows(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallPodFlows(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPodFlows", reflect.TypeOf((*MockClient)(nil).InstallPodFlows), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPodFlows", reflect.TypeOf((*MockClient)(nil).InstallPodFlows), arg0, arg1, arg2, arg3)
 }
 
 // InstallPolicyRuleFlows mocks base method

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -607,7 +607,7 @@ func cmdAddDelCheckTest(testNS ns.NetNS, tc testCase, dataDir string) {
 	ovsPortUUID := uuid.New().String()
 	ovsServiceMock.EXPECT().CreatePort(ovsPortname, ovsPortname, mock.Any()).Return(ovsPortUUID, nil).AnyTimes()
 	ovsServiceMock.EXPECT().GetOFPort(ovsPortname).Return(int32(10), nil).AnyTimes()
-	ofServiceMock.EXPECT().InstallPodFlows(ovsPortname, mock.Any(), mock.Any(), mock.Any(), mock.Any()).Return(nil)
+	ofServiceMock.EXPECT().InstallPodFlows(ovsPortname, mock.Any(), mock.Any(), mock.Any()).Return(nil)
 
 	close(tester.networkReadyCh)
 	// Test ips allocation
@@ -821,7 +821,7 @@ func TestCNIServerChaining(t *testing.T) {
 			routeMock.EXPECT().MigrateRoutesToGw(hostVeth.Name),
 			ovsServiceMock.EXPECT().CreatePort(ovsPortname, ovsPortname, mock.Any()).Return(ovsPortUUID, nil),
 			ovsServiceMock.EXPECT().GetOFPort(ovsPortname).Return(testContainerOFPort, nil),
-			ofServiceMock.EXPECT().InstallPodFlows(ovsPortname, []net.IP{podIP}, containerIntf.HardwareAddr, gwMAC, mock.Any()),
+			ofServiceMock.EXPECT().InstallPodFlows(ovsPortname, []net.IP{podIP}, containerIntf.HardwareAddr, mock.Any()),
 		)
 		mock.InOrder(orderedCalls...)
 		cniResp, err := server.CmdAdd(ctx, cniReq)

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -81,29 +81,20 @@ type testPeerConfig struct {
 }
 
 type testConfig struct {
-	bridge       string
-	localGateway *testPortConfig
-	localPods    []*testLocalPodConfig
-	peers        []*testPeerConfig
-	tunnelOFPort uint32
-	serviceCIDR  *net.IPNet
-	globalMAC    net.HardwareAddr
-	enableIPv6   bool
-	enableIPv4   bool
+	bridge      string
+	nodeConfig  *config1.NodeConfig
+	localPods   []*testLocalPodConfig
+	peers       []*testPeerConfig
+	serviceCIDR *net.IPNet
+	globalMAC   net.HardwareAddr
+	enableIPv6  bool
+	enableIPv4  bool
 }
 
 var (
 	_, podIPv4CIDR, _ = net.ParseCIDR("192.168.1.0/24")
 	_, podIPv6CIDR, _ = net.ParseCIDR("fd74:ca9b:172:19::/64")
-
-	ofTestNodeConfig config1.NodeConfig
 )
-
-func init() {
-	nodeIP, nodeSubnet, _ := net.ParseCIDR("10.10.10.1/24")
-	nodeSubnet.IP = nodeIP
-	ofTestNodeConfig.NodeIPAddr = nodeSubnet
-}
 
 func TestConnectivityFlows(t *testing.T) {
 	// Initialize ovs metrics (Prometheus) to test them
@@ -167,7 +158,7 @@ func TestReplayFlowsNetworkPolicyFlows(t *testing.T) {
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
-	_, err = c.Initialize(roundInfo, &config1.NodeConfig{}, config1.TrafficEncapModeEncap, config1.HostGatewayOFPort)
+	_, err = c.Initialize(roundInfo, &config1.NodeConfig{}, config1.TrafficEncapModeEncap)
 	require.Nil(t, err, "Failed to initialize OFClient")
 
 	defer func() {
@@ -215,9 +206,9 @@ func TestReplayFlowsNetworkPolicyFlows(t *testing.T) {
 }
 
 func testExternalFlows(t *testing.T, config *testConfig) {
-	nodeIP := ofTestNodeConfig.NodeIPAddr.IP
-	localSubnet := ofTestNodeConfig.PodIPv4CIDR
-	if err := c.InstallExternalFlows(nodeIP, *localSubnet); err != nil {
+	nodeIP := config.nodeConfig.NodeIPAddr.IP
+	localSubnet := config.nodeConfig.PodIPv4CIDR
+	if err := c.InstallExternalFlows(); err != nil {
 		t.Errorf("Failed to install OpenFlow entries to allow Pod to communicate to the external addresses: %v", err)
 	}
 	for _, tableFlow := range prepareExternalFlows(nodeIP, localSubnet, config.globalMAC) {
@@ -247,17 +238,7 @@ func testReplayFlows(t *testing.T) {
 }
 
 func testInitialize(t *testing.T, config *testConfig) {
-	if config.enableIPv4 {
-		ofTestNodeConfig.PodIPv4CIDR = podIPv4CIDR
-	} else {
-		ofTestNodeConfig.PodIPv4CIDR = nil
-	}
-	if config.enableIPv6 {
-		ofTestNodeConfig.PodIPv6CIDR = podIPv6CIDR
-	} else {
-		ofTestNodeConfig.PodIPv6CIDR = nil
-	}
-	if _, err := c.Initialize(roundInfo, &ofTestNodeConfig, config1.TrafficEncapModeEncap, config1.HostGatewayOFPort); err != nil {
+	if _, err := c.Initialize(roundInfo, config.nodeConfig, config1.TrafficEncapModeEncap); err != nil {
 		t.Errorf("Failed to initialize openflow client: %v", err)
 	}
 	for _, tableFlow := range prepareDefaultFlows(config) {
@@ -267,17 +248,17 @@ func testInitialize(t *testing.T, config *testConfig) {
 }
 
 func testInstallTunnelFlows(t *testing.T, config *testConfig) {
-	err := c.InstallDefaultTunnelFlows(config.tunnelOFPort)
+	err := c.InstallDefaultTunnelFlows()
 	if err != nil {
 		t.Fatalf("Failed to install Openflow entries for tunnel port: %v", err)
 	}
-	for _, tableFlow := range prepareTunnelFlows(config.tunnelOFPort, config.globalMAC) {
+	for _, tableFlow := range prepareTunnelFlows(config1.DefaultTunOFPort, config.globalMAC) {
 		ofTestUtils.CheckFlowExists(t, ovsCtlClient, tableFlow.tableID, true, tableFlow.flows)
 	}
 }
 
 func testInstallServiceFlows(t *testing.T, config *testConfig) {
-	err := c.InstallClusterServiceFlows(true, true)
+	err := c.InstallClusterServiceFlows()
 	if err != nil {
 		t.Fatalf("Failed to install Openflow entries to skip service CIDR from egress table: %v", err)
 	}
@@ -287,51 +268,55 @@ func testInstallServiceFlows(t *testing.T, config *testConfig) {
 }
 
 func testInstallNodeFlows(t *testing.T, config *testConfig) {
+	gatewayConfig := config.nodeConfig.GatewayConfig
 	for _, node := range config.peers {
 		peerConfig := map[*net.IPNet]net.IP{
 			&node.subnet: node.gateway,
 		}
-		err := c.InstallNodeFlows(node.name, config.localGateway.mac, peerConfig, node.nodeAddress, config.tunnelOFPort, config.localGateway.ofPort, 0)
+		err := c.InstallNodeFlows(node.name, peerConfig, node.nodeAddress, 0)
 		if err != nil {
 			t.Fatalf("Failed to install Openflow entries for node connectivity: %v", err)
 		}
-		for _, tableFlow := range prepareNodeFlows(config.tunnelOFPort, node.subnet, node.gateway, node.nodeAddress, config.globalMAC, config.localGateway.mac) {
+		for _, tableFlow := range prepareNodeFlows(config1.DefaultTunOFPort, node.subnet, node.gateway, node.nodeAddress, config.globalMAC, gatewayConfig.MAC) {
 			ofTestUtils.CheckFlowExists(t, ovsCtlClient, tableFlow.tableID, true, tableFlow.flows)
 		}
 	}
 }
 
 func testUninstallNodeFlows(t *testing.T, config *testConfig) {
+	gatewayConfig := config.nodeConfig.GatewayConfig
 	for _, node := range config.peers {
 		err := c.UninstallNodeFlows(node.name)
 		if err != nil {
 			t.Fatalf("Failed to uninstall Openflow entries for node connectivity: %v", err)
 		}
-		for _, tableFlow := range prepareNodeFlows(config.tunnelOFPort, node.subnet, node.gateway, node.nodeAddress, config.globalMAC, config.localGateway.mac) {
+		for _, tableFlow := range prepareNodeFlows(config1.DefaultTunOFPort, node.subnet, node.gateway, node.nodeAddress, config.globalMAC, gatewayConfig.MAC) {
 			ofTestUtils.CheckFlowExists(t, ovsCtlClient, tableFlow.tableID, false, tableFlow.flows)
 		}
 	}
 }
 
 func testInstallPodFlows(t *testing.T, config *testConfig) {
+	gatewayConfig := config.nodeConfig.GatewayConfig
 	for _, pod := range config.localPods {
-		err := c.InstallPodFlows(pod.name, pod.ips, pod.mac, config.localGateway.mac, pod.ofPort)
+		err := c.InstallPodFlows(pod.name, pod.ips, pod.mac, pod.ofPort)
 		if err != nil {
 			t.Fatalf("Failed to install Openflow entries for pod: %v", err)
 		}
-		for _, tableFlow := range preparePodFlows(pod.ips, pod.mac, pod.ofPort, config.localGateway.mac, config.globalMAC) {
+		for _, tableFlow := range preparePodFlows(pod.ips, pod.mac, pod.ofPort, gatewayConfig.MAC, config.globalMAC) {
 			ofTestUtils.CheckFlowExists(t, ovsCtlClient, tableFlow.tableID, true, tableFlow.flows)
 		}
 	}
 }
 
 func testUninstallPodFlows(t *testing.T, config *testConfig) {
+	gatewayConfig := config.nodeConfig.GatewayConfig
 	for _, pod := range config.localPods {
 		err := c.UninstallPodFlows(pod.name)
 		if err != nil {
 			t.Fatalf("Failed to uninstall Openflow entries for pod: %v", err)
 		}
-		for _, tableFlow := range preparePodFlows(pod.ips, pod.mac, pod.ofPort, config.localGateway.mac, config.globalMAC) {
+		for _, tableFlow := range preparePodFlows(pod.ips, pod.mac, pod.ofPort, gatewayConfig.MAC, config.globalMAC) {
 			ofTestUtils.CheckFlowExists(t, ovsCtlClient, tableFlow.tableID, false, tableFlow.flows)
 		}
 	}
@@ -345,7 +330,7 @@ func TestNetworkPolicyFlows(t *testing.T) {
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 
-	_, err = c.Initialize(roundInfo, &config1.NodeConfig{PodIPv4CIDR: podIPv4CIDR, PodIPv6CIDR: podIPv6CIDR}, config1.TrafficEncapModeEncap, config1.HostGatewayOFPort)
+	_, err = c.Initialize(roundInfo, &config1.NodeConfig{PodIPv4CIDR: podIPv4CIDR, PodIPv6CIDR: podIPv6CIDR}, config1.TrafficEncapModeEncap)
 	require.Nil(t, err, "Failed to initialize OFClient")
 
 	defer func() {
@@ -486,7 +471,7 @@ func TestProxyServiceFlows(t *testing.T) {
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 
-	_, err = c.Initialize(roundInfo, &config1.NodeConfig{}, config1.TrafficEncapModeEncap, config1.HostGatewayOFPort)
+	_, err = c.Initialize(roundInfo, &config1.NodeConfig{}, config1.TrafficEncapModeEncap)
 	require.Nil(t, err, "Failed to initialize OFClient")
 
 	defer func() {
@@ -819,11 +804,19 @@ func checkOVSFlowMetrics(t *testing.T, client ofClient.Client) {
 }
 
 func testInstallGatewayFlows(t *testing.T, config *testConfig) {
-	err := c.InstallGatewayFlows(config.localGateway.ips, config.localGateway.mac, config.localGateway.ofPort)
+	gatewayConfig := config.nodeConfig.GatewayConfig
+	err := c.InstallGatewayFlows()
 	if err != nil {
 		t.Fatalf("Failed to install Openflow entries for gateway: %v", err)
 	}
-	for _, tableFlow := range prepareGatewayFlows(config.localGateway.ips, config.localGateway.mac, config.localGateway.ofPort, config.globalMAC) {
+	var ips []net.IP
+	if config.enableIPv4 {
+		ips = append(ips, gatewayConfig.IPv4)
+	}
+	if config.enableIPv6 {
+		ips = append(ips, gatewayConfig.IPv6)
+	}
+	for _, tableFlow := range prepareGatewayFlows(ips, gatewayConfig.MAC, config.globalMAC) {
 		ofTestUtils.CheckFlowExists(t, ovsCtlClient, tableFlow.tableID, true, tableFlow.flows)
 	}
 }
@@ -831,18 +824,26 @@ func testInstallGatewayFlows(t *testing.T, config *testConfig) {
 func prepareConfiguration() *testConfig {
 	podMAC, _ := net.ParseMAC("aa:aa:aa:aa:aa:13")
 	gwMAC, _ := net.ParseMAC("aa:aa:aa:aa:aa:11")
+	nodeIP, nodeSubnet, _ := net.ParseCIDR("10.10.10.1/24")
+	nodeSubnet.IP = nodeIP
+
+	gatewayConfig := &config1.GatewayConfig{
+		IPv4: net.ParseIP("192.168.1.1"),
+		MAC:  gwMAC,
+	}
+	nodeConfig := &config1.NodeConfig{
+		NodeIPAddr:    nodeSubnet,
+		GatewayConfig: gatewayConfig,
+		PodIPv4CIDR:   podIPv4CIDR,
+	}
+
 	podCfg := &testLocalPodConfig{
 		name: "container-1",
 		testPortConfig: &testPortConfig{
 			ips:    []net.IP{net.ParseIP("192.168.1.3")},
 			mac:    podMAC,
-			ofPort: uint32(3),
+			ofPort: uint32(11),
 		},
-	}
-	gwCfg := &testPortConfig{
-		ips:    []net.IP{net.ParseIP("192.168.1.1")},
-		mac:    gwMAC,
-		ofPort: uint32(1),
 	}
 	_, serviceCIDR, _ := net.ParseCIDR("172.16.0.0/16")
 	_, peerSubnet, _ := net.ParseCIDR("192.168.2.0/24")
@@ -854,33 +855,37 @@ func prepareConfiguration() *testConfig {
 	}
 	vMAC, _ := net.ParseMAC("aa:bb:cc:dd:ee:ff")
 	return &testConfig{
-		bridge:       br,
-		localGateway: gwCfg,
-		localPods:    []*testLocalPodConfig{podCfg},
-		peers:        []*testPeerConfig{peerNode},
-		tunnelOFPort: uint32(2),
-		serviceCIDR:  serviceCIDR,
-		globalMAC:    vMAC,
-		enableIPv4:   true,
-		enableIPv6:   false,
+		bridge:      br,
+		nodeConfig:  nodeConfig,
+		localPods:   []*testLocalPodConfig{podCfg},
+		peers:       []*testPeerConfig{peerNode},
+		serviceCIDR: serviceCIDR,
+		globalMAC:   vMAC,
+		enableIPv4:  true,
+		enableIPv6:  false,
 	}
 }
 
 func prepareIPv6Configuration() *testConfig {
 	podMAC, _ := net.ParseMAC("aa:aa:aa:aa:aa:13")
 	gwMAC, _ := net.ParseMAC("aa:aa:aa:aa:aa:11")
+
+	gatewayConfig := &config1.GatewayConfig{
+		IPv6: net.ParseIP("fd74:ca9b:172:19::1"),
+		MAC:  gwMAC,
+	}
+	nodeConfig := &config1.NodeConfig{
+		GatewayConfig: gatewayConfig,
+		PodIPv6CIDR:   podIPv6CIDR,
+	}
+
 	podCfg := &testLocalPodConfig{
 		name: "container-1",
 		testPortConfig: &testPortConfig{
 			ips:    []net.IP{net.ParseIP("fd74:ca9b:172:19::3")},
 			mac:    podMAC,
-			ofPort: uint32(3),
+			ofPort: uint32(11),
 		},
-	}
-	gwCfg := &testPortConfig{
-		ips:    []net.IP{net.ParseIP("fd74:ca9b:172:19::1")},
-		mac:    gwMAC,
-		ofPort: uint32(1),
 	}
 	_, serviceCIDR, _ := net.ParseCIDR("ee74:ca9b:2345:a33::/64")
 	_, peerSubnet, _ := net.ParseCIDR("fd74:ca9b:172:20::/64")
@@ -892,15 +897,14 @@ func prepareIPv6Configuration() *testConfig {
 	}
 	vMAC, _ := net.ParseMAC("aa:bb:cc:dd:ee:ff")
 	return &testConfig{
-		bridge:       br,
-		localGateway: gwCfg,
-		localPods:    []*testLocalPodConfig{podCfg},
-		peers:        []*testPeerConfig{peerNode},
-		tunnelOFPort: uint32(2),
-		serviceCIDR:  serviceCIDR,
-		globalMAC:    vMAC,
-		enableIPv4:   false,
-		enableIPv6:   true,
+		bridge:      br,
+		nodeConfig:  nodeConfig,
+		localPods:   []*testLocalPodConfig{podCfg},
+		peers:       []*testPeerConfig{peerNode},
+		serviceCIDR: serviceCIDR,
+		globalMAC:   vMAC,
+		enableIPv4:  false,
+		enableIPv6:  true,
 	}
 }
 
@@ -975,13 +979,13 @@ func preparePodFlows(podIPs []net.IP, podMAC net.HardwareAddr, podOFPort uint32,
 	return flows
 }
 
-func prepareGatewayFlows(gwIPs []net.IP, gwMAC net.HardwareAddr, gwOFPort uint32, vMAC net.HardwareAddr) []expectTableFlows {
+func prepareGatewayFlows(gwIPs []net.IP, gwMAC net.HardwareAddr, vMAC net.HardwareAddr) []expectTableFlows {
 	flows := []expectTableFlows{
 		{
 			uint8(0),
 			[]*ofTestUtils.ExpectFlow{
 				{
-					MatchStr: fmt.Sprintf("priority=200,in_port=%d", gwOFPort),
+					MatchStr: fmt.Sprintf("priority=200,in_port=%d", config1.HostGatewayOFPort),
 					ActStr:   "load:0x1->NXM_NX_REG0[0..15],goto_table:10",
 				},
 			},
@@ -991,7 +995,7 @@ func prepareGatewayFlows(gwIPs []net.IP, gwMAC net.HardwareAddr, gwOFPort uint32
 			[]*ofTestUtils.ExpectFlow{
 				{
 					MatchStr: fmt.Sprintf("priority=200,dl_dst=%s", gwMAC.String()),
-					ActStr:   fmt.Sprintf("load:0x%x->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],goto_table:90", gwOFPort),
+					ActStr:   fmt.Sprintf("load:0x%x->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],goto_table:90", config1.HostGatewayOFPort),
 				},
 			},
 		},
@@ -1008,11 +1012,11 @@ func prepareGatewayFlows(gwIPs []net.IP, gwMAC net.HardwareAddr, gwOFPort uint32
 					uint8(10),
 					[]*ofTestUtils.ExpectFlow{
 						{
-							MatchStr: fmt.Sprintf("priority=200,arp,in_port=%d,arp_spa=%s,arp_sha=%s", gwOFPort, gwIP, gwMAC),
+							MatchStr: fmt.Sprintf("priority=200,arp,in_port=%d,arp_spa=%s,arp_sha=%s", config1.HostGatewayOFPort, gwIP, gwMAC),
 							ActStr:   "goto_table:20",
 						},
 						{
-							MatchStr: fmt.Sprintf("priority=200,ip,in_port=%d", gwOFPort),
+							MatchStr: fmt.Sprintf("priority=200,ip,in_port=%d", config1.HostGatewayOFPort),
 							ActStr:   "goto_table:29",
 						},
 					},


### PR DESCRIPTION
Some of these funcs take NodeConfig attributes and OFPort constants as
input arguments, while some directly read NodeConfig or use OFPort
constants.
This commit changes all Openflow client funcs to be consistent and
do not require extra arguments for NodeConfig attributes and OFPort
constants.