### PR TITLE
Use VMware Harbor registry for flow-aggregator Docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,6 +326,8 @@ else
 	docker build --pull -t antrea/flow-aggregator:$(DOCKER_IMG_VERSION) -f build/images/flow-aggregator/Dockerfile .
 endif
 	docker tag antrea/flow-aggregator:$(DOCKER_IMG_VERSION) antrea/flow-aggregator
+	docker tag antrea/flow-aggregator:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/flow-aggregator
+	docker tag antrea/flow-aggregator:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/flow-aggregator:$(DOCKER_IMG_VERSION)
 
 .PHONY: verify
 verify:

--- a/build/yamls/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator.yml
@@ -61,7 +61,7 @@ spec:
         - --v=0
         command:
         - flow-aggregator
-        image: antrea/flow-aggregator
+        image: projects.registry.vmware.com/antrea/flow-aggregator:latest
         imagePullPolicy: IfNotPresent
         name: flow-aggregator
         ports:

--- a/build/yamls/flow-aggregator/base/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator/base/flow-aggregator.yml
@@ -36,7 +36,7 @@ spec:
         command:
           - flow-aggregator
         name: flow-aggregator
-        image: antrea/flow-aggregator
+        image: flow-aggregator
         ports:
           - containerPort: 4739
         volumeMounts:

--- a/hack/generate-manifest-flow-aggregator.sh
+++ b/hack/generate-manifest-flow-aggregator.sh
@@ -113,7 +113,7 @@ $KUSTOMIZE edit add base $BASE
 find ../../patches/$MODE -name \*.yml -exec cp {} . \;
 
 if [ "$MODE" == "dev" ]; then
-    $KUSTOMIZE edit set image flow-aggregator=antrea/flow-aggregator:latest
+    $KUSTOMIZE edit set image flow-aggregator=projects.registry.vmware.com/antrea/flow-aggregator:latest
     $KUSTOMIZE edit add patch imagePullPolicy.yml
 fi
 

--- a/hack/release/prepare-assets.sh
+++ b/hack/release/prepare-assets.sh
@@ -78,7 +78,7 @@ export IMG_NAME=projects.registry.vmware.com/antrea/octant-antrea-ubuntu
 export IMG_NAME=projects.registry.vmware.com/antrea/antrea-windows
 ./hack/generate-manifest-windows.sh --mode release > "$OUTPUT_DIR"/antrea-windows.yml
 
-export IMG_NAME=antrea/flow-aggregator
+export IMG_NAME=projects.registry.vmware.com/antrea/flow-aggregator
 ./hack/generate-manifest-flow-aggregator.sh --mode release > "$OUTPUT_DIR"/flow-aggregator.yml
 
 ls "$OUTPUT_DIR" | cat


### PR DESCRIPTION
Changes are the same as in
https://github.com/vmware-tanzu/antrea/pull/1617 but for the
antrea/flow-aggregator Docker image.

There was also a typo in the flow-aggregator YAML: the image key didn't
match the one used in generate-manifest-flow-aggregator.sh when invoking
kustomize.