### PR TITLE
Fix next table decision of l2ForwardingCalcTable

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -338,7 +338,7 @@ func (c *client) InstallPodFlows(interfaceName string, podInterfaceIPs []net.IP,
 	localGatewayMAC := c.nodeConfig.GatewayConfig.MAC
 	flows := []binding.Flow{
 		c.podClassifierFlow(ofPort, cookie.Pod),
-		c.l2ForwardCalcFlow(podInterfaceMAC, ofPort, cookie.Pod),
+		c.l2ForwardCalcFlow(podInterfaceMAC, ofPort, false, cookie.Pod),
 	}
 
 	// Add support for IPv4 ARP responder.
@@ -516,7 +516,7 @@ func (c *client) InstallGatewayFlows() error {
 
 	flows := []binding.Flow{
 		c.gatewayClassifierFlow(cookie.Default),
-		c.l2ForwardCalcFlow(gatewayConfig.MAC, config.HostGatewayOFPort, cookie.Default),
+		c.l2ForwardCalcFlow(gatewayConfig.MAC, config.HostGatewayOFPort, true, cookie.Default),
 	}
 	flows = append(flows, c.gatewayIPSpoofGuardFlows(cookie.Default)...)
 
@@ -547,7 +547,7 @@ func (c *client) InstallGatewayFlows() error {
 func (c *client) InstallDefaultTunnelFlows() error {
 	flows := []binding.Flow{
 		c.tunnelClassifierFlow(config.DefaultTunOFPort, cookie.Default),
-		c.l2ForwardCalcFlow(globalVirtualMAC, config.DefaultTunOFPort, cookie.Default),
+		c.l2ForwardCalcFlow(globalVirtualMAC, config.DefaultTunOFPort, true, cookie.Default),
 	}
 	if err := c.ofEntryOperations.AddAll(flows); err != nil {
 		return err

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -689,12 +689,11 @@ func (c *client) serviceLBBypassFlow(ipProtocol binding.Protocol) binding.Flow {
 }
 
 // l2ForwardCalcFlow generates the flow that matches dst MAC and loads ofPort to reg.
-func (c *client) l2ForwardCalcFlow(dstMAC net.HardwareAddr, ofPort uint32, category cookie.Category) binding.Flow {
+func (c *client) l2ForwardCalcFlow(dstMAC net.HardwareAddr, ofPort uint32, skipIngressRules bool, category cookie.Category) binding.Flow {
 	l2FwdCalcTable := c.pipeline[l2ForwardingCalcTable]
-	// Skip ingress NetworkPolicy enforcement for traffic to the tunnel or
-	// gateway interface.
 	nextTable := l2FwdCalcTable.GetNext()
-	if ofPort != config.DefaultTunOFPort && ofPort != config.HostGatewayOFPort {
+	if !skipIngressRules {
+		// Go to ingress NetworkPolicy tables for traffic to local Pods.
 		nextTable = c.ingressEntryTable
 	}
 	return l2FwdCalcTable.BuildFlow(priorityNormal).


### PR DESCRIPTION
Before the commit, ofPort number is used to decide whether NetworkPolicy
ingress tables should be bypassed after l2ForwardingCalcTable - when
the output ofPort is DefaultTunOFPort or HostGatewayOFPort, the flow
will go to conntrackCommitTable and such bypass the ingress rule tables.
However, in the noEncap and networkPolicyOnly modes, the default tunnel
port is not created on the bridge, and DefaultTunOFPort can be used by
a Pod's OVS port, so the implementation might mistakenly bypass ingress
rule enforcement for traffic to the Pod.
This commit fixes the problem by letting the callers decide whether or
not to bypass ingress rule tables.