### PR TITLE
Support using arbitrary Antrea image to trigger Cloud CI

### DIFF
--- a/ci/jenkins/jobs/job-templates.yaml
+++ b/ci/jenkins/jobs/job-templates.yaml
@@ -174,13 +174,12 @@
          days-to-keep: 7
          num-to-keep: 30
      - github:
-         url: https://github.com/vmware-tanzu/antrea/
+         url: '{repo_url}'
      scm:
      - git:
-         branches:
-         - master
+         branches: '{branches}'
          name: origin
-         url: https://github.com/vmware-tanzu/antrea
+         url: '{repo_url}'
      publishers: '{publishers}'
      wrappers: '{wrappers}'
 

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -584,7 +584,20 @@
           test_name: eks-conformance-net-policy
           node: antrea-cloud
           description: 'This is EKS conformance and network policy test for antrea.'
-          parameters: []
+          parameters:
+          - string:
+              default: https://github.com/vmware-tanzu/antrea/
+              description: The repository to checkout Antrea for this test.
+              name: ANTREA_REPO
+              trim: 'true'
+          - string:
+              default: master
+              description: The branch or SHA commit ID to checkout and build Antrea for this test.
+              name: ANTREA_GIT_REVISION
+              trim: 'true'
+          branches:
+          - '${{ANTREA_GIT_REVISION}}'
+          repo_url: '${{ANTREA_REPO}}'
           builders:
           - shell: |-
               #!/bin/bash
@@ -605,6 +618,9 @@
             - project:
               - cloud-{name}-eks-cleanup
               property-file: 'ci_properties.txt'
+          - email:
+              notify-every-unstable-build: true
+              recipients: projectantrea-dev@googlegroups.com
           wrappers:
           - credentials-binding:
             - text:
@@ -627,18 +643,33 @@
               description: The cluster name of the last finished build.
               name: CLUSTERNAME
               trim: 'false'
+          branches:
+          - '${{ANTREA_GIT_REVISION}}'
+          repo_url: '${{ANTREA_REPO}}'
           publishers:
           - email:
               notify-every-unstable-build: true
-              recipients: dingyang@vmware.com zhengshengz@vmware.com
-              send-to-individuals: false
+              recipients: projectantrea-dev@googlegroups.com
           triggers: []
           wrappers: []
       - 'cloud-{name}-{test_name}':
           test_name: gke-conformance-net-policy
           node: antrea-cloud
           description: 'This is GKE conformance and network policy test for antrea.'
-          parameters: []
+          parameters:
+          - string:
+              default: https://github.com/vmware-tanzu/antrea/
+              description: The repository to checkout Antrea for this test.
+              name: ANTREA_REPO
+              trim: 'true'
+          - string:
+              default: master
+              description: The branch or SHA commit ID to checkout and build Antrea for this test.
+              name: ANTREA_GIT_REVISION
+              trim: 'true'
+          branches:
+          - '${{ANTREA_GIT_REVISION}}'
+          repo_url: '${{ANTREA_REPO}}'
           builders:
           - shell: |-
               #!/bin/bash
@@ -662,6 +693,9 @@
             - project:
               - cloud-{name}-gke-cleanup
               property-file: 'ci_properties.txt'
+          - email:
+              notify-every-unstable-build: true
+              recipients: projectantrea-dev@googlegroups.com
           wrappers: []
       - 'cloud-{name}-{test_name}':
           test_name: gke-cleanup
@@ -677,18 +711,33 @@
               description: The cluster name of the last finished build.
               name: CLUSTERNAME
               trim: 'false'
+          branches:
+          - '${{ANTREA_GIT_REVISION}}'
+          repo_url: '${{ANTREA_REPO}}'
           publishers:
           - email:
               notify-every-unstable-build: true
