### PR TITLE
[Flow-Aggregator] Add correlate fields and fix e2e tests with stats and network policy

### DIFF
--- a/pkg/agent/flowexporter/exporter/exporter.go
+++ b/pkg/agent/flowexporter/exporter/exporter.go
@@ -273,6 +273,9 @@ func (exp *flowExporter) sendFlowRecords() error {
 				return err
 			}
 		}
+		if err := exp.flowRecords.ValidateAndUpdateStats(key, record); err != nil {
+			return err
+		}
 		return nil
 	}
 	err := exp.flowRecords.ForAllFlowRecordsDo(addAndSendFlowRecord)

--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -118,9 +118,12 @@ var (
 		"destinationPodNamespace",
 		"destinationNodeName",
 		"destinationClusterIPv4",
+		"destinationServicePort",
 		"destinationServicePortName",
 		"ingressNetworkPolicyName",
 		"ingressNetworkPolicyNamespace",
+		"egressNetworkPolicyName",
+		"egressNetworkPolicyNamespace",
 	}
 )
 


### PR DESCRIPTION
This PR is a follow-up fix for bumping go-ipfix to v0.4.2 with following changes:

- add `destinationServicePort`, `egressNetworkPolicyName` and `egressNetworkPolicyNamespace` in correlation fields
- add stats update function in flow-exporter without which the delta values are 0 (found in e2e tests)
- add network policy testing for inter Node flows
- fix bandwidth unit parsing problem