### PR TITLE
Use default K8s version supported by AKS for cloud CI

### DIFF
--- a/ci/jenkins/README.md
+++ b/ci/jenkins/README.md
@@ -91,7 +91,7 @@ should be deleted. This ensures that all tests are run on a clean testbed.
 
   |  K8s Version   |  Node Type          |  Node OS        |  Status  |
   | :------------: | :-----------------: | :-------------: | :------: |
-  |    1.16.13     |  Standard_DS2_v2    |  Ubuntu 16.04   |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-aks-conformance-net-policy)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-aks-conformance-net-policy/)|
+  |    1.18.10     |  Standard_DS2_v2    |  Ubuntu 16.04   |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-aks-conformance-net-policy)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-aks-conformance-net-policy/)|
 
 * [daily-elk-flow-collector-validate](https://jenkins.antrea-ci.rocks/job/antrea-daily-elk-flow-collector-validate-for-period/):
   [![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=antrea-daily-elk-flow-collector-validate-for-period)](http://jenkins.antrea-ci.rocks/view/cloud/job/antrea-daily-elk-flow-collector-validate-for-period/)

--- a/ci/test-conformance-aks.sh
+++ b/ci/test-conformance-aks.sh
@@ -40,7 +40,7 @@ Setup a AKS cluster to run K8s e2e community tests (Conformance & Network Policy
 
         --cluster-name           The cluster name to be used for the generated AKS cluster. Must be specified if not run in Jenkins environment.
         --kubeconfig             Path to save kubeconfig of generated AKS cluster.
-        --k8s-version            AKS K8s cluster version. Defaults to first supported version in the Azure region.
+        --k8s-version            AKS K8s cluster version. Defaults to the default K8s version for AKS in the Azure region.
         --azure-app-id           Azure Service Principal Application ID.
         --azure-tenant-id        Azure Service Principal Tenant ID.
         --azure-password         Azure Service Principal Password.
@@ -142,7 +142,7 @@ function setup_aks() {
     az group create --name ${RESOURCE_GROUP} --location $REGION
 
     if [[ -z ${K8S_VERSION+x} ]]; then
-        K8S_VERSION=$(az aks get-versions -l ${REGION} | grep "orchestratorVersion" | head -n1 | cut -d'"' -f4)
+        K8S_VERSION=$(az aks get-versions -l ${REGION} -o json | jq -r '.orchestrators[] | select(.default==true).orchestratorVersion')
     fi
 
     echo '=== Creating a cluster in AKS ==='


### PR DESCRIPTION
This will fix the AKS CI failure caused by the Sonobuoy version increase

See https://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-aks-conformance-net-policy/80/console