### PR TITLE
E2E improvements and fixes for Antrea-native Policy

### DIFF
--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -152,7 +152,7 @@ func testMutateACNPNoTier(t *testing.T) {
 	invalidNpErr := fmt.Errorf("ACNP tier not mutated to default tier")
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("acnp-no-tier").
-		SetAppliedToGroup(map[string]string{"pod": "a"}, nil, nil, nil).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}}).
 		SetPriority(10.0)
 	acnp := builder.Get()
 	log.Debugf("creating ACNP %v", acnp.Name)
@@ -170,7 +170,7 @@ func testMutateANPNoTier(t *testing.T) {
 	invalidNpErr := fmt.Errorf("ANP tier not mutated to default tier")
 	builder := &AntreaNetworkPolicySpecBuilder{}
 	builder = builder.SetName("x", "anp-no-tier").
-		SetAppliedToGroup(map[string]string{"pod": "a"}, nil).
+		SetAppliedToGroup([]ANPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}}).
 		SetPriority(10.0)
 	anp := builder.Get()
 	log.Debugf("creating ANP %v", anp.Name)
@@ -188,7 +188,7 @@ func testMutateACNPNoRuleName(t *testing.T) {
 	mutateErr := fmt.Errorf("ACNP Rule name not mutated automatically")
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("acnp-no-rule-name").
-		SetAppliedToGroup(map[string]string{"pod": "a"}, nil, nil, nil).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}}).
 		SetPriority(10.0).
 		AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "x"},
 			nil, nil, nil, secv1alpha1.RuleActionAllow, "")
@@ -213,7 +213,7 @@ func testMutateANPNoRuleName(t *testing.T) {
 	mutateErr := fmt.Errorf("ANP Rule name not mutated automatically")
 	builder := &AntreaNetworkPolicySpecBuilder{}
 	builder = builder.SetName("x", "anp-no-rule-name").
-		SetAppliedToGroup(map[string]string{"pod": "a"}, nil).
+		SetAppliedToGroup([]ANPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}}).
 		SetPriority(10.0).
 		AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "x"},
 			nil, nil, nil, secv1alpha1.RuleActionAllow, "")
@@ -237,7 +237,8 @@ func testMutateANPNoRuleName(t *testing.T) {
 func testInvalidACNPNoPriority(t *testing.T) {
 	invalidNpErr := fmt.Errorf("invalid Antrea ClusterNetworkPolicy without a priority accepted")
 	builder := &ClusterNetworkPolicySpecBuilder{}
-	builder = builder.SetName("acnp-no-priority").SetAppliedToGroup(map[string]string{"pod": "a"}, nil, nil, nil)
+	builder = builder.SetName("acnp-no-priority").
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
 	acnp := builder.Get()
 	log.Debugf("creating ACNP %v", acnp.Name)
 	if _, err := k8sUtils.CreateOrUpdateACNP(acnp); err == nil {
@@ -249,7 +250,8 @@ func testInvalidACNPNoPriority(t *testing.T) {
 func testInvalidACNPRuleNameNotUnique(t *testing.T) {
 	invalidNpErr := fmt.Errorf("invalid Antrea ClusterNetworkPolicy without unique rule names accepted")
 	builder := &ClusterNetworkPolicySpecBuilder{}
-	builder = builder.SetName("acnp-rule-name-not-unique").SetAppliedToGroup(map[string]string{"pod": "a"}, nil, nil, nil).
+	builder = builder.SetName("acnp-rule-name-not-unique").
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}}).
 		AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "x"},
 			nil, nil, nil, secv1alpha1.RuleActionAllow, "not-unique").
 		AddIngress(v1.ProtocolTCP, &p81, nil, nil, nil, map[string]string{"pod": "c"}, map[string]string{"ns": "x"},
@@ -265,7 +267,8 @@ func testInvalidACNPRuleNameNotUnique(t *testing.T) {
 func testInvalidACNPTierDoesNotExist(t *testing.T) {
 	invalidNpErr := fmt.Errorf("invalid Antrea ClusterNetworkPolicy without existing Tier accepted")
 	builder := &ClusterNetworkPolicySpecBuilder{}
-	builder = builder.SetName("acnp-tier-not-exist").SetAppliedToGroup(map[string]string{"pod": "a"}, nil, nil, nil).
+	builder = builder.SetName("acnp-tier-not-exist").
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}}).
 		SetTier("i-dont-exist")
 	acnp := builder.Get()
 	log.Debugf("creating ACNP %v", acnp.Name)
@@ -280,7 +283,7 @@ func testInvalidACNPPortRangePortUnset(t *testing.T) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("acnp-egress-port-range-port-unset").
 		SetPriority(1.0).
-		SetAppliedToGroup(map[string]string{"pod": "b"}, nil, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "b"}}})
 	builder.AddEgress(v1.ProtocolTCP, nil, nil, &p8085, nil, map[string]string{"pod": "c"}, map[string]string{"ns": "x"},
 		nil, nil, nil, secv1alpha1.RuleActionDrop, "acnp-port-range")
 
@@ -297,7 +300,7 @@ func testInvalidACNPPortRangeEndPortSmall(t *testing.T) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("acnp-egress-port-range-endport-small").
 		SetPriority(1.0).
-		SetAppliedToGroup(map[string]string{"pod": "b"}, nil, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "b"}}})
 	builder.AddEgress(v1.ProtocolTCP, &p8082, nil, &p8081, nil, map[string]string{"pod": "c"}, map[string]string{"ns": "x"},
 		nil, nil, nil, secv1alpha1.RuleActionDrop, "acnp-port-range")
 
