### PR TITLE
Switch to VMware Harbor registry for Antrea Docker images

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -338,7 +338,7 @@ jobs:
     - uses: actions/checkout@v2
     - run: make
     - name: Save Antrea image to tarball
-      run:  docker save -o antrea-ubuntu.tar antrea/antrea-ubuntu:latest
+      run:  docker save -o antrea-ubuntu.tar projects.registry.vmware.com/antrea/antrea-ubuntu:latest
     - name: Upload Antrea image for subsequent jobs
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/kind_upgrade.yml
+++ b/.github/workflows/kind_upgrade.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v2
     - run: make
     - name: Save Antrea image to tarball
-      run:  docker save -o antrea-ubuntu.tar antrea/antrea-ubuntu:latest
+      run:  docker save -o antrea-ubuntu.tar projects.registry.vmware.com/antrea/antrea-ubuntu:latest
     - name: Upload Antrea image for subsequent jobs
       uses: actions/upload-artifact@v2
       with:

--- a/Makefile
+++ b/Makefile
@@ -252,6 +252,7 @@ ubuntu:
 	@echo "===> Building antrea/antrea-ubuntu Docker image <==="
 	docker build --pull -t antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.ubuntu .
 	docker tag antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) antrea/antrea-ubuntu
+	docker tag antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/antrea-ubuntu
 
 # Build bins in a golang container, and build the antrea-ubuntu Docker image.
 .PHONY: build-ubuntu
@@ -263,6 +264,7 @@ else
 	docker build --pull -t antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.ubuntu .
 endif
 	docker tag antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) antrea/antrea-ubuntu
+	docker tag antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/antrea-ubuntu
 
 .PHONY: build-windows
 build-windows:
@@ -273,6 +275,7 @@ else
 	docker build --pull -t antrea/antrea-windows:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.windows .
 endif
 	docker tag antrea/antrea-windows:$(DOCKER_IMG_VERSION) antrea/antrea-windows
+	docker tag antrea/antrea-windows:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/antrea-windows
 
 .PHONY: build-ubuntu-coverage
 build-ubuntu-coverage:
@@ -283,6 +286,7 @@ else
 	docker build --pull -t antrea/antrea-ubuntu-coverage:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.coverage .
 endif
 	docker tag antrea/antrea-ubuntu-coverage:$(DOCKER_IMG_VERSION) antrea/antrea-ubuntu-coverage
+	docker tag antrea/antrea-ubuntu-coverage:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/antrea-ubuntu-coverage
 
 .PHONY: manifest
 manifest:
@@ -305,6 +309,7 @@ octant-antrea-ubuntu:
 	@echo "===> Building antrea/octant-antrea-ubuntu Docker image <==="
 	docker build --pull -t antrea/octant-antrea-ubuntu:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.octant.ubuntu .
 	docker tag antrea/octant-antrea-ubuntu:$(DOCKER_IMG_VERSION) antrea/octant-antrea-ubuntu
+	docker tag antrea/octant-antrea-ubuntu:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/octant-antrea-ubuntu
 
 .PHONY: verify
 verify:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1337,7 +1337,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: antrea-controller
         ports:
@@ -1509,7 +1509,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -1570,7 +1570,7 @@ spec:
         - --log_file_max_num=4
         command:
         - start_ovs
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -1604,7 +1604,7 @@ spec:
       initContainers:
       - command:
         - install_cni_chaining
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: install-cni
         resources:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1337,7 +1337,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: antrea-controller
         ports:
@@ -1511,7 +1511,7 @@ spec:
               fieldPath: spec.nodeName
         - name: ANTREA_CLOUD_EKS
           value: "true"
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -1572,7 +1572,7 @@ spec:
         - --log_file_max_num=4
         command:
         - start_ovs
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -1606,7 +1606,7 @@ spec:
       initContainers:
       - command:
         - install_cni_chaining
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: install-cni
         resources:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1337,7 +1337,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: antrea-controller
         ports:
