### PR TITLE
Fix policyOnlyMode and cloud support for AKS & EKS

### DIFF
--- a/build/yamls/antrea-eks-node-init.yml
+++ b/build/yamls/antrea-eks-node-init.yml
@@ -19,12 +19,20 @@ spec:
     spec:
       hostPID: true
       hostNetwork: true
+      volumes:
+      - hostPath:
+          path: /var/run/aws-node
+          type: DirectoryOrCreate
+        name: host-aws-node-run-dir
       containers:
         - name: node-init
           image: gcr.io/google-containers/startup-script:v1
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
+          volumeMounts:
+          - mountPath: /var/run/aws-node
+            name: host-aws-node-run-dir
           env:
           - name: STARTUP_SCRIPT
             value: |
@@ -38,6 +46,8 @@ spec:
                   echo "Antrea node init already done. Exiting"
                   exit
               fi
+
+              echo "Initializing node for Antrea"
 
               while true; do
                   cni_conf=$(ls /etc/cni/net.d | head -n1)
@@ -64,13 +74,10 @@ spec:
                   echo "Waiting for aws-k8s-agent"
               done
 
-              # copied from https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml#L199
-              # Fetch running containers from aws-k8s-agent and kill it
+              # Fetch running containers from aws-k8s-agent and kill them
               echo "\n"
-              for pod in $(curl "localhost:61679/v1/pods" 2> /dev/null | jq -r '. | keys[]'); do
-                  container_name=$(echo "$pod" | awk -F_ ' { print $1 } ')
-                  container_id=$(echo "$pod" | awk -F_ ' { print $3 } ' | cut -c1-12)
-                  echo "Restarting container. Name: ${container_name}, ID: ${container_id}"
+              for container_id in $(cat /var/run/aws-node/ipam.json | jq -r '.allocations | .[] | .containerID'); do
+                  echo "Restarting container with ID: ${container_id}"
                   docker kill "${container_id}" || true
               done
 

--- a/ci/test-conformance-aks.sh
+++ b/ci/test-conformance-aks.sh
@@ -28,6 +28,7 @@ RUN_CLEANUP_ONLY=false
 KUBECONFIG_PATH="$HOME/jenkins/out/aks"
 TEST_FAILURE=false
 MODE="report"
+KUBE_CONFORMANCE_IMAGE_VERSION=v1.18.5
 
 _usage="Usage: $0 [--cluster-name <AKSClusterNameToUse>] [--kubeconfig <KubeconfigSavePath>] [--k8s-version <ClusterVersion>]\
                   [--azure-app-id <AppID>] [--azure-tenant-id <TenantID>] [--azure-password <Password>] \
@@ -189,6 +190,7 @@ function deliver_antrea_to_aks() {
 function run_conformance() {
     echo "=== Running Antrea Conformance and Network Policy Tests ==="
     ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-conformance --e2e-network-policy \
+      --kube-conformance-image-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
       --log-mode ${MODE} > ${GIT_CHECKOUT_DIR}/aks-test.log
 
     if grep -Fxq "Failed tests:" ${GIT_CHECKOUT_DIR}/aks-test.log

--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -31,6 +31,7 @@ RUN_CLEANUP_ONLY=false
 KUBECONFIG_PATH="$HOME/jenkins/out/eks"
 MODE="report"
 TEST_FAILURE=false
+KUBE_CONFORMANCE_IMAGE_VERSION=v1.18.5
 
 _usage="Usage: $0 [--cluster-name <EKSClusterNameToUse>] [--kubeconfig <KubeconfigSavePath>] [--k8s-version <ClusterVersion>]\
                   [--aws-access-key <AccessKey>] [--aws-secret-key <SecretKey>] [--aws-region <Region>] [--ssh-key <SSHKey] \
@@ -187,6 +188,7 @@ function run_conformance() {
     # access through node external IP. See https://github.com/vmware-tanzu/antrea/issues/690
     skip_regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]|NodePort"
     ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-conformance --e2e-network-policy --e2e-conformance-skip ${skip_regex} \
