### PR TITLE
Remove the pod reference in v1beta1 AddressGroup

### DIFF
--- a/.github/workflows/kind_upgrade.yml
+++ b/.github/workflows/kind_upgrade.yml
@@ -73,7 +73,18 @@ jobs:
         sudo mv kind /usr/local/bin
     - name: Run test
       run: |
-        ./ci/kind/test-upgrade-antrea.sh --from-version-n-minus 1
+        mkdir log
+        ANTREA_LOG_DIR=$PWD/log ./ci/kind/test-upgrade-antrea.sh --from-version-n-minus 1
+    - name: Tar log files
+      if: ${{ failure() }}
+      run: tar -czf log.tar.gz log
+    - name: Upload test log
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: upgrade-from-antrea-version-n-1.tar.gz
+        path: log.tar.gz
+        retention-days: 30
 
   from-N-2:
     name: Upgrade from Antrea version N-2
@@ -102,7 +113,18 @@ jobs:
         sudo mv kind /usr/local/bin
     - name: Run test
       run: |
-        ./ci/kind/test-upgrade-antrea.sh --from-version-n-minus 2
+        mkdir log
+        ANTREA_LOG_DIR=$PWD/log ./ci/kind/test-upgrade-antrea.sh --from-version-n-minus 2
+    - name: Tar log files
+      if: ${{ failure() }}
+      run: tar -czf log.tar.gz log
+    - name: Upload test log
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: upgrade-from-antrea-version-n-2.tar.gz
+        path: log.tar.gz
+        retention-days: 30
 
   compatible-N-1:
     name: API compatible with client version N-1
@@ -131,7 +153,18 @@ jobs:
           sudo mv kind /usr/local/bin
       - name: Run test
         run: |
-          ./ci/kind/test-upgrade-antrea.sh --from-version-n-minus 1 --controller-only
+          mkdir log
+          ANTREA_LOG_DIR=$PWD/log ./ci/kind/test-upgrade-antrea.sh --from-version-n-minus 1 --controller-only
+      - name: Tar log files
+        if: ${{ failure() }}
+        run: tar -czf log.tar.gz log
+      - name: Upload test log
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: api-compatible-with-client-version-n-1.tar.gz
+          path: log.tar.gz
+          retention-days: 30
 
   compatible-N-2:
     name: API compatible with client version N-2
@@ -160,7 +193,18 @@ jobs:
           sudo mv kind /usr/local/bin
       - name: Run test
         run: |
-          ./ci/kind/test-upgrade-antrea.sh --from-version-n-minus 2 --controller-only
+          mkdir log
+          ANTREA_LOG_DIR=$PWD/log ./ci/kind/test-upgrade-antrea.sh --from-version-n-minus 2 --controller-only
+      - name: Tar log files
+        if: ${{ failure() }}
+        run: tar -czf log.tar.gz log
+      - name: Upload test log
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: api-compatible-with-client-version-n-2.tar.gz
+          path: log.tar.gz
+          retention-days: 30
 
   # Runs after all other jobs in the workflow and deletes Antrea Docker images uploaded as temporary
   # artifacts. It uses a third-party, MIT-licensed action (geekyeggo/delete-artifact). While Github

--- a/ci/kind/test-upgrade-antrea.sh
+++ b/ci/kind/test-upgrade-antrea.sh
@@ -158,7 +158,7 @@ popd
 rm -rf $TMP_DIR
 
 rc=0
-go test -v -run=TestUpgrade github.com/vmware-tanzu/antrea/test/e2e -provider=kind -upgrade.toYML=antrea-new.yml --upgrade.controllerOnly=$CONTROLLER_ONLY || rc=$?
+go test -v -run=TestUpgrade github.com/vmware-tanzu/antrea/test/e2e -provider=kind -upgrade.toYML=antrea-new.yml --upgrade.controllerOnly=$CONTROLLER_ONLY --logs-export-dir=$ANTREA_LOG_DIR || rc=$?
 
 $THIS_DIR/kind-setup.sh destroy kind
 

--- a/pkg/apis/controlplane/v1beta1/conversion_test.go
+++ b/pkg/apis/controlplane/v1beta1/conversion_test.go
@@ -146,11 +146,17 @@ func TestConvertBetweenV1beta1GroupMemberPodAndControlplaneGroupMember(t *testin
 
 	var convertedCPGroupMember controlplane.GroupMember
 	var convertedV1B1GroupMemberPod GroupMemberPod
-	err := Convert_controlplane_GroupMember_To_v1beta1_GroupMemberPod(&cpGroupMember, &convertedV1B1GroupMemberPod, nil)
+	err := Convert_controlplane_GroupMember_To_v1beta1_GroupMemberPod(&cpGroupMember, &convertedV1B1GroupMemberPod, true)
 	require.Errorf(t, err, "should not be able to convert group member with multiple IPs to GroupMemberPod")
 	require.NoError(t,
-		Convert_controlplane_GroupMember_To_v1beta1_GroupMemberPod(&cpPodGroupMember, &convertedV1B1GroupMemberPod, nil))
+		Convert_controlplane_GroupMember_To_v1beta1_GroupMemberPod(&cpPodGroupMember, &convertedV1B1GroupMemberPod, true))
 	assert.Equal(t, v1b1GroupMemberPod, convertedV1B1GroupMemberPod, "controlplane.GroupMember -> v1beta1.GroupMemberPod")
