### PR TITLE
[Flow-Aggregator] Agent side changes for Flow Aggregator

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1200,11 +1200,15 @@ data:
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
     #enablePrometheusMetrics: true
 
-    # Provide flow collector address as string with format <IP>:<port>[:<proto>], where proto is tcp or udp.
-    # IP can be either IPv4 or IPv6. However, IPv6 address should be wrapped with [].
-    # This also enables the flow exporter that sends IPFIX flow records of conntrack flows on OVS bridge.
-    # If no L4 transport proto is given, we consider tcp as default.
-    #flowCollectorAddr: ""
+    # Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
+    # HOST can either be the DNS name or the IP of the Flow Collector. For example,
+    # "flow-aggregator.flow-aggregator.svc" can be provided as DNS name to connect
+    # to the Antrea Flow Aggregator service. If IP, it can be either IPv4 or IPv6.
+    # However, IPv6 address should be wrapped with [].
+    # If PORT is empty, we default to 4739, the standard IPFIX port.
+    # If no PROTO is given, we consider "tcp" as default. We support "tcp" and "udp"
+    # L4 transport protocols.
+    #flowCollectorAddr: "flow-aggregator.flow-aggregator.svc:tcp"
 
     # Provide flow poll interval as a duration string. This determines how often the flow exporter dumps connections from the conntrack module.
     # Flow poll interval should be greater than or equal to 1s (one second).
@@ -1271,7 +1275,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-mdmtkcfh59
+  name: antrea-config-tkk482c56m
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1378,7 +1382,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-mdmtkcfh59
+          name: antrea-config-tkk482c56m
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1600,6 +1604,7 @@ spec:
         - mountPath: /var/log/openvswitch
           name: host-var-log-antrea
           subPath: openvswitch
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       initContainers:
       - command:
@@ -1642,7 +1647,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-mdmtkcfh59
+          name: antrea-config-tkk482c56m
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1200,11 +1200,15 @@ data:
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
     #enablePrometheusMetrics: true
 
-    # Provide flow collector address as string with format <IP>:<port>[:<proto>], where proto is tcp or udp.
-    # IP can be either IPv4 or IPv6. However, IPv6 address should be wrapped with [].
-    # This also enables the flow exporter that sends IPFIX flow records of conntrack flows on OVS bridge.
-    # If no L4 transport proto is given, we consider tcp as default.
-    #flowCollectorAddr: ""
+    # Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
+    # HOST can either be the DNS name or the IP of the Flow Collector. For example,
+    # "flow-aggregator.flow-aggregator.svc" can be provided as DNS name to connect
+    # to the Antrea Flow Aggregator service. If IP, it can be either IPv4 or IPv6.
+    # However, IPv6 address should be wrapped with [].
+    # If PORT is empty, we default to 4739, the standard IPFIX port.
+    # If no PROTO is given, we consider "tcp" as default. We support "tcp" and "udp"
+    # L4 transport protocols.
+    #flowCollectorAddr: "flow-aggregator.flow-aggregator.svc:tcp"
 
     # Provide flow poll interval as a duration string. This determines how often the flow exporter dumps connections from the conntrack module.
     # Flow poll interval should be greater than or equal to 1s (one second).
@@ -1271,7 +1275,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-mdmtkcfh59
+  name: antrea-config-tkk482c56m
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1378,7 +1382,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-mdmtkcfh59
+          name: antrea-config-tkk482c56m
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1602,6 +1606,7 @@ spec:
         - mountPath: /var/log/openvswitch
           name: host-var-log-antrea
           subPath: openvswitch
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       initContainers:
       - command:
@@ -1644,7 +1649,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-mdmtkcfh59
+          name: antrea-config-tkk482c56m
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1200,11 +1200,15 @@ data:
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
     #enablePrometheusMetrics: true
 
