### PR TITLE
Update traceflow graph message for service destinations

### DIFF
--- a/pkg/apis/ops/v1alpha1/types.go
+++ b/pkg/apis/ops/v1alpha1/types.go
@@ -215,7 +215,7 @@ type Observation struct {
 	TTL int32 `json:"ttl,omitempty" yaml:"ttl,omitempty"`
 	// TranslatedSrcIP is the translated source IP.
 	TranslatedSrcIP string `json:"translatedSrcIP,omitempty" yaml:"translatedSrcIP,omitempty"`
-	// TranslatedSrcIP is the translated destination IP.
+	// TranslatedDstIP is the translated destination IP.
 	TranslatedDstIP string `json:"translatedDstIP,omitempty" yaml:"translatedDstIP,omitempty"`
 	// TunnelDstIP is the tunnel destination IP.
 	TunnelDstIP string `json:"tunnelDstIP,omitempty" yaml:"tunnelDstIP,omitempty"`


### PR DESCRIPTION
Add destination pod name & IP in load balancing stage when destination is a service. 

Example graph:
<img width="702" alt="tfgraph" src="https://user-images.githubusercontent.com/32829088/101740842-4fd1f580-3b04-11eb-8582-2b5458d0be56.png">