+	var convertedV1B1GroupMemberPodWithoutPodRef GroupMemberPod
+	require.NoError(t,
+		Convert_controlplane_GroupMember_To_v1beta1_GroupMemberPod(&cpPodGroupMember, &convertedV1B1GroupMemberPodWithoutPodRef, false))
+	expectedV1b1GroupMemberPodWithoutPodRef := *v1b1GroupMemberPod.DeepCopy()
+	expectedV1b1GroupMemberPodWithoutPodRef.Pod = nil
+	assert.Equal(t, expectedV1b1GroupMemberPodWithoutPodRef, convertedV1B1GroupMemberPodWithoutPodRef, "controlplane.GroupMember -> v1beta1.GroupMemberPod")
 	require.NoError(t,
 		Convert_v1beta1_GroupMemberPod_To_controlplane_GroupMember(&v1b1GroupMemberPod, &convertedCPGroupMember, nil))
 	assert.Equal(t, cpPodGroupMember, convertedCPGroupMember, "v1beta1.GroupMemberPod -> controlplane.GroupMember")
@@ -169,9 +175,11 @@ func TestConvertBetweenV1beta1AndControlplaneAddressGroup(t *testing.T) {
 	}
 	var convertedCPAddressGroup controlplane.AddressGroup
 	var convertedV1B1AddressGroup AddressGroup
+	expectedV1B1AddressGroup := v1b1AddressGroup.DeepCopy()
+	expectedV1B1AddressGroup.Pods[0].Pod = nil
 	require.NoError(t,
 		Convert_controlplane_AddressGroup_To_v1beta1_AddressGroup(&cpAddressGroup, &convertedV1B1AddressGroup, nil))
-	assert.Equal(t, v1b1AddressGroup, convertedV1B1AddressGroup)
+	assert.Equal(t, *expectedV1B1AddressGroup, convertedV1B1AddressGroup)
 	require.NoError(t,
 		Convert_v1beta1_AddressGroup_To_controlplane_AddressGroup(&v1b1AddressGroup, &convertedCPAddressGroup, nil))
 	assert.Equal(t, cpAddressGroup, convertedCPAddressGroup)
@@ -193,9 +201,12 @@ func TestConvertBetweenV1beta1AndControlplaneAddressGroupPatch(t *testing.T) {
 	}
 	var convertedCPPatch controlplane.AddressGroupPatch
 	var convertedV1B1Patch AddressGroupPatch
+	expectedV1B1AddressGroupPatch := v1b1AddressGroupPatch.DeepCopy()
+	expectedV1B1AddressGroupPatch.AddedPods[0].Pod = nil
+	expectedV1B1AddressGroupPatch.RemovedPods[0].Pod = nil
 	require.NoError(t,
 		Convert_controlplane_AddressGroupPatch_To_v1beta1_AddressGroupPatch(&cpAddressGroupPatch, &convertedV1B1Patch, nil))
-	assert.Equal(t, v1b1AddressGroupPatch, convertedV1B1Patch)
+	assert.Equal(t, *expectedV1B1AddressGroupPatch, convertedV1B1Patch)
 	require.NoError(t,
 		Convert_v1beta1_AddressGroupPatch_To_controlplane_AddressGroupPatch(&v1b1AddressGroupPatch, &convertedCPPatch, nil))
 	assert.Equal(t, cpAddressGroupPatch, convertedCPPatch)

--- a/pkg/apis/controlplane/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/controlplane/v1beta1/zz_generated.conversion.go
@@ -211,11 +211,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddConversionFunc((*controlplane.GroupMember)(nil), (*GroupMemberPod)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_controlplane_GroupMember_To_v1beta1_GroupMemberPod(a.(*controlplane.GroupMember), b.(*GroupMemberPod), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddConversionFunc((*AddressGroupPatch)(nil), (*controlplane.AddressGroupPatch)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta1_AddressGroupPatch_To_controlplane_AddressGroupPatch(a.(*AddressGroupPatch), b.(*controlplane.AddressGroupPatch), scope)
 	}); err != nil {


### PR DESCRIPTION
To be backwards compatible, AddressGroup v1beta1 must not include
PodReferences in its members, otherwise the agents that use v1beta1 will
think the members have changed and will add new IPs to the openflow
entries of relevant NetworkPolicies and delete old IPs from them, while
the old IPs and new IPs are actually the same. In current
implementation, deleting old IPs is executed after adding new IPs, so it
leads to some IPs missing in the openflow entries.

Fixes #1587