### PR TITLE
[Flow-Aggregator] Add security support for flow aggregator

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1404,6 +1404,9 @@ data:
     # Flow export frequency should be greater than or equal to 1.
     #flowExportFrequency: 12
 
+    # Enable TLS communication from flow exporter to flow aggregator.
+    #enableTLSToFlowAggregator: true
+
     # Provide the port range used by NodePortLocal. When the NodePortLocal feature is enabled, a port from that range will be assigned
     # whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
     # and all Node traffic directed to that port will be forwarded to the Pod.
@@ -1486,7 +1489,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-mdcdght696
+  name: antrea-config-mc9bkf47f4
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1606,7 +1609,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-mdcdght696
+          name: antrea-config-mc9bkf47f4
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1870,7 +1873,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-mdcdght696
+          name: antrea-config-mc9bkf47f4
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1404,6 +1404,9 @@ data:
     # Flow export frequency should be greater than or equal to 1.
     #flowExportFrequency: 12
 
+    # Enable TLS communication from flow exporter to flow aggregator.
+    #enableTLSToFlowAggregator: true
+
     # Provide the port range used by NodePortLocal. When the NodePortLocal feature is enabled, a port from that range will be assigned
     # whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
     # and all Node traffic directed to that port will be forwarded to the Pod.
@@ -1486,7 +1489,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-mdcdght696
+  name: antrea-config-mc9bkf47f4
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1606,7 +1609,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-mdcdght696
+          name: antrea-config-mc9bkf47f4
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1872,7 +1875,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-mdcdght696
+          name: antrea-config-mc9bkf47f4
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1404,6 +1404,9 @@ data:
     # Flow export frequency should be greater than or equal to 1.
     #flowExportFrequency: 12
 
+    # Enable TLS communication from flow exporter to flow aggregator.
+    #enableTLSToFlowAggregator: true
+
     # Provide the port range used by NodePortLocal. When the NodePortLocal feature is enabled, a port from that range will be assigned
     # whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
     # and all Node traffic directed to that port will be forwarded to the Pod.
@@ -1486,7 +1489,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-hgkcdthg86
+  name: antrea-config-bkc6dfdhgt
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1606,7 +1609,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-hgkcdthg86
+          name: antrea-config-bkc6dfdhgt
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1873,7 +1876,7 @@ spec:
           path: /home/kubernetes/bin
         name: host-cni-bin
       - configMap:
-          name: antrea-config-hgkcdthg86
+          name: antrea-config-bkc6dfdhgt
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1409,6 +1409,9 @@ data:
     # Flow export frequency should be greater than or equal to 1.
     #flowExportFrequency: 12
 
+    # Enable TLS communication from flow exporter to flow aggregator.
+    #enableTLSToFlowAggregator: true
+
     # Provide the port range used by NodePortLocal. When the NodePortLocal feature is enabled, a port from that range will be assigned
     # whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
     # and all Node traffic directed to that port will be forwarded to the Pod.
@@ -1491,7 +1494,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-tg88b52gfg
+  name: antrea-config-ftckkg2dc8
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1620,7 +1623,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-tg88b52gfg
+          name: antrea-config-ftckkg2dc8
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1919,7 +1922,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-tg88b52gfg
+          name: antrea-config-ftckkg2dc8
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1409,6 +1409,9 @@ data:
     # Flow export frequency should be greater than or equal to 1.
     #flowExportFrequency: 12
 
+    # Enable TLS communication from flow exporter to flow aggregator.
+    #enableTLSToFlowAggregator: true
+
     # Provide the port range used by NodePortLocal. When the NodePortLocal feature is enabled, a port from that range will be assigned
     # whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
     # and all Node traffic directed to that port will be forwarded to the Pod.
@@ -1491,7 +1494,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-hm5ktckh9k
+  name: antrea-config-md64tc85t9
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1611,7 +1614,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-hm5ktckh9k
+          name: antrea-config-md64tc85t9
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1875,7 +1878,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-hm5ktckh9k
+          name: antrea-config-md64tc85t9
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -117,6 +117,9 @@ featureGates:
 # Flow export frequency should be greater than or equal to 1.
 #flowExportFrequency: 12
 