@@ -1509,7 +1509,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -1570,7 +1570,7 @@ spec:
         - --log_file_max_num=4
         command:
         - start_ovs
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -1604,7 +1604,7 @@ spec:
       initContainers:
       - command:
         - install_cni
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: install-cni
         resources:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1351,7 +1351,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: antrea-controller
         ports:
@@ -1528,7 +1528,7 @@ spec:
             secretKeyRef:
               key: psk
               name: antrea-ipsec
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -1589,7 +1589,7 @@ spec:
         - --log_file_max_num=4
         command:
         - start_ovs
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -1621,7 +1621,7 @@ spec:
           subPath: openvswitch
       - command:
         - start_ovs_ipsec
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -1653,7 +1653,7 @@ spec:
       initContainers:
       - command:
         - install_cni
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: install-cni
         resources:

--- a/build/yamls/antrea-octant.yml
+++ b/build/yamls/antrea-octant.yml
@@ -50,7 +50,7 @@ spec:
           value: "true"
         - name: KUBECONFIG
           value: /kube/admin.conf
-        image: antrea/octant-antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/octant-antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: antrea-octant
         ports:

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -130,7 +130,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: antrea/antrea-windows:latest
+        image: projects.registry.vmware.com/antrea/antrea-windows:latest
         imagePullPolicy: IfNotPresent
         name: antrea-agent
         volumeMounts:
@@ -151,7 +151,7 @@ spec:
         - /k/antrea/Install-WindowsCNI.ps1
         command:
         - pwsh
-        image: antrea/antrea-windows:latest
+        image: projects.registry.vmware.com/antrea/antrea-windows:latest
         imagePullPolicy: IfNotPresent
         name: install-cni
         volumeMounts:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1342,7 +1342,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: antrea-controller
         ports:
@@ -1514,7 +1514,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -1575,7 +1575,7 @@ spec:
         - --log_file_max_num=4
         command:
         - start_ovs
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -1609,7 +1609,7 @@ spec:
       initContainers:
       - command:
         - install_cni
-        image: antrea/antrea-ubuntu:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: install-cni
         resources:

--- a/build/yamls/patches/coverage/startAgentCov.yml
+++ b/build/yamls/patches/coverage/startAgentCov.yml
@@ -12,6 +12,3 @@ spec:
       - name: antrea-agent
         command: ["/bin/sh"]
         args: ["-c", "sleep 2; antrea-agent-coverage -test.run=TestBincoverRunMain -test.coverprofile=antrea-agent.cov.out -args-file=/agent-arg-file; while true; do sleep 5 & wait $!; done"]
-        image: antrea/antrea-ubuntu-coverage:latest
-      - name: antrea-ovs
-        image: antrea/antrea-ubuntu-coverage:latest

--- a/build/yamls/patches/coverage/startControllerCov.yml
+++ b/build/yamls/patches/coverage/startControllerCov.yml
@@ -9,4 +9,3 @@ spec:
         - command: ["/bin/sh"]
           args: ["-c", "antrea-controller-coverage -test.run=TestBincoverRunMain -test.coverprofile=antrea-controller.cov.out -args-file=/controller-arg-file; while true; do sleep 5 & wait $!; done"]
           name: antrea-controller