-    # Provide flow collector address as string with format <IP>:<port>[:<proto>], where proto is tcp or udp.
-    # IP can be either IPv4 or IPv6. However, IPv6 address should be wrapped with [].
-    # This also enables the flow exporter that sends IPFIX flow records of conntrack flows on OVS bridge.
-    # If no L4 transport proto is given, we consider tcp as default.
-    #flowCollectorAddr: ""
+    # Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
+    # HOST can either be the DNS name or the IP of the Flow Collector. For example,
+    # "flow-aggregator.flow-aggregator.svc" can be provided as DNS name to connect
+    # to the Antrea Flow Aggregator service. If IP, it can be either IPv4 or IPv6.
+    # However, IPv6 address should be wrapped with [].
+    # If PORT is empty, we default to 4739, the standard IPFIX port.
+    # If no PROTO is given, we consider "tcp" as default. We support "tcp" and "udp"
+    # L4 transport protocols.
+    #flowCollectorAddr: "flow-aggregator.flow-aggregator.svc:tcp"
 
     # Provide flow poll interval as a duration string. This determines how often the flow exporter dumps connections from the conntrack module.
     # Flow poll interval should be greater than or equal to 1s (one second).
@@ -1271,7 +1275,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-b5dkk776t2
+  name: antrea-config-ccm9d925m4
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1378,7 +1382,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-b5dkk776t2
+          name: antrea-config-ccm9d925m4
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1600,6 +1604,7 @@ spec:
         - mountPath: /var/log/openvswitch
           name: host-var-log-antrea
           subPath: openvswitch
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       initContainers:
       - command:
@@ -1642,7 +1647,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-b5dkk776t2
+          name: antrea-config-ccm9d925m4
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1205,11 +1205,15 @@ data:
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
     #enablePrometheusMetrics: true
 
-    # Provide flow collector address as string with format <IP>:<port>[:<proto>], where proto is tcp or udp.
-    # IP can be either IPv4 or IPv6. However, IPv6 address should be wrapped with [].
-    # This also enables the flow exporter that sends IPFIX flow records of conntrack flows on OVS bridge.
-    # If no L4 transport proto is given, we consider tcp as default.
-    #flowCollectorAddr: ""
+    # Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
+    # HOST can either be the DNS name or the IP of the Flow Collector. For example,
+    # "flow-aggregator.flow-aggregator.svc" can be provided as DNS name to connect
+    # to the Antrea Flow Aggregator service. If IP, it can be either IPv4 or IPv6.
+    # However, IPv6 address should be wrapped with [].
+    # If PORT is empty, we default to 4739, the standard IPFIX port.
+    # If no PROTO is given, we consider "tcp" as default. We support "tcp" and "udp"
+    # L4 transport protocols.
+    #flowCollectorAddr: "flow-aggregator.flow-aggregator.svc:tcp"
 
     # Provide flow poll interval as a duration string. This determines how often the flow exporter dumps connections from the conntrack module.
     # Flow poll interval should be greater than or equal to 1s (one second).
@@ -1276,7 +1280,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-6kg9kdbg49
+  name: antrea-config-mcfc2b62gk
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1392,7 +1396,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-6kg9kdbg49
+          name: antrea-config-mcfc2b62gk
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1649,6 +1653,7 @@ spec:
         - mountPath: /var/log/strongswan
           name: host-var-log-antrea
           subPath: strongswan
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       initContainers:
       - command:
@@ -1691,7 +1696,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-6kg9kdbg49
+          name: antrea-config-mcfc2b62gk
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1205,11 +1205,15 @@ data:
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
     #enablePrometheusMetrics: true
 
-    # Provide flow collector address as string with format <IP>:<port>[:<proto>], where proto is tcp or udp.
-    # IP can be either IPv4 or IPv6. However, IPv6 address should be wrapped with [].
-    # This also enables the flow exporter that sends IPFIX flow records of conntrack flows on OVS bridge.
-    # If no L4 transport proto is given, we consider tcp as default.
-    #flowCollectorAddr: ""
+    # Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
+    # HOST can either be the DNS name or the IP of the Flow Collector. For example,
+    # "flow-aggregator.flow-aggregator.svc" can be provided as DNS name to connect
+    # to the Antrea Flow Aggregator service. If IP, it can be either IPv4 or IPv6.
+    # However, IPv6 address should be wrapped with [].
+    # If PORT is empty, we default to 4739, the standard IPFIX port.
+    # If no PROTO is given, we consider "tcp" as default. We support "tcp" and "udp"
+    # L4 transport protocols.
+    #flowCollectorAddr: "flow-aggregator.flow-aggregator.svc:tcp"
 
     # Provide flow poll interval as a duration string. This determines how often the flow exporter dumps connections from the conntrack module.
     # Flow poll interval should be greater than or equal to 1s (one second).
