### PR TITLE
Support retrieving flows of multi-tables of ovsflows command

### DIFF
--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -242,10 +242,12 @@ or flows in a specified OVS flow table.
 antctl get ovsflows
 antctl get ovsflows -p POD -n NAMESPACE
 antctl get ovsflows --networkpolicy NETWORKPOLICY -n NAMESPACE
-antctl get ovsflows -T TABLE
+antctl get ovsflows -T TABLE_A,TABLE_B
+antctl get ovsflows -T TABLE_A,TABLE_B_NUM
+antctl get ovsflows -T TABLE_A_NUM,TABLE_B_NUM
 ```
 
-An OVS flow table can be specified using the table name or the table number.
+OVS flow tables can be specified using table names, or the table numbers.
 `antctl get ovsflow --help` lists all Antrea flow tables. For more information
 about Antrea OVS pipeline and flows, please refer to the [OVS pipeline doc](design/ovs-pipeline.md).
 

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -314,7 +314,7 @@ var CommandList = &commandList{
 						},
 						{
 							name:      "table",
-							usage:     "Antrea OVS flow table name or number",
+							usage:     "Comma separated Antrea OVS flow table names or numbers",
 							shorthand: "T",
 						},
 					},


### PR DESCRIPTION
When debugging traffic paths in OVS, we need to check flows in multiple tables most of the time. To make the debugging more convenient, this commit makes the `ovsflows` command accepting multiple tables instead of one.