-              recipients: dingyang@vmware.com zhengshengz@vmware.com
-              send-to-individuals: false
+              recipients: projectantrea-dev@googlegroups.com
           triggers: []
           wrappers: []
       - 'cloud-{name}-{test_name}':
           test_name: aks-conformance-net-policy
           node: antrea-cloud
           description: 'This is AKS conformance and network policy test for antrea.'
-          parameters: []
+          parameters:
+          - string:
+              default: https://github.com/vmware-tanzu/antrea/
+              description: The repository to checkout Antrea for this test.
+              name: ANTREA_REPO
+              trim: 'true'
+          - string:
+              default: master
+              description: The branch or SHA commit ID to checkout and build Antrea for this test.
+              name: ANTREA_GIT_REVISION
+              trim: 'true'
+          branches:
+          - '${{ANTREA_GIT_REVISION}}'
+          repo_url: '${{ANTREA_REPO}}'
           builders:
           - shell: |-
               #!/bin/bash
@@ -710,6 +759,9 @@
             - project:
               - cloud-{name}-aks-cleanup
               property-file: 'ci_properties.txt'
+          - email:
+              notify-every-unstable-build: true
+              recipients: projectantrea-dev@googlegroups.com
           wrappers:
           - credentials-binding:
             - text:
@@ -735,11 +787,13 @@
               description: The cluster name of the last finished build.
               name: CLUSTERNAME
               trim: 'false'
+          branches:
+          - '${{ANTREA_GIT_REVISION}}'
+          repo_url: '${{ANTREA_REPO}}'
           publishers:
           - email:
               notify-every-unstable-build: true
-              recipients: dingyang@vmware.com zhengshengz@vmware.com rahulj@vmware.com
-              send-to-individuals: false
+              recipients: projectantrea-dev@googlegroups.com rahulj@vmware.com
           triggers: []
           wrappers: []
       - '{name}-{test_name}-matrix-compatibility-test':

