### PR TITLE
Change L2 forwarding flows for traffic to gateway and tunnel

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -545,11 +545,14 @@ func (c *client) InstallGatewayFlows() error {
 }
 
 func (c *client) InstallDefaultTunnelFlows() error {
-	flow := c.tunnelClassifierFlow(config.DefaultTunOFPort, cookie.Default)
-	if err := c.ofEntryOperations.Add(flow); err != nil {
+	flows := []binding.Flow{
+		c.tunnelClassifierFlow(config.DefaultTunOFPort, cookie.Default),
+		c.l2ForwardCalcFlow(globalVirtualMAC, config.DefaultTunOFPort, cookie.Default),
+	}
+	if err := c.ofEntryOperations.AddAll(flows); err != nil {
 		return err
 	}
-	c.defaultTunnelFlows = []binding.Flow{flow}
+	c.defaultTunnelFlows = flows
 	return nil
 }
 


### PR DESCRIPTION
Let the packets to the tunnel port go through L2ForwardingCalcTable
as well, to be consistent with other types of traffic.
Redirect packets to gateway and tunnel, as well as BUM packets to
conntrackCommitTable and bypass ingress NetworkPolicy enforcement.