### PR TITLE
[Windows] Fix br-int NetIPAddress not found issue

### DIFF
--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -152,12 +152,11 @@ func (i *Initializer) prepareOVSBridge() error {
 	}
 	// TODO: Configure IPv6 Address.
 	if err = util.ConfigureInterfaceAddressWithDefaultGateway(brName, uplinkNetConfig.IP, uplinkNetConfig.Gateway); err != nil {
-		if strings.Contains(err.Error(), "Instance MSFT_NetIPAddress already exists") {
-			err = nil
-			klog.V(4).Infof("Address: %s already exists on interface %s", uplinkNetConfig.IP.String(), brName)
-		} else {
+		if !strings.Contains(err.Error(), "Instance MSFT_NetIPAddress already exists") {
 			return err
 		}
+		err = nil
+		klog.V(4).Infof("Address: %s already exists when configuring IP on interface %s", uplinkNetConfig.IP.String(), brName)
 	}
 	// Restore the host routes which are lost when moving the network configuration of the uplink interface to OVS bridge interface.
 	if err = i.restoreHostRoutes(); err != nil {

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -150,14 +150,14 @@ func (i *Initializer) prepareOVSBridge() error {
 	if err = util.SetAdapterMACAddress(brName, &uplinkNetConfig.MAC); err != nil {
 		return err
 	}
-	// Remove existing IP addresses to avoid a candidate error of "Instance MSFT_NetIPAddress already exists" when
-	// adding it on the adapter.
-	if err = util.RemoveIPv4AddrsFromAdapter(brName); err != nil {
-		return err
-	}
 	// TODO: Configure IPv6 Address.
 	if err = util.ConfigureInterfaceAddressWithDefaultGateway(brName, uplinkNetConfig.IP, uplinkNetConfig.Gateway); err != nil {
-		return err
+		if strings.Contains(err.Error(), "Instance MSFT_NetIPAddress already exists") {
+			err = nil
+			klog.V(4).Infof("Address: %s already exists on interface %s", uplinkNetConfig.IP.String(), brName)
+		} else {
+			return err
+		}
 	}
 	// Restore the host routes which are lost when moving the network configuration of the uplink interface to OVS bridge interface.
 	if err = i.restoreHostRoutes(); err != nil {

--- a/pkg/agent/util/net_windows.go
+++ b/pkg/agent/util/net_windows.go
@@ -300,30 +300,6 @@ func GetLocalBroadcastIP(ipNet *net.IPNet) net.IP {
 	return lastAddr
 }
 
-func RemoveIPv4AddrsFromAdapter(adapterName string) error {
-	cmd := fmt.Sprintf("Remove-NetIPAddress  -Confirm:$false -AddressFamily IPv4 -InterfaceAlias %s", adapterName)
-	return InvokePSCommand(cmd)
-}
-
-func GetAdapterIPv4Addr(adapterName string) (*net.IPNet, error) {
-	adapter, err := net.InterfaceByName(adapterName)
-	if err != nil {
-		return nil, err
-	}
-	addrs, err := adapter.Addrs()
-	if err != nil {
-		return nil, err
-	}
-	for _, ip := range addrs {
-		if ip, ok := ip.(*net.IPNet); ok {
-			if ip.IP.To4() != nil {
-				return ip, nil
-			}
-		}
-	}
-	return nil, fmt.Errorf("failed to find a valid IP on adapter %s", adapterName)
-}
-
 // GetDefaultGatewayByInterfaceIndex returns the default gateway configured on the speicified interface.
 func GetDefaultGatewayByInterfaceIndex(ifIndex int) (string, error) {
 	cmd := fmt.Sprintf("$(Get-NetRoute -InterfaceIndex %d -DestinationPrefix 0.0.0.0/0 ).NextHop", ifIndex)


### PR DESCRIPTION
Do not remove the NetIPAddress on br-int anymore to avoid the
"No matching MSFT_NetIPAddress objects found" issue because the
NetIPAddress may not exist on br-int.

Instead, always try to configure NetIPAddress on the interface
and ignore the "MSFT_NetIPAddress already exists" error.

Fixes: #1644
Signed-off-by: Rui Cao <rcao@vmware.com>