### PR TITLE
Revise OVS pipeline: use macRewriteMark as the only mark to reset dst MAC

### DIFF
--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -775,15 +775,11 @@ func (c *client) l3FwdFlowToPod(localGatewayMAC net.HardwareAddr, podInterfaceIP
 	var flows []binding.Flow
 	for _, ip := range podInterfaceIPs {
 		ipProtocol := getIPProtocol(ip)
-		flowBuilder := l3FwdTable.BuildFlow(priorityNormal).MatchProtocol(ipProtocol)
-		if c.enableProxy {
-			flowBuilder = flowBuilder.MatchRegRange(int(marksReg), macRewriteMark, macRewriteMarkRange)
-		} else {
-			flowBuilder = flowBuilder.MatchDstMAC(globalVirtualMAC)
-		}
-		// Rewrite src MAC to local gateway MAC, and rewrite dst MAC to pod MAC
-		flows = append(flows, flowBuilder.MatchDstIP(ip).
+		flows = append(flows, l3FwdTable.BuildFlow(priorityNormal).MatchProtocol(ipProtocol).
+			MatchRegRange(int(marksReg), macRewriteMark, macRewriteMarkRange).
+			MatchDstIP(ip).
 			Action().SetSrcMAC(localGatewayMAC).
+			// Rewrite src MAC to local gateway MAC, and rewrite dst MAC to pod MAC
 			Action().SetDstMAC(podInterfaceMAC).
 			Action().DecTTL().
 			Action().GotoTable(l3FwdTable.GetNext()).
@@ -1455,7 +1451,6 @@ func (c *client) hostBridgeUplinkFlows(localSubnet net.IPNet, category cookie.Ca
 			MatchProtocol(binding.ProtocolIP).
 			MatchRegRange(int(marksReg), markTrafficFromBridge, binding.Range{0, 15}).
 			MatchDstIPNet(localSubnet).
-			Action().SetDstMAC(globalVirtualMAC).
 			Action().LoadRegRange(int(marksReg), macRewriteMark, macRewriteMarkRange).
 			Action().GotoTable(conntrackTable).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
@@ -1491,14 +1486,13 @@ func (c *client) uplinkSNATFlows(category cookie.Category) []binding.Flow {
 			Action().GotoTable(conntrackTable).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done(),
-		// Rewrite dMAC with the global vMAC if the packet is a reply to a
-		// Pod from an external address.
+		// Mark the packet to indicate its destination MAC should be rewritten to the real MAC in the L3Forwarding
+		// table, if the packet is a reply to a Pod from an external address.
 		c.pipeline[conntrackStateTable].BuildFlow(priorityHigh).
 			MatchProtocol(binding.ProtocolIP).
 			MatchCTStateNew(false).MatchCTStateTrk(true).
 			MatchCTMark(snatCTMark, nil).
 			MatchRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
-			Action().SetDstMAC(globalVirtualMAC).
 			Action().LoadRegRange(int(marksReg), macRewriteMark, macRewriteMarkRange).
 			Action().GotoTable(ctStateNext).
 			Cookie(c.cookieAllocator.Request(category).Raw()).

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -1273,7 +1273,7 @@ func prepareExternalFlows(nodeIP net.IP, localSubnet *net.IPNet, vMAC net.Hardwa
 			[]*ofTestUtils.ExpectFlow{
 				{
 					MatchStr: "priority=210,ct_state=-new+trk,ct_mark=0x40,ip,reg0=0x4/0xffff",
-					ActStr:   fmt.Sprintf("set_field:%s->eth_dst,load:0x1->NXM_NX_REG0[19],goto_table:42", vMAC.String()),
+					ActStr:   "load:0x1->NXM_NX_REG0[19],goto_table:42",
 				},
 				{
 					MatchStr: fmt.Sprintf("priority=200,ip,reg0=0x4/0xffff"),


### PR DESCRIPTION
Some flow entries are using the global vMAC as the mark when resetting dst MAC, while
others are using macRewriteMark originally. With this change, macRewriteMark is working
as the only mark.