### PR TITLE
Necessary change in codegen image after update to Go 1.15

### DIFF
--- a/build/images/codegen/Dockerfile
+++ b/build/images/codegen/Dockerfile
@@ -29,7 +29,7 @@ RUN go get k8s.io/code-generator/cmd/client-gen@kubernetes-$K8S_VERSION && \
     go get k8s.io/kube-openapi/cmd/openapi-gen@$KUBEOPENAPI_VERSION && \
     go get k8s.io/code-generator/cmd/go-to-protobuf@kubernetes-$K8S_VERSION && \
     go get k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo@kubernetes-$K8S_VERSION && \
-    go get github.com/golang/mock/mockgen@1.3.1 && \
+    go get github.com/golang/mock/mockgen@v1.4.4 && \
     go get github.com/golang/protobuf/protoc-gen-go@v1.3.2 && \
     go get golang.org/x/tools/cmd/goimports
 

--- a/hack/update-codegen-dockerized.sh
+++ b/hack/update-codegen-dockerized.sh
@@ -131,10 +131,11 @@ git checkout HEAD -- hack/boilerplate/license_header.raw.txt
 go mod vendor
 # In Go 1.14, vendoring changed (see release notes at
 # https://golang.org/doc/go1.14), and the presence of a go.mod file specifying
-# go 1.14 or higher causes the go command to default to -mod=vendor. This causes
-# the go-to-protobuf command below to complain about missing packages under
-# vendor/, which were not downloaded by "go mod vendor". We can workaround this
-# easily by renaming the vendor directory.
+# go 1.14 or higher causes the go command to default to -mod=vendor when a
+# top-level vendor directory is present in the module. This causes the
+# go-to-protobuf command below to complain about missing packages under vendor/,
+# which were not downloaded by "go mod vendor". We can workaround this easily by
+# renaming the vendor directory.
 mv vendor /tmp/includes
 $GOPATH/bin/go-to-protobuf \
   --proto-import /tmp/includes \

--- a/hack/update-codegen-dockerized.sh
+++ b/hack/update-codegen-dockerized.sh
@@ -129,12 +129,18 @@ git checkout HEAD -- hack/boilerplate/license_header.raw.txt
 # Download vendored modules to the vendor directory so it's easier to
 # specify the search path of required protobuf files.
 go mod vendor
+# In Go 1.14, vendoring changed (see release notes at
+# https://golang.org/doc/go1.14), and the presence of a go.mod file specifying
+# go 1.14 or higher causes the go command to default to -mod=vendor. This causes
+# the go-to-protobuf command below to complain about missing packages under
+# vendor/, which were not downloaded by "go mod vendor". We can workaround this
+# easily by renaming the vendor directory.
+mv vendor /tmp/includes
 $GOPATH/bin/go-to-protobuf \
-  --proto-import vendor \
+  --proto-import /tmp/includes \
   --packages "${ANTREA_PKG}/pkg/apis/stats/v1alpha1,${ANTREA_PKG}/pkg/apis/controlplane/v1beta1,${ANTREA_PKG}/pkg/apis/controlplane/v1beta2" \
   --go-header-file hack/boilerplate/license_header.go.txt
-# Clean up vendor directory.
-rm -rf vendor
+rm -rf /tmp/includes
 
 set +x
 


### PR DESCRIPTION
https://github.com/vmware-tanzu/antrea/pull/1420 updated the version of
Go used in the Antrea build infra from 1.13 to 1.15, including the
version of Go used in the antrea/codegen Docker image. However, an
updated codegen image was never pushed to the Dockerhub registry. It
turns out that an additional change was required in the image, caused by
a change of behavior in Go vendoring introduced in Go 1.14.

This is also the opportunity to update the version of mockgen (which
does not cause any change in the generated code).