### PR TITLE
Add metrics of Antrea Proxy

### DIFF
--- a/docs/prometheus-integration.md
+++ b/docs/prometheus-integration.md
@@ -191,6 +191,19 @@ internal-networkpolicy processed
 - **antrea_controller_network_policy_sync_duration_milliseconds:** The
 duration of syncing internal-networkpolicy
 
+#### Antrea Proxy Metrics
+
+- **antrea_proxy_sync_proxy_rules_duration_seconds:** SyncProxyRules duration
+of AntreaProxy in seconds
+- **antrea_proxy_total_endpoints_installed:** The number of Endpoints
+installed by AntreaProxy
+- **antrea_proxy_total_endpoints_updates:** The cumulative number of Endpoint
+updates received by AntreaProxy
+- **antrea_proxy_total_services_installed:** The number of Services installed
+by AntreaProxy
+- **antrea_proxy_total_services_updates:** The cumulative number of Service
+updates received by AntreaProxy
+
 ### Common Metrics Provided by Infrastructure
 
 #### Apiserver Metrics

--- a/pkg/agent/proxy/metrics/metrics.go
+++ b/pkg/agent/proxy/metrics/metrics.go
@@ -1,0 +1,128 @@
+package metrics
+
+import (
+	"sync"
+
+	kmetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/klog"
+)
+
+const (
+	metricNSAntrea = "antrea"
+	subsystemProxy = "proxy"
+)
+
+var (
+	once sync.Once
+
+	SyncProxyDuration = kmetrics.NewHistogram(
+		&kmetrics.HistogramOpts{
+			Namespace:   metricNSAntrea,
+			Subsystem:   subsystemProxy,
+			ConstLabels: map[string]string{"ip_family": "v4"},
+			Name:        "sync_proxy_rules_duration_seconds",
+			Help:        "SyncProxyRules duration of AntreaProxy in seconds",
+		},
+	)
+	ServicesInstalledTotal = kmetrics.NewGauge(
+		&kmetrics.GaugeOpts{
+			Namespace:   metricNSAntrea,
+			Subsystem:   subsystemProxy,
+			ConstLabels: map[string]string{"ip_family": "v4"},
+			Name:        "total_services_installed",
+			Help:        "The number of Services installed by AntreaProxy",
+		},
+	)
+	EndpointsInstalledTotal = kmetrics.NewGauge(
+		&kmetrics.GaugeOpts{
+			Namespace:   metricNSAntrea,
+			Subsystem:   subsystemProxy,
+			ConstLabels: map[string]string{"ip_family": "v4"},
+			Name:        "total_endpoints_installed",
+			Help:        "The number of Endpoints installed by AntreaProxy",
+		},
+	)
+	ServicesUpdatesTotal = kmetrics.NewCounter(
+		&kmetrics.CounterOpts{
+			Namespace:   metricNSAntrea,
+			Subsystem:   subsystemProxy,
+			ConstLabels: map[string]string{"ip_family": "v4"},
+			Name:        "total_services_updates",
+			Help:        "The cumulative number of Service updates received by AntreaProxy",
+		},
+	)
+	EndpointsUpdatesTotal = kmetrics.NewCounter(
+		&kmetrics.CounterOpts{
+			Namespace:   metricNSAntrea,
+			Subsystem:   subsystemProxy,
+			ConstLabels: map[string]string{"ip_family": "v4"},
+			Name:        "total_endpoints_updates",
+			Help:        "The cumulative number of Endpoint updates received by AntreaProxy",
+		},
+	)
+
+	SyncProxyDurationV6 = kmetrics.NewHistogram(
+		&kmetrics.HistogramOpts{
+			Namespace:   metricNSAntrea,
+			Subsystem:   subsystemProxy,
+			ConstLabels: map[string]string{"ip_family": "v6"},
+			Name:        "sync_proxy_rules_duration_seconds",
+			Help:        "SyncProxyRules duration of AntreaProxy in seconds",
+		},
+	)
+	ServicesInstalledTotalV6 = kmetrics.NewGauge(
+		&kmetrics.GaugeOpts{
+			Namespace:   metricNSAntrea,
+			Subsystem:   subsystemProxy,
+			ConstLabels: map[string]string{"ip_family": "v6"},
+			Name:        "total_services_installed",
+			Help:        "The number of Services installed by AntreaProxy",
+		},
+	)
+	EndpointsInstalledTotalV6 = kmetrics.NewGauge(
+		&kmetrics.GaugeOpts{
+			Namespace:   metricNSAntrea,
+			Subsystem:   subsystemProxy,
+			ConstLabels: map[string]string{"ip_family": "v6"},
+			Name:        "total_endpoints_installed",
+			Help:        "The number of Endpoints installed by AntreaProxy",
+		},
+	)
+	ServicesUpdatesTotalV6 = kmetrics.NewCounter(
+		&kmetrics.CounterOpts{
+			Namespace:   metricNSAntrea,
+			Subsystem:   subsystemProxy,
+			ConstLabels: map[string]string{"ip_family": "v6"},
+			Name:        "total_services_updates",
+			Help:        "The cumulative number of Service updates received by AntreaProxy",
+		},
+	)
+	EndpointsUpdatesTotalV6 = kmetrics.NewCounter(
+		&kmetrics.CounterOpts{
+			Namespace:   metricNSAntrea,
+			Subsystem:   subsystemProxy,
+			ConstLabels: map[string]string{"ip_family": "v6"},
+			Name:        "total_endpoints_updates",
+			Help:        "The cumulative number of Endpoint updates received by AntreaProxy",
+		},
+	)
+)
+
+func Register() {
+	once.Do(func() {
+		klog.Infof("Registering Antrea Proxy prometheus metrics")
+		legacyregistry.MustRegister(
+			SyncProxyDuration,
+			ServicesInstalledTotal,
+			EndpointsInstalledTotal,
+			ServicesUpdatesTotal,
+			EndpointsUpdatesTotal,
+			SyncProxyDurationV6,
+			ServicesInstalledTotalV6,
+			EndpointsInstalledTotalV6,
+			ServicesUpdatesTotalV6,
+			EndpointsUpdatesTotalV6,
+		)
+	})
+}

