### PR TITLE
Fix ARP flow not installed issue in networkpolicy-only mode

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -687,12 +687,11 @@ func (c *client) DeleteStaleFlows() error {
 func (c *client) setupPolicyOnlyFlows() error {
 	// Rewrites MAC to gw port if the packet received is unmatched by local Pod flows.
 	flows := c.l3FwdFlowRouteToGW(c.nodeConfig.GatewayConfig.MAC, cookie.Default)
-	if c.IsIPv4Enabled() {
-		flows = append(flows,
-			// Replies any ARP request with the same global virtual MAC.
-			c.arpResponderStaticFlow(cookie.Default),
-		)
-	}
+	// If IPv6 is enabled, this flow will never get hit.
+	flows = append(flows,
+		// Replies any ARP request with the same global virtual MAC.
+		c.arpResponderStaticFlow(cookie.Default),
+	)
 	if err := c.ofEntryOperations.AddAll(flows); err != nil {
 		return fmt.Errorf("failed to setup policy-only flows: %w", err)
 	}


### PR DESCRIPTION
This PR fixes #1572 

arpResponderStaticFlow is changed to be installed only in IPv4 mode by #1518, since 'ARP uses broadcast, but IPv6 doesn't support broadcast' https://github.com/vmware-tanzu/antrea/pull/1272#discussion_r508149290.
However, IsIPv4Enabled() is determined by `c.nodeConfig.PodIPv4CIDR != nil` (pkg/agent/openflow/client.go#L827), and in `pka/agent/agent.go`, when networkpolicy-only mode is true, setting nodeConfig.PodIPv4CIDR is skipped:
```	
if i.networkConfig.TrafficEncapMode.IsNetworkPolicyOnly() {
		return nil
	}

	// Parse all PodCIDRs first, so that we could support IPv4/IPv6 dual-stack configurations.
	if node.Spec.PodCIDRs != nil {
		for _, podCIDR := range node.Spec.PodCIDRs {
			_, localSubnet, err := net.ParseCIDR(podCIDR)
			if err != nil {
				klog.Errorf("Failed to parse subnet from CIDR string %s: %v", node.Spec.PodCIDR, err)
				return err
			}
			if localSubnet.IP.To4() != nil {
				if i.nodeConfig.PodIPv4CIDR != nil {
					klog.Warningf("One IPv4 PodCIDR is already configured on this Node, ignore the IPv4 Subnet CIDR %s", localSubnet.String())
				}
```
As a result, the arpResponderStaticFlow is never installed for IPv4 networkpolicy-only mode, which causes pods to not able to communicate to apiserver:
```
 kubectl exec -it antrea-agent-vg6rf -n kube-system -c antrea-ovs -- ovs-ofctl dump-flows br-int table=20
 cookie=0x1000000000000, duration=2756.860s, table=20, n_packets=0, n_bytes=0, priority=190,arp actions=NORMAL
 cookie=0x1000000000000, duration=2756.861s, table=20, n_packets=0, n_bytes=0, priority=0 actions=drop
```
```
sonobuoy logs
namespace="sonobuoy" pod="sonobuoy" container="kube-sonobuoy"
time="2020-11-18T22:04:29Z" level=info msg="Scanning plugins in ./plugins.d (pwd: /)"
time="2020-11-18T22:04:29Z" level=info msg="Scanning plugins in /etc/sonobuoy/plugins.d (pwd: /)"
time="2020-11-18T22:04:29Z" level=info msg="Directory (/etc/sonobuoy/plugins.d) does not exist"
time="2020-11-18T22:04:29Z" level=info msg="Scanning plugins in ~/sonobuoy/plugins.d (pwd: /)"
time="2020-11-18T22:04:29Z" level=info msg="Directory (~/sonobuoy/plugins.d) does not exist"
time="2020-11-18T22:04:59Z" level=error msg="could not get api group resources: Get \"https://10.100.0.1:443/api?timeout=32s\": dial tcp 10.100.0.1:443: i/o timeout"
time="2020-11-18T22:04:59Z" level=info msg="no-exit was specified, sonobuoy is now blocking"
```
This PR fixes this issue by always installing the arpResponderStaticFlow. In IPv6 cases, this flow will simply not get hit.