--- a/ci/test-conformance-aks.sh
+++ b/ci/test-conformance-aks.sh
@@ -22,6 +22,8 @@ function echoerr {
 
 REGION="westus"
 RESOURCE_GROUP="antrea-ci-rg"
+SSH_KEY_PATH="$HOME/.ssh/id_rsa.pub"
+SSH_PRIVATE_KEY_PATH="$HOME/.ssh/id_rsa"
 RUN_ALL=true
 RUN_SETUP_ONLY=false
 RUN_CLEANUP_ONLY=false
@@ -118,12 +120,19 @@ function setup_aks() {
 
     # Save the cluster information for cleanup on Jenkins environment
     echo "CLUSTERNAME=${CLUSTER}" > ${GIT_CHECKOUT_DIR}/ci_properties.txt
+    if [[ -n ${ANTREA_GIT_REVISION+x} ]]; then
+        echo "ANTREA_REPO=${ANTREA_REPO}" > ${GIT_CHECKOUT_DIR}/ci_properties.txt
+        echo "ANTREA_GIT_REVISION=${ANTREA_GIT_REVISION}" > ${GIT_CHECKOUT_DIR}/ci_properties.txt
+    fi
 
     echo "=== Using the following az cli version ==="
     az --version
 
     echo "=== Logging into Azure Cloud ==="
     az login --service-principal --username ${AZURE_APP_ID} --password ${AZURE_PASSWORD} --tenant ${AZURE_TENANT_ID}
+    # enable the 'Node Public IP' preview feature
+    az feature register --name NodePublicIPPreview --namespace Microsoft.ContainerService
+    az provider register -n Microsoft.ContainerService
 
     printf "\n"
     echo "=== Using the following kubectl ==="
@@ -137,10 +146,17 @@ function setup_aks() {
     fi
 
     echo '=== Creating a cluster in AKS ==='
+    # enable-node-public-ip is a preview feature and may be changed/removed in a future release. For more details, see
+    # https://docs.microsoft.com/en-us/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools-preview
+    # without public node ip, ssh into worker nodes in the AKS cluster can only be done through a `jump` pod deployed
+    # in the cluster, which is very tedious and makes loading Antrea tarball into Nodes challenging.
+    # https://docs.microsoft.com/en-us/azure/aks/ssh
     az aks create \
         --resource-group ${RESOURCE_GROUP} \
         --name ${CLUSTER} \
         --node-count 2 \
+        --enable-node-public-ip \
+        --ssh-key-value ${SSH_KEY_PATH} \
         --network-plugin azure \
         --kubernetes-version ${K8S_VERSION} \
         --service-principal ${AZURE_APP_ID} \
@@ -165,6 +181,54 @@ function setup_aks() {
 }
 
 function deliver_antrea_to_aks() {
+    echo "====== Building Antrea for the Following Commit ======"
+    git show --numstat
+
+    export GO111MODULE=on
+    export GOROOT=/usr/local/go
+    export PATH=${GOROOT}/bin:$PATH
+
+    if [[ -z ${GIT_CHECKOUT_DIR+x} ]]; then
+        GIT_CHECKOUT_DIR=..
+    fi
+    make clean -C ${GIT_CHECKOUT_DIR}
+    if [[ -n ${JOB_NAME+x} ]]; then
+        docker images | grep "${JOB_NAME}" | awk '{print $3}' | xargs -r docker rmi -f || true > /dev/null
+    fi
+    # Clean up dangling images generated in previous builds. Recent ones must be excluded
+    # because they might be being used in other builds running simultaneously.
+    docker image prune -f --filter "until=2h" || true > /dev/null
+
+    cd ${GIT_CHECKOUT_DIR}
+    VERSION="$CLUSTER" make
+    if [[ "$?" -ne "0" ]]; then
+        echo "=== Antrea Image build failed ==="
+        exit 1
+    fi
+
+    echo "=== Loading the Antrea image to each Node ==="
+
+    antrea_image="antrea-ubuntu"
+    DOCKER_IMG_VERSION=${CLUSTER}
+    docker save -o ${antrea_image}.tar antrea/antrea-ubuntu:${DOCKER_IMG_VERSION}
+
+    CLUSTER_RESOURCE_GROUP=$(az aks show --resource-group ${RESOURCE_GROUP} --name ${CLUSTER} --query nodeResourceGroup -o tsv)
+    SCALE_SET_NAME=$(az vmss list --resource-group ${CLUSTER_RESOURCE_GROUP} --query [0].name -o tsv)
+    NODE_IPS=$(az vmss list-instance-public-ips --resource-group ${CLUSTER_RESOURCE_GROUP}  --name ${SCALE_SET_NAME} | grep ipAddress | awk -F'"' '{print $4}')
+
+    NETWORK_NSG=$(az network nsg list -g ${CLUSTER_RESOURCE_GROUP} -o table | grep ${CLUSTER_RESOURCE_GROUP} | awk -F' ' '{print $2}')
+    # Create a firewall rule to allow ssh access into the worker node through public IPs
+    az network nsg rule create -g ${CLUSTER_RESOURCE_GROUP} --nsg-name ${NETWORK_NSG} -n SshRule --priority 100 \
+        --source-address-prefixes Internet --destination-port-ranges 22 --access Allow --protocol Tcp --direction Inbound
+    # Wait for the rule to take effect
+    sleep 30
+
+    for IP in ${NODE_IPS}; do
+        scp -o StrictHostKeyChecking=no -i ${SSH_PRIVATE_KEY_PATH} ${antrea_image}.tar azureuser@${IP}:~
+        ssh -o StrictHostKeyChecking=no -i ${SSH_PRIVATE_KEY_PATH} -n azureuser@${IP} "sudo docker load -i ~/${antrea_image}.tar ; sudo docker tag antrea/antrea-ubuntu:${DOCKER_IMG_VERSION} antrea/antrea-ubuntu:latest"
+    done
+    rm ${antrea_image}.tar
+
     echo "=== Configuring Antrea for AKS cluster ==="
 
     if [[ -z ${GIT_CHECKOUT_DIR+x} ]]; then
@@ -177,7 +241,7 @@ function deliver_antrea_to_aks() {
     kubectl rollout status --timeout=2m deployment.apps/antrea-controller -n kube-system
     kubectl rollout status --timeout=2m daemonset/antrea-agent -n kube-system
 
-  # Restart all Pods in all Namespaces (kube-system, etc) so they can be managed by Antrea.
+    # Restart all Pods in all Namespaces (kube-system, etc) so they can be managed by Antrea.
     kubectl delete pods -n kube-system $(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork \
                         --no-headers=true | grep '<none>' | awk '{ print $1 }')
     kubectl rollout status --timeout=2m deployment.apps/coredns -n kube-system

--- a/ci/test-conformance-gke.sh
+++ b/ci/test-conformance-gke.sh
@@ -20,8 +20,9 @@ function echoerr {
     >&2 echo "$@"
 }
 
-GKE_ZONE="us-west1"
+GKE_ZONE="us-west1-a"
 GKE_HOST="UBUNTU"
+MACHINE_TYPE="e2-standard-4"
 GKE_SERVICE_CIDR="10.94.0.0/16"
 GKE_PROJECT="antrea"
 KUBECONFIG_PATH="$HOME/jenkins/out/gke"
@@ -34,21 +35,22 @@ KUBE_CONFORMANCE_IMAGE_VERSION=v1.18.5
 
 _usage="Usage: $0 [--cluster-name <GKEClusterNameToUse>]  [--kubeconfig <KubeconfigSavePath>] [--k8s-version <ClusterVersion>] \
                   [--svc-account <Name>] [--user <Name>] [--gke-project <Project>] [--gke-zone <Zone>] [--log-mode <SonobuoyResultLogLevel>] \
-                  [--svc-cidr <ServiceCIDR>] [--host-type <HostType] [--gloud-path] [--setup-only] [--cleanup-only]
+                  [--svc-cidr <ServiceCIDR>] [--host-type <HostType] [--machine-type <MachineType] [--gloud-path] [--setup-only] [--cleanup-only]
 
 Setup a GKE cluster to run K8s e2e community tests (Conformance & Network Policy).
 Before running the script, login to gcloud with \`gcloud auth login\` or \`gcloud auth activate-service-account\`
 and create the project to be used for cluster with \`gcloud projects create\`.
 
         --cluster-name        The cluster name to be used for the generated GKE cluster. Must be specified if not run in Jenkins environment.
-        --kubeconfig          Path to save kubeconfig of generated EKS cluster.
+        --kubeconfig          Path to save kubeconfig of generated GKE cluster.
         --k8s-version         GKE K8s cluster version. Defaults to the latest supported master version documented at https://cloud.google.com/kubernetes-engine/docs/release-notes.
         --svc-account         Service acount name if logged in with service account. Use --user instead if logged in with gcloud auth login.
         --user                Email address if logged in with user account. Use --svc-account instead if logged in with service account.
         --gke-project         The GKE project to be used. Needs to be pre-created before running the script.
-        --gke-zone            The GKE zone where the cluster will be initiated. Defaults to us-west1.
+        --gke-zone            The GKE zone where the cluster will be initiated. Defaults to us-west1-a.
         --svc-cidr            The service CIDR to be used for cluster. Defaults to 10.94.0.0/16.
         --host-type           The host type of worker node. Defaults to UBUNTU.
+        --machine-type        The machine type of worker node. Defaults to e2-standard-4.
         --gcloud-path         The path of gcloud installation. Only need to be explicitly set for Jenkins environments.
         --log-mode            Use the flag to set either 'report', 'detail', or 'dump' level data for sonobouy results.
         --setup-only          Only perform setting up the cluster and run test.
@@ -100,6 +102,10 @@ case $key in
     GKE_HOST="$2"
     shift 2
     ;;
+    --machine-type)
+    MACHINE_TYPE="$2"
+    shift 2
+    ;;
     --k8s-version)
     K8S_VERSION="$2"
     shift 2
@@ -145,6 +151,10 @@ function setup_gke() {
 
     echo "=== This cluster to be created is named: ${CLUSTER} ==="
     echo "CLUSTERNAME=${CLUSTER}" > ${GIT_CHECKOUT_DIR}/ci_properties.txt
+    if [[ -n ${ANTREA_GIT_REVISION+x} ]]; then
+        echo "ANTREA_REPO=${ANTREA_REPO}" > ${GIT_CHECKOUT_DIR}/ci_properties.txt
+        echo "ANTREA_GIT_REVISION=${ANTREA_GIT_REVISION}" > ${GIT_CHECKOUT_DIR}/ci_properties.txt
+    fi
 
     echo "=== Using the following gcloud version ==="
     ${GCLOUD_PATH} --version
@@ -152,9 +162,10 @@ function setup_gke() {
     which kubectl
 
     echo '=== Creating a cluster in GKE ==='
-    ${GCLOUD_PATH} container --project ${GKE_PROJECT} clusters create ${CLUSTER} --image-type ${GKE_HOST} \
-                     --cluster-version ${K8S_VERSION} --zone ${GKE_ZONE} \
-                     --enable-ip-alias --services-ipv4-cidr ${GKE_SERVICE_CIDR}
+    ${GCLOUD_PATH} container --project ${GKE_PROJECT} clusters create ${CLUSTER} \
+        --image-type ${GKE_HOST} --machine-type ${MACHINE_TYPE} \
+        --cluster-version ${K8S_VERSION} --zone ${GKE_ZONE} \
+        --enable-ip-alias --services-ipv4-cidr ${GKE_SERVICE_CIDR}
     if [[ $? -ne 0 ]]; then
         echo "=== Failed to deploy GKE cluster! ==="
         exit 1
@@ -173,14 +184,49 @@ function setup_gke() {
 }
 
 function deliver_antrea_to_gke() {
+    echo "====== Building Antrea for the Following Commit ======"
+    git show --numstat
+
+    export GO111MODULE=on
+    export GOROOT=/usr/local/go
+    export PATH=${GOROOT}/bin:$PATH
+
+    if [[ -z ${GIT_CHECKOUT_DIR+x} ]]; then
+        GIT_CHECKOUT_DIR=..
+    fi
+    make clean -C ${GIT_CHECKOUT_DIR}
+    if [[ -n ${JOB_NAME+x} ]]; then
+        docker images | grep "${JOB_NAME}" | awk '{print $3}' | xargs -r docker rmi -f || true > /dev/null
+    fi
+    # Clean up dangling images generated in previous builds. Recent ones must be excluded
+    # because they might be being used in other builds running simultaneously.
+    docker image prune -f --filter "until=2h" || true > /dev/null
+
+    cd ${GIT_CHECKOUT_DIR}
+    VERSION="$CLUSTER" make
+    if [[ "$?" -ne "0" ]]; then
+        echo "=== Antrea Image build failed ==="
+        exit 1
+    fi
+
+    echo "=== Loading the Antrea image to each Node ==="
+    antrea_image="antrea-ubuntu"
+    DOCKER_IMG_VERSION=${CLUSTER}
+    docker save -o ${antrea_image}.tar antrea/antrea-ubuntu:${DOCKER_IMG_VERSION}
+
+    node_names=$(kubectl get nodes -o wide --no-headers=true | awk '{print $1}')
+    for node_name in ${node_names}; do
+        ${GCLOUD_PATH} compute scp ${antrea_image}.tar ubuntu@${node_name}:~ --zone ${GKE_ZONE}
+        ${GCLOUD_PATH} compute ssh ubuntu@${node_name} --command="sudo docker load -i ~/${antrea_image}.tar ; sudo docker tag antrea/antrea-ubuntu:${DOCKER_IMG_VERSION} antrea/antrea-ubuntu:latest" --zone ${GKE_ZONE}
+    done
+    rm ${antrea_image}.tar
 
     echo "=== Configuring Antrea for cluster ==="
-
     if [[ -n ${SVC_ACCOUNT_NAME+x} ]]; then
-        ${GCLOUD_PATH} projects add-iam-policy-binding $GKE_PROJECT --member serviceAccount:${SVC_ACCOUNT_NAME} --role roles/container.admin
+        ${GCLOUD_PATH} projects add-iam-policy-binding ${GKE_PROJECT} --member serviceAccount:${SVC_ACCOUNT_NAME} --role roles/container.admin
         kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user ${SVC_ACCOUNT_NAME}
     elif [[ -n ${USER_EMAIL+x} ]]; then
-        ${GCLOUD_PATH} projects add-iam-policy-binding $GKE_PROJECT --member user:${USER_EMAIL} --role roles/container.admin
+        ${GCLOUD_PATH} projects add-iam-policy-binding ${GKE_PROJECT} --member user:${USER_EMAIL} --role roles/container.admin
         kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user ${USER_EMAIL}
     else
         echo "Neither service account or user email info is set, cannot create cluster-admin-binding!"
@@ -188,9 +234,6 @@ function deliver_antrea_to_gke() {
         exit 1
     fi
 
-    if [[ -z ${GIT_CHECKOUT_DIR+x} ]]; then
-        GIT_CHECKOUT_DIR=..
-    fi
     kubectl apply -f ${GIT_CHECKOUT_DIR}/build/yamls/antrea-gke-node-init.yml
     sed -i "s|#defaultMTU: 1450|defaultMTU: 1500|g" ${GIT_CHECKOUT_DIR}/build/yamls/antrea-gke.yml
     sed -i "s|#serviceCIDR: 10.96.0.0/12|serviceCIDR: ${GKE_SERVICE_CIDR}|g" ${GIT_CHECKOUT_DIR}/build/yamls/antrea-gke.yml
@@ -203,7 +246,7 @@ function deliver_antrea_to_gke() {
 
     # Restart all Pods in all Namespaces (kube-system, etc) so they can be managed by Antrea.
     kubectl delete pods -n kube-system $(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork \
-                        --no-headers=true | grep '<none>' | awk '{ print $1 }')
+        --no-headers=true | grep '<none>' | awk '{ print $1 }')
     kubectl rollout status --timeout=2m deployment.apps/kube-dns -n kube-system
     # wait for other pods in the kube-system namespace to become ready
     sleep 5


### PR DESCRIPTION
This PR fixes #936.

The cloud e2e tests on Jenkins (AKS, EKS and GKE) now supports using arbitrary branch/commit of Antrea in any fork (defaults to upstream/master) for conformance test. A manual run of such test can be triggered by Jenkins admin.
Each job will now checkout the specified Antrea repo, build the Antrea image and load it to each cloud Node via ssh, before deploying corresponding Antrea yml.
All three cloud platforms have been manually tested and verified that the Antrea image run is the specified one.

Some minor changes:
- `<projectantrea-dev@googlegroups.com>` has been added to the notification list for each test job and cleanup job.
- Preview feature `Node Public IP` has been enabled in AKS for easier scp/ssh to the cluster Nodes when delivering Antrea image. https://docs.microsoft.com/en-us/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools-preview
- Default zone for GKE cluster has been changed from `us-west1` to `us-west1-a`, to get around the issue of figuring out which specific zone each Node is assigned when doing `gcloud compute ssh`.
- Default node machine type in GKE has been upgraded to `e2-standard-4`, since some instances of cpu shortage which prevented antrea controller to be scheduled are seen in test runs.