### PR TITLE
fix ansible version check

### DIFF
--- a/test/e2e/infra/vagrant/playbook/roles/common/tasks/busybox.yml
+++ b/test/e2e/infra/vagrant/playbook/roles/common/tasks/busybox.yml
@@ -2,10 +2,10 @@
   docker_image:
     name: busybox:latest
     pull: yes
-  when: ansible_version.full < "2.8.0"
+  when: ansible_version.full is version_compare('2.8.0', '<')
 
 - name: Pull busybox:latest docker image (Ansible >= '2.8.0')
   docker_image:
     name: busybox:latest
     source: pull
-  when: ansible_version.full >= "2.8.0"
+  when: ansible_version.full is version_compare('2.8.0', '>=')

--- a/test/e2e/infra/vagrant/playbook/roles/common/tasks/main.yml
+++ b/test/e2e/infra/vagrant/playbook/roles/common/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: "Checking that Ansible version >= '2.4.0'"
   assert:
-    that: ansible_version.full >= "2.4.0"
+    that: ansible_version.full is version_compare('2.4.0', '>=')
 
 - import_tasks: base.yml
 


### PR DESCRIPTION
Using string comparsion may cause trouble in version check. For instance, I have `ansible 2.10.3` on my laptop and caused 

```
TASK [common : Checking that Ansible version >= '2.4.0'] ***********************
fatal: [k8s-node-master]: FAILED! => {
    "assertion": "ansible_version.full >= \"2.4.0\"",
    "changed": false,
    "evaluated_to": false,
    "msg": "Assertion failed"
}
```

when runing `./infra/vagrant/provision.sh`