### PR TITLE
[Flow-aggregator]Support destination service port field in Flow Exporter

### DIFF
--- a/pkg/agent/flowexporter/connections/conntrack.go
+++ b/pkg/agent/flowexporter/connections/conntrack.go
@@ -44,13 +44,13 @@ func filterAntreaConns(conns []*flowexporter.Connection, nodeConfig *config.Node
 		srcIP := conn.TupleOrig.SourceAddress
 		dstIP := conn.TupleReply.SourceAddress
 
-		// Only get Pod-to-Pod flows.
+		// Consider Pod-to-Pod, Pod-To-Service and Pod-To-External flows.
 		if srcIP.Equal(nodeConfig.GatewayConfig.IPv4) || dstIP.Equal(nodeConfig.GatewayConfig.IPv4) {
-			klog.V(4).Infof("Detected flow through IPv4 gateway :%v", conn)
+			klog.V(4).Infof("Detected flow for which one of the endpoint is host gateway %s :%+v", nodeConfig.GatewayConfig.IPv4.String(), conn)
 			continue
 		}
 		if srcIP.Equal(nodeConfig.GatewayConfig.IPv6) || dstIP.Equal(nodeConfig.GatewayConfig.IPv6) {
-			klog.V(4).Infof("Detected flow through IPv6 gateway :%v", conn)
+			klog.V(4).Infof("Detected flow for which one of the endpoint is host gateway %s :%+v", nodeConfig.GatewayConfig.IPv6.String(), conn)
 			continue
 		}
 

--- a/pkg/agent/flowexporter/exporter/exporter.go
+++ b/pkg/agent/flowexporter/exporter/exporter.go
@@ -57,6 +57,7 @@ var (
 		"destinationPodNamespace",
 		"destinationNodeName",
 		"destinationClusterIPv4",
+		"destinationServicePort",
 		"destinationServicePortName",
 		"ingressNetworkPolicyName",
 		"ingressNetworkPolicyNamespace",
@@ -335,6 +336,8 @@ func (exp *flowExporter) sendDataRecord(dataRec ipfix.IPFIXRecord, record flowex
 				// this dummy IP address.
 				_, err = dataRec.AddInfoElement(ie, net.IP{0, 0, 0, 0})
 			}
+		case "destinationServicePort":
+			_, err = dataRec.AddInfoElement(ie, record.Conn.TupleOrig.DestinationPort)
 		case "destinationServicePortName":
 			_, err = dataRec.AddInfoElement(ie, record.Conn.DestinationServicePortName)
 		case "ingressNetworkPolicyName":

--- a/pkg/agent/flowexporter/exporter/exporter_test.go
+++ b/pkg/agent/flowexporter/exporter/exporter_test.go
@@ -168,7 +168,7 @@ func TestFlowExporter_sendDataRecord(t *testing.T) {
 			mockDataRec.EXPECT().AddInfoElement(ie, nil).Return(tempBytes, nil)
 		case "destinationClusterIPv4":
 			mockDataRec.EXPECT().AddInfoElement(ie, net.IP{0, 0, 0, 0}).Return(tempBytes, nil)
-		case "sourceTransportPort", "destinationTransportPort":
+		case "sourceTransportPort", "destinationTransportPort", "destinationServicePort":
 			mockDataRec.EXPECT().AddInfoElement(ie, uint16(0)).Return(tempBytes, nil)
 		case "protocolIdentifier":
 			mockDataRec.EXPECT().AddInfoElement(ie, uint8(0)).Return(tempBytes, nil)


### PR DESCRIPTION
This information will be useful as it is not available through
servicePortName (it contains only the port name).

Added some miscellaneous fixes that were removed as part of IPv6 branch merging with master.

PS: This is a simple change that is missing in the master too. The intermediate process added destinationServicePort as one of the correlated fields, so created PR against feature/flow-aggregator branch. 