### PR TITLE
Add Antrea upgrade matrix test job

### DIFF
--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -136,7 +136,7 @@
     builders:
       - shell: |-
           #!/bin/bash
-          set -ex
+          set -e
           TEST_FAIL_E2E=0
           TEST_FAIL_NP=0
           TEST_FAIL_CONFORMANCE=0

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -954,3 +954,88 @@
              - timeout:
                  timeout: 600
                  type: absolute
+      - '{name}-{test_name}-matrix-compatibility-test':
+          test_name: upgrade
+          node: 'antrea-test-node'
+          description: 'This is the upgrade matrix compatibility test for Antrea. In this test, more than half of all Antrea agents are old-versioned.'
+          axes:
+            - axis:
+               type: user-defined
+               name: TEST_OS
+               values:
+                - ubuntu-1804
+                - centos-7
+                - photon-3
+            - axis:
+               type: user-defined
+               name: K8S_VERSION
+               values:
+                - v1.17.5
+                - v1.18.2
+            - axis:
+               type: user-defined
+               name: IS_MATRIX_TEST
+               values:
+                - true
+            - axis:
+               type: slave
+               name: labels
+               values:
+                - antrea-test-node
+          builders:
+            - builder-matrix
+          branches:
+          - '${{GIT_BRANCH}}'
+          included_regions: []
+          cron: 'H 15 * * 6'
+          ignore_post_commit_hooks: false
+          parameters:
+          - string:
+              name: OLD_ANTREA_VERSION
+              trim: 'true'
+              default: 'LATEST'
+              description:  |-
+                  The old Antrea version tag. Example: v0.1.0.
+                  If it's 'LATEST', we use the latest release tag by default.
+          - string:
+              default: 'main'
+              description: |-
+                  The branch name of the latest Antrea repo. It must match one of the following patterns:
+                  - <branchName>
+                  - refs/heads/<branchName>
+                  - <remoteRepoName>/<branchName>
+                  - remotes/<remoteRepoName>/<branchName>
+                  - refs/remotes/<remoteRepoName>/<branchName>
+                  Tracks/checks out the specified branch.
+                  E.g. main, feature1, refs/heads/main, refs/heads/feature1/main, origin/main, remotes/origin/main, refs/remotes/origin/main, ...
+                  - <commitId>
+                  Checks out the specified commit.
+                  E.g. 5062ac843f2b947733e6a3b105977056821bd352, 5062ac84, ...
+                  - refs/tags/<tagName>
+                  Tracks/checks out the specified tag.
+                  E.g. refs/tags/git-2.3.0
+                  - <Wildcards>
+                  The syntax is of the form: REPOSITORYNAME/BRANCH. In addition, BRANCH is recognized as a shorthand of */BRANCH, '*' is recognized as a wildcard, and '**' is recognized as wildcard that includes the separator '/'. Therefore, origin/branches* would match origin/branches-foo but not origin/branches/foo, while origin/branches** would match both origin/branches-foo and origin/branches/foo.
+                  - :<regular expression>
+                  The syntax is of the form: :regexp. Regular expression syntax in branches to build will only build those branches whose names match the regular expression.
+                  Examples:
+                      - :^(?!(origin/prefix)).*
+                      matches: origin or origin/main or origin/feature
+                      does not match: origin/prefix or origin/prefix_123 or origin/prefix-abc
+              name: GIT_BRANCH
+              trim: 'true'
+          publishers:
+          - archive:
+              allow-empty: true
+              artifacts: 'IS_MATRIX_TEST/*/K8S_VERSION/*/TEST_OS/*/labels/antrea-test-node/antrea-test-logs.tar.gz, IS_MATRIX_TEST/*/K8S_VERSION/*/TEST_OS/*/labels/antrea-test-node/ci/jenkins/*sonobuoy*.tar.gz'
+              case-sensitive: true
+              default-excludes: true
+              fingerprint: false
+              only-if-success: false
+          - email:
+              recipients: projectantrea-dev@googlegroups.com
+          wrappers:
+             - workspace-cleanup
+             - timeout:
+                 timeout: 600
+                 type: absolute


### PR DESCRIPTION
This is the upgrade matrix compatibility test for Antrea. We want to test whether Antrea can pass all tests when upgrading under various OSs and K8S versions.

In this test, (node_num+1)/2 of all Antrea agents are using an old-versioned image (version defined by OLD_ANTREA_VERSION parameter). Other agents and the Antrea controller are using image built by latest code on master branch by default (version defined by GIT_BRANCH parameter). Then we run Antrea E2E, K8S Conformance and NetworkPolicy tests under each OS and K8S version combination.

This PR is excepted to be merged after #1705 is merged.