+# Enable TLS communication from flow exporter to flow aggregator.
+#enableTLSToFlowAggregator: true
+
 # Provide the port range used by NodePortLocal. When the NodePortLocal feature is enabled, a port from that range will be assigned
 # whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
 # and all Node traffic directed to that port will be forwarded to the Pod.

--- a/build/yamls/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator.yml
@@ -6,6 +6,112 @@ metadata:
   name: flow-aggregator
 ---
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: flow-aggregator
+  name: flow-aggregator
+  namespace: flow-aggregator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: flow-aggregator
+  name: flow-aggregator-role
+  namespace: flow-aggregator
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - flow-aggregator-ca
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resourceNames:
+  - flow-aggregator-client-tls
+  resources:
+  - secrets
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: flow-aggregator
+  name: flow-exporter-role
+  namespace: flow-aggregator
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - flow-aggregator-ca
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resourceNames:
+  - flow-aggregator-client-tls
+  resources:
+  - secrets
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: flow-aggregator
+  name: flow-aggregator-role-binding
+  namespace: flow-aggregator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: flow-aggregator-role
+subjects:
+- kind: ServiceAccount
+  name: flow-aggregator
+  namespace: flow-aggregator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: flow-aggregator
+  name: flow-exporter-role-binding
+  namespace: flow-aggregator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: flow-exporter-role
+subjects:
+- kind: ServiceAccount
+  name: antrea-agent
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: flow-aggregator
+  name: flow-aggregator-ca
+  namespace: flow-aggregator
+---
+apiVersion: v1
 data:
   flow-aggregator.conf: |
     # Provide the flow collector address as string with format <IP>:<port>[:<proto>], where proto is tcp or udp.
@@ -18,14 +124,17 @@ data:
     # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
     #flowExportInterval: 60s
 
-    # Provide the transport protocol for the flow aggregator collecting process, which is tcp or udp.
-    #aggregatorTransportProtocol: "tcp"
+    # Provide the transport protocol for the flow aggregator collecting process, which is tls, tcp or udp.
+    #aggregatorTransportProtocol: "tls"
+
+    # Provide DNS name or IP address of flow aggregator for generating TLS certificate. It must match the flowCollectorAddr parameter in the antrea-agent config.
+    #flowAggregatorAddress: "flow-aggregator.flow-aggregator.svc"
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: flow-aggregator
-  name: flow-aggregator-configmap-kggb5829gb
+  name: flow-aggregator-configmap-ccfdtmg954
   namespace: flow-aggregator
 ---
 apiVersion: v1
@@ -87,7 +196,8 @@ spec:
           name: flow-aggregator-config
           readOnly: true
           subPath: flow-aggregator.conf
+      serviceAccountName: flow-aggregator
       volumes:
       - configMap:
-          name: flow-aggregator-configmap-kggb5829gb
+          name: flow-aggregator-configmap-ccfdtmg954
         name: flow-aggregator-config

--- a/build/yamls/flow-aggregator/base/conf/flow-aggregator.conf
+++ b/build/yamls/flow-aggregator/base/conf/flow-aggregator.conf
@@ -8,5 +8,8 @@
 # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 #flowExportInterval: 60s
 
-# Provide the transport protocol for the flow aggregator collecting process, which is tcp or udp.
-#aggregatorTransportProtocol: "tcp"
+# Provide the transport protocol for the flow aggregator collecting process, which is tls, tcp or udp.
+#aggregatorTransportProtocol: "tls"
+
+# Provide DNS name or IP address of flow aggregator for generating TLS certificate. It must match the flowCollectorAddr parameter in the antrea-agent config.
+#flowAggregatorAddress: "flow-aggregator.flow-aggregator.svc"