@@ -1276,7 +1280,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-669cb7d7kt
+  name: antrea-config-5c77mt4c28
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1383,7 +1387,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-669cb7d7kt
+          name: antrea-config-5c77mt4c28
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1605,6 +1609,7 @@ spec:
         - mountPath: /var/log/openvswitch
           name: host-var-log-antrea
           subPath: openvswitch
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       initContainers:
       - command:
@@ -1647,7 +1652,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-669cb7d7kt
+          name: antrea-config-5c77mt4c28
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/agent.yml
+++ b/build/yamls/base/agent.yml
@@ -17,6 +17,7 @@ spec:
         component: antrea-agent
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       priorityClassName: system-node-critical
       tolerations:
         # Mark it as a critical add-on.

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -89,11 +89,15 @@ featureGates:
 # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
 #enablePrometheusMetrics: true
 
-# Provide flow collector address as string with format <IP>:<port>[:<proto>], where proto is tcp or udp.
-# IP can be either IPv4 or IPv6. However, IPv6 address should be wrapped with [].
-# This also enables the flow exporter that sends IPFIX flow records of conntrack flows on OVS bridge.
-# If no L4 transport proto is given, we consider tcp as default.
-#flowCollectorAddr: ""
+# Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
+# HOST can either be the DNS name or the IP of the Flow Collector. For example,
+# "flow-aggregator.flow-aggregator.svc" can be provided as DNS name to connect
+# to the Antrea Flow Aggregator service. If IP, it can be either IPv4 or IPv6.
+# However, IPv6 address should be wrapped with [].
+# If PORT is empty, we default to 4739, the standard IPFIX port.
+# If no PROTO is given, we consider "tcp" as default. We support "tcp" and "udp"
+# L4 transport protocols.
+#flowCollectorAddr: "flow-aggregator.flow-aggregator.svc:tcp"
 
 # Provide flow poll interval as a duration string. This determines how often the flow exporter dumps connections from the conntrack module.
 # Flow poll interval should be greater than or equal to 1s (one second).

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -324,7 +324,7 @@ func run(o *Options) error {
 			o.config.FlowExportFrequency,
 			v4Enabled,
 			v6Enabled)
