### PR TITLE
Update Emergency Tier's Priority to 50

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1075,6 +1075,7 @@ rules:
   - watch
   - list
   - create
+  - update
 - apiGroups:
   - ops.antrea.tanzu.vmware.com
   resources:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1378,6 +1378,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: SERVICEACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1075,6 +1075,7 @@ rules:
   - watch
   - list
   - create
+  - update
 - apiGroups:
   - ops.antrea.tanzu.vmware.com
   resources:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1378,6 +1378,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: SERVICEACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1075,6 +1075,7 @@ rules:
   - watch
   - list
   - create
+  - update
 - apiGroups:
   - ops.antrea.tanzu.vmware.com
   resources:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1378,6 +1378,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: SERVICEACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1392,6 +1392,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: SERVICEACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1075,6 +1075,7 @@ rules:
   - watch
   - list
   - create
+  - update
 - apiGroups:
   - ops.antrea.tanzu.vmware.com
   resources:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1383,6 +1383,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: SERVICEACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1075,6 +1075,7 @@ rules:
   - watch
   - list
   - create
+  - update
 - apiGroups:
   - ops.antrea.tanzu.vmware.com
   resources:

--- a/build/yamls/base/controller-rbac.yml
+++ b/build/yamls/base/controller-rbac.yml
@@ -130,6 +130,7 @@ rules:
       - watch
       - list
       - create
+      - update
   - apiGroups:
       - ops.antrea.tanzu.vmware.com
     resources:

--- a/build/yamls/base/controller.yml
+++ b/build/yamls/base/controller.yml
@@ -222,6 +222,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # Provide ServiceAccount name for validation webhook.
+            - name: SERVICEACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
           ports:
             - containerPort: 10349
               name: api

--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -86,7 +86,7 @@ Tier CRD object, that will be enforced after developer-created K8s NetworkPolici
 The details for these tiers are shown below:
 
 ```text
-    Emergency   -> Tier name "emergency" with priority "5"
+    Emergency   -> Tier name "emergency" with priority "20"
     SecurityOps -> Tier name "securityops" with priority "50"
     NetworkOps  -> Tier name "networkops" with priority "100"
     Platform    -> Tier name "platform" with priority "150"
@@ -149,7 +149,7 @@ All of the above commands produce output similar to what is shown below:
 
 ```text
     NAME          PRIORITY   AGE
-    emergency     5          27h
+    emergency     20         27h
     securityops   50         27h
     networkops    100        27h
     platform      150        27h

--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -86,10 +86,10 @@ Tier CRD object, that will be enforced after developer-created K8s NetworkPolici
 The details for these tiers are shown below:
 
 ```text
-    Emergency   -> Tier name "emergency" with priority "20"
-    SecurityOps -> Tier name "securityops" with priority "50"
-    NetworkOps  -> Tier name "networkops" with priority "100"
-    Platform    -> Tier name "platform" with priority "150"
+    Emergency   -> Tier name "emergency" with priority "50"
+    SecurityOps -> Tier name "securityops" with priority "100"
+    NetworkOps  -> Tier name "networkops" with priority "150"
+    Platform    -> Tier name "platform" with priority "200"
     Application -> Tier name "application" with priority "250"
     Baseline    -> Tier name "baseline" with priority "253"
 ```

--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -149,10 +149,10 @@ All of the above commands produce output similar to what is shown below:
 
 ```text
     NAME          PRIORITY   AGE
-    emergency     20         27h
-    securityops   50         27h
-    networkops    100        27h
-    platform      150        27h
+    emergency     50         27h
+    securityops   100        27h
+    networkops    150        27h
+    platform      200        27h
     application   250        27h
 ```
 