--- a/build/yamls/flow-aggregator/base/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator/base/flow-aggregator.yml
@@ -5,6 +5,79 @@ metadata:
   name: flow-aggregator
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flow-aggregator-ca
+  namespace: flow-aggregator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flow-aggregator
+  namespace: flow-aggregator
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: flow-aggregator-role
+  namespace: flow-aggregator
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["flow-aggregator-ca"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["flow-aggregator-client-tls"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: flow-aggregator-role-binding
+  namespace: flow-aggregator
+subjects:
+  - kind: ServiceAccount
+    name: flow-aggregator
+    namespace: flow-aggregator
+roleRef:
+  kind: Role
+  name: flow-aggregator-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: flow-exporter-role
+  namespace: flow-aggregator
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["flow-aggregator-ca"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["flow-aggregator-client-tls"]
+    verbs: ["get"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: flow-exporter-role-binding
+  namespace: flow-aggregator
+subjects:
+- kind: ServiceAccount
+  name: antrea-agent
+  namespace: kube-system
+roleRef:
+  kind: Role
+  name: flow-exporter-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: flow-aggregator
@@ -55,6 +128,7 @@ spec:
           name: flow-aggregator-config
           readOnly: true
           subPath: flow-aggregator.conf
+      serviceAccountName: flow-aggregator
       volumes:
       - name: flow-aggregator-config
         configMap:

--- a/ci/test-elk-flow-collector.sh
+++ b/ci/test-elk-flow-collector.sh
@@ -77,7 +77,7 @@ config_antrea() {
   echo "=== Configuring Antrea Flow Exporter Address ==="
   sed -i -e "s/#flowCollectorAddr.*/flowCollectorAddr: \"${LOGSTASH_IP}:${LOGSTASH_PORT}:${LOGSTASH_PROTOCOL}\"/g" ${GIT_CHECKOUT_DIR}/build/yamls/antrea.yml
   sed -i -e "s/#  FlowExporter: false/  FlowExporter: true/g" ${GIT_CHECKOUT_DIR}/build/yamls/antrea.yml
-  sed -i -e "s/#  AntreaProxy: false/  AntreaProxy: true/g" ${GIT_CHECKOUT_DIR}/build/yamls/antrea.yml
+  sed -i -e "s/#enableTLSToFlowAggregator: true/enableTLSToFlowAggregator: false/g" ${GIT_CHECKOUT_DIR}/build/yamls/antrea.yml
 }
 
 # Antrea agent flow exporter starts to send CoreDNS flow records.

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -353,8 +353,10 @@ func run(o *Options) error {
 		flowExporter := exporter.NewFlowExporter(
 			flowrecords.NewFlowRecords(connStore),
 			o.config.FlowExportFrequency,
+			o.config.EnableTLSToFlowAggregator,
 			v4Enabled,
-			v6Enabled)
+			v6Enabled,
+			k8sClient)
 		go wait.Until(func() { flowExporter.Export(o.flowCollectorAddr, o.flowCollectorProto, stopCh, pollDone) }, 0, stopCh)
 	}
 

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -120,6 +120,9 @@ type AgentConfig struct {
 	// Flow export frequency should be greater than or equal to 1.
 	// Defaults to "12".
 	FlowExportFrequency uint `yaml:"flowExportFrequency,omitempty"`
+	// Enable TLS communication from flow exporter to flow aggregator.
+	// Defaults to true.
+	EnableTLSToFlowAggregator bool `yaml:"enableTLSToFlowAggregator,omitempty"`
 	// Provide the port range used by NodePortLocal. When the NodePortLocal feature is enabled, a port from that range will be assigned
 	// whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
 	// and all Node traffic directed to that port will be forwarded to the Pod.

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -61,7 +61,8 @@ type Options struct {
 func newOptions() *Options {
 	return &Options{
 		config: &AgentConfig{
-			EnablePrometheusMetrics: true,
+			EnablePrometheusMetrics:   true,
+			EnableTLSToFlowAggregator: true,
 		},
 	}
 }

--- a/cmd/flow-aggregator/config.go
+++ b/cmd/flow-aggregator/config.go
@@ -28,6 +28,9 @@ type FlowAggregatorConfig struct {
 	// Defaults to "60s".
 	FlowExportInterval string `yaml:"flowExportInterval,omitempty"`
 	// Transport protocol over which the aggregator collects IPFIX records from all Agents.
-	// Defaults to "tcp"
+	// Defaults to "tls"
 	AggregatorTransportProtocol flowaggregator.AggregatorTransportProtocol `yaml:"aggregatorTransportProtocol,omitempty"`
+	// Provide DNS name or IP address of flow aggregator for generating TLS certificate.
+	// Defaults to "flow-aggregator.flow-aggregator.svc"
+	flowAggregatorAddress string `yaml:"flowAggregatorAddress,omitempty"`
 }

--- a/cmd/flow-aggregator/options.go
+++ b/cmd/flow-aggregator/options.go
@@ -32,7 +32,8 @@ const (
 	defaultExternalFlowCollectorTransport = "tcp"
 	defaultExternalFlowCollectorPort      = "4739"
 	defaultFlowExportInterval             = 60 * time.Second
-	defaultAggregatorTransportProtocol    = flowaggregator.AggregatorTransportProtocolTCP
+	defaultAggregatorTransportProtocol    = flowaggregator.AggregatorTransportProtocolTLS
+	defaultFlowAggregatorAddress          = "flow-aggregator.flow-aggregator.svc"
 )
 
 type Options struct {
@@ -48,6 +49,8 @@ type Options struct {
 	exportInterval time.Duration
 	// Transport protocol over which the aggregator collects IPFIX records from all Agents
 	aggregatorTransportProtocol flowaggregator.AggregatorTransportProtocol
+	// DNS name or IP address of flow aggregator for generating TLS certificate
+	flowAggregatorAddress string
 }
 
 func newOptions() *Options {
@@ -104,6 +107,11 @@ func (o *Options) validate(args []string) error {
 			return err
 		}
 		o.aggregatorTransportProtocol = transportProtocol
+	}
+	if o.config.flowAggregatorAddress == "" {
+		o.flowAggregatorAddress = defaultFlowAggregatorAddress
+	} else {
+		o.flowAggregatorAddress = o.config.flowAggregatorAddress
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/ti-mo/conntrack v0.3.0
 	github.com/vishvananda/netlink v1.1.0
-	github.com/vmware/go-ipfix v0.4.3
+	github.com/vmware/go-ipfix v0.4.4
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
 	golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495
 	golang.org/x/mod v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -408,8 +408,8 @@ github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYp
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/vmware/go-ipfix v0.4.3 h1:6fzvm15xBxbyqIRLOr0nmhyoODLFJp3FBlXqScJG7kI=
-github.com/vmware/go-ipfix v0.4.3/go.mod h1:lQz3f4r2pZWo0q8s8BtZ0xo5fPSOYsYteqJgBASP69o=
+github.com/vmware/go-ipfix v0.4.4 h1:WxbijNZH6F4W9czZ7O/4yWJo3B49MX93NR5dBwJwqiI=
+github.com/vmware/go-ipfix v0.4.4/go.mod h1:lQz3f4r2pZWo0q8s8BtZ0xo5fPSOYsYteqJgBASP69o=
 github.com/wenyingd/ofnet v0.0.0-20210205051801-5a4f247248d4 h1:HwolNov6r/aM4zwA3MiSzxJKUTi3MypPOR6PRCTg1sA=
 github.com/wenyingd/ofnet v0.0.0-20210205051801-5a4f247248d4/go.mod h1:8mMMWAYBNUeTGXYKizOLETfN3WIbu3P5DgvS2jiXKdI=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=

--- a/pkg/agent/flowexporter/exporter/certificate.go
+++ b/pkg/agent/flowexporter/exporter/certificate.go
@@ -1,0 +1,54 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	CAConfigMapName       = "flow-aggregator-ca"
+	CAConfigMapKey        = "ca.crt"
+	CAConfigMapNamespace  = "flow-aggregator"
+	ClientSecretNamespace = "flow-aggregator"
+	// #nosec G101: false positive triggered by variable name which includes "Secret"
+	ClientSecretName = "flow-aggregator-client-tls"
+)
+
+func getCACert(k8sClient kubernetes.Interface) ([]byte, error) {
+	caConfigMap, err := k8sClient.CoreV1().ConfigMaps(CAConfigMapNamespace).Get(context.TODO(), CAConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error getting ConfigMap %s: %v", CAConfigMapName, err)
+	}
+	if caConfigMap.Data == nil || caConfigMap.Data[CAConfigMapKey] == "" {
+		return nil, fmt.Errorf("error getting data from ConfigMap %s: %v", CAConfigMapName, err)
+	}
+	return []byte(caConfigMap.Data[CAConfigMapKey]), nil
+}
+
+func getClientCertKey(k8sClient kubernetes.Interface) ([]byte, []byte, error) {
+	clientSecret, err := k8sClient.CoreV1().Secrets(ClientSecretNamespace).Get(context.TODO(), ClientSecretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("error getting Secret %s: %v", ClientSecretName, err)
+	}
+	if clientSecret.Data == nil || clientSecret.Data["tls.crt"] == nil || clientSecret.Data["tls.key"] == nil {
+		return nil, nil, fmt.Errorf("error getting data from Secret %s: %v", ClientSecretName, err)
+	}
+	return clientSecret.Data["tls.crt"], clientSecret.Data["tls.key"], nil
+}

--- a/pkg/agent/flowexporter/exporter/exporter.go
+++ b/pkg/agent/flowexporter/exporter/exporter.go
@@ -18,12 +18,12 @@ import (
 	"fmt"
 	"hash/fnv"
 	"net"
-	"strings"
 	"time"
 
 	ipfixentities "github.com/vmware/go-ipfix/pkg/entities"
 	"github.com/vmware/go-ipfix/pkg/exporter"
 	ipfixregistry "github.com/vmware/go-ipfix/pkg/registry"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/flowexporter"
@@ -71,27 +71,21 @@ var (
 	AntreaInfoElementsIPv6 = append(antreaInfoElementsCommon, []string{"destinationClusterIPv6"}...)
 )
 
-const (
-	// flowAggregatorDNSName is a static DNS name for the deployed Flow Aggregator
-	// Service in the K8s cluster. By default, both the Name and Namespace of the
-	// Service are set to "flow-aggregator".
-	flowAggregatorDNSName = "flow-aggregator.flow-aggregator.svc"
-	defaultIPFIXPort      = "4739"
-)
-
 type flowExporter struct {
-	flowRecords     *flowrecords.FlowRecords
-	process         ipfix.IPFIXExportingProcess
-	elementsListv4  []*ipfixentities.InfoElementWithValue
-	elementsListv6  []*ipfixentities.InfoElementWithValue
-	exportFrequency uint
-	pollCycle       uint
-	templateIDv4    uint16
-	templateIDv6    uint16
-	registry        ipfix.IPFIXRegistry
-	v4Enabled       bool
-	v6Enabled       bool
-	collectorAddr   net.Addr
+	flowRecords               *flowrecords.FlowRecords
+	process                   ipfix.IPFIXExportingProcess
+	elementsListv4            []*ipfixentities.InfoElementWithValue
+	elementsListv6            []*ipfixentities.InfoElementWithValue
+	exportFrequency           uint
+	pollCycle                 uint
+	templateIDv4              uint16
+	templateIDv6              uint16
+	registry                  ipfix.IPFIXRegistry
+	v4Enabled                 bool
+	v6Enabled                 bool
+	collectorAddr             net.Addr
+	enableTLSToFlowAggregator bool
+	k8sClient                 kubernetes.Interface
 }
 
 func genObservationID() (uint32, error) {
@@ -104,7 +98,7 @@ func genObservationID() (uint32, error) {
 	return h.Sum32(), nil
 }
 
-func NewFlowExporter(records *flowrecords.FlowRecords, exportFrequency uint, v4Enabled bool, v6Enabled bool) *flowExporter {
+func NewFlowExporter(records *flowrecords.FlowRecords, exportFrequency uint, enableTLSToFlowAggregator bool, v4Enabled bool, v6Enabled bool, k8sClient kubernetes.Interface) *flowExporter {
 	registry := ipfix.NewIPFIXRegistry()
 	registry.LoadRegistry()
 	return &flowExporter{
@@ -120,6 +114,8 @@ func NewFlowExporter(records *flowrecords.FlowRecords, exportFrequency uint, v4E
 		v4Enabled,
 		v6Enabled,
 		nil,
+		enableTLSToFlowAggregator,
+		k8sClient,
 	}
 }
 
@@ -175,23 +171,31 @@ func (exp *flowExporter) initFlowExporter(collectorAddr string, collectorProto s
 		return fmt.Errorf("cannot generate obsID for IPFIX ipfixexport: %v", err)
 	}
 
-	if strings.Contains(collectorAddr, flowAggregatorDNSName) {
-		hostIPs, err := net.LookupIP(flowAggregatorDNSName)
-		if err != nil {
-			return err
-		}
-		// Currently, supporting only IPv4 for Flow Aggregator.
-		ip := hostIPs[0].To4()
-		if ip != nil {
-			// Update the collector address with resolved IP of flow aggregator
-			collectorAddr = net.JoinHostPort(ip.String(), defaultIPFIXPort)
-		} else {
-			return fmt.Errorf("resolved Flow Aggregator address %v is not supported", hostIPs[0])
-		}
-	}
-
 	var expInput exporter.ExporterInput
-	if collectorProto == "tcp" {
+	if exp.enableTLSToFlowAggregator {
+		// if CA certificate, client certificate and key do not exist during initialization,
+		// it will retry to obtain the credentials in next export cycle
+		caCert, err := getCACert(exp.k8sClient)
+		if err != nil {
+			return fmt.Errorf("cannot retrieve CA cert: %v", err)
+		}
+		clientCert, clientKey, err := getClientCertKey(exp.k8sClient)
+		if err != nil {
+			return fmt.Errorf("cannot retrieve client cert and key: %v", err)
+		}
+		// TLS transport does not need any tempRefTimeout, so sending 0.
+		expInput = exporter.ExporterInput{
+			CollectorAddress:    collectorAddr,
+			CollectorProtocol:   collectorProto,
+			ObservationDomainID: obsID,
+			TempRefTimeout:      0,
+			PathMTU:             0,
+			IsEncrypted:         true,
+			CACert:              caCert,
+			ClientCert:          clientCert,
+			ClientKey:           clientKey,
+		}
+	} else if collectorProto == "tcp" {
 		// TCP transport does not need any tempRefTimeout, so sending 0.
 		// tempRefTimeout is the template refresh timeout, which specifies how often
 		// the exporting process should send the template again.

--- a/pkg/agent/flowexporter/exporter/exporter_test.go
+++ b/pkg/agent/flowexporter/exporter/exporter_test.go
@@ -66,6 +66,8 @@ func testFlowExporter_sendTemplateSet(t *testing.T, v4Enabled bool, v6Enabled bo
 		v4Enabled,
 		v6Enabled,
 		nil,
+		false,
+		nil,
 	}
 
 	if v4Enabled {
@@ -170,6 +172,8 @@ func testFlowExporter_sendDataSet(t *testing.T, v4Enabled bool, v6Enabled bool) 
 		mockIPFIXRegistry,
 		v4Enabled,
 		v6Enabled,
+		nil,
+		false,
 		nil,
 	}
 

--- a/pkg/flowaggregator/certificate.go
+++ b/pkg/flowaggregator/certificate.go
@@ -1,0 +1,181 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flowaggregator
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+)
+
+const (
+	CAConfigMapName       = "flow-aggregator-ca"
+	CAConfigMapKey        = "ca.crt"
+	CAConfigMapNamespace  = "flow-aggregator"
+	ClientSecretNamespace = "flow-aggregator"
+	// #nosec G101: false positive triggered by variable name which includes "Secret"
+	ClientSecretName = "flow-aggregator-client-tls"
+)
+
+var (
+	validFrom = time.Now().Add(-time.Hour) // valid an hour earlier to avoid flakes due to clock skew
+	maxAge    = time.Hour * 24 * 365       // one year self-signed certs
+)
+
+func generateCACertKey() (*x509.Certificate, *rsa.PrivateKey, []byte, error) {
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: fmt.Sprintf("flow-aggregator-ca@%d", time.Now().Unix()),
+		},
+		NotBefore:             validFrom,
+		NotAfter:              validFrom.Add(maxAge),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	// generate private key for CA
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	// generate CA certificate
+	caCert, err := x509.CreateCertificate(rand.Reader, cert, cert, &caKey.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	caPEM := new(bytes.Buffer)
+	pem.Encode(caPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caCert,
+	})
+
+	return cert, caKey, caPEM.Bytes(), err
+}
+
+func generateCertKey(caCert *x509.Certificate, caKey *rsa.PrivateKey, isServer bool, flowAggregatorAddress string) ([]byte, []byte, error) {
+	var cert *x509.Certificate
+	if isServer {
+		cert = &x509.Certificate{
+			SerialNumber: big.NewInt(2),
+			Subject: pkix.Name{
+				CommonName: fmt.Sprintf("flow-aggregator-server-certificate@%d", time.Now().Unix()),
+			},
+			NotBefore:   validFrom,
+			NotAfter:    validFrom.Add(maxAge),
+			ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			KeyUsage:    x509.KeyUsageDigitalSignature,
+		}
+		if ip := net.ParseIP(flowAggregatorAddress); ip != nil {
+			cert.IPAddresses = []net.IP{ip}
+		} else {
+			cert.DNSNames = []string{flowAggregatorAddress}
+		}
+	} else {
+		cert = &x509.Certificate{
+			SerialNumber: big.NewInt(3),
+			Subject: pkix.Name{
+				CommonName: fmt.Sprintf("flow-aggregator-client-certificate@%d", time.Now().Unix()),
+			},
+			NotBefore:   validFrom,
+			NotAfter:    validFrom.Add(maxAge),
+			ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+			KeyUsage:    x509.KeyUsageDigitalSignature,
+		}
+	}
+	// generate private key for certificate
+	certKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+	// sign the certificate using CA certificate and key
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, caCert, &certKey.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM := new(bytes.Buffer)
+	pem.Encode(certPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+
+	certKeyPEM := new(bytes.Buffer)
+	pem.Encode(certKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(certKey),
+	})
+
+	return certPEM.Bytes(), certKeyPEM.Bytes(), nil
+}
+
+func syncCAAndClientCert(caCert, clientCert, clientKey []byte, k8sClient kubernetes.Interface) error {
+	klog.Info("Syncing CA certificate, client certificate and client key with ConfigMap")
+	caConfigMap, err := k8sClient.CoreV1().ConfigMaps(CAConfigMapNamespace).Get(context.TODO(), CAConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error getting ConfigMap %s: %v", CAConfigMapName, err)
+	}
+	caConfigMap.Data = map[string]string{
+		CAConfigMapKey: string(caCert),
+	}
+	if _, err := k8sClient.CoreV1().ConfigMaps(CAConfigMapNamespace).Update(context.TODO(), caConfigMap, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("error updating ConfigMap %s: %v", CAConfigMapName, err)
+	}
+
+	secret, err := k8sClient.CoreV1().Secrets(ClientSecretNamespace).Get(context.TODO(), ClientSecretName, metav1.GetOptions{})
+	exists := true
+	if err != nil {
+		exists = false
+		secret = &v1.Secret{
+			Data: map[string][]byte{
+				"tls.crt": clientCert,
+				"tls.key": clientKey,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ClientSecretName,
+				Namespace: ClientSecretNamespace,
+			},
+			Type: v1.SecretTypeTLS,
+		}
+	}
+	secret.Data = map[string][]byte{
+		"tls.crt": clientCert,
+		"tls.key": clientKey,
+	}
+	if exists {
+		if _, err := k8sClient.CoreV1().Secrets(ClientSecretNamespace).Update(context.TODO(), secret, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to update Secret %s: %v", ClientSecretName, err)
+		}
+	} else {
+		if _, err := k8sClient.CoreV1().Secrets(ClientSecretNamespace).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("failed to create Secret %s: %v", ClientSecretName, err)
+		}
+	}
+	return nil
+}

--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -53,6 +53,8 @@ func TestFlowAggregator_sendTemplateSet(t *testing.T) {
 		mockIPFIXExpProc,
 		testTemplateID,
 		mockIPFIXRegistry,
+		"",
+		nil,
 	}
 
 	// Following consists of all elements that are in ianaInfoElements and antreaInfoElements (globals)

--- a/pkg/util/flowexport/flowexport.go
+++ b/pkg/util/flowexport/flowexport.go
@@ -78,7 +78,7 @@ func ParseFlowIntervalString(intervalString string) (time.Duration, error) {
 // ParseTransportProtocol parses the transport protocol input for the flow aggregator
 func ParseTransportProtocol(trasnportProtocolInput flowaggregator.AggregatorTransportProtocol) (flowaggregator.AggregatorTransportProtocol, error) {
 	upperProtocolInput := flowaggregator.AggregatorTransportProtocol(strings.ToUpper(string(trasnportProtocolInput)))
-	if (upperProtocolInput != flowaggregator.AggregatorTransportProtocolUDP) && (upperProtocolInput != flowaggregator.AggregatorTransportProtocolTCP) {
+	if (upperProtocolInput != flowaggregator.AggregatorTransportProtocolTLS) && (upperProtocolInput != flowaggregator.AggregatorTransportProtocolUDP) && (upperProtocolInput != flowaggregator.AggregatorTransportProtocolTCP) {
 		return "", fmt.Errorf("collecting process over %s proto is not supported", trasnportProtocolInput)
 	}
 	return upperProtocolInput, nil

--- a/plugins/octant/go.sum
+++ b/plugins/octant/go.sum
@@ -591,7 +591,7 @@ github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmF
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vmware-tanzu/octant v0.16.1 h1:fkofB9oZ4yTqOaKf0JEhdibnIGBEOJ4OYOZL4Kli74A=
 github.com/vmware-tanzu/octant v0.16.1/go.mod h1:FhWXp2v0bgOQEwuOMOE49DXUu+uwWt8lXh7aOHtrA8A=
-github.com/vmware/go-ipfix v0.4.3/go.mod h1:lQz3f4r2pZWo0q8s8BtZ0xo5fPSOYsYteqJgBASP69o=
+github.com/vmware/go-ipfix v0.4.4/go.mod h1:lQz3f4r2pZWo0q8s8BtZ0xo5fPSOYsYteqJgBASP69o=
 github.com/wenyingd/ofnet v0.0.0-20201109024835-6fd225d8c8d1/go.mod h1:8mMMWAYBNUeTGXYKizOLETfN3WIbu3P5DgvS2jiXKdI=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSfTONNIgpN5RA8prR7fF8nkF6cTWTcNerRO8=


### PR DESCRIPTION
fixes #1610 
This PR aims to provide TLS support between flow exporter and flow aggregator.
Flow Aggregator generates its own CA, server certificate and key, client certificate and key. Then it distributes CA as ConfigMap, client certificate and key as Secret for Flow Exporter to use. 
It also moves go-ipfix to v0.4.4 with support for collector DNS address resolution and disabling address resolution for TLS (we will need DNS name in server certificate)