+       --kube-conformance-image-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
        --log-mode ${MODE} > ${GIT_CHECKOUT_DIR}/eks-test.log
 
     if grep -Fxq "Failed tests:" ${GIT_CHECKOUT_DIR}/eks-test.log

--- a/ci/test-conformance-gke.sh
+++ b/ci/test-conformance-gke.sh
@@ -26,11 +26,11 @@ GKE_SERVICE_CIDR="10.94.0.0/16"
 GKE_PROJECT="antrea"
 KUBECONFIG_PATH="$HOME/jenkins/out/gke"
 MODE="report"
-
 RUN_ALL=true
 RUN_SETUP_ONLY=false
 RUN_CLEANUP_ONLY=false
 TEST_FAILURE=false
+KUBE_CONFORMANCE_IMAGE_VERSION=v1.18.5
 
 _usage="Usage: $0 [--cluster-name <GKEClusterNameToUse>]  [--kubeconfig <KubeconfigSavePath>] [--k8s-version <ClusterVersion>] \
                   [--svc-account <Name>] [--user <Name>] [--gke-project <Project>] [--gke-zone <Zone>] [--log-mode <SonobuoyResultLogLevel>] \
@@ -218,6 +218,7 @@ function run_conformance() {
     ${GCLOUD_PATH} compute firewall-rules create allow-nodeport --allow tcp:30000-32767
 
     ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-conformance --e2e-network-policy \
+      --kube-conformance-image-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
       --log-mode ${MODE} > ${GIT_CHECKOUT_DIR}/gke-test.log
 
     ${GCLOUD_PATH} compute firewall-rules delete allow-nodeport

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -177,19 +177,25 @@ func run(o *Options) error {
 		statsCollector = stats.NewCollector(antreaClientProvider, ofClient, networkPolicyController)
 	}
 
