### PR TITLE
Skip AntreaProxy LB for established connections without ServiceMark

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -485,14 +485,12 @@ func (c *client) InstallClusterServiceFlows() error {
 		c.l2ForwardOutputServiceHairpinFlow(),
 	}
 	if c.IsIPv4Enabled() {
-		flows = append(flows,
-			c.serviceHairpinResponseDNATFlow(binding.ProtocolIP),
-			c.serviceLBBypassFlow(binding.ProtocolIP))
+		flows = append(flows, c.serviceHairpinResponseDNATFlow(binding.ProtocolIP))
+		flows = append(flows, c.serviceLBBypassFlows(binding.ProtocolIP)...)
 	}
 	if c.IsIPv6Enabled() {
-		flows = append(flows,
-			c.serviceHairpinResponseDNATFlow(binding.ProtocolIPv6),
-			c.serviceLBBypassFlow(binding.ProtocolIPv6))
+		flows = append(flows, c.serviceHairpinResponseDNATFlow(binding.ProtocolIPv6))
+		flows = append(flows, c.serviceLBBypassFlows(binding.ProtocolIPv6)...)
 	}
 	if err := c.ofEntryOperations.AddAll(flows); err != nil {
 		return err


### PR DESCRIPTION
When running manual tests on AntreaProxy by enabling AntreaProxy with
ongoing connections and checking if these connections were disrupted, I
observed some strange behavior. AntreaProxy would try to load-balance
the connection but the selected endpoint would be ignored and instead
the endpoint selected by kube-proxy would keep being used. This is good
because it means the connection wasn't disrupted. However, this behavior
is a bit surprising. It seems that because the connection was already
committed, the DNAT action invoked by AntreaProxy was ignored
altogether.

To avoid confusion in the future to people troubleshooting the OVS
pipeline, this commit adds a flow to the ConntrackState table, to bypass
AntreaProxy for established connections, even if these connections don't
have the ServiceMark added by AntreaProxy. These are connections for
which load-balancing was done by kube-proxy prior to AntreaProxy being
enabled in the cluster.

Co-authored-by: Quan Tian <qtian@vmware.com>