-          image: antrea/antrea-ubuntu-coverage:latest

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -299,7 +299,7 @@ function deliver_antrea {
     if [[ "$COVERAGE" == true ]]; then
         docker save -o antrea-ubuntu-coverage.tar antrea/antrea-ubuntu-coverage:${DOCKER_IMG_VERSION}
     else
-        docker save -o antrea-ubuntu.tar antrea/antrea-ubuntu:${DOCKER_IMG_VERSION}
+        docker save -o antrea-ubuntu.tar projects.registry.vmware.com/antrea/antrea-ubuntu:${DOCKER_IMG_VERSION}
     fi
 
     kubectl get nodes -o wide --no-headers=true | awk '$3 == "master" {print $6}' | while read master_ip; do

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -197,7 +197,7 @@ function deliver_antrea_windows {
     export_govc_env_var
 
     cp -f build/yamls/*.yml $WORKDIR
-    docker save -o antrea-ubuntu.tar antrea/antrea-ubuntu:latest
+    docker save -o antrea-ubuntu.tar projects.registry.vmware.com/antrea/antrea-ubuntu:latest
 
     echo "===== Deliver Antrea to Linux nodes ====="
     kubectl get nodes -o wide --no-headers=true | awk '$3 != "master" && $1 !~ /win/ {print $6}' | while read IP; do
@@ -240,7 +240,7 @@ function deliver_antrea_windows {
         elif [ "$TESTCASE" == "windows-conformance" ]; then
             if ! (test -f antrea-windows.tar.gz); then
                 ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "docker pull ${DOCKER_REGISTRY}/antrea/golang:1.15 && docker tag ${DOCKER_REGISTRY}/antrea/golang:1.15 golang:1.15"
-                ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "rm -rf antrea && git clone ${ghprbAuthorRepoGitUrl} antrea && cd antrea && git checkout $GIT_BRANCH && sed -i \"s|build/images/Dockerfile.build.windows .|build/images/Dockerfile.build.windows . --network host|g\" Makefile && DOCKER_REGISTRY=${DOCKER_REGISTRY} make build-windows && docker save -o antrea-windows.tar antrea/antrea-windows:latest && gzip -f antrea-windows.tar" || true
+                ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "rm -rf antrea && git clone ${ghprbAuthorRepoGitUrl} antrea && cd antrea && git checkout $GIT_BRANCH && sed -i \"s|build/images/Dockerfile.build.windows .|build/images/Dockerfile.build.windows . --network host|g\" Makefile && DOCKER_REGISTRY=${DOCKER_REGISTRY} make build-windows && docker save -o antrea-windows.tar projects.registry.vmware.com/antrea/antrea-windows:latest && gzip -f antrea-windows.tar" || true
                 for i in `seq 2`; do
                     timeout 2m scp -o StrictHostKeyChecking=no -T Administrator@${IP}:antrea/antrea-windows.tar.gz . && break
                 done
@@ -297,7 +297,7 @@ function deliver_antrea {
     done
 
     cp -f build/yamls/*.yml $WORKDIR
-    docker save -o antrea-ubuntu.tar antrea/antrea-ubuntu:latest
+    docker save -o antrea-ubuntu.tar projects.registry.vmware.com/antrea/antrea-ubuntu:latest
 
     kubectl get nodes -o wide --no-headers=true | awk '$3 != "master" {print $6}' | while read IP; do
         rsync -avr --progress --inplace -e "ssh -o StrictHostKeyChecking=no" antrea-ubuntu.tar jenkins@[${IP}]:${WORKDIR}/antrea-ubuntu.tar

--- a/ci/kind/kind-setup.sh
+++ b/ci/kind/kind-setup.sh
@@ -19,7 +19,7 @@
 # and docker bridge network connecting to worker Node.
 
 CLUSTER_NAME=""
-ANTREA_IMAGE="antrea/antrea-ubuntu:latest"
+ANTREA_IMAGE="projects.registry.vmware.com/antrea/antrea-ubuntu:latest"
 IMAGES=$ANTREA_IMAGE
 ANTREA_CNI=true
 POD_CIDR="10.10.0.0/16"

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -99,7 +99,7 @@ if $coverage; then
     manifest_args="$manifest_args --coverage"
     COMMON_IMAGES_LIST+=("antrea/antrea-ubuntu-coverage:latest")
 else
-    COMMON_IMAGES_LIST+=("antrea/antrea-ubuntu:latest")
+    COMMON_IMAGES_LIST+=("projects.registry.vmware.com/antrea/antrea-ubuntu:latest")
 fi
 printf -v COMMON_IMAGES "%s " "${COMMON_IMAGES_LIST[@]}"
 

--- a/ci/kind/test-upgrade-antrea.sh
+++ b/ci/kind/test-upgrade-antrea.sh
@@ -120,14 +120,14 @@ fi
 
 echo "Running upgrade test for tag $FROM_TAG"
 
-DOCKER_IMAGES=("busybox" "antrea/antrea-ubuntu:$FROM_TAG")
+DOCKER_IMAGES=("busybox" "projects.registry.vmware.com/antrea/antrea-ubuntu:$FROM_TAG")
 
 for img in "${DOCKER_IMAGES[@]}"; do
     echo "Pulling $img"
     docker pull $img > /dev/null
 done
 
-DOCKER_IMAGES+=("antrea/antrea-ubuntu:latest")
+DOCKER_IMAGES+=("projects.registry.vmware.com/antrea/antrea-ubuntu:latest")
 
 echo "Creating Kind cluster"
 IMAGES="${DOCKER_IMAGES[@]}"
@@ -150,7 +150,7 @@ export KUSTOMIZE=$ROOT_DIR/hack/.bin/kustomize
 TMP_ANTREA_DIR=$(mktemp -d)
 git clone --branch $FROM_TAG --depth 1 https://github.com/vmware-tanzu/antrea.git $TMP_ANTREA_DIR
 pushd $TMP_ANTREA_DIR > /dev/null
-export IMG_NAME=antrea/antrea-ubuntu
+export IMG_NAME=projects.registry.vmware.com/antrea/antrea-ubuntu
 export IMG_TAG=$FROM_TAG
 ./hack/generate-manifest.sh --mode release --kind | kubectl apply -f -
 ./hack/generate-manifest.sh --mode release --kind | docker exec -i kind-control-plane dd of=/root/antrea.yml

--- a/ci/test-conformance-aks.sh
+++ b/ci/test-conformance-aks.sh
@@ -210,7 +210,8 @@ function deliver_antrea_to_aks() {
 
     antrea_image="antrea-ubuntu"
     DOCKER_IMG_VERSION=${CLUSTER}
-    docker save -o ${antrea_image}.tar antrea/antrea-ubuntu:${DOCKER_IMG_VERSION}
+    DOCKER_IMG_NAME="projects.registry.vmware.com/antrea/antrea-ubuntu"
+    docker save -o ${antrea_image}.tar ${DOCKER_IMG_NAME}:${DOCKER_IMG_VERSION}
 
     CLUSTER_RESOURCE_GROUP=$(az aks show --resource-group ${RESOURCE_GROUP} --name ${CLUSTER} --query nodeResourceGroup -o tsv)
     SCALE_SET_NAME=$(az vmss list --resource-group ${CLUSTER_RESOURCE_GROUP} --query [0].name -o tsv)
@@ -225,7 +226,7 @@ function deliver_antrea_to_aks() {
 
     for IP in ${NODE_IPS}; do
         scp -o StrictHostKeyChecking=no -i ${SSH_PRIVATE_KEY_PATH} ${antrea_image}.tar azureuser@${IP}:~
-        ssh -o StrictHostKeyChecking=no -i ${SSH_PRIVATE_KEY_PATH} -n azureuser@${IP} "sudo docker load -i ~/${antrea_image}.tar ; sudo docker tag antrea/antrea-ubuntu:${DOCKER_IMG_VERSION} antrea/antrea-ubuntu:latest"
+        ssh -o StrictHostKeyChecking=no -i ${SSH_PRIVATE_KEY_PATH} -n azureuser@${IP} "sudo docker load -i ~/${antrea_image}.tar ; sudo docker tag ${DOCKER_IMG_NAME}:${DOCKER_IMG_VERSION} ${DOCKER_IMG_NAME}:latest"
     done
     rm ${antrea_image}.tar
 

--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -198,11 +198,12 @@ function deliver_antrea_to_eks() {
     echo "=== Loading the Antrea image to each Node ==="
     antrea_image="antrea-ubuntu"
     DOCKER_IMG_VERSION=${CLUSTER}
-    docker save -o ${antrea_image}.tar antrea/antrea-ubuntu:${DOCKER_IMG_VERSION}
+    DOCKER_IMG_NAME="projects.registry.vmware.com/antrea/antrea-ubuntu"
+    docker save -o ${antrea_image}.tar ${DOCKER_IMG_NAME}:${DOCKER_IMG_VERSION}
 
     kubectl get nodes -o wide --no-headers=true | awk '{print $7}' | while read IP; do
         scp -o StrictHostKeyChecking=no -i ${SSH_PRIVATE_KEY_PATH} ${antrea_image}.tar ec2-user@${IP}:~
-        ssh -o StrictHostKeyChecking=no -i ${SSH_PRIVATE_KEY_PATH} -n ec2-user@${IP} "sudo docker load -i ~/${antrea_image}.tar ; sudo docker tag antrea/antrea-ubuntu:${DOCKER_IMG_VERSION} antrea/antrea-ubuntu:latest"
+        ssh -o StrictHostKeyChecking=no -i ${SSH_PRIVATE_KEY_PATH} -n ec2-user@${IP} "sudo docker load -i ~/${antrea_image}.tar ; sudo docker tag ${DOCKER_IMG_NAME}:${DOCKER_IMG_VERSION} ${DOCKER_IMG_NAME}:latest"
     done
     rm ${antrea_image}.tar
 

--- a/ci/test-conformance-gke.sh
+++ b/ci/test-conformance-gke.sh
@@ -212,12 +212,13 @@ function deliver_antrea_to_gke() {
     echo "=== Loading the Antrea image to each Node ==="
     antrea_image="antrea-ubuntu"
     DOCKER_IMG_VERSION=${CLUSTER}
-    docker save -o ${antrea_image}.tar antrea/antrea-ubuntu:${DOCKER_IMG_VERSION}
+    DOCKER_IMG_NAME="projects.registry.vmware.com/antrea/antrea-ubuntu"
+    docker save -o ${antrea_image}.tar ${DOCKER_IMG_NAME}:${DOCKER_IMG_VERSION}
 
     node_names=$(kubectl get nodes -o wide --no-headers=true | awk '{print $1}')
     for node_name in ${node_names}; do
         ${GCLOUD_PATH} compute scp ${antrea_image}.tar ubuntu@${node_name}:~ --zone ${GKE_ZONE}
-        ${GCLOUD_PATH} compute ssh ubuntu@${node_name} --command="sudo docker load -i ~/${antrea_image}.tar ; sudo docker tag antrea/antrea-ubuntu:${DOCKER_IMG_VERSION} antrea/antrea-ubuntu:latest" --zone ${GKE_ZONE}
+        ${GCLOUD_PATH} compute ssh ubuntu@${node_name} --command="sudo docker load -i ~/${antrea_image}.tar ; sudo docker tag ${DOCKER_IMG_NAME}:${DOCKER_IMG_VERSION} ${DOCKER_IMG_NAME}:latest" --zone ${GKE_ZONE}
     done
     rm ${antrea_image}.tar
 

--- a/docs/kind.md
+++ b/docs/kind.md
@@ -65,14 +65,14 @@ kind create cluster --config kind-config.yml
 
 ### Deploy Antrea to your Kind cluster
 
-These instructions assume that you have built the `antrea/antrea-ubuntu` Docker
-image locally (e.g. by running `make` from the root of the repository).
+These instructions assume that you have built the Antrea Docker image locally
+(e.g. by running `make` from the root of the repository).
 
 ```bash
 # "fix" the host's veth interfaces (for the different Kind Nodes)
 kind get nodes | xargs ./hack/kind-fix-networking.sh
 # load the Antrea Docker image in the Nodes
-kind load docker-image antrea/antrea-ubuntu:latest
+kind load docker-image projects.registry.vmware.com/antrea/antrea-ubuntu:latest
 # deploy Antrea
 ./hack/generate-manifest.sh --kind | kubectl apply -f -
 ```

--- a/hack/generate-manifest-octant.sh
+++ b/hack/generate-manifest-octant.sh
@@ -114,7 +114,7 @@ $KUSTOMIZE edit add base $BASE
 find ../../patches/$MODE -name \*.yml -exec cp {} . \;
 
 if [ "$MODE" == "dev" ]; then
-    $KUSTOMIZE edit set image octant-antrea=antrea/octant-antrea-ubuntu:latest
+    $KUSTOMIZE edit set image octant-antrea=projects.registry.vmware.com/antrea/octant-antrea-ubuntu:latest
     $KUSTOMIZE edit add patch imagePullPolicy.yml
 fi
 

--- a/hack/generate-manifest-windows.sh
+++ b/hack/generate-manifest-windows.sh
@@ -113,7 +113,7 @@ $KUSTOMIZE edit add base $BASE
 find ../../patches/$MODE -name \*.yml -exec cp {} . \;
 
 if [ "$MODE" == "dev" ]; then
-    $KUSTOMIZE edit set image antrea-windows=antrea/antrea-windows:latest
+    $KUSTOMIZE edit set image antrea-windows=projects.registry.vmware.com/antrea/antrea-windows:latest
     $KUSTOMIZE edit add patch imagePullPolicy.yml
 fi
 

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -353,7 +353,7 @@ $KUSTOMIZE edit add base $BASE
 find ../../patches/$MODE -name \*.yml -exec cp {} . \;
 
 if [ "$MODE" == "dev" ]; then
-    $KUSTOMIZE edit set image antrea=antrea/antrea-ubuntu:latest
+    $KUSTOMIZE edit set image antrea=projects.registry.vmware.com/antrea/antrea-ubuntu:latest
     $KUSTOMIZE edit add patch agentImagePullPolicy.yml
     $KUSTOMIZE edit add patch controllerImagePullPolicy.yml
     if $VERBOSE_LOG; then

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -353,7 +353,11 @@ $KUSTOMIZE edit add base $BASE
 find ../../patches/$MODE -name \*.yml -exec cp {} . \;
 
 if [ "$MODE" == "dev" ]; then
-    $KUSTOMIZE edit set image antrea=projects.registry.vmware.com/antrea/antrea-ubuntu:latest
+    if $COVERAGE; then
+        $KUSTOMIZE edit set image antrea=antrea/antrea-ubuntu-coverage:latest
+    else
+        $KUSTOMIZE edit set image antrea=projects.registry.vmware.com/antrea/antrea-ubuntu:latest
+    fi
     $KUSTOMIZE edit add patch agentImagePullPolicy.yml
     $KUSTOMIZE edit add patch controllerImagePullPolicy.yml
     if $VERBOSE_LOG; then

--- a/hack/netpol/test-kind.sh
+++ b/hack/netpol/test-kind.sh
@@ -14,7 +14,7 @@ echo "===> Creating Kind cluster <==="
 
 kind create cluster --config $KIND_CONFIG
 kind get nodes | xargs $ROOT_DIR/hack/kind-fix-networking.sh
-kind load docker-image antrea/antrea-ubuntu:latest
+kind load docker-image projects.registry.vmware.com/antrea/antrea-ubuntu:latest
 kind load docker-image antrea/netpol:latest
 # pre-load the test container image on all the Nodes
 docker pull antrea/netpol-test

--- a/hack/release/prepare-assets.sh
+++ b/hack/release/prepare-assets.sh
@@ -64,7 +64,7 @@ sed "s/AntreaVersion=\"latest\"/AntreaVersion=\"$VERSION\"/" ./hack/windows/Star
 
 export IMG_TAG=$VERSION
 
-export IMG_NAME=antrea/antrea-ubuntu
+export IMG_NAME=projects.registry.vmware.com/antrea/antrea-ubuntu
 ./hack/generate-manifest.sh --mode release > "$OUTPUT_DIR"/antrea.yml
 ./hack/generate-manifest.sh --mode release --ipsec > "$OUTPUT_DIR"/antrea-ipsec.yml
 ./hack/generate-manifest.sh --mode release --cloud EKS --encap-mode networkPolicyOnly > "$OUTPUT_DIR"/antrea-eks.yml
@@ -72,10 +72,10 @@ export IMG_NAME=antrea/antrea-ubuntu
 ./hack/generate-manifest.sh --mode release --cloud AKS --encap-mode networkPolicyOnly > "$OUTPUT_DIR"/antrea-aks.yml
 ./hack/generate-manifest.sh --mode release --kind > "$OUTPUT_DIR"/antrea-kind.yml
 
-export IMG_NAME=antrea/octant-antrea-ubuntu
+export IMG_NAME=projects.registry.vmware.com/antrea/octant-antrea-ubuntu
 ./hack/generate-manifest-octant.sh --mode release > "$OUTPUT_DIR"/antrea-octant.yml
 
-export IMG_NAME=antrea/antrea-windows
+export IMG_NAME=projects.registry.vmware.com/antrea/antrea-windows
 ./hack/generate-manifest-windows.sh --mode release > "$OUTPUT_DIR"/antrea-windows.yml
 
 ls "$OUTPUT_DIR" | cat

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -42,14 +42,14 @@ messages.
 
 #### Managing the cluster
 
-Use the following Bash scripts to manage the Kubernetes nodes with Vagrant:
+Use the following Bash scripts to manage the Kubernetes Nodes with Vagrant:
 
 * `./infra/vagrant/provision.sh`: create the required VMs and provision them
-* `./infra/vagrant/push_antrea.sh`: load the antrea/antrea-ubuntu Docker image
-  to each node, along with the Antrea deployment YAML
-* `./infra/vagrant/suspend.sh`: suspend all node VMs
-* `./infra/vagrant/resume.sh`: resume all node VMs
-* `./infra/vagrant/destroy.sh`: destoy all node VMs, you will need to run
+* `./infra/vagrant/push_antrea.sh`: load Antrea Docker image to each Node, along
+  with the Antrea deployment YAML
+* `./infra/vagrant/suspend.sh`: suspend all Node VMs
+* `./infra/vagrant/resume.sh`: resume all Node VMs
+* `./infra/vagrant/destroy.sh`: destoy all Node VMs, you will need to run
   `provision.sh` again to create a new cluster
 
 Note that `./infra/vagrant/provision.sh` can take a while to complete but it
@@ -160,7 +160,7 @@ then make the code changes on the local repo and
 You can load the new image into the kind cluster using the command below:
 
 ```bash
-kind load docker-image antrea/antrea-ubuntu:latest --name <kind_cluster_name>
+kind load docker-image projects.registry.vmware.com/antrea/antrea-ubuntu:latest --name <kind_cluster_name>
 ```
 
 ## Running the performance test

--- a/test/e2e/infra/vagrant/push_antrea.sh
+++ b/test/e2e/infra/vagrant/push_antrea.sh
@@ -24,7 +24,7 @@ done
 
 : "${NUM_WORKERS:=1}"
 SAVED_IMG=/tmp/antrea-ubuntu.tar
-IMG_NAME=antrea/antrea-ubuntu:latest
+IMG_NAME=projects.registry.vmware.com/antrea/antrea-ubuntu:latest
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 


### PR DESCRIPTION
All "user-facing" images (antrea/antrea-ubuntu, antrea/antrea-windows,
antrea/octant-antrea-ubuntu) are now pulled from the VMware Harbor
distribution registry (projects.registry.vmware.com) to avoid Docker
pull rate limiting.

The YAML manifests (top-of-tree and releases) now refer to the new
registry.

This is not a complete transition from Dockerhub to Harbor. Images used
for build purposes (e.g. antrea/openvswitch) are still pulled from
Dockerhub by default. Rate limiting is not as much of an issue for these
(not user-facing, Github workflows are not subject to rate limiting, we
have workarounds for the Jenkins CI jobs). One thing to keep is mind is
that we cannot push to the VMware Harbor registry from outside of the
the VMware corporate network. This is why all images are pushed to
the Dockerhub registry, which is then mirrored by the distribution
Harbor registry.

See #1555