--- a/pkg/controller/networkpolicy/tier.go
+++ b/pkg/controller/networkpolicy/tier.go
@@ -137,7 +137,7 @@ func (n *NetworkPolicyController) InitializeTiers() {
 		if err == nil {
 			// Tier is already present.
 			klog.V(2).Infof("%s Tier already created", t.Name)
-			// Update existing Emergency Tier's priority from 5 to 20.
+			// Update Tier Priority if it is not set to desired Priority.
 			oldPrio, ok := oldPriorityMap[t.Name]
 			if ok && oldPrio == oldTier.Spec.Priority {
 				tToUpdate := oldTier.DeepCopy()

--- a/pkg/controller/networkpolicy/tier.go
+++ b/pkg/controller/networkpolicy/tier.go
@@ -42,15 +42,17 @@ var (
 	BaselineTierPriority = int32(253)
 	// defaultTierName maintains the name of the default Tier in Antrea.
 	defaultTierName = "application"
+	// emergencyTierName maintains the name of the Emergency Tier in Antrea.
+	emergencyTierName = "emergency"
 	// priorityMap maintains the Tier priority associated with system generated
 	// Tier names.
 	priorityMap = map[string]int32{
-		"baseline":      BaselineTierPriority,
-		defaultTierName: DefaultTierPriority,
-		"platform":      int32(150),
-		"networkops":    int32(100),
-		"securityops":   int32(50),
-		"emergency":     int32(20),
+		"baseline":        BaselineTierPriority,
+		defaultTierName:   DefaultTierPriority,
+		"platform":        int32(150),
+		"networkops":      int32(100),
+		"securityops":     int32(50),
+		emergencyTierName: int32(20),
 	}
 	// staticTierSet maintains the names of the static tiers such that they can
 	// be converted to corresponding Tier CRD names.
@@ -104,10 +106,10 @@ var (
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "emergency",
+				Name: emergencyTierName,
 			},
 			Spec: secv1alpha1.TierSpec{
-				Priority:    priorityMap["emergency"],
+				Priority:    priorityMap[emergencyTierName],
 				Description: "[READ-ONLY]: System generated Emergency Tier",
 			},
 		},
@@ -121,10 +123,16 @@ var (
 func (n *NetworkPolicyController) InitializeTiers() {
 	for _, t := range systemGeneratedTiers {
 		// Check if Tier is already present.
-		_, err := n.tierLister.Get(t.Name)
+		oldTier, err := n.tierLister.Get(t.Name)
 		if err == nil {
 			// Tier is already present.
 			klog.V(2).Infof("%s Tier already created", t.Name)
+			// Update existing Emergency Tier's priority from 5 to 20.
+			if t.Name == emergencyTierName && oldTier.Spec.Priority == 5 {
+				tToUpdate := oldTier.DeepCopy()
+				tToUpdate.Spec.Priority = 20
+				n.initTierUpdates(tToUpdate)
+			}
 			continue
 		}
 		n.initTier(t)
@@ -145,6 +153,34 @@ func (n *NetworkPolicyController) initTier(t *secv1alpha1.Tier) {
 		if err != nil && !errors.IsAlreadyExists(err) {
 			klog.Warningf("Failed to create %s Tier on init: %v. Retry attempt: %d", t.Name, err, retryAttempt)
 			// Tier creation may fail because antrea APIService is not yet ready
+			// to accept requests for validation. Retry fixed number of times
+			// not exceeding 2 * 5 = 10s.
+			time.Sleep(backoff)
+			backoff *= 2
+			if backoff > maxBackoffTime {
+				backoff = maxBackoffTime
+			}
+			retryAttempt += 1
+			continue
+		}
+		return
+	}
+}
+
+// initTierUpdates attempts to update Tiers using an
+// exponential backoff period from 1 to max of 8secs.
+func (n *NetworkPolicyController) initTierUpdates(t *secv1alpha1.Tier) {
+	var err error
+	const maxBackoffTime = 8 * time.Second
+	backoff := 1 * time.Second
+	retryAttempt := 1
+	for {
+		klog.V(2).Infof("Updating %s Tier", t.Name)
+		_, err = n.crdClient.SecurityV1alpha1().Tiers().Update(context.TODO(), t, metav1.UpdateOptions{})
+		// Attempt to recreate Tier after a backoff only if it does not exist.
+		if err != nil {
+			klog.Warningf("Failed to update %s Tier on init: %v. Retry attempt: %d", t.Name, err, retryAttempt)
+			// Tier update may fail because antrea APIService is not yet ready
 			// to accept requests for validation. Retry fixed number of times
 			// not exceeding 2 * 5 = 10s.
 			time.Sleep(backoff)

--- a/pkg/controller/networkpolicy/tier.go
+++ b/pkg/controller/networkpolicy/tier.go
@@ -50,7 +50,7 @@ var (
 		"platform":      int32(150),
 		"networkops":    int32(100),
 		"securityops":   int32(50),
-		"emergency":     int32(5),
+		"emergency":     int32(20),
 	}
 	// staticTierSet maintains the names of the static tiers such that they can
 	// be converted to corresponding Tier CRD names.

--- a/pkg/controller/networkpolicy/validate.go
+++ b/pkg/controller/networkpolicy/validate.go
@@ -449,10 +449,10 @@ func (t *tierValidator) updateValidate(curObj, oldObj interface{}, userInfo auth
 	reason := ""
 	curTier := curObj.(*secv1alpha1.Tier)
 	oldTier := oldObj.(*secv1alpha1.Tier)
-	// Allow an exception of Emergency Tier Priority update from 5 to 20 as we downgrade its priority intentionally
+	// Allow exception of Tier Priority updates as we downgrade their priority intentionally
 	// from antrea-controller.
-	if curTier.Name == emergencyTierName {
-		if curTier.Spec.Priority == 20 && oldTier.Spec.Priority == 5 {
+	if oldPrio, ok := oldPriorityMap[curTier.Name]; ok {
+		if oldPrio == oldTier.Spec.Priority && priorityMap[curTier.Name] == curTier.Spec.Priority {
 			return "", true
 		}
 	}

--- a/pkg/controller/networkpolicy/validate.go
+++ b/pkg/controller/networkpolicy/validate.go
@@ -449,6 +449,13 @@ func (t *tierValidator) updateValidate(curObj, oldObj interface{}, userInfo auth
 	reason := ""
 	curTier := curObj.(*secv1alpha1.Tier)
 	oldTier := oldObj.(*secv1alpha1.Tier)
+	// Allow an exception of Emergency Tier Priority update from 5 to 20 as we downgrade its priority intentionally
+	// from antrea-controller.
+	if curTier.Name == emergencyTierName {
+		if curTier.Spec.Priority == 20 && oldTier.Spec.Priority == 5 {
+			return "", true
+		}
+	}
 	if curTier.Spec.Priority != oldTier.Spec.Priority {
 		allowed = false
 		reason = "update to Tier priority is not allowed"

--- a/pkg/controller/networkpolicy/validate.go
+++ b/pkg/controller/networkpolicy/validate.go
@@ -451,8 +451,14 @@ func (t *tierValidator) updateValidate(curObj, oldObj interface{}, userInfo auth
 	reason := ""
 	curTier := curObj.(*secv1alpha1.Tier)
 	oldTier := oldObj.(*secv1alpha1.Tier)
+	// Retrieve antrea-controller's Namespace
+	ns := env.GetPodNamespace()
+	if ns == "" {
+		// antrea-controller by default is created in the kube-system Namespace
+		ns = "kube-system"
+	}
 	// Allow exception of Tier Priority updates performed by the antrea-controller
-	if serviceaccount.MatchesUsername("kube-system", env.GetAntreaControllerServiceAccount(), userInfo.Username) {
+	if serviceaccount.MatchesUsername(ns, env.GetAntreaControllerServiceAccount(), userInfo.Username) {
 		return "", true
 	}
 	if curTier.Spec.Priority != oldTier.Spec.Priority {

--- a/pkg/controller/networkpolicy/validate.go
+++ b/pkg/controller/networkpolicy/validate.go
@@ -70,6 +70,8 @@ var (
 	reservedTierNames = sets.NewString("baseline", "application", "platform", "networkops", "securityops", "emergency")
 )
 
+const defaultControllerNamespace = "kube-system"
+
 // RegisterAntreaPolicyValidator registers an Antrea-native policy validator
 // to the resource registry. A new validator must be registered by calling
 // this function before the Run phase of the APIServer.
@@ -452,13 +454,13 @@ func (t *tierValidator) updateValidate(curObj, oldObj interface{}, userInfo auth
 	curTier := curObj.(*secv1alpha1.Tier)
 	oldTier := oldObj.(*secv1alpha1.Tier)
 	// Retrieve antrea-controller's Namespace
-	ns := env.GetPodNamespace()
-	if ns == "" {
+	namespace := env.GetPodNamespace()
+	if namespace == "" {
 		// antrea-controller by default is created in the kube-system Namespace
-		ns = "kube-system"
+		namespace = defaultControllerNamespace
 	}
 	// Allow exception of Tier Priority updates performed by the antrea-controller
-	if serviceaccount.MatchesUsername(ns, env.GetAntreaControllerServiceAccount(), userInfo.Username) {
+	if serviceaccount.MatchesUsername(namespace, env.GetAntreaControllerServiceAccount(), userInfo.Username) {
 		return "", true
 	}
 	if curTier.Spec.Priority != oldTier.Spec.Priority {

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -26,6 +26,7 @@ const (
 	nodeNameEnvKey     = "NODE_NAME"
 	podNameEnvKey      = "POD_NAME"
 	podNamespaceEnvKey = "POD_NAMESPACE"
+	svcAcctNameEnvKey  = "SERVICEACCOUNT_NAME"
 
 	antreaCloudEKSEnvKey = "ANTREA_CLOUD_EKS"
 )
@@ -64,6 +65,16 @@ func GetPodNamespace() string {
 		klog.Warningf("Environment variable %s not found", podNamespaceEnvKey)
 	}
 	return podNamespace
+}
+
+// GetAntreaCtrlServiceAccountName returns the ServiceAccount's name associated with antrea-controller.
+func GetAntreaControllerServiceAccount() string {
+	svcAcctName := os.Getenv(svcAcctNameEnvKey)
+	if svcAcctName == "" {
+		// default value set for antrea-controller
+		svcAcctName = "antrea-controller"
+	}
+	return svcAcctName
 }
 
 func getBoolEnvVar(name string, defaultValue bool) bool {

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -67,7 +67,7 @@ func GetPodNamespace() string {
 	return podNamespace
 }
 
-// GetAntreaControllerServiceAccountName returns the ServiceAccount's name associated with antrea-controller.
+// GetAntreaControllerServiceAccountName returns the ServiceAccount name associated with antrea-controller.
 func GetAntreaControllerServiceAccount() string {
 	svcAcctName := os.Getenv(svcAcctNameEnvKey)
 	if svcAcctName == "" {

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -67,7 +67,7 @@ func GetPodNamespace() string {
 	return podNamespace
 }
 
-// GetAntreaCtrlServiceAccountName returns the ServiceAccount's name associated with antrea-controller.
+// GetAntreaControllerServiceAccountName returns the ServiceAccount's name associated with antrea-controller.
 func GetAntreaControllerServiceAccount() string {
 	svcAcctName := os.Getenv(svcAcctNameEnvKey)
 	if svcAcctName == "" {


### PR DESCRIPTION
This PR updates the priority of Tiers created by Antrea, and space them out evenly. The current Antrea generated Tier priorities do not allow enough room for user defined Tiers to be created, for example Emergency Tier allows only 4 user created Tiers with higher priority. Since it ultimately is up to the users as to which Tiers go atop and the purpose of Antrea created Tiers is mainly that of convenience, we decided to distribute the priorities more evenly across available priority space. For example, setting the priority of the top most Tier of Emergency to a value of 50 gives enough room for admins to create their own Tier hierarchy without having to rely on Antrea created Tiers.

Summary of change:
```
Tier Name        Old Priority        Updated Priority
emergency         5                         50
securityops       50                        100
networkops        100                       150
platform          150                       200
```
**NOTE**: Existing users of Antrea created Tiers are advised to re-evaluate their Tier hierarchy and take action to recreate any user created Tier resource, such that they continue to be enforced as per user's intention.