+	var proxier k8sproxy.Provider
+	if features.DefaultFeatureGate.Enabled(features.AntreaProxy) {
+		v4Enabled := config.IsIPv4Enabled(nodeConfig, networkConfig.TrafficEncapMode)
+		v6Enabled := config.IsIPv6Enabled(nodeConfig, networkConfig.TrafficEncapMode)
+		switch {
+		case v4Enabled && v6Enabled:
+			proxier = proxy.NewDualStackProxier(nodeConfig.Name, informerFactory, ofClient)
+		case v4Enabled:
+			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, false)
+		case v6Enabled:
+			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, true)
+		default:
+			return fmt.Errorf("at least one of IPv4 or IPv6 should be enabled")
+		}
+	}
+
 	isChaining := false
 	if networkConfig.TrafficEncapMode.IsNetworkPolicyOnly() {
 		isChaining = true
-	}
-	var proxier k8sproxy.Provider
-	if features.DefaultFeatureGate.Enabled(features.AntreaProxy) {
-		if nodeConfig.PodIPv4CIDR != nil && nodeConfig.PodIPv6CIDR != nil {
-			proxier = proxy.NewDualStackProxier(nodeConfig.Name, informerFactory, ofClient)
-		} else if nodeConfig.PodIPv4CIDR != nil {
-			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, false)
-		} else {
-			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, true)
-		}
 	}
 	cniServer := cniserver.New(
 		o.config.CNISocket,
@@ -258,6 +264,7 @@ func run(o *Options) error {
 
 	agentQuerier := querier.NewAgentQuerier(
 		nodeConfig,
+		networkConfig,
 		ifaceStore,
 		k8sClient,
 		ofClient,

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -335,8 +335,9 @@ func (i *Initializer) initOpenFlowPipeline() error {
 		// Set up flow entries to enable Service connectivity. The agent proxy handles
 		// ClusterIP Services while the upstream kube-proxy is leveraged to handle
 		// any other kinds of Services.
-		if err := i.ofClient.InstallClusterServiceFlows(
-			i.nodeConfig.PodIPv4CIDR != nil, i.nodeConfig.PodIPv6CIDR != nil); err != nil {
+		v4Enabled := config.IsIPv4Enabled(i.nodeConfig, i.networkConfig.TrafficEncapMode)
+		v6Enabled := config.IsIPv6Enabled(i.nodeConfig, i.networkConfig.TrafficEncapMode)
+		if err := i.ofClient.InstallClusterServiceFlows(v4Enabled, v6Enabled); err != nil {
 			klog.Errorf("Failed to setup default OpenFlow entries for ClusterIP Services: %v", err)
 			return err
 		}

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -107,3 +107,17 @@ type NetworkConfig struct {
 	EnableIPSecTunnel bool
 	IPSecPSK          string
 }
+
+// IsIPv4Enabled returns true if the cluster network supports IPv4.
+// TODO: support dual-stack in networkPolicyOnly mode.
+func IsIPv4Enabled(nodeConfig *NodeConfig, trafficEncapMode TrafficEncapModeType) bool {
+	return nodeConfig.PodIPv4CIDR != nil ||
+		(trafficEncapMode.IsNetworkPolicyOnly() && nodeConfig.NodeIPAddr.IP.To4() != nil)
+}
+
+// IsIPv6Enabled returns true if the cluster network supports IPv6.
+// TODO: support dual-stack in networkPolicyOnly mode.
+func IsIPv6Enabled(nodeConfig *NodeConfig, trafficEncapMode TrafficEncapModeType) bool {
+	return nodeConfig.PodIPv6CIDR != nil ||
+		(trafficEncapMode.IsNetworkPolicyOnly() && nodeConfig.NodeIPAddr.IP.To4() == nil)
+}

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -586,10 +586,10 @@ func (c *client) Initialize(roundInfo types.RoundInfo, nodeConfig *config.NodeCo
 	c.encapMode = encapMode
 	c.gatewayPort = gatewayOFPort
 
-	if c.nodeConfig.PodIPv4CIDR != nil {
+	if config.IsIPv4Enabled(nodeConfig, encapMode) {
 		c.ipProtocols = append(c.ipProtocols, binding.ProtocolIP)
 	}
-	if c.nodeConfig.PodIPv6CIDR != nil {
+	if config.IsIPv6Enabled(nodeConfig, encapMode) {
 		c.ipProtocols = append(c.ipProtocols, binding.ProtocolIPv6)
 	}
 
@@ -833,9 +833,9 @@ func (c *client) InitialTLVMap() error {
 }
 
 func (c *client) IsIPv4Enabled() bool {
-	return c.nodeConfig.PodIPv4CIDR != nil
+	return config.IsIPv4Enabled(c.nodeConfig, c.encapMode)
 }
 
 func (c *client) IsIPv6Enabled() bool {
-	return c.nodeConfig.PodIPv6CIDR != nil
+	return config.IsIPv6Enabled(c.nodeConfig, c.encapMode)
 }

--- a/pkg/agent/querier/querier.go
+++ b/pkg/agent/querier/querier.go
@@ -35,6 +35,7 @@ var _ AgentQuerier = new(agentQuerier)
 
 type AgentQuerier interface {
 	GetNodeConfig() *config.NodeConfig
+	GetNetworkConfig() *config.NetworkConfig
 	GetInterfaceStore() interfacestore.InterfaceStore
 	GetK8sClient() clientset.Interface
 	GetAgentInfo(agentInfo *v1beta1.AntreaAgentInfo, partial bool)
@@ -45,6 +46,7 @@ type AgentQuerier interface {
 
 type agentQuerier struct {
 	nodeConfig               *config.NodeConfig
+	networkConfig            *config.NetworkConfig
 	interfaceStore           interfacestore.InterfaceStore
 	k8sClient                clientset.Interface
 	ofClient                 openflow.Client
@@ -55,6 +57,7 @@ type agentQuerier struct {
 
 func NewAgentQuerier(
 	nodeConfig *config.NodeConfig,
+	networkConfig *config.NetworkConfig,
 	interfaceStore interfacestore.InterfaceStore,
 	k8sClient clientset.Interface,
 	ofClient openflow.Client,
@@ -64,6 +67,7 @@ func NewAgentQuerier(
 ) *agentQuerier {
 	return &agentQuerier{
 		nodeConfig:               nodeConfig,
+		networkConfig:            networkConfig,
 		interfaceStore:           interfaceStore,
 		k8sClient:                k8sClient,
 		ofClient:                 ofClient,
@@ -75,6 +79,11 @@ func NewAgentQuerier(
 // GetNodeConfig returns NodeConfig.
 func (aq agentQuerier) GetNodeConfig() *config.NodeConfig {
 	return aq.nodeConfig
+}
+
+// GetNetworkConfig returns NetworkConfig.
+func (aq agentQuerier) GetNetworkConfig() *config.NetworkConfig {
+	return aq.networkConfig
 }
 
 // GetInterfaceStore returns InterfaceStore.

--- a/pkg/agent/querier/testing/mock_querier.go
+++ b/pkg/agent/querier/testing/mock_querier.go
@@ -94,6 +94,20 @@ func (mr *MockAgentQuerierMockRecorder) GetK8sClient() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetK8sClient", reflect.TypeOf((*MockAgentQuerier)(nil).GetK8sClient))
 }
 
+// GetNetworkConfig mocks base method
+func (m *MockAgentQuerier) GetNetworkConfig() *config.NetworkConfig {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNetworkConfig")
+	ret0, _ := ret[0].(*config.NetworkConfig)
+	return ret0
+}
+
+// GetNetworkConfig indicates an expected call of GetNetworkConfig
+func (mr *MockAgentQuerierMockRecorder) GetNetworkConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkConfig", reflect.TypeOf((*MockAgentQuerier)(nil).GetNetworkConfig))
+}
+
 // GetNetworkPolicyInfoQuerier mocks base method
 func (m *MockAgentQuerier) GetNetworkPolicyInfoQuerier() querier.AgentNetworkPolicyInfoQuerier {
 	m.ctrl.T.Helper()

--- a/pkg/support/dump_others.go
+++ b/pkg/support/dump_others.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util/iptables"
 )
 
@@ -53,7 +54,10 @@ func (d *agentDumper) DumpHostNetworkInfo(basedir string) error {
 
 func (d *agentDumper) dumpIPTables(basedir string) error {
 	nodeConfig := d.aq.GetNodeConfig()
-	c, err := iptables.New(nodeConfig.PodIPv4CIDR != nil, nodeConfig.PodIPv6CIDR != nil)
+	networkConfig := d.aq.GetNetworkConfig()
+	v4Enabled := config.IsIPv4Enabled(nodeConfig, networkConfig.TrafficEncapMode)
+	v6Enabled := config.IsIPv6Enabled(nodeConfig, networkConfig.TrafficEncapMode)
+	c, err := iptables.New(v4Enabled, v6Enabled)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
policyOnlyMode was broken since adding support for IPv6 clusters in the
code base. This is because the code used the Node's PodCIDR(s) to
determine which address family was supported, which doesn't work in
policyOnlyMode, for which IPAM is not the responsibility of Antrea.

Instead we now use the following rules:
* if there is an IPv4 PodCIDR for the Node, then v4 is supported
* otherwise, if policyOnlyMode is used and the Node's IP address
  (primary, as reported by K8s) is an IPv4 address then v4 is supported
Same rules for v6.

This may not work for dual-stack, but IIRC none of the cloud services
support IPv6 / dual-stack. There are also other issues for dual-stack
support in Antrea, which themselves depend on upstream issues.

Additionally, we include the following changes:
* the build/yamls/antrea-eks-node-init.yml manifest is updated to
  account for a breaking change in the AWS CNI introspection API.
* we pin the K8s conformance test image for all clouds to v1.18.5 to
  avoid issues with recently-added conformance tests.

Fixes #1572