### PR TITLE
Fix metrics flow parsing error caused by traceflow flows

### DIFF
--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -35,6 +35,7 @@ import (
 	secv1alpha1 "github.com/vmware-tanzu/antrea/pkg/apis/security/v1alpha1"
 	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
 	mocks "github.com/vmware-tanzu/antrea/pkg/ovs/openflow/testing"
+	ovsctltest "github.com/vmware-tanzu/antrea/pkg/ovs/ovsctl/testing"
 )
 
 var (
@@ -802,6 +803,98 @@ func TestParseMetricFlow(t *testing.T) {
 			require.Equal(t, tc.metric.Bytes, metric.Bytes)
 			require.Equal(t, tc.metric.Sessions, metric.Sessions)
 			require.Equal(t, tc.metric.Packets, metric.Packets)
+		})
+	}
+}
+
+func TestNetworkPolicyMetrics(t *testing.T) {
+	tests := []struct {
+		name         string
+		egressFlows  []string
+		ingressFlows []string
+		want         map[uint32]*types.RuleMetric
+	}{
+		{
+			name: "Normal flows",
+			egressFlows: []string{
+				"table=61, n_packets=1, n_bytes=74, priority=200,ct_state=+new,ct_label=0x200000000/0xffffffff00000000,ip actions=goto_table:70",
+				"table=61, n_packets=11, n_bytes=1661, priority=200,ct_state=-new,ct_label=0x200000000/0xffffffff00000000,ip actions=goto_table:70",
+				"table=61, n_packets=0, n_bytes=0, priority=200,ct_state=+new,ct_label=0x600000000/0xffffffff00000000,ip actions=goto_table:70",
+				"table=61, n_packets=0, n_bytes=0, priority=200,ct_state=-new,ct_label=0x600000000/0xffffffff00000000,ip actions=goto_table:70",
+				"table=61, n_packets=4, n_bytes=336, priority=200,reg0=0x100000/0x100000,reg3=0x4 actions=drop",
+				"table=61, n_packets=0, n_bytes=0, priority=200,reg0=0x100000/0x100000,reg3=0x8 actions=drop",
+				"table=61, n_packets=1502362, n_bytes=601635949, priority=0 actions=goto_table:70",
+			},
+			ingressFlows: []string{
+				"table=101, n_packets=1, n_bytes=74, priority=200,ct_state=+new,ct_label=0x1/0xffffffff,ip actions=resubmit(,105)",
+				"table=101, n_packets=11, n_bytes=1661, priority=200,ct_state=-new,ct_label=0x1/0xffffffff,ip actions=resubmit(,105)",
+				"table=101, n_packets=2, n_bytes=148, priority=200,ct_state=+new,ct_label=0x5/0xffffffff,ip actions=resubmit(,105)",
+				"table=101, n_packets=12, n_bytes=943, priority=200,ct_state=-new,ct_label=0x5/0xffffffff,ip actions=resubmit(,105)",
+				"table=101, n_packets=0, n_bytes=0, priority=200,reg0=0x100000/0x100000,reg3=0x3 actions=drop",
+				"table=101, n_packets=4, n_bytes=338, priority=200,reg0=0x100000/0x100000,reg3=0xb actions=drop",
+				"table=101, n_packets=1407190, n_bytes=509746586, priority=0 actions=resubmit(,105)",
+			},
+			want: map[uint32]*types.RuleMetric{
+				2:  {Bytes: 1735, Sessions: 1, Packets: 12},
+				6:  {Bytes: 0, Sessions: 0, Packets: 0},
+				4:  {Bytes: 336, Sessions: 4, Packets: 4},
+				8:  {Bytes: 0, Sessions: 0, Packets: 0},
+				1:  {Bytes: 1735, Sessions: 1, Packets: 12},
+				5:  {Bytes: 1091, Sessions: 2, Packets: 14},
+				3:  {Bytes: 0, Sessions: 0, Packets: 0},
+				11: {Bytes: 338, Sessions: 4, Packets: 4},
+			},
+		},
+		{
+			name: "Flows with traceflow flows",
+			egressFlows: []string{
+				"table=61, n_packets=0, n_bytes=0, hard_timeout=300, priority=202,ip,reg0=0x100000/0x100000,reg3=0x4,nw_tos=28 actions=controller(max_len=128,id=15768)",
+				"table=61, n_packets=0, n_bytes=0, hard_timeout=300, priority=202,ip,reg0=0x100000/0x100000,reg3=0x8,nw_tos=28 actions=controller(max_len=128,id=15768)",
+				"table=61, n_packets=1, n_bytes=74, priority=200,ct_state=+new,ct_label=0x200000000/0xffffffff00000000,ip actions=goto_table:70",
+				"table=61, n_packets=11, n_bytes=1661, priority=200,ct_state=-new,ct_label=0x200000000/0xffffffff00000000,ip actions=goto_table:70",
+				"table=61, n_packets=0, n_bytes=0, priority=200,ct_state=+new,ct_label=0x600000000/0xffffffff00000000,ip actions=goto_table:70",
+				"table=61, n_packets=0, n_bytes=0, priority=200,ct_state=-new,ct_label=0x600000000/0xffffffff00000000,ip actions=goto_table:70",
+				"table=61, n_packets=4, n_bytes=336, priority=200,reg0=0x100000/0x100000,reg3=0x4 actions=drop",
+				"table=61, n_packets=0, n_bytes=0, priority=200,reg0=0x100000/0x100000,reg3=0x8 actions=drop",
+				"table=61, n_packets=1502362, n_bytes=601635949, priority=0 actions=goto_table:70",
+			},
+			ingressFlows: []string{
+				"table=101, n_packets=0, n_bytes=0, hard_timeout=300, priority=202,ip,reg0=0x100000/0x100000,reg3=0x3,nw_tos=28 actions=controller(max_len=128,id=15768)",
+				"table=101, n_packets=0, n_bytes=0, hard_timeout=300, priority=202,ip,reg0=0x100000/0x100000,reg3=0xb,nw_tos=28 actions=controller(max_len=128,id=15768)",
+				"table=101, n_packets=1, n_bytes=74, priority=200,ct_state=+new,ct_label=0x1/0xffffffff,ip actions=resubmit(,105)",
+				"table=101, n_packets=11, n_bytes=1661, priority=200,ct_state=-new,ct_label=0x1/0xffffffff,ip actions=resubmit(,105)",
+				"table=101, n_packets=2, n_bytes=148, priority=200,ct_state=+new,ct_label=0x5/0xffffffff,ip actions=resubmit(,105)",
+				"table=101, n_packets=12, n_bytes=943, priority=200,ct_state=-new,ct_label=0x5/0xffffffff,ip actions=resubmit(,105)",
+				"table=101, n_packets=0, n_bytes=0, priority=200,reg0=0x100000/0x100000,reg3=0x3 actions=drop",
+				"table=101, n_packets=4, n_bytes=338, priority=200,reg0=0x100000/0x100000,reg3=0xb actions=drop",
+				"table=101, n_packets=1407190, n_bytes=509746586, priority=0 actions=resubmit(,105)",
+			},
+			want: map[uint32]*types.RuleMetric{
+				2:  {Bytes: 1735, Sessions: 1, Packets: 12},
+				6:  {Bytes: 0, Sessions: 0, Packets: 0},
+				4:  {Bytes: 336, Sessions: 4, Packets: 4},
+				8:  {Bytes: 0, Sessions: 0, Packets: 0},
+				1:  {Bytes: 1735, Sessions: 1, Packets: 12},
+				5:  {Bytes: 1091, Sessions: 2, Packets: 14},
+				3:  {Bytes: 0, Sessions: 0, Packets: 0},
+				11: {Bytes: 338, Sessions: 4, Packets: 4},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			c = prepareClient(ctrl)
+			mockOVSClient := ovsctltest.NewMockOVSCtlClient(ctrl)
+			c.ovsctlClient = mockOVSClient
+			gomock.InOrder(
+				mockOVSClient.EXPECT().DumpTableFlows(uint8(EgressMetricTable)).Return(tt.egressFlows, nil),
+				mockOVSClient.EXPECT().DumpTableFlows(uint8(IngressMetricTable)).Return(tt.ingressFlows, nil),
+			)
+			got := c.NetworkPolicyMetrics()
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow/cookie"
 	"github.com/vmware-tanzu/antrea/pkg/agent/types"
 	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
+	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsctl"
 	"github.com/vmware-tanzu/antrea/third_party/proxy"
 )
 
@@ -341,6 +342,8 @@ type client struct {
 	packetInHandlers map[uint8]map[string]PacketInHandler
 	// Supported IP Protocols (IP or IPv6) on the current Node.
 	ipProtocols []binding.Protocol
+	// ovsctlClient is the interface for executing OVS "ovs-ofctl" and "ovs-appctl" commands.
+	ovsctlClient ovsctl.OVSCtlClient
 }
 
 func (c *client) GetTunnelVirtualMAC() net.HardwareAddr {
@@ -1881,6 +1884,7 @@ func NewClient(bridgeName, mgmtAddr string, enableProxy, enableAntreaPolicy bool
 		groupCache:               sync.Map{},
 		globalConjMatchFlowCache: map[string]*conjMatchFlowContext{},
 		packetInHandlers:         map[uint8]map[string]PacketInHandler{},
+		ovsctlClient:             ovsctl.NewClient(bridgeName),
 	}
 	c.ofEntryOperations = c
 	if enableAntreaPolicy {


### PR DESCRIPTION
When traceflow is being executed, there are other flows in metrics
tables, causing the function parseMetricFlow panic. We should filter out
all other flows.

For #1614

Depends on #1606, otherwise unit test will fail.