### PR TITLE
Set OVS max revalidator delay to 200ms

### DIFF
--- a/build/images/scripts/start_ovs
+++ b/build/images/scripts/start_ovs
@@ -90,6 +90,11 @@ function start_ovs {
         ovs-vsctl --no-wait set open_vswitch . other_config:flow-restore-wait="true"
         log_info $CONTAINER_NAME "ovs-vswitchd set hw-offload to $offload"
         ovs-vsctl --no-wait set open_vswitch . other_config:hw-offload=$offload
+        # Set max revalidator delay to 200ms to ensure that learned flows are added to the
+        # datapath flow cache faster, so that Service SessionAffinity "takes effect"
+        # faster in AntreaProxy. It should not have a significant impact on performance.
+        # See https://github.com/vmware-tanzu/antrea/issues/1583
+        ovs-vsctl --no-wait set open_vswitch . other_config:max-revalidator=200
         /usr/share/openvswitch/scripts/ovs-ctl --no-ovsdb-server --system-id=random start --db-file=$OVS_DB_FILE
         log_info $CONTAINER_NAME "Started ovs-vswitchd"
     fi


### PR DESCRIPTION
The default value (500ms) causes a K8s upstream conformance test to fail
and may increase the risk of users reporting issues if they think
SessionAffinity is not implemented properly. Of course there is still a
delay before a learned flow is installed in the datapath flow cache and
takes effect, but the delay is at least smaller now. This delay cannot
be avoided when using the learn action.

Reducing the delay to 200ms may have an impact on performance with a
large number of datapath flows. Hopefully this impact is not
significant. There are other measures we could investigate if we notice
performance issues (e.g. reduce the max-idle delay for cached datapath
flows to reduce the size of the cache).

Fixes #1583