### PR TITLE
Add default value of kubeconfig for antrea-octant-plugin

### DIFF
--- a/docs/octant-plugin-installation.md
+++ b/docs/octant-plugin-installation.md
@@ -87,7 +87,8 @@ You can follow the steps listed below to install octant and antrea-octant-plugin
     rpm -i octant_0.16.1_Linux-64bit.rpm
     ```
 
-2. Export your kubeconfig path (file location depends on your setup) to environment variable $KUBECONFIG.
+2. Export your kubeconfig path (file location depends on your setup) to environment variable $KUBECONFIG,
+   otherwise `~/.kube/config` will be used.
 
     ```bash
     export KUBECONFIG=/etc/kubernetes/admin.conf

--- a/plugins/octant/cmd/antrea-octant-plugin/main.go
+++ b/plugins/octant/cmd/antrea-octant-plugin/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/vmware-tanzu/octant/pkg/navigation"
 	"github.com/vmware-tanzu/octant/pkg/plugin"
@@ -33,8 +34,7 @@ var (
 )
 
 const (
-	kubeConfig = "KUBECONFIG"
-	title      = "Antrea"
+	title = "Antrea"
 )
 
 type antreaOctantPlugin struct {
@@ -44,8 +44,12 @@ type antreaOctantPlugin struct {
 }
 
 func newAntreaOctantPlugin() *antreaOctantPlugin {
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
+	}
 	// Create a k8s client.
-	config, err := clientcmd.BuildConfigFromFlags("", os.Getenv(kubeConfig))
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		log.Fatalf("Failed to build kubeConfig %v", err)
 	}


### PR DESCRIPTION
Use default location of kubeconfig (~/.kube/config) for antrea-octant-plugin
when $KUBECONFIG is not set.