-		go wait.Until(func() { flowExporter.Export(o.flowCollector, stopCh, pollDone) }, 0, stopCh)
+		go wait.Until(func() { flowExporter.Export(o.flowCollectorAddr, o.flowCollectorProto, stopCh, pollDone) }, 0, stopCh)
 	}
 
 	<-stopCh

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -101,10 +101,15 @@ type AgentConfig struct {
 	// Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener
 	// Defaults to true.
 	EnablePrometheusMetrics bool `yaml:"enablePrometheusMetrics,omitempty"`
-	// Provide the flow collector address as string with format <IP>:<port>[:<proto>], where proto is tcp or udp. This also
-	// enables the flow exporter that sends IPFIX flow records of conntrack flows on OVS bridge. If no L4 transport proto
-	// is given, we consider tcp as default.
-	// Defaults to "".
+	// Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
+	// HOST can either be the DNS name or the IP of the Flow Collector. For example,
+	// "flow-aggregator.flow-aggregator.svc" can be provided as DNS name to connect
+	// to the Antrea Flow Aggregator service. If IP, it can be either IPv4 or IPv6.
+	// However, IPv6 address should be wrapped with [].
+	// If PORT is empty, we default to 4739, the standard IPFIX port.
+	// If no PROTO is given, we consider "tcp" as default. We support "tcp" and
+	// "udp" L4 transport protocols.
+	// Defaults to "flow-aggregator.flow-aggregator.svc:4739:tcp".
 	FlowCollectorAddr string `yaml:"flowCollectorAddr,omitempty"`
 	// Provide flow poll interval in format "0s". This determines how often flow exporter dumps connections in conntrack module.
 	// Flow poll interval should be greater than or equal to 1s(one second).

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -33,13 +33,16 @@ import (
 )
 
 const (
-	defaultOVSBridge           = "br-int"
-	defaultHostGateway         = "antrea-gw0"
-	defaultHostProcPathPrefix  = "/host"
-	defaultServiceCIDR         = "10.96.0.0/12"
-	defaultTunnelType          = ovsconfig.GeneveTunnel
-	defaultFlowPollInterval    = 5 * time.Second
-	defaultFlowExportFrequency = 12
+	defaultOVSBridge              = "br-int"
+	defaultHostGateway            = "antrea-gw0"
+	defaultHostProcPathPrefix     = "/host"
+	defaultServiceCIDR            = "10.96.0.0/12"
+	defaultTunnelType             = ovsconfig.GeneveTunnel
+	defaultFlowCollectorAddress   = "flow-aggregator.flow-aggregator.svc:4739:tcp"
+	defaultFlowCollectorTransport = "tcp"
+	defaultFlowCollectorPort      = "4739"
+	defaultFlowPollInterval       = 5 * time.Second
+	defaultFlowExportFrequency    = 12
 )
 
 type Options struct {
@@ -47,8 +50,10 @@ type Options struct {
 	configFile string
 	// The configuration object
 	config *AgentConfig
-	// IPFIX flow collector
-	flowCollector net.Addr
+	// IPFIX flow collector address
+	flowCollectorAddr string
+	// IPFIX flow collector L4 protocol
+	flowCollectorProto string
 	// Flow exporter poll interval
 	pollInterval time.Duration
 }
@@ -179,6 +184,9 @@ func (o *Options) setDefaults() {
 	}
 
 	if o.config.FeatureGates[string(features.FlowExporter)] {
+		if o.config.FlowCollectorAddr == "" {
+			o.config.FlowCollectorAddr = defaultFlowCollectorAddress
+		}
 		if o.config.FlowPollInterval == "" {
 			o.pollInterval = defaultFlowPollInterval
 		}
@@ -191,54 +199,43 @@ func (o *Options) setDefaults() {
 
 func (o *Options) validateFlowExporterConfig() error {
 	if features.DefaultFeatureGate.Enabled(features.FlowExporter) {
-		if o.config.FlowCollectorAddr == "" {
-			return fmt.Errorf("IPFIX flow collector address should be provided")
-		} else {
-			// Check if it is TCP or UDP
-			strSlice, err := parseFlowCollectorAddr(o.config.FlowCollectorAddr)
-			if err != nil {
-				return err
-			}
-			var proto string
-			if len(strSlice) == 2 {
-				// If no separator ":" and proto is given, then default to TCP.
-				proto = "tcp"
-			} else if len(strSlice) > 2 {
-				if (strSlice[2] != "udp") && (strSlice[2] != "tcp") {
-					return fmt.Errorf("IPFIX flow collector over %s proto is not supported", strSlice[2])
-				}
-				proto = strSlice[2]
-			} else {
-				return fmt.Errorf("IPFIX flow collector is given in invalid format")
-			}
-
-			// Convert the string input in net.Addr format
-			hostPortAddr := strSlice[0] + ":" + strSlice[1]
-			_, _, err = net.SplitHostPort(hostPortAddr)
-			if err != nil {
-				return fmt.Errorf("IPFIX flow collector is given in invalid format: %v", err)
-			}
-			if proto == "udp" {
-				o.flowCollector, err = net.ResolveUDPAddr("udp", hostPortAddr)
-				if err != nil {
-					return fmt.Errorf("IPFIX flow collector over UDP proto cannot be resolved: %v", err)
-				}
-			} else {
-				o.flowCollector, err = net.ResolveTCPAddr("tcp", hostPortAddr)
-				if err != nil {
-					return fmt.Errorf("IPFIX flow collector over TCP proto cannot be resolved: %v", err)
-				}
-			}
+		var host, port, proto string
+		strSlice, err := parseFlowCollectorAddr(o.config.FlowCollectorAddr)
+		if err != nil {
+			return err
 		}
-		if o.config.FlowPollInterval != "" {
-			var err error
-			o.pollInterval, err = time.ParseDuration(o.config.FlowPollInterval)
-			if err != nil {
-				return fmt.Errorf("FlowPollInterval is not provided in right format: %v", err)
+		if len(strSlice) == 3 {
+			host = strSlice[0]
+			if strSlice[1] == "" {
+				port = defaultFlowCollectorPort
+			} else {
+				port = strSlice[1]
 			}
-			if o.pollInterval < time.Second {
-				return fmt.Errorf("FlowPollInterval should be greater than or equal to one second")
+			if (strSlice[2] != "udp") && (strSlice[2] != "tcp") {
+				return fmt.Errorf("connection over %s transport proto is not supported", strSlice[2])
 			}
+			proto = strSlice[2]
+		} else if len(strSlice) == 2 {
+			host = strSlice[0]
+			port = strSlice[1]
+			proto = defaultFlowCollectorTransport
+		} else if len(strSlice) == 1 {
+			host = strSlice[0]
+			port = defaultFlowCollectorPort
+			proto = defaultFlowCollectorTransport
+		} else {
+			return fmt.Errorf("flow collector address is given in invalid format")
+		}
+		o.flowCollectorAddr = net.JoinHostPort(host, port)
+		o.flowCollectorProto = proto
+
+		// Parse the given flowPollInterval config
+		o.pollInterval, err = time.ParseDuration(o.config.FlowPollInterval)
+		if err != nil {
+			return fmt.Errorf("FlowPollInterval is not provided in right format")
+		}
+		if o.pollInterval < time.Second {
+			return fmt.Errorf("FlowPollInterval should be greater than or equal to one second")
 		}
 	}
 	return nil

--- a/cmd/antrea-agent/options_test.go
+++ b/cmd/antrea-agent/options_test.go
@@ -28,9 +28,12 @@ func TestOptions_validateFlowExporterConfig(t *testing.T) {
 		{collector: "192.168.1.100:2002:tcp", pollInterval: "5s", expCollectorNet: "tcp", expCollectorStr: "192.168.1.100:2002", expPollIntervalStr: "5s", expError: nil},
 		{collector: "192.168.1.100:2002:udp", pollInterval: "5s", expCollectorNet: "udp", expCollectorStr: "192.168.1.100:2002", expPollIntervalStr: "5s", expError: nil},
 		{collector: "192.168.1.100:2002", pollInterval: "5s", expCollectorNet: "tcp", expCollectorStr: "192.168.1.100:2002", expPollIntervalStr: "5s", expError: nil},
-		{collector: "192.168.1.100:2002:sctp", pollInterval: "5s", expCollectorNet: "", expCollectorStr: "", expPollIntervalStr: "", expError: fmt.Errorf("IPFIX flow collector over %s proto is not supported", "sctp")},
-		{collector: "192.168.1.100:2002", pollInterval: "5ss", expCollectorNet: "tcp", expCollectorStr: "192.168.1.100:2002", expPollIntervalStr: "", expError: fmt.Errorf("FlowPollInterval is not provided in right format: ")},
-		{collector: "192.168.1.100:2002", pollInterval: "1ms", expCollectorNet: "tcp", expCollectorStr: "192.168.1.100:2002", expPollIntervalStr: "", expError: fmt.Errorf("FlowPollInterval should be greater than or equal to one second")},
+		{collector: "192.168.1.100:2002:sctp", pollInterval: "5s", expCollectorNet: "", expCollectorStr: "", expPollIntervalStr: "0s", expError: fmt.Errorf("connection over %s transport proto is not supported", "sctp")},
+		{collector: "192.168.1.100:2002", pollInterval: "5ss", expCollectorNet: "tcp", expCollectorStr: "192.168.1.100:2002", expPollIntervalStr: "0s", expError: fmt.Errorf("FlowPollInterval is not provided in right format")},
+		{collector: "192.168.1.100:2002", pollInterval: "1ms", expCollectorNet: "tcp", expCollectorStr: "192.168.1.100:2002", expPollIntervalStr: "0s", expError: fmt.Errorf("FlowPollInterval should be greater than or equal to one second")},
+		{collector: "flow-aggregator.flow-aggregator.svc::tcp", pollInterval: "5s", expCollectorNet: "tcp", expCollectorStr: "flow-aggregator.flow-aggregator.svc:4739", expPollIntervalStr: "5s", expError: nil},
+		{collector: "flow-aggregator.flow-aggregator.svc::sctp", pollInterval: "5s", expCollectorNet: "", expCollectorStr: "", expPollIntervalStr: "0s", expError: fmt.Errorf("connection over %s transport proto is not supported", "sctp")},
+		{collector: ":abbbsctp::", pollInterval: "5s", expCollectorNet: "", expCollectorStr: "", expPollIntervalStr: "5s", expError: fmt.Errorf("flow collector address is given in invalid format")},
 	}
 	assert.Equal(t, features.DefaultFeatureGate.Enabled(features.FlowExporter), true)
 	for _, tc := range testcases {
@@ -42,14 +45,13 @@ func TestOptions_validateFlowExporterConfig(t *testing.T) {
 		err := testOptions.validateFlowExporterConfig()
 
 		if tc.expError != nil {
-			assert.NotNil(t, err)
+			assert.Equalf(t, tc.expError, err, "not expected error for input: %v, %v", tc.collector, tc.pollInterval)
 		} else {
-			assert.Equal(t, tc.expCollectorNet, testOptions.flowCollector.Network())
-			assert.Equal(t, tc.expCollectorStr, testOptions.flowCollector.String())
-			assert.Equal(t, tc.expPollIntervalStr, testOptions.pollInterval.String())
+			assert.Equalf(t, tc.expCollectorNet, testOptions.flowCollectorProto, "failed for input: %v, %v", tc.collector, tc.pollInterval)
+			assert.Equalf(t, tc.expCollectorStr, testOptions.flowCollectorAddr, "failed for input: %v, %v", tc.collector, tc.pollInterval)
+			assert.Equalf(t, tc.expPollIntervalStr, testOptions.pollInterval.String(), "failed for input: %v, %v", tc.collector, tc.pollInterval)
 		}
 	}
-
 }
 
 func TestParseFlowCollectorAddr(t *testing.T) {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -412,7 +412,7 @@ func (data *TestData) deployAntreaFlowExporter(ipfixCollector string) error {
 	return data.mutateAntreaConfigMap(func(data map[string]string) {
 		antreaAgentConf, _ := data["antrea-agent.conf"]
 		antreaAgentConf = strings.Replace(antreaAgentConf, "#  FlowExporter: false", "  FlowExporter: true", 1)
-		antreaAgentConf = strings.Replace(antreaAgentConf, "#flowCollectorAddr: \"\"", fmt.Sprintf("flowCollectorAddr: \"%s\"", ipfixCollector), 1)
+		antreaAgentConf = strings.Replace(antreaAgentConf, "#flowCollectorAddr: \"flow-aggregator.flow-aggregator.svc:tcp\"", fmt.Sprintf("flowCollectorAddr: \"%s\"", ipfixCollector), 1)
 		antreaAgentConf = strings.Replace(antreaAgentConf, "#flowPollInterval: \"5s\"", "flowPollInterval: \"1s\"", 1)
 		antreaAgentConf = strings.Replace(antreaAgentConf, "#flowExportFrequency: 12", "flowExportFrequency: 5", 1)
 		data["antrea-agent.conf"] = antreaAgentConf


### PR DESCRIPTION
Agent side changes for Flow Aggregator
    
With this PR, if FlowExporter feature is enabled and flowCollectorAddr
can be used to take in as input address for both flow aggregator and external flow collector.
We resolve the flow aggregator IP using the static DNS name: "flow-aggregator.flow-aggregator.svc".
Default for flowCollectorAddr is "flow-aggregator.flow-aggregator.svc:tcp"

In addition, modified antrea-agent base manifest to set appropriate
DNS policy.

This is dependent on PR #1596 and will be merged after it. Please look for the latest commit.