### PR TITLE
Fix wrong TCP flags and CNP flows in Antrea Traceflow

### DIFF
--- a/pkg/agent/controller/traceflow/traceflow_controller.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller.go
@@ -363,7 +363,9 @@ func (c *Controller) injectPacket(tf *opsv1alpha1.Traceflow) error {
 	if tf.Spec.Packet.TransportHeader.TCP != nil {
 		srcTCPPort = uint16(tf.Spec.Packet.TransportHeader.TCP.SrcPort)
 		dstTCPPort = uint16(tf.Spec.Packet.TransportHeader.TCP.DstPort)
-		flagsTCP = uint8(tf.Spec.Packet.TransportHeader.TCP.Flags)
+		if tf.Spec.Packet.TransportHeader.TCP.Flags != 0 {
+			flagsTCP = uint8(tf.Spec.Packet.TransportHeader.TCP.Flags)
+		}
 	}
 	if tf.Spec.Packet.TransportHeader.UDP != nil {
 		srcUDPPort = uint16(tf.Spec.Packet.TransportHeader.UDP.SrcPort)

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -777,7 +777,7 @@ func (c *client) SendTraceflowPacket(
 	case 6:
 		packetOutBuilder = packetOutBuilder.SetIPProtocol(binding.ProtocolTCP)
 		if TCPSrcPort == 0 {
-			// #nosec G404: random number generator not used for security purposes
+			// #nosec G404: random number generator not used for security purposes.
 			TCPSrcPort = uint16(rand.Uint32())
 		}
 		packetOutBuilder = packetOutBuilder.SetTCPSrcPort(TCPSrcPort)
@@ -810,7 +810,7 @@ func (c *client) InstallTraceflowFlows(dataplaneTag uint8) error {
 	}
 	c.conjMatchFlowLock.Lock()
 	defer c.conjMatchFlowLock.Unlock()
-	// Copy default drop rules
+	// Copy default drop rules.
 	for _, ctx := range c.globalConjMatchFlowCache {
 		if ctx.dropFlow != nil {
 			copyFlowBuilder := ctx.dropFlow.CopyToBuilder(priorityNormal+2, false)
@@ -824,12 +824,13 @@ func (c *client) InstallTraceflowFlows(dataplaneTag uint8) error {
 					Done())
 		}
 	}
-	// Copy Antrea NetworkPolicy drop rules
+	// Copy Antrea NetworkPolicy drop rules.
 	for _, conj := range c.policyCache.List() {
 		for _, flow := range conj.(*policyRuleConjunction).metricFlows {
 			if flow.IsDropFlow() {
 				copyFlowBuilder := flow.CopyToBuilder(priorityNormal+2, false)
-				// Generate both IPv4 and IPv6 flows if the original drop flow doesn't match IP/IPv6
+				// Generate both IPv4 and IPv6 flows if the original drop flow doesn't match IP/IPv6.
+				// DSCP field is in IP/IPv6 headers so IP/IPv6 match is required in a flow.
 				if flow.FlowProtocol() == "" {
 					copyFlowBuilderIPv6 := flow.CopyToBuilder(priorityNormal+2, false)
 					copyFlowBuilderIPv6 = copyFlowBuilderIPv6.MatchProtocol(binding.ProtocolIPv6)

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane/v1beta2"
 	"github.com/vmware-tanzu/antrea/pkg/apis/ops/v1alpha1"
+	secv1alpha1 "github.com/vmware-tanzu/antrea/pkg/apis/security/v1alpha1"
 	"github.com/vmware-tanzu/antrea/pkg/features"
 )
 
@@ -50,6 +51,96 @@ func skipIfTraceflowDisabled(t *testing.T, data *TestData) {
 	} else if !featureGate.Enabled(features.AntreaProxy) {
 		t.Skip("Skipping test because Traceflow is not enabled in the Controller")
 	}
+}
+
+// TestTraceflowIntraNodeANP verifies if traceflow can trace intra node traffic with some Antrea NetworkPolicy sets.
+func TestTraceflowIntraNodeANP(t *testing.T) {
+	skipIfNotIPv4Cluster(t)
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+	skipIfAntreaPolicyDisabled(t, data)
+	skipIfTraceflowDisabled(t, data)
+	k8sUtils, err = NewKubernetesUtils(data)
+	failOnError(err, t)
+
+	node1 := nodeName(0)
+	node1Pods, _, node1CleanupFn := createTestBusyboxPods(t, data, 2, node1)
+	defer node1CleanupFn()
+
+	var denyIngress *secv1alpha1.NetworkPolicy
+	denyIngressName := "test-anp-deny-ingress"
+	if denyIngress, err = data.createANPDenyIngress("antrea-e2e", node1Pods[1], denyIngressName); err != nil {
+		t.Fatalf("Error when creating Antrea NetworkPolicy: %v", err)
+	}
+	defer func() {
+		if err = data.deleteAntreaNetworkpolicy(denyIngress); err != nil {
+			t.Errorf("Error when deleting Antrea NetworkPolicy: %v", err)
+		}
+	}()
+	antreaPod, err := data.getAntreaPodOnNode(node1)
+	if err = data.waitForNetworkpolicyRealized(antreaPod, denyIngressName, v1beta2.AntreaNetworkPolicy); err != nil {
+		t.Fatal(err)
+	}
+
+	testcases := []testcase{
+		{
+			name: "ANPDenyIngress",
+			tf: &v1alpha1.Traceflow{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", testNamespace, node1Pods[0], testNamespace, node1Pods[1])),
+				},
+				Spec: v1alpha1.TraceflowSpec{
+					Source: v1alpha1.Source{
+						Namespace: testNamespace,
+						Pod:       node1Pods[0],
+					},
+					Destination: v1alpha1.Destination{
+						Namespace: testNamespace,
+						Pod:       node1Pods[1],
+					},
+					Packet: v1alpha1.Packet{
+						IPHeader: v1alpha1.IPHeader{
+							Protocol: 6,
+						},
+						TransportHeader: v1alpha1.TransportHeader{
+							TCP: &v1alpha1.TCPHeader{
+								DstPort: 80,
+								Flags:   2,
+							},
+						},
+					},
+				},
+			},
+			expectedPhase: v1alpha1.Succeeded,
+			expectedResults: []v1alpha1.NodeResult{
+				{
+					Node: node1,
+					Observations: []v1alpha1.Observation{
+						{
+							Component: v1alpha1.SpoofGuard,
+							Action:    v1alpha1.Forwarded,
+						},
+						{
+							Component:     v1alpha1.NetworkPolicy,
+							ComponentInfo: "IngressMetric",
+							Action:        v1alpha1.Dropped,
+						},
+					},
+				},
+			},
+		},
+	}
+	t.Run("traceflowANPGroupTest", func(t *testing.T) {
+		for _, tc := range testcases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				runTestTraceflow(t, data, tc)
+			})
+		}
+	})
 }
 
 // TestTraceflowIntraNode verifies if traceflow can trace intra node traffic with some NetworkPolicies set.
@@ -94,10 +185,10 @@ func TestTraceflowIntraNode(t *testing.T) {
 	}()
 
 	antreaPod, err := data.getAntreaPodOnNode(node1)
-	if err = data.waitForNetworkpolicyRealized(antreaPod, allowAllEgressName); err != nil {
+	if err = data.waitForNetworkpolicyRealized(antreaPod, allowAllEgressName, v1beta2.K8sNetworkPolicy); err != nil {
 		t.Fatal(err)
 	}
-	if err = data.waitForNetworkpolicyRealized(antreaPod, denyAllIngressName); err != nil {
+	if err = data.waitForNetworkpolicyRealized(antreaPod, denyAllIngressName, v1beta2.K8sNetworkPolicy); err != nil {
 		t.Fatal(err)
 	}
 
@@ -392,10 +483,10 @@ func TestTraceflowInterNode(t *testing.T) {
 	}()
 
 	antreaPod, err := data.getAntreaPodOnNode(node2)
-	if err = data.waitForNetworkpolicyRealized(antreaPod, allowAllEgressName); err != nil {
+	if err = data.waitForNetworkpolicyRealized(antreaPod, allowAllEgressName, v1beta2.K8sNetworkPolicy); err != nil {
 		t.Fatal(err)
 	}
-	if err = data.waitForNetworkpolicyRealized(antreaPod, denyAllIngressName); err != nil {
+	if err = data.waitForNetworkpolicyRealized(antreaPod, denyAllIngressName, v1beta2.K8sNetworkPolicy); err != nil {
 		t.Fatal(err)
 	}
 
@@ -714,6 +805,54 @@ func compareObservations(expected v1alpha1.NodeResult, actual v1alpha1.NodeResul
 	return nil
 }
 
+// createANPDenyIngress creates an Antrea NetworkPolicy that denies ingress traffic for pods of specific label.
+func (data *TestData) createANPDenyIngress(key string, value string, name string) (*secv1alpha1.NetworkPolicy, error) {
+	dropACT := secv1alpha1.RuleActionDrop
+	anp := secv1alpha1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"antrea-e2e": name,
+			},
+		},
+		Spec: secv1alpha1.NetworkPolicySpec{
+			Tier:     defaultTierName,
+			Priority: 250,
+			AppliedTo: []secv1alpha1.NetworkPolicyPeer{
+				{
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							key: value,
+						},
+					},
+				},
+			},
+			Ingress: []secv1alpha1.Rule{
+				{
+					Action: &dropACT,
+					Ports:  []secv1alpha1.NetworkPolicyPort{},
+					From:   []secv1alpha1.NetworkPolicyPeer{},
+					To:     []secv1alpha1.NetworkPolicyPeer{},
+				},
+			},
+			Egress: []secv1alpha1.Rule{},
+		},
+	}
+	anpCreated, err := k8sUtils.securityClient.NetworkPolicies(testNamespace).Create(context.TODO(), &anp, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return anpCreated, nil
+}
+
+// deleteAntreaNetworkpolicy deletes an Antrea NetworkPolicy.
+func (data *TestData) deleteAntreaNetworkpolicy(policy *secv1alpha1.NetworkPolicy) error {
+	if err := k8sUtils.securityClient.NetworkPolicies(testNamespace).Delete(context.TODO(), policy.Name, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("unable to cleanup policy %v: %v", policy.Name, err)
+	}
+	return nil
+}
+
 // createNPDenyAllIngress creates a NetworkPolicy that denies all ingress traffic for pods of specific label.
 func (data *TestData) createNPDenyAllIngress(key string, value string, name string) (*networkingv1.NetworkPolicy, error) {
 	spec := &networkingv1.NetworkPolicySpec{
@@ -740,14 +879,18 @@ func (data *TestData) createNPAllowAllEgress(name string) (*networkingv1.Network
 }
 
 // waitForNetworkpolicyRealized waits for the NetworkPolicy to be realized by the antrea-agent Pod.
-func (data *TestData) waitForNetworkpolicyRealized(pod string, networkpolicy string) error {
+func (data *TestData) waitForNetworkpolicyRealized(pod string, networkpolicy string, npType v1beta2.NetworkPolicyType) error {
+	npOption := "K8sNP"
+	if npType == v1beta2.AntreaNetworkPolicy {
+		npOption = "ANP"
+	}
 	if err := wait.Poll(200*time.Millisecond, 5*time.Second, func() (bool, error) {
-		cmds := []string{"antctl", "get", "networkpolicy", "-S", networkpolicy, "-n", testNamespace, "-T", "K8sNP"}
+		cmds := []string{"antctl", "get", "networkpolicy", "-S", networkpolicy, "-n", testNamespace, "-T", npOption}
 		stdout, stderr, err := runAntctl(pod, cmds, data)
 		if err != nil {
 			return false, fmt.Errorf("Error when executing antctl get NetworkPolicy, stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
 		}
-		return strings.Contains(stdout, fmt.Sprintf("%s:%s/%s", v1beta2.K8sNetworkPolicy, testNamespace, networkpolicy)), nil
+		return strings.Contains(stdout, fmt.Sprintf("%s:%s/%s", npType, testNamespace, networkpolicy)), nil
 	}); err == wait.ErrWaitTimeout {
 		return fmt.Errorf("NetworkPolicy %s isn't realized in time", networkpolicy)
 	} else if err != nil {


### PR DESCRIPTION
This PR fixes two bugs:
1. When destination Service is set, the actual tcpFlags is set to 0 if tcpHeader exists with tcpFlags=0 or not set, which should be forced set to 2.
2. When CNP/ANP drop rule exists, Traceflow cannot generate OVS flows properly.