### PR TITLE
Minor code cleanup in controllers

### DIFF
--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -283,12 +283,9 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	klog.Infof("Starting %s", controllerName)
 	defer klog.Infof("Shutting down %s", controllerName)
 
-	klog.Infof("Waiting for caches to sync for %s", controllerName)
-	if !cache.WaitForCacheSync(stopCh, c.nodeListerSynced) {
-		klog.Errorf("Unable to sync caches for %s", controllerName)
+	if !cache.WaitForNamedCacheSync(controllerName, stopCh, c.nodeListerSynced) {
 		return
 	}
-	klog.Infof("Caches are synced for %s", controllerName)
 
 	if err := c.reconcile(); err != nil {
 		klog.Errorf("Error during %s reconciliation", controllerName)

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -1078,8 +1078,7 @@ func (n *NetworkPolicyController) Run(stopCh <-chan struct{}) {
 	cacheSyncs := []cache.InformerSynced{n.podListerSynced, n.namespaceListerSynced, n.networkPolicyListerSynced}
 	// Only wait for cnpListerSynced and anpListerSynced when AntreaPolicy feature gate is enabled.
 	if features.DefaultFeatureGate.Enabled(features.AntreaPolicy) {
-		cacheSyncs = append(cacheSyncs, n.cnpListerSynced)
-		cacheSyncs = append(cacheSyncs, n.anpListerSynced)
+		cacheSyncs = append(cacheSyncs, n.cnpListerSynced, n.anpListerSynced)
 	}
 	if !cache.WaitForNamedCacheSync(controllerName, stopCh, cacheSyncs...) {
 		return

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -61,6 +61,7 @@ import (
 )
 
 const (
+	controllerName = "NetworkPolicyController"
 	// NetworkPolicyController is the only writer of the antrea network policy
 	// storages and will keep re-enqueuing failed items until they succeed.
 	// Set resyncPeriod to 0 to disable resyncing.
@@ -1071,26 +1072,18 @@ func (n *NetworkPolicyController) Run(stopCh <-chan struct{}) {
 	defer n.addressGroupQueue.ShutDown()
 	defer n.internalNetworkPolicyQueue.ShutDown()
 
-	klog.Info("Starting NetworkPolicy controller")
-	defer klog.Info("Shutting down NetworkPolicy controller")
+	klog.Infof("Starting %s", controllerName)
+	defer klog.Infof("Shutting down %s", controllerName)
 
-	klog.Info("Waiting for caches to sync for NetworkPolicy controller")
-	if !cache.WaitForCacheSync(stopCh, n.podListerSynced, n.namespaceListerSynced, n.networkPolicyListerSynced) {
-		klog.Error("Unable to sync caches for NetworkPolicy controller")
-		return
-	}
+	cacheSyncs := []cache.InformerSynced{n.podListerSynced, n.namespaceListerSynced, n.networkPolicyListerSynced}
 	// Only wait for cnpListerSynced and anpListerSynced when AntreaPolicy feature gate is enabled.
 	if features.DefaultFeatureGate.Enabled(features.AntreaPolicy) {
-		if !cache.WaitForCacheSync(stopCh, n.cnpListerSynced) {
-			klog.Error("Unable to sync CNP caches for NetworkPolicy controller")
-			return
-		}
-		if !cache.WaitForCacheSync(stopCh, n.anpListerSynced) {
-			klog.Error("Unable to sync ANP caches for NetworkPolicy controller")
-			return
-		}
+		cacheSyncs = append(cacheSyncs, n.cnpListerSynced)
+		cacheSyncs = append(cacheSyncs, n.anpListerSynced)
 	}
-	klog.Info("Caches are synced for NetworkPolicy controller")
+	if !cache.WaitForNamedCacheSync(controllerName, stopCh, cacheSyncs...) {
+		return
+	}
 
 	for i := 0; i < defaultWorkers; i++ {
 		go wait.Until(n.appliedToGroupWorker, time.Second, stopCh)

--- a/pkg/controller/stats/aggregator.go
+++ b/pkg/controller/stats/aggregator.go
@@ -313,8 +313,7 @@ func (a *Aggregator) Run(stopCh <-chan struct{}) {
 
 	cacheSyncs := []cache.InformerSynced{a.npListerSynced}
 	if features.DefaultFeatureGate.Enabled(features.AntreaPolicy) {
-		cacheSyncs = append(cacheSyncs, a.cnpListerSynced)
-		cacheSyncs = append(cacheSyncs, a.anpListerSynced)
+		cacheSyncs = append(cacheSyncs, a.cnpListerSynced, a.anpListerSynced)
 	}
 	if !cache.WaitForNamedCacheSync("stats aggregator", stopCh, cacheSyncs...) {
 		return

--- a/pkg/controller/stats/aggregator.go
+++ b/pkg/controller/stats/aggregator.go
@@ -311,18 +311,14 @@ func (a *Aggregator) Run(stopCh <-chan struct{}) {
 	klog.Info("Starting stats aggregator")
 	defer klog.Info("Shutting down stats aggregator")
 
-	klog.Info("Waiting for caches to sync for stats aggregator")
-	if !cache.WaitForCacheSync(stopCh, a.npListerSynced) {
-		klog.Error("Unable to sync caches for stats aggregator")
+	cacheSyncs := []cache.InformerSynced{a.npListerSynced}
+	if features.DefaultFeatureGate.Enabled(features.AntreaPolicy) {
+		cacheSyncs = append(cacheSyncs, a.cnpListerSynced)
+		cacheSyncs = append(cacheSyncs, a.anpListerSynced)
+	}
+	if !cache.WaitForNamedCacheSync("stats aggregator", stopCh, cacheSyncs...) {
 		return
 	}
-	if features.DefaultFeatureGate.Enabled(features.AntreaPolicy) {
-		if !cache.WaitForCacheSync(stopCh, a.cnpListerSynced, a.anpListerSynced) {
-			klog.Error("Unable to sync Antrea policy caches for stats aggregator")
-			return
-		}
-	}
-	klog.Info("Caches are synced for stats aggregator")
 
 	for {
 		select {

--- a/pkg/controller/traceflow/controller.go
+++ b/pkg/controller/traceflow/controller.go
@@ -38,6 +38,8 @@ import (
 )
 
 const (
+	controllerName = "TraceflowController"
+
 	// Set resyncPeriod to 0 to disable resyncing.
 	resyncPeriod time.Duration = 0
 
@@ -124,15 +126,12 @@ func (c *Controller) enqueueTraceflow(tf *opsv1alpha1.Traceflow) {
 func (c *Controller) Run(stopCh <-chan struct{}) {
 	defer c.queue.ShutDown()
 
-	klog.Info("Starting Traceflow controller")
-	defer klog.Info("Shutting down Traceflow controller")
+	klog.Infof("Starting %s", controllerName)
+	defer klog.Infof("Shutting down %s", controllerName)
 
-	klog.Info("Waiting for caches to sync for Traceflow controller")
-	if !cache.WaitForCacheSync(stopCh, c.traceflowListerSynced) {
-		klog.Error("Unable to sync caches for Traceflow controller")
+	if !cache.WaitForNamedCacheSync(controllerName, stopCh, c.traceflowListerSynced) {
 		return
 	}
-	klog.Info("Caches are synced for Traceflow controller")
 
 	// Load all data plane tags from CRD into controller's cache.
 	tfs, err := c.traceflowLister.List(labels.Everything())


### PR DESCRIPTION
Use WaitForNamedCacheSync instead of WaitForCacheSync when possible, as
recommended by the K8s documentation. This leads to code which is
slightly less verbose. When we wrote the first controllers for Antrea,
we used a version of client-go which did not have WaitForNamedCacheSync
yet.