### PR TITLE
Increase test timeout on Windows platform

### DIFF
--- a/pkg/agent/controller/noderoute/node_route_controller_test.go
+++ b/pkg/agent/controller/noderoute/node_route_controller_test.go
@@ -17,6 +17,7 @@ package noderoute
 import (
 	"context"
 	"net"
+	"runtime"
 	"testing"
 	"time"
 
@@ -148,8 +149,14 @@ func TestControllerWithDuplicatePodCIDR(t *testing.T) {
 		c.processNextWorkItem()
 	}()
 
+	var testTimeout time.Duration
+	if runtime.GOOS == "windows" {
+		testTimeout = 10 * time.Second
+	} else {
+		testTimeout = 5 * time.Second
+	}
 	select {
-	case <-time.After(5 * time.Second):
+	case <-time.After(testTimeout):
 		t.Errorf("Test didn't finish in time")
 	case <-finishCh:
 	}


### PR DESCRIPTION
The test on Windows is slower than other platforms.
Increase the timeout value to avoid failure.

Fixes: #1562

Signed-off-by: Rui Cao <rcao@vmware.com>