@@ -312,7 +315,8 @@ func testInvalidACNPPortRangeEndPortSmall(t *testing.T) {
 func testInvalidANPNoPriority(t *testing.T) {
 	invalidNpErr := fmt.Errorf("invalid Antrea NetworkPolicy without a priority accepted")
 	builder := &AntreaNetworkPolicySpecBuilder{}
-	builder = builder.SetName("x", "anp-no-priority").SetAppliedToGroup(map[string]string{"pod": "a"}, nil)
+	builder = builder.SetName("x", "anp-no-priority").
+		SetAppliedToGroup([]ANPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
 	anp := builder.Get()
 	log.Debugf("creating ANP %v", anp.Name)
 	if _, err := k8sUtils.CreateOrUpdateANP(anp); err == nil {
@@ -324,7 +328,8 @@ func testInvalidANPNoPriority(t *testing.T) {
 func testInvalidANPRuleNameNotUnique(t *testing.T) {
 	invalidNpErr := fmt.Errorf("invalid Antrea NetworkPolicy without unique rule names accepted")
 	builder := &AntreaNetworkPolicySpecBuilder{}
-	builder = builder.SetName("x", "anp-rule-name-not-unique").SetAppliedToGroup(map[string]string{"pod": "a"}, nil).
+	builder = builder.SetName("x", "anp-rule-name-not-unique").
+		SetAppliedToGroup([]ANPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}}).
 		AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "x"},
 			nil, nil, nil, secv1alpha1.RuleActionAllow, "not-unique").
 		AddIngress(v1.ProtocolTCP, &p81, nil, nil, nil, map[string]string{"pod": "c"}, map[string]string{"ns": "x"},
@@ -340,7 +345,8 @@ func testInvalidANPRuleNameNotUnique(t *testing.T) {
 func testInvalidANPTierDoesNotExist(t *testing.T) {
 	invalidNpErr := fmt.Errorf("invalid Antrea NetworkPolicy without existing Tier accepted")
 	builder := &AntreaNetworkPolicySpecBuilder{}
-	builder = builder.SetName("x", "anp-tier-not-exist").SetAppliedToGroup(map[string]string{"pod": "a"}, nil).
+	builder = builder.SetName("x", "anp-tier-not-exist").
+		SetAppliedToGroup([]ANPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}}).
 		SetTier("i-dont-exist")
 	anp := builder.Get()
 	log.Debugf("creating ANP %v", anp.Name)
@@ -355,7 +361,7 @@ func testInvalidANPPortRangePortUnset(t *testing.T) {
 	builder := &AntreaNetworkPolicySpecBuilder{}
 	builder = builder.SetName("y", "anp-egress-port-range-port-unset").
 		SetPriority(1.0).
-		SetAppliedToGroup(map[string]string{"pod": "b"}, nil)
+		SetAppliedToGroup([]ANPAppliedToSpec{{PodSelector: map[string]string{"pod": "b"}}})
 	builder.AddEgress(v1.ProtocolTCP, nil, nil, &p8085, nil, map[string]string{"pod": "c"}, map[string]string{"ns": "x"},
 		nil, nil, nil, secv1alpha1.RuleActionDrop, "anp-port-range")
 
@@ -372,7 +378,7 @@ func testInvalidANPPortRangeEndPortSmall(t *testing.T) {
 	builder := &AntreaNetworkPolicySpecBuilder{}
 	builder = builder.SetName("y", "anp-egress-port-range-endport-small").
 		SetPriority(1.0).
-		SetAppliedToGroup(map[string]string{"pod": "b"}, nil)
+		SetAppliedToGroup([]ANPAppliedToSpec{{PodSelector: map[string]string{"pod": "b"}}})
 	builder.AddEgress(v1.ProtocolTCP, &p8082, nil, &p8081, nil, map[string]string{"pod": "c"}, map[string]string{"ns": "x"},
 		nil, nil, nil, secv1alpha1.RuleActionDrop, "anp-port-range")
 
@@ -442,7 +448,7 @@ func testInvalidTierACNPRefDelete(t *testing.T) {
 	}
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("acnp-for-tier").
-		SetAppliedToGroup(map[string]string{"pod": "a"}, nil, nil, nil).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}}).
 		SetTier("tier-acnp").
 		SetPriority(13.0)
 	acnp := builder.Get()
@@ -466,7 +472,7 @@ func testInvalidTierANPRefDelete(t *testing.T) {
 	}
 	builder := &AntreaNetworkPolicySpecBuilder{}
 	builder = builder.SetName("x", "anp-for-tier").
-		SetAppliedToGroup(map[string]string{"pod": "a"}, nil).
+		SetAppliedToGroup([]ANPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}}).
 		SetTier("tier-anp").
 		SetPriority(13.0)
 	anp := builder.Get()
@@ -488,7 +494,7 @@ func testACNPAllowXBtoA(t *testing.T) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("acnp-allow-xb-to-a").
 		SetPriority(1.0).
-		SetAppliedToGroup(map[string]string{"pod": "a"}, nil, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
 	builder.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "x"},
 		nil, nil, nil, secv1alpha1.RuleActionAllow, "")
 
@@ -520,7 +526,7 @@ func testACNPAllowXBtoYA(t *testing.T) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("acnp-allow-xb-to-ya").
 		SetPriority(2.0).
-		SetAppliedToGroup(map[string]string{"pod": "a"}, map[string]string{"ns": "y"}, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": "y"}}})
 	builder.AddIngress(v1.ProtocolTCP, nil, &port81Name, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "x"},
 		nil, nil, nil, secv1alpha1.RuleActionAllow, "")
 
