### PR TITLE
Push image of flow aggregator in feature branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,8 @@ jobs:
     - name: Build flow-aggregator Docker image
       run: make flow-aggregator-ubuntu
     - name: Push flow-aggregator Docker image to registry
-      if: ${{ github.repository == 'vmware-tanzu/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      # Will remove the feature/flow-aggregator branch later
+      if: ${{ github.repository == 'vmware-tanzu/antrea' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/feature/flow-aggregator')}}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
A tiny change in github workflow to push flow aggregator image before PRs merged in the master branch. 
This is a temporary solution to unblock the e2e test PR, will remove this change later.