--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -27,6 +27,7 @@ import (
 	utilnet "k8s.io/utils/net"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
+	"github.com/vmware-tanzu/antrea/pkg/agent/proxy/metrics"
 	"github.com/vmware-tanzu/antrea/pkg/agent/proxy/types"
 	"github.com/vmware-tanzu/antrea/pkg/agent/querier"
 	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
@@ -39,7 +40,6 @@ const (
 	componentName = "antrea-agent-proxy"
 )
 
-// TODO: Add metrics
 type proxier struct {
 	once            sync.Once
 	endpointsConfig *config.EndpointsConfig
@@ -290,6 +290,12 @@ func (p *proxier) installServices() {
 func (p *proxier) syncProxyRules() {
 	start := time.Now()
 	defer func() {
+		delta := time.Since(start)
+		if p.isIPv6 {
+			metrics.SyncProxyDuration.Observe(delta.Seconds())
+		} else {
+			metrics.SyncProxyDurationV6.Observe(delta.Seconds())
+		}
 		klog.V(4).Infof("syncProxyRules took %v", time.Since(start))
 	}()
 	if !p.isInitialized() {
@@ -303,6 +309,18 @@ func (p *proxier) syncProxyRules() {
 	p.removeStaleServices()
 	p.installServices()
 	p.removeStaleEndpoints(staleEndpoints)
+
+	counter := 0
+	for _, endpoints := range p.endpointsMap {
+		counter += len(endpoints)
+	}
+	if p.isIPv6 {
+		metrics.ServicesInstalledTotalV6.Set(float64(len(p.serviceMap)))
+		metrics.EndpointsInstalledTotalV6.Set(float64(counter))
+	} else {
+		metrics.ServicesInstalledTotal.Set(float64(len(p.serviceMap)))
+		metrics.EndpointsInstalledTotal.Set(float64(counter))
+	}
 }
 
 func (p *proxier) SyncLoop() {
@@ -314,6 +332,11 @@ func (p *proxier) OnEndpointsAdd(endpoints *corev1.Endpoints) {
 }
 
 func (p *proxier) OnEndpointsUpdate(oldEndpoints, endpoints *corev1.Endpoints) {
+	if p.isIPv6 {
+		metrics.EndpointsUpdatesTotalV6.Inc()
+	} else {
+		metrics.EndpointsUpdatesTotal.Inc()
+	}
 	if p.endpointsChanges.OnEndpointUpdate(oldEndpoints, endpoints) && p.isInitialized() {
 		p.runner.Run()
 	}
@@ -335,6 +358,11 @@ func (p *proxier) OnServiceAdd(service *corev1.Service) {
 }
 
 func (p *proxier) OnServiceUpdate(oldService, service *corev1.Service) {
+	if p.isIPv6 {
+		metrics.ServicesUpdatesTotalV6.Inc()
+	} else {
+		metrics.ServicesUpdatesTotal.Inc()
+	}
 	var isIPv6 bool
 	if oldService != nil {
 		isIPv6 = utilnet.IsIPv6String(oldService.Spec.ClusterIP)
@@ -399,7 +427,7 @@ func NewProxier(
 		runtime.NewScheme(),
 		corev1.EventSource{Component: componentName, Host: hostname},
 	)
-
+	metrics.Register()
 	klog.Infof("Creating proxier with IPv6 enabled=%t", isIPv6)
 	p := &proxier{
 		endpointsConfig:      config.NewEndpointsConfig(informerFactory.Core().V1().Endpoints(), resyncPeriod),


### PR DESCRIPTION
Added metrics below:
- antrea_proxy_sync_proxy_rules_duration_seconds: SyncProxyRules latency
in seconds of AntreaProxy
- antrea_proxy_total_endpoints_installed: The number of Endpoints
installed by AntreaProxy
- antrea_proxy_total_endpoints_update: The cumulative number of Endpoint
updates at AntreaProxy
- antrea_proxy_total_services_installed: The number of Services installed
by AntreaProxy
- antrea_proxy_total_services_update: The cumulative number of Service
updates at AntreaProxy