@@ -550,14 +556,14 @@ func testACNPPriorityOverrideDefaultDeny(t *testing.T) {
 	builder1 := &ClusterNetworkPolicySpecBuilder{}
 	builder1 = builder1.SetName("acnp-priority2").
 		SetPriority(2).
-		SetAppliedToGroup(nil, map[string]string{"ns": "x"}, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": "x"}}})
 	builder1.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, map[string]string{"ns": "z"},
 		nil, nil, nil, secv1alpha1.RuleActionAllow, "")
 
 	builder2 := &ClusterNetworkPolicySpecBuilder{}
 	builder2 = builder2.SetName("acnp-priority1").
 		SetPriority(1).
-		SetAppliedToGroup(map[string]string{"pod": "a"}, map[string]string{"ns": "x"}, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": "x"}}})
 	builder2.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, map[string]string{"ns": "z"},
 		nil, nil, nil, secv1alpha1.RuleActionDrop, "")
 
@@ -591,7 +597,7 @@ func testACNPAllowNoDefaultIsolation(t *testing.T) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("acnp-allow-x-ingress-y-egress-z").
 		SetPriority(1.1).
-		SetAppliedToGroup(nil, map[string]string{"ns": "x"}, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": "x"}}})
 	builder.AddIngress(v1.ProtocolTCP, &p81, nil, nil, nil, nil, map[string]string{"ns": "y"},
 		nil, nil, nil, secv1alpha1.RuleActionAllow, "")
 	builder.AddEgress(v1.ProtocolTCP, &p81, nil, nil, nil, nil, map[string]string{"ns": "z"},
@@ -618,7 +624,7 @@ func testACNPDropEgress(t *testing.T) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("acnp-deny-a-to-z-egress").
 		SetPriority(1.0).
-		SetAppliedToGroup(map[string]string{"pod": "a"}, nil, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
 	builder.AddEgress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, map[string]string{"ns": "z"},
 		nil, nil, nil, secv1alpha1.RuleActionDrop, "")
 
@@ -659,7 +665,7 @@ func testBaselineNamespaceIsolation(t *testing.T) {
 	builder = builder.SetName("acnp-baseline-isolate-ns-x").
 		SetTier("baseline").
 		SetPriority(1.0).
-		SetAppliedToGroup(nil, map[string]string{"ns": "x"}, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": "x"}}})
 	builder.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, nil,
 		nil, &[]metav1.LabelSelectorRequirement{nsExpOtherThanX},
 		nil, secv1alpha1.RuleActionDrop, "")
@@ -715,7 +721,7 @@ func testACNPPriorityOverride(t *testing.T) {
 	builder1 := &ClusterNetworkPolicySpecBuilder{}
 	builder1 = builder1.SetName("acnp-priority1").
 		SetPriority(1.001).
-		SetAppliedToGroup(map[string]string{"pod": "a"}, map[string]string{"ns": "x"}, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": "x"}}})
 	podZBIP, _ := podIPs["z/b"]
 	cidr := podZBIP + "/32"
 	// Highest priority. Drops traffic from z/b to x/a.
@@ -725,7 +731,7 @@ func testACNPPriorityOverride(t *testing.T) {
 	builder2 := &ClusterNetworkPolicySpecBuilder{}
 	builder2 = builder2.SetName("acnp-priority2").
 		SetPriority(1.002).
-		SetAppliedToGroup(map[string]string{"pod": "a"}, map[string]string{"ns": "x"}, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": "x"}}})
 	// Medium priority. Allows traffic from z to x/a.
 	builder2.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, map[string]string{"ns": "z"},
 		nil, nil, nil, secv1alpha1.RuleActionAllow, "")
@@ -733,7 +739,7 @@ func testACNPPriorityOverride(t *testing.T) {
 	builder3 := &ClusterNetworkPolicySpecBuilder{}
 	builder3 = builder3.SetName("acnp-priority3").
 		SetPriority(1.003).
-		SetAppliedToGroup(nil, map[string]string{"ns": "x"}, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": "x"}}})
 	// Lowest priority. Drops traffic from z to x.
 	builder3.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, map[string]string{"ns": "z"},
 		nil, nil, nil, secv1alpha1.RuleActionDrop, "")
@@ -788,7 +794,7 @@ func testACNPTierOverride(t *testing.T) {
 	builder1 = builder1.SetName("acnp-tier-emergency").
 		SetTier("emergency").
 		SetPriority(100).
-		SetAppliedToGroup(map[string]string{"pod": "a"}, map[string]string{"ns": "x"}, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": "x"}}})
 	podZBIP, _ := podIPs["z/b"]
 	cidr := podZBIP + "/32"
 	// Highest priority tier. Drops traffic from z/b to x/a.
@@ -799,7 +805,7 @@ func testACNPTierOverride(t *testing.T) {
 	builder2 = builder2.SetName("acnp-tier-securityops").
 		SetTier("securityops").
 		SetPriority(10).
-		SetAppliedToGroup(map[string]string{"pod": "a"}, map[string]string{"ns": "x"}, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": "x"}}})
 	// Medium priority tier. Allows traffic from z to x/a.
 	builder2.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, map[string]string{"ns": "z"},
 		nil, nil, nil, secv1alpha1.RuleActionAllow, "")
@@ -808,7 +814,7 @@ func testACNPTierOverride(t *testing.T) {
 	builder3 = builder3.SetName("acnp-tier-application").
 		SetTier("application").
 		SetPriority(1).
-		SetAppliedToGroup(nil, map[string]string{"ns": "x"}, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": "x"}}})
 	// Lowest priority tier. Drops traffic from z to x.
 	builder3.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, map[string]string{"ns": "z"},
 		nil, nil, nil, secv1alpha1.RuleActionDrop, "")
@@ -868,7 +874,7 @@ func testACNPCustomTiers(t *testing.T) {
 	builder1 = builder1.SetName("acnp-tier-high").
 		SetTier("high-priority").
 		SetPriority(100).
-		SetAppliedToGroup(map[string]string{"pod": "a"}, map[string]string{"ns": "x"}, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": "x"}}})
 	// Medium priority tier. Allows traffic from z to x/a.
 	builder1.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, map[string]string{"ns": "z"},
 		nil, nil, nil, secv1alpha1.RuleActionAllow, "")
@@ -877,7 +883,7 @@ func testACNPCustomTiers(t *testing.T) {
 	builder2 = builder2.SetName("acnp-tier-low").
 		SetTier("low-priority").
 		SetPriority(1).
-		SetAppliedToGroup(nil, map[string]string{"ns": "x"}, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": "x"}}})
 	// Lowest priority tier. Drops traffic from z to x.
 	builder2.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, map[string]string{"ns": "z"},
 		nil, nil, nil, secv1alpha1.RuleActionDrop, "")
@@ -915,14 +921,14 @@ func testACNPPriorityConflictingRule(t *testing.T) {
 	builder1 := &ClusterNetworkPolicySpecBuilder{}
 	builder1 = builder1.SetName("acnp-drop").
 		SetPriority(1).
-		SetAppliedToGroup(nil, map[string]string{"ns": "x"}, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": "x"}}})
 	builder1.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, map[string]string{"ns": "z"},
 		nil, nil, nil, secv1alpha1.RuleActionDrop, "")
 
 	builder2 := &ClusterNetworkPolicySpecBuilder{}
 	builder2 = builder2.SetName("acnp-allow").
 		SetPriority(2).
-		SetAppliedToGroup(nil, map[string]string{"ns": "x"}, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": "x"}}})
 	// The following ingress rule will take no effect as it is exactly the same as ingress rule of cnp-drop,
 	// but cnp-allow has lower priority.
 	builder2.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, map[string]string{"ns": "z"},
@@ -961,7 +967,7 @@ func testACNPRulePrioirty(t *testing.T) {
 	// acnp-deny will apply to all pods in namespace x
 	builder1 = builder1.SetName("acnp-deny").
 		SetPriority(5).
-		SetAppliedToGroup(nil, map[string]string{"ns": "x"}, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": "x"}}})
 	builder1.AddEgress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, map[string]string{"ns": "y"},
 		nil, nil, nil, secv1alpha1.RuleActionDrop, "")
 	// This rule should take no effect as it will be overridden by the first rule of cnp-allow
@@ -972,7 +978,7 @@ func testACNPRulePrioirty(t *testing.T) {
 	// acnp-allow will also apply to all pods in namespace x
 	builder2 = builder2.SetName("acnp-allow").
 		SetPriority(5).
-		SetAppliedToGroup(nil, map[string]string{"ns": "x"}, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": "x"}}})
 	builder2.AddEgress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, map[string]string{"ns": "z"},
 		nil, nil, nil, secv1alpha1.RuleActionAllow, "")
 	// This rule should take no effect as it will be overridden by the first rule of cnp-drop
@@ -1011,7 +1017,7 @@ func testACNPPortRange(t *testing.T) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("acnp-deny-a-to-z-egress-port-range").
 		SetPriority(1.0).
-		SetAppliedToGroup(map[string]string{"pod": "a"}, nil, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
 	builder.AddEgress(v1.ProtocolTCP, &p8080, nil, &p8085, nil, nil, map[string]string{"ns": "z"},
 		nil, nil, nil, secv1alpha1.RuleActionDrop, "acnp-port-range")
 
@@ -1045,7 +1051,7 @@ func testANPPortRange(t *testing.T) {
 	builder := &AntreaNetworkPolicySpecBuilder{}
 	builder = builder.SetName("y", "anp-deny-yb-to-xc-egress-port-range").
 		SetPriority(1.0).
-		SetAppliedToGroup(map[string]string{"pod": "b"}, nil)
+		SetAppliedToGroup([]ANPAppliedToSpec{{PodSelector: map[string]string{"pod": "b"}}})
 	builder.AddEgress(v1.ProtocolTCP, &p8080, nil, &p8085, nil, map[string]string{"pod": "c"}, map[string]string{"ns": "x"},
 		nil, nil, nil, secv1alpha1.RuleActionDrop, "anp-port-range")
 
@@ -1069,12 +1075,11 @@ func testANPPortRange(t *testing.T) {
 
 // testANPBasic tests traffic from X/B to Y/A on port 80 will be dropped, after applying Antrea NetworkPolicy
 // that specifies that. Also it tests that a K8s NetworkPolicy with same appliedTo will not affect its behavior.
-// TODO: test with K8s NP having the same name and namespace as ANP after Issue #1173 is resolved.
 func testANPBasic(t *testing.T) {
 	builder := &AntreaNetworkPolicySpecBuilder{}
-	builder = builder.SetName("y", "np1").
+	builder = builder.SetName("y", "np-same-name").
 		SetPriority(1.0).
-		SetAppliedToGroup(map[string]string{"pod": "a"}, nil)
+		SetAppliedToGroup([]ANPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
 	builder.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "x"},
 		nil, nil, nil, secv1alpha1.RuleActionDrop, "")
 
@@ -1091,7 +1096,7 @@ func testANPBasic(t *testing.T) {
 	}
 	// build a K8s NetworkPolicy that has the same appliedTo but allows all traffic.
 	k8sNPBuilder := &NetworkPolicySpecBuilder{}
-	k8sNPBuilder = k8sNPBuilder.SetName("y", "np2").
+	k8sNPBuilder = k8sNPBuilder.SetName("y", "np-same-name").
 		SetPodSelector(map[string]string{"pod": "a"})
 	k8sNPBuilder.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil,
 		nil, nil, nil, nil)
@@ -1116,7 +1121,7 @@ func testAuditLoggingBasic(t *testing.T, data *TestData) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("test-log-acnp-deny").
 		SetPriority(1.0).
-		SetAppliedToGroup(map[string]string{"pod": "a"}, map[string]string{"ns": "x"}, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": "x"}}})
 	builder.AddEgress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, map[string]string{"ns": "z"},
 		nil, nil, nil, secv1alpha1.RuleActionDrop, "")
 	builder.AddEgressLogging()
@@ -1159,12 +1164,12 @@ func testAuditLoggingBasic(t *testing.T, data *TestData) {
 func testAppliedToPerRule(t *testing.T) {
 	builder := &AntreaNetworkPolicySpecBuilder{}
 	builder = builder.SetName("y", "np1").SetPriority(1.0)
-	anpATGrp1 := ANPRuleAppliedToSpec{PodSelector: map[string]string{"pod": "a"}, PodSelectorMatchExp: nil}
-	anpATGrp2 := ANPRuleAppliedToSpec{PodSelector: map[string]string{"pod": "b"}, PodSelectorMatchExp: nil}
+	anpATGrp1 := ANPAppliedToSpec{PodSelector: map[string]string{"pod": "a"}, PodSelectorMatchExp: nil}
+	anpATGrp2 := ANPAppliedToSpec{PodSelector: map[string]string{"pod": "b"}, PodSelectorMatchExp: nil}
 	builder.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "x"},
-		nil, nil, []ANPRuleAppliedToSpec{anpATGrp1}, secv1alpha1.RuleActionDrop, "")
+		nil, nil, []ANPAppliedToSpec{anpATGrp1}, secv1alpha1.RuleActionDrop, "")
 	builder.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "z"},
-		nil, nil, []ANPRuleAppliedToSpec{anpATGrp2}, secv1alpha1.RuleActionDrop, "")
+		nil, nil, []ANPAppliedToSpec{anpATGrp2}, secv1alpha1.RuleActionDrop, "")
 
 	reachability := NewReachability(allPods, true)
 	reachability.Expect(Pod("x/b"), Pod("y/a"), false)
@@ -1181,14 +1186,14 @@ func testAppliedToPerRule(t *testing.T) {
 
 	builder2 := &ClusterNetworkPolicySpecBuilder{}
 	builder2 = builder2.SetName("cnp1").SetPriority(1.0)
-	cnpATGrp1 := ACNPRuleAppliedToSpec{PodSelector: map[string]string{"pod": "a"}, PodSelectorMatchExp: nil}
-	cnpATGrp2 := ACNPRuleAppliedToSpec{
+	cnpATGrp1 := ACNPAppliedToSpec{PodSelector: map[string]string{"pod": "a"}, PodSelectorMatchExp: nil}
+	cnpATGrp2 := ACNPAppliedToSpec{
 		PodSelector: map[string]string{"pod": "b"}, NSSelector: map[string]string{"ns": "y"},
 		PodSelectorMatchExp: nil, NSSelectorMatchExp: nil}
 	builder2.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "x"},
-		nil, nil, []ACNPRuleAppliedToSpec{cnpATGrp1}, secv1alpha1.RuleActionDrop, "")
+		nil, nil, []ACNPAppliedToSpec{cnpATGrp1}, secv1alpha1.RuleActionDrop, "")
 	builder2.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "z"},
-		nil, nil, []ACNPRuleAppliedToSpec{cnpATGrp2}, secv1alpha1.RuleActionDrop, "")
+		nil, nil, []ACNPAppliedToSpec{cnpATGrp2}, secv1alpha1.RuleActionDrop, "")
 
 	reachability2 := NewReachability(allPods, true)
 	reachability2.Expect(Pod("x/b"), Pod("x/a"), false)
@@ -1379,7 +1384,7 @@ func TestAntreaPolicyStatus(t *testing.T) {
 	anpBuilder := &AntreaNetworkPolicySpecBuilder{}
 	anpBuilder = anpBuilder.SetName(testNamespace, "anp-applied-to-two-nodes").
 		SetPriority(1.0).
-		SetAppliedToGroup(map[string]string{"app": "nginx"}, nil)
+		SetAppliedToGroup([]ANPAppliedToSpec{{PodSelector: map[string]string{"app": "nginx"}}})
 	anpBuilder.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "x"},
 		nil, nil, nil, secv1alpha1.RuleActionAllow, "")
 	anp := anpBuilder.Get()
@@ -1391,7 +1396,7 @@ func TestAntreaPolicyStatus(t *testing.T) {
 	acnpBuilder := &ClusterNetworkPolicySpecBuilder{}
 	acnpBuilder = acnpBuilder.SetName("acnp-applied-to-two-nodes").
 		SetPriority(1.0).
-		SetAppliedToGroup(map[string]string{"app": "nginx"}, nil, nil, nil)
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"app": "nginx"}}})
 	acnpBuilder.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "x"},
 		nil, nil, nil, secv1alpha1.RuleActionAllow, "")
 	acnp := acnpBuilder.Get()

--- a/test/e2e/utils/anpspecbuilder.go
+++ b/test/e2e/utils/anpspecbuilder.go
@@ -28,9 +28,9 @@ type AntreaNetworkPolicySpecBuilder struct {
 	Namespace string
 }
 
-type ANPRuleAppliedToSpec struct {
+type ANPAppliedToSpec struct {
 	PodSelector         map[string]string
-	PodSelectorMatchExp *[]metav1.LabelSelectorRequirement
+	PodSelectorMatchExp []metav1.LabelSelectorRequirement
 }
 
 func (b *AntreaNetworkPolicySpecBuilder) Get() *secv1alpha1.NetworkPolicy {
@@ -65,20 +65,28 @@ func (b *AntreaNetworkPolicySpecBuilder) SetTier(tier string) *AntreaNetworkPoli
 	return b
 }
 
+func (b *AntreaNetworkPolicySpecBuilder) SetAppliedToGroup(specs []ANPAppliedToSpec) *AntreaNetworkPolicySpecBuilder {
+	for _, spec := range specs {
+		appliedToPeer := b.GetAppliedToPeer(spec.PodSelector, spec.PodSelectorMatchExp)
+		b.Spec.AppliedTo = append(b.Spec.AppliedTo, appliedToPeer)
+	}
+	return b
+}
+
 func (b *AntreaNetworkPolicySpecBuilder) GetAppliedToPeer(podSelector map[string]string,
-	podSelectorMatchExp *[]metav1.LabelSelectorRequirement) secv1alpha1.NetworkPolicyPeer {
+	podSelectorMatchExp []metav1.LabelSelectorRequirement) secv1alpha1.NetworkPolicyPeer {
 	var ps *metav1.LabelSelector
 	if podSelector != nil {
 		ps = &metav1.LabelSelector{
 			MatchLabels: podSelector,
 		}
 		if podSelectorMatchExp != nil {
-			ps.MatchExpressions = *podSelectorMatchExp
+			ps.MatchExpressions = podSelectorMatchExp
 		}
 	}
 	if podSelectorMatchExp != nil {
 		ps = &metav1.LabelSelector{
-			MatchExpressions: *podSelectorMatchExp,
+			MatchExpressions: podSelectorMatchExp,
 		}
 	}
 	return secv1alpha1.NetworkPolicyPeer{
@@ -86,21 +94,13 @@ func (b *AntreaNetworkPolicySpecBuilder) GetAppliedToPeer(podSelector map[string
 	}
 }
 
-func (b *AntreaNetworkPolicySpecBuilder) SetAppliedToGroup(podSelector map[string]string,
-	podSelectorMatchExp *[]metav1.LabelSelectorRequirement) *AntreaNetworkPolicySpecBuilder {
-	appliedToPeer := b.GetAppliedToPeer(podSelector, podSelectorMatchExp)
-	b.Spec.AppliedTo = append(b.Spec.AppliedTo, appliedToPeer)
-	return b
-}
-
 func (b *AntreaNetworkPolicySpecBuilder) AddIngress(protoc v1.Protocol,
 	port *int, portName *string, endPort *int32, cidr *string,
 	podSelector map[string]string, nsSelector map[string]string,
-	podSelectorMatchExp *[]metav1.LabelSelectorRequirement, nsSelectorMatchExp *[]metav1.LabelSelectorRequirement,
-	ruleAppliedToSpecs []ANPRuleAppliedToSpec, action secv1alpha1.RuleAction, name string) *AntreaNetworkPolicySpecBuilder {
+	podSelectorMatchExp []metav1.LabelSelectorRequirement, nsSelectorMatchExp []metav1.LabelSelectorRequirement,
+	ruleAppliedToSpecs []ANPAppliedToSpec, action secv1alpha1.RuleAction, name string) *AntreaNetworkPolicySpecBuilder {
 
-	var ps *metav1.LabelSelector
-	var ns *metav1.LabelSelector
+	var ps, ns *metav1.LabelSelector
 	var appliedTos []secv1alpha1.NetworkPolicyPeer
 	if b.Spec.Ingress == nil {
 		b.Spec.Ingress = []secv1alpha1.Rule{}
@@ -111,12 +111,12 @@ func (b *AntreaNetworkPolicySpecBuilder) AddIngress(protoc v1.Protocol,
 			MatchLabels: podSelector,
 		}
 		if podSelectorMatchExp != nil {
-			ps.MatchExpressions = *podSelectorMatchExp
+			ps.MatchExpressions = podSelectorMatchExp
 		}
 	}
 	if podSelectorMatchExp != nil {
 		ps = &metav1.LabelSelector{
-			MatchExpressions: *podSelectorMatchExp,
+			MatchExpressions: podSelectorMatchExp,
 		}
 	}
 	if nsSelector != nil {
@@ -124,12 +124,12 @@ func (b *AntreaNetworkPolicySpecBuilder) AddIngress(protoc v1.Protocol,
 			MatchLabels: nsSelector,
 		}
 		if nsSelectorMatchExp != nil {
-			ns.MatchExpressions = *nsSelectorMatchExp
+			ns.MatchExpressions = nsSelectorMatchExp
 		}
 	}
 	if nsSelectorMatchExp != nil {
 		ns = &metav1.LabelSelector{
-			MatchExpressions: *nsSelectorMatchExp,
+			MatchExpressions: nsSelectorMatchExp,
 		}
 	}
 	var ipBlock *secv1alpha1.IPBlock
@@ -190,8 +190,8 @@ func (b *AntreaNetworkPolicySpecBuilder) AddIngress(protoc v1.Protocol,
 func (b *AntreaNetworkPolicySpecBuilder) AddEgress(protoc v1.Protocol,
 	port *int, portName *string, endPort *int32, cidr *string,
 	podSelector map[string]string, nsSelector map[string]string,
-	podSelectorMatchExp *[]metav1.LabelSelectorRequirement, nsSelectorMatchExp *[]metav1.LabelSelectorRequirement,
-	ruleAppliedToSpecs []ANPRuleAppliedToSpec, action secv1alpha1.RuleAction, name string) *AntreaNetworkPolicySpecBuilder {
+	podSelectorMatchExp []metav1.LabelSelectorRequirement, nsSelectorMatchExp []metav1.LabelSelectorRequirement,
+	ruleAppliedToSpecs []ANPAppliedToSpec, action secv1alpha1.RuleAction, name string) *AntreaNetworkPolicySpecBuilder {
 
 	// For simplicity, we just reuse the Ingress code here.  The underlying data model for ingress/egress is identical
 	// With the exception of calling the rule `To` vs. `From`.

--- a/test/e2e/utils/cnpspecbuilder.go
+++ b/test/e2e/utils/cnpspecbuilder.go
@@ -27,11 +27,11 @@ type ClusterNetworkPolicySpecBuilder struct {
 	Name string
 }
 
-type ACNPRuleAppliedToSpec struct {
+type ACNPAppliedToSpec struct {
 	PodSelector         map[string]string
 	NSSelector          map[string]string
-	PodSelectorMatchExp *[]metav1.LabelSelectorRequirement
-	NSSelectorMatchExp  *[]metav1.LabelSelectorRequirement
+	PodSelectorMatchExp []metav1.LabelSelectorRequirement
+	NSSelectorMatchExp  []metav1.LabelSelectorRequirement
 }
 
 func (b *ClusterNetworkPolicySpecBuilder) Get() *secv1alpha1.ClusterNetworkPolicy {
@@ -64,10 +64,18 @@ func (b *ClusterNetworkPolicySpecBuilder) SetTier(tier string) *ClusterNetworkPo
 	return b
 }
 
+func (b *ClusterNetworkPolicySpecBuilder) SetAppliedToGroup(specs []ACNPAppliedToSpec) *ClusterNetworkPolicySpecBuilder {
+	for _, spec := range specs {
+		appliedToPeer := b.GetAppliedToPeer(spec.PodSelector, spec.NSSelector, spec.PodSelectorMatchExp, spec.NSSelectorMatchExp)
+		b.Spec.AppliedTo = append(b.Spec.AppliedTo, appliedToPeer)
+	}
+	return b
+}
+
 func (b *ClusterNetworkPolicySpecBuilder) GetAppliedToPeer(podSelector map[string]string,
 	nsSelector map[string]string,
-	podSelectorMatchExp *[]metav1.LabelSelectorRequirement,
-	nsSelectorMatchExp *[]metav1.LabelSelectorRequirement) secv1alpha1.NetworkPolicyPeer {
+	podSelectorMatchExp []metav1.LabelSelectorRequirement,
+	nsSelectorMatchExp []metav1.LabelSelectorRequirement) secv1alpha1.NetworkPolicyPeer {
 
 	var ps *metav1.LabelSelector
 	var ns *metav1.LabelSelector
@@ -77,12 +85,12 @@ func (b *ClusterNetworkPolicySpecBuilder) GetAppliedToPeer(podSelector map[strin
 			MatchLabels: podSelector,
 		}
 		if podSelectorMatchExp != nil {
-			ps.MatchExpressions = *podSelectorMatchExp
+			ps.MatchExpressions = podSelectorMatchExp
 		}
 	}
 	if podSelectorMatchExp != nil {
 		ps = &metav1.LabelSelector{
-			MatchExpressions: *podSelectorMatchExp,
+			MatchExpressions: podSelectorMatchExp,
 		}
 	}
 	if nsSelector != nil {
@@ -90,12 +98,12 @@ func (b *ClusterNetworkPolicySpecBuilder) GetAppliedToPeer(podSelector map[strin
 			MatchLabels: nsSelector,
 		}
 		if nsSelectorMatchExp != nil {
-			ns.MatchExpressions = *nsSelectorMatchExp
+			ns.MatchExpressions = nsSelectorMatchExp
 		}
 	}
 	if nsSelectorMatchExp != nil {
 		ns = &metav1.LabelSelector{
-			MatchExpressions: *nsSelectorMatchExp,
+			MatchExpressions: nsSelectorMatchExp,
 		}
 	}
 	return secv1alpha1.NetworkPolicyPeer{
@@ -104,21 +112,11 @@ func (b *ClusterNetworkPolicySpecBuilder) GetAppliedToPeer(podSelector map[strin
 	}
 }
 
-func (b *ClusterNetworkPolicySpecBuilder) SetAppliedToGroup(podSelector map[string]string,
-	nsSelector map[string]string,
-	podSelectorMatchExp *[]metav1.LabelSelectorRequirement,
-	nsSelectorMatchExp *[]metav1.LabelSelectorRequirement) *ClusterNetworkPolicySpecBuilder {
-
-	appliedToPeer := b.GetAppliedToPeer(podSelector, nsSelector, podSelectorMatchExp, nsSelectorMatchExp)
-	b.Spec.AppliedTo = append(b.Spec.AppliedTo, appliedToPeer)
-	return b
-}
-
 func (b *ClusterNetworkPolicySpecBuilder) AddIngress(protoc v1.Protocol,
 	port *int, portName *string, endPort *int32, cidr *string,
 	podSelector map[string]string, nsSelector map[string]string,
 	podSelectorMatchExp *[]metav1.LabelSelectorRequirement, nsSelectorMatchExp *[]metav1.LabelSelectorRequirement,
-	ruleAppliedToSpecs []ACNPRuleAppliedToSpec, action secv1alpha1.RuleAction, name string) *ClusterNetworkPolicySpecBuilder {
+	ruleAppliedToSpecs []ACNPAppliedToSpec, action secv1alpha1.RuleAction, name string) *ClusterNetworkPolicySpecBuilder {
 
 	var ps *metav1.LabelSelector
 	var ns *metav1.LabelSelector
@@ -212,7 +210,7 @@ func (b *ClusterNetworkPolicySpecBuilder) AddEgress(protoc v1.Protocol,
 	port *int, portName *string, endPort *int32, cidr *string,
 	podSelector map[string]string, nsSelector map[string]string,
 	podSelectorMatchExp *[]metav1.LabelSelectorRequirement, nsSelectorMatchExp *[]metav1.LabelSelectorRequirement,
-	ruleAppliedToSpecs []ACNPRuleAppliedToSpec, action secv1alpha1.RuleAction, name string) *ClusterNetworkPolicySpecBuilder {
+	ruleAppliedToSpecs []ACNPAppliedToSpec, action secv1alpha1.RuleAction, name string) *ClusterNetworkPolicySpecBuilder {
 
 	// For simplicity, we just reuse the Ingress code here.  The underlying data model for ingress/egress is identical
 	// With the exception of calling the rule `To` vs. `From`.

--- a/test/e2e/utils/networkpolicyspecbuilder.go
+++ b/test/e2e/utils/networkpolicyspecbuilder.go
@@ -52,7 +52,9 @@ func (n *NetworkPolicySpecBuilder) SetName(namespace string, name string) *Netwo
 }
 
 // TODO: Add tests to match expressions
-func (n *NetworkPolicySpecBuilder) AddIngress(protoc v1.Protocol, port *int, portName *string, cidr *string, exceptCIDRs []string, podSelector map[string]string, nsSelector map[string]string, podSelectorMatchExp *[]metav1.LabelSelectorRequirement, nsSelectorMatchExp *[]metav1.LabelSelectorRequirement) *NetworkPolicySpecBuilder {
+func (n *NetworkPolicySpecBuilder) AddIngress(protoc v1.Protocol, port *int, portName *string, cidr *string, exceptCIDRs []string,
+	podSelector map[string]string, nsSelector map[string]string,
+	podSelectorMatchExp []metav1.LabelSelectorRequirement, nsSelectorMatchExp []metav1.LabelSelectorRequirement) *NetworkPolicySpecBuilder {
 
 	var ps *metav1.LabelSelector
 	var ns *metav1.LabelSelector
@@ -65,13 +67,13 @@ func (n *NetworkPolicySpecBuilder) AddIngress(protoc v1.Protocol, port *int, por
 			MatchLabels: podSelector,
 		}
 		if podSelectorMatchExp != nil {
-			ps.MatchExpressions = *podSelectorMatchExp
+			ps.MatchExpressions = podSelectorMatchExp
 		}
 	}
 
 	if podSelectorMatchExp != nil {
 		ps = &metav1.LabelSelector{
-			MatchExpressions: *podSelectorMatchExp,
+			MatchExpressions: podSelectorMatchExp,
 		}
 	}
 
@@ -80,13 +82,13 @@ func (n *NetworkPolicySpecBuilder) AddIngress(protoc v1.Protocol, port *int, por
 			MatchLabels: nsSelector,
 		}
 		if nsSelectorMatchExp != nil {
-			ns.MatchExpressions = *nsSelectorMatchExp
+			ns.MatchExpressions = nsSelectorMatchExp
 		}
 	}
 
 	if nsSelectorMatchExp != nil {
 		ns = &metav1.LabelSelector{
-			MatchExpressions: *nsSelectorMatchExp,
+			MatchExpressions: nsSelectorMatchExp,
 		}
 	}
 
@@ -150,7 +152,10 @@ func (n *NetworkPolicySpecBuilder) WithEgressDNS() *NetworkPolicySpecBuilder {
 	return n
 }
 
-func (n *NetworkPolicySpecBuilder) AddEgress(protoc v1.Protocol, port *int, portName *string, cidr *string, exceptCIDRs []string, podSelector map[string]string, nsSelector map[string]string, podSelectorMatchExp *[]metav1.LabelSelectorRequirement, nsSelectorMatchExp *[]metav1.LabelSelectorRequirement) *NetworkPolicySpecBuilder {
+func (n *NetworkPolicySpecBuilder) AddEgress(protoc v1.Protocol, port *int, portName *string, cidr *string, exceptCIDRs []string,
+	podSelector map[string]string, nsSelector map[string]string,
+	podSelectorMatchExp []metav1.LabelSelectorRequirement, nsSelectorMatchExp []metav1.LabelSelectorRequirement) *NetworkPolicySpecBuilder {
+
 	// For simplicity, we just reuse the Ingress code here.  The underlying data model for ingress/egress is identical
 	// With the exception of calling the rule `To` vs. `From`.
 	i := &NetworkPolicySpecBuilder{}


### PR DESCRIPTION
This PR is based on #1396 

- Make `PodSelectorMatchExp` and `NSSelectorMatchExp` to not be pointers in np builder files
- Unify rule and spec appliedTo struct in Antrea-native policy builders
- Resolve a TODO item to test ANP and K8s NetworkPolicy with the same name/namespace.