### PR TITLE
Bug fix in AntreaProxy IPv6 and modification of related e2e tests

### DIFF
--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -289,7 +289,7 @@ var (
 
 	globalVirtualMAC, _ = net.ParseMAC("aa:bb:cc:dd:ee:ff")
 	hairpinIP           = net.ParseIP("169.254.169.252").To4()
-	hairpinIPv6         = net.ParseIP("FE80::aabb:ccdd:eeff").To16()
+	hairpinIPv6         = net.ParseIP("fc00::aabb:ccdd:eeff").To16()
 )
 
 type OFEntryOperations interface {
@@ -982,7 +982,7 @@ func (c *client) serviceHairpinResponseDNATFlow(ipProtocol binding.Protocol) bin
 	if ipProtocol == binding.ProtocolIPv6 {
 		hpIP = hairpinIPv6
 		from = "NXM_NX_IPV6_SRC"
-		to = "NXM_NX_IPV6_SRC"
+		to = "NXM_NX_IPV6_DST"
 	}
 	return c.pipeline[serviceHairpinTable].BuildFlow(priorityNormal).MatchProtocol(ipProtocol).
 		MatchDstIP(hpIP).
@@ -1648,8 +1648,8 @@ func (c *client) serviceLearnFlow(groupID binding.GroupIDType, svcIP net.IP, svc
 			Done()
 	} else if ipProtocol == binding.ProtocolIPv6 {
 		return learnFlowBuilderLearnAction.
-			MatchLearnedDstIP().
-			MatchLearnedSrcIP().
+			MatchLearnedDstIPv6().
+			MatchLearnedSrcIPv6().
 			LoadXXRegToXXReg(int(endpointIPv6XXReg), int(endpointIPv6XXReg), endpointIPv6XXRegRange, endpointIPv6XXRegRange).
 			LoadRegToReg(int(endpointPortReg), int(endpointPortReg), endpointPortRegRange, endpointPortRegRange).
 			LoadReg(int(serviceLearnReg), marksRegServiceSelected, serviceLearnRegRange).

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -265,6 +265,8 @@ type LearnAction interface {
 	MatchLearnedSCTPv6DstPort() LearnAction
 	MatchLearnedSrcIP() LearnAction
 	MatchLearnedDstIP() LearnAction
+	MatchLearnedSrcIPv6() LearnAction
+	MatchLearnedDstIPv6() LearnAction
 	MatchReg(regID int, data uint32, rng Range) LearnAction
 	LoadReg(regID int, data uint32, rng Range) LearnAction
 	LoadRegToReg(fromRegID, toRegID int, fromRng, toRng Range) LearnAction

--- a/pkg/ovs/openflow/ofctrl_action.go
+++ b/pkg/ovs/openflow/ofctrl_action.go
@@ -404,7 +404,8 @@ func (a *ofLearnAction) MatchTransportDst(protocol Protocol) LearnAction {
 	a.nxLearn.AddMatch(&ofctrl.LearnField{Name: "NXM_OF_IP_PROTO"}, 1*8, nil, ipTypeVal)
 	// OXM_OF fields support TCP, UDP and SCTP, but NXM_OF fields only support TCP and UDP. So here using "OXM_OF_" to
 	// generate the field name.
-	fieldName := fmt.Sprintf("OXM_OF_%s_DST", strings.ToUpper(string(protocol)))
+	trimProtocol := strings.ReplaceAll(string(protocol), "v6", "")
+	fieldName := fmt.Sprintf("OXM_OF_%s_DST", strings.ToUpper(trimProtocol))
 	a.nxLearn.AddMatch(&ofctrl.LearnField{Name: fieldName}, 2*8, &ofctrl.LearnField{Name: fieldName}, nil)
 	return a
 }
@@ -457,6 +458,18 @@ func (a *ofLearnAction) MatchLearnedDstIP() LearnAction {
 	return a
 }
 
+// MatchLearnedSrcIPv6 makes the learned flow to match the ipv6_src of current IPv6 packet.
+func (a *ofLearnAction) MatchLearnedSrcIPv6() LearnAction {
+	a.nxLearn.AddMatch(&ofctrl.LearnField{Name: "NXM_NX_IPV6_SRC"}, 16*8, &ofctrl.LearnField{Name: "NXM_NX_IPV6_SRC"}, nil)
+	return a
+}
+
+// MatchLearnedDstIPv6 makes the learned flow to match the ipv6_dst of current IPv6 packet.
+func (a *ofLearnAction) MatchLearnedDstIPv6() LearnAction {
+	a.nxLearn.AddMatch(&ofctrl.LearnField{Name: "NXM_NX_IPV6_DST"}, 16*8, &ofctrl.LearnField{Name: "NXM_NX_IPV6_DST"}, nil)
+	return a
+}
+
 // MatchReg makes the learned flow to match the data in the reg of specific range.
 func (a *ofLearnAction) MatchReg(regID int, data uint32, rng Range) LearnAction {
 	toField := &ofctrl.LearnField{Name: fmt.Sprintf("NXM_NX_REG%d", regID), Start: uint16(rng[0])}
@@ -472,7 +485,7 @@ func (a *ofLearnAction) MatchReg(regID int, data uint32, rng Range) LearnAction 
 
 // MatchXXReg makes the learned flow to match the data in the xxreg of specific range.
 func (a *ofLearnAction) MatchXXReg(regID int, data []byte, rng Range) LearnAction {
-	s := fmt.Sprintf("NXM_NX_XXREG%d", regID)
+	s := fmt.Sprintf("%s%d", NxmFieldXXReg, regID)
 	toField := &ofctrl.LearnField{Name: s, Start: uint16(rng[0])}
 	offset := (rng.Length()-1)/8 + 1
 	if offset < 2 {
@@ -494,8 +507,8 @@ func (a *ofLearnAction) LoadRegToReg(fromRegID, toRegID int, fromRng, toRng Rang
 // LoadXXRegToXXReg makes the learned flow to load reg[fromXxRegID] to reg[toXxRegID]
 // with specific ranges.
 func (a *ofLearnAction) LoadXXRegToXXReg(fromXxRegID, toXxRegID int, fromRng, toRng Range) LearnAction {
-	fromField := &ofctrl.LearnField{Name: fmt.Sprintf("NXM_NX_XXREG%d", fromXxRegID), Start: uint16(fromRng[0])}
-	toField := &ofctrl.LearnField{Name: fmt.Sprintf("NXM_NX_XXREG%d", toXxRegID), Start: uint16(toRng[0])}
+	fromField := &ofctrl.LearnField{Name: fmt.Sprintf("%s%d", NxmFieldXXReg, fromXxRegID), Start: uint16(fromRng[0])}
+	toField := &ofctrl.LearnField{Name: fmt.Sprintf("%s%d", NxmFieldXXReg, toXxRegID), Start: uint16(toRng[0])}
 	a.nxLearn.AddLoadAction(toField, uint16(toRng.Length()), fromField, nil)
 	return a
 }

--- a/pkg/ovs/openflow/ofctrl_flow.go
+++ b/pkg/ovs/openflow/ofctrl_flow.go
@@ -86,7 +86,7 @@ func (f *ofFlow) MatchString() string {
 	}
 
 	if len(f.matchers) > 0 {
-		repr += fmt.Sprintf(",%s", strings.Join(f.matchers, ","))
+		repr = fmt.Sprintf("%s,%s", repr, strings.Join(f.matchers, ","))
 	}
 	return repr
 }

--- a/test/e2e/bandwidth_test.go
+++ b/test/e2e/bandwidth_test.go
@@ -64,7 +64,7 @@ func benchmarkBandwidthService(t *testing.T, endpointNode, clientNode string) {
 	}
 	defer teardownTest(t, data)
 
-	svc, err := data.createService("perftest-b", iperfPort, iperfPort, map[string]string{"antrea-e2e": "perftest-b"}, false, v1.ServiceTypeClusterIP)
+	svc, err := data.createService("perftest-b", iperfPort, iperfPort, map[string]string{"antrea-e2e": "perftest-b"}, false, v1.ServiceTypeClusterIP, nil)
 	if err != nil {
 		t.Fatalf("Error when creating perftest service: %v", err)
 	}

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -373,7 +373,7 @@ func testReconcileGatewayRoutesOnStartup(t *testing.T, data *TestData, isIPv6 bo
 
 	t.Logf("Retrieving gateway routes on Node '%s'", nodeName)
 	var routes []Route
-	if err := wait.PollImmediate(1*time.Second, defaultTimeout, func() (found bool, err error) {
+	if err := wait.PollImmediate(defaultInterval, defaultTimeout, func() (found bool, err error) {
 		routes, err = getGatewayRoutes()
 		if err != nil {
 			return false, err
@@ -467,7 +467,7 @@ func testReconcileGatewayRoutesOnStartup(t *testing.T, data *TestData, isIPv6 bo
 
 	// We expect the agent to delete the extra route we added and add back the route we deleted
 	t.Logf("Waiting for gateway routes to converge")
-	if err := wait.Poll(1*time.Second, defaultTimeout, func() (bool, error) {
+	if err := wait.Poll(defaultInterval, defaultTimeout, func() (bool, error) {
 		newRoutes, err := getGatewayRoutes()
 		if err != nil {
 			return false, err
@@ -600,7 +600,7 @@ func TestDeletePreviousRoundFlowsOnStartup(t *testing.T) {
 
 	waitForNextRoundNum := func(roundNum uint64) uint64 {
 		var nextRoundNum uint64
-		if err := wait.Poll(1*time.Second, defaultTimeout, func() (bool, error) {
+		if err := wait.Poll(defaultInterval, defaultTimeout, func() (bool, error) {
 			nextRoundNum = roundNumber(podName)
 			if nextRoundNum != roundNum {
 				return true, nil
@@ -675,7 +675,7 @@ func TestDeletePreviousRoundFlowsOnStartup(t *testing.T) {
 	// In theory there should be no need to poll here because the agent only persists the new
 	// round number after stale flows have been deleted, but it is probably better not to make
 	// this assumption in an e2e test.
-	if err := wait.PollImmediate(1*time.Second, smallTimeout, func() (bool, error) {
+	if err := wait.PollImmediate(defaultInterval, smallTimeout, func() (bool, error) {
 		return !checkFlow(), nil
 
 	}); err != nil {

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -387,7 +387,7 @@ func createPerftestPods(data *TestData) (podAIP *PodIPs, podBIP *PodIPs, podCIP 
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when waiting for the perftest client Pod: %v", err)
 	}
 
-	svcB, err = data.createService("perftest-b", iperfPort, iperfPort, map[string]string{"antrea-e2e": "perftest-b"}, false, v1.ServiceTypeClusterIP)
+	svcB, err = data.createService("perftest-b", iperfPort, iperfPort, map[string]string{"antrea-e2e": "perftest-b"}, false, v1.ServiceTypeClusterIP, nil)
 	if err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when creating perftest service: %v", err)
 	}
@@ -401,7 +401,7 @@ func createPerftestPods(data *TestData) (podAIP *PodIPs, podBIP *PodIPs, podCIP 
 	}
 
 	// svcC will be needed when adding RemoteServiceAccess testcase
-	svcC, err = data.createService("perftest-c", iperfPort, iperfPort, map[string]string{"antrea-e2e": "perftest-c"}, false, v1.ServiceTypeClusterIP)
+	svcC, err = data.createService("perftest-c", iperfPort, iperfPort, map[string]string{"antrea-e2e": "perftest-c"}, false, v1.ServiceTypeClusterIP, nil)
 	if err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when creating perftest service: %v", err)
 	}

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -53,7 +53,8 @@ import (
 )
 
 const (
-	defaultTimeout = 90 * time.Second
+	defaultTimeout  = 90 * time.Second
+	defaultInterval = 1 * time.Second
 
 	// antreaNamespace is the K8s Namespace in which all Antrea resources are running.
 	antreaNamespace            string = "kube-system"
@@ -93,6 +94,8 @@ const (
 	perftoolImage       = "projects.registry.vmware.com/antrea/perftool"
 	ipfixCollectorImage = "projects.registry.vmware.com/antrea/ipfix-collector:v0.4.2"
 	ipfixCollectorPort  = "4739"
+
+	nginxLBService = "nginx-loadbalancer"
 )
 
 type ClusterNode struct {
@@ -353,7 +356,7 @@ func (data *TestData) deleteNamespace(namespace string, timeout time.Duration) e
 		}
 		return fmt.Errorf("error when deleting '%s' Namespace: %v", namespace, err)
 	}
-	err := wait.Poll(1*time.Second, timeout, func() (bool, error) {
+	err := wait.Poll(defaultInterval, timeout, func() (bool, error) {
 		if ns, err := data.clientset.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{}); err != nil {
 			if errors.IsNotFound(err) {
 				// Success
@@ -505,7 +508,7 @@ func (data *TestData) getAgentContainersRestartCount() (int, error) {
 // waitForAntreaDaemonSetPods waits for the K8s apiserver to report that all the Antrea Pods are
 // available, i.e. all the Nodes have one or more of the Antrea daemon Pod running and available.
 func (data *TestData) waitForAntreaDaemonSetPods(timeout time.Duration) error {
-	err := wait.Poll(1*time.Second, timeout, func() (bool, error) {
+	err := wait.Poll(defaultInterval, timeout, func() (bool, error) {
 		daemonSet, err := data.clientset.AppsV1().DaemonSets(antreaNamespace).Get(context.TODO(), antreaDaemonSet, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("error when getting Antrea daemonset: %v", err)
@@ -553,7 +556,7 @@ func (data *TestData) waitForAntreaDaemonSetPods(timeout time.Duration) error {
 
 // waitForCoreDNSPods waits for the K8s apiserver to report that all the CoreDNS Pods are available.
 func (data *TestData) waitForCoreDNSPods(timeout time.Duration) error {
-	err := wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
+	err := wait.PollImmediate(defaultInterval, timeout, func() (bool, error) {
 		deployment, err := data.clientset.AppsV1().Deployments("kube-system").Get(context.TODO(), "coredns", metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("error when retrieving CoreDNS deployment: %v", err)
@@ -663,7 +666,7 @@ func (data *TestData) deleteAntrea(timeout time.Duration) error {
 		}
 		return fmt.Errorf("error when trying to delete Antrea DaemonSet: %v", err)
 	}
-	err := wait.Poll(1*time.Second, timeout, func() (bool, error) {
+	err := wait.Poll(defaultInterval, timeout, func() (bool, error) {
 		if _, err := data.clientset.AppsV1().DaemonSets(antreaNamespace).Get(context.TODO(), antreaDaemonSet, metav1.GetOptions{}); err != nil {
 			if errors.IsNotFound(err) {
 				// Antrea DaemonSet does not exist any more, success
@@ -804,7 +807,7 @@ func (data *TestData) deletePodAndWait(timeout time.Duration, name string) error
 		return err
 	}
 
-	if err := wait.Poll(1*time.Second, timeout, func() (bool, error) {
+	if err := wait.Poll(defaultInterval, timeout, func() (bool, error) {
 		if _, err := data.clientset.CoreV1().Pods(testNamespace).Get(context.TODO(), name, metav1.GetOptions{}); err != nil {
 			if errors.IsNotFound(err) {
 				return true, nil
@@ -825,7 +828,7 @@ type PodCondition func(*corev1.Pod) (bool, error)
 // podWaitFor polls the K8s apiserver until the specified Pod is found (in the test Namespace) and
 // the condition predicate is met (or until the provided timeout expires).
 func (data *TestData) podWaitFor(timeout time.Duration, name, namespace string, condition PodCondition) (*corev1.Pod, error) {
-	err := wait.Poll(1*time.Second, timeout, func() (bool, error) {
+	err := wait.Poll(defaultInterval, timeout, func() (bool, error) {
 		if pod, err := data.clientset.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{}); err != nil {
 			if errors.IsNotFound(err) {
 				return false, nil
@@ -949,7 +952,7 @@ func (data *TestData) deleteAntreaAgentOnNode(nodeName string, gracePeriodSecond
 		return 0, fmt.Errorf("error when deleting antrea-agent Pods on Node '%s': %v", nodeName, err)
 	}
 
-	if err := wait.Poll(1*time.Second, timeout, func() (bool, error) {
+	if err := wait.Poll(defaultInterval, timeout, func() (bool, error) {
 		for _, pod := range pods.Items {
 			if _, err := data.clientset.CoreV1().Pods(antreaNamespace).Get(context.TODO(), pod.Name, metav1.GetOptions{}); err != nil {
 				if errors.IsNotFound(err) {
@@ -968,7 +971,7 @@ func (data *TestData) deleteAntreaAgentOnNode(nodeName string, gracePeriodSecond
 	delay := time.Since(start)
 
 	// wait for new antrea-agent Pod
-	if err := wait.Poll(1*time.Second, timeout, func() (bool, error) {
+	if err := wait.Poll(defaultInterval, timeout, func() (bool, error) {
 		pods, err := data.clientset.CoreV1().Pods(antreaNamespace).List(context.TODO(), listOptions)
 		if err != nil {
 			return false, fmt.Errorf("failed to list antrea-agent Pods on Node '%s': %v", nodeName, err)
@@ -1040,7 +1043,7 @@ func (data *TestData) restartAntreaControllerPod(timeout time.Duration) (*corev1
 
 	var newPod *corev1.Pod
 	// wait for new antrea-controller Pod
-	if err := wait.Poll(1*time.Second, timeout, func() (bool, error) {
+	if err := wait.Poll(defaultInterval, timeout, func() (bool, error) {
 		pods, err := data.clientset.CoreV1().Pods(antreaNamespace).List(context.TODO(), listOptions)
 		if err != nil {
 			return false, fmt.Errorf("failed to list antrea-controller Pods: %v", err)
@@ -1102,7 +1105,7 @@ func validatePodIP(podNetworkCIDR string, ip net.IP) (bool, error) {
 
 // createService creates a service with port and targetPort.
 func (data *TestData) createService(serviceName string, port, targetPort int, selector map[string]string, affinity bool,
-	serviceType corev1.ServiceType) (*corev1.Service, error) {
+	serviceType corev1.ServiceType, ipFamily *corev1.IPFamily) (*corev1.Service, error) {
 	affinityType := corev1.ServiceAffinityNone
 	if affinity {
 		affinityType = corev1.ServiceAffinityClientIP
@@ -1124,18 +1127,19 @@ func (data *TestData) createService(serviceName string, port, targetPort int, se
 			}},
 			Type:     serviceType,
 			Selector: selector,
+			IPFamily: ipFamily,
 		},
 	}
 	return data.clientset.CoreV1().Services(testNamespace).Create(context.TODO(), &service, metav1.CreateOptions{})
 }
 
 // createNginxClusterIPService create a nginx service with the given name.
-func (data *TestData) createNginxClusterIPService(affinity bool) (*corev1.Service, error) {
-	return data.createService("nginx", 80, 80, map[string]string{"app": "nginx"}, affinity, corev1.ServiceTypeClusterIP)
+func (data *TestData) createNginxClusterIPService(affinity bool, ipFamily *corev1.IPFamily) (*corev1.Service, error) {
+	return data.createService("nginx", 80, 80, map[string]string{"app": "nginx"}, affinity, corev1.ServiceTypeClusterIP, ipFamily)
 }
 
-func (data *TestData) createNginxLoadBalancerService(affinity bool, ingressIPs []string) (*corev1.Service, error) {
-	svc, err := data.createService("nginx-loadbalancer", 80, 80, map[string]string{"app": "nginx"}, affinity, corev1.ServiceTypeLoadBalancer)
+func (data *TestData) createNginxLoadBalancerService(affinity bool, ingressIPs []string, ipFamily *corev1.IPFamily) (*corev1.Service, error) {
+	svc, err := data.createService(nginxLBService, 80, 80, map[string]string{"app": "nginx"}, affinity, corev1.ServiceTypeLoadBalancer, ipFamily)
 	if err != nil {
 		return svc, err
 	}
@@ -1158,6 +1162,29 @@ func (data *TestData) deleteService(name string) error {
 		return fmt.Errorf("unable to cleanup service %v: %v", name, err)
 	}
 	return nil
+}
+
+// Deletes a Service in the test namespace then waits us to timeout for the Service not to be visible to the
+// client any more.
+func (data *TestData) deleteServiceAndWait(timeout time.Duration, name string) error {
+	if err := data.deleteService(name); err != nil {
+		return err
+	}
+
+	if err := wait.Poll(defaultInterval, timeout, func() (bool, error) {
+		if _, err := data.clientset.CoreV1().Services(testNamespace).Get(context.TODO(), name, metav1.GetOptions{}); err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, fmt.Errorf("error when getting Service: %v", err)
+		}
+		// Keep trying
+		return false, nil
+	}); err == wait.ErrWaitTimeout {
+		return fmt.Errorf("Service '%s' still visible to client after %v", name, timeout)
+	} else {
+		return err
+	}
 }
 
 // createNetworkPolicy creates a network policy with spec.

--- a/test/e2e/ipsec_test.go
+++ b/test/e2e/ipsec_test.go
@@ -19,7 +19,6 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
-	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -126,7 +125,7 @@ func TestIPSecDeleteStaleTunnelPorts(t *testing.T) {
 	}
 
 	t.Logf("Checking that tunnel port has been created")
-	if err := wait.PollImmediate(1*time.Second, defaultTimeout, func() (found bool, err error) {
+	if err := wait.PollImmediate(defaultInterval, defaultTimeout, func() (found bool, err error) {
 		return doesOVSPortExist(), nil
 	}); err == wait.ErrWaitTimeout {
 		t.Fatalf("Timed out while waiting for OVS tunnel port to be created")
@@ -138,7 +137,7 @@ func TestIPSecDeleteStaleTunnelPorts(t *testing.T) {
 	data.redeployAntrea(t, false)
 
 	t.Logf("Checking that tunnel port has been deleted")
-	if err := wait.PollImmediate(1*time.Second, defaultTimeout, func() (found bool, err error) {
+	if err := wait.PollImmediate(defaultInterval, defaultTimeout, func() (found bool, err error) {
 		return !doesOVSPortExist(), nil
 	}); err == wait.ErrWaitTimeout {
 		t.Fatalf("Timed out while waiting for OVS tunnel port to be deleted")

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -385,7 +385,6 @@ func (k *KubernetesUtils) waitForPodInNamespace(ns string, pod string) (*string,
 
 func (k *KubernetesUtils) waitForHTTPServers(allPods []Pod) error {
 	const maxTries = 10
-	const sleepInterval = 1 * time.Second
 	log.Infof("waiting for HTTP servers (ports 80, 81 and 8080:8085) to become ready")
 	var wrong int
 	for i := 0; i < maxTries; i++ {
@@ -401,7 +400,7 @@ func (k *KubernetesUtils) waitForHTTPServers(allPods []Pod) error {
 			return nil
 		}
 		log.Debugf("%d HTTP servers not ready", wrong)
-		time.Sleep(sleepInterval)
+		time.Sleep(defaultInterval)
 	}
 	return errors.Errorf("after %d tries, %d HTTP servers are not ready", maxTries, wrong)
 }

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -708,7 +708,7 @@ func createAndWaitForPod(t *testing.T, data *TestData, createFunc func(name stri
 }
 
 func waitForAgentCondition(t *testing.T, data *TestData, podName string, conditionType v1beta1.AgentConditionType, expectedStatus corev1.ConditionStatus) {
-	if err := wait.Poll(1*time.Second, defaultTimeout, func() (bool, error) {
+	if err := wait.Poll(defaultInterval, defaultTimeout, func() (bool, error) {
 		cmds := []string{"antctl", "get", "agentinfo", "-o", "json"}
 		t.Logf("cmds: %s", cmds)
 

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -451,7 +451,7 @@ func TestTraceflowInterNode(t *testing.T) {
 	require.NoError(t, data.createNginxPod("nginx", node2))
 	nginxIP, err := data.podWaitForIPs(defaultTimeout, "nginx", testNamespace)
 	require.NoError(t, err)
-	svc, err := data.createNginxClusterIPService(false)
+	svc, err := data.createNginxClusterIPService(false, nil)
 	require.NoError(t, err)
 
 	// TODO: Extend the test cases to support IPv6 address after Traceflow IPv6 is supported. Currently we only use IPv4 address.
@@ -768,7 +768,7 @@ func (data *TestData) waitForTraceflow(t *testing.T, name string, phase v1alpha1
 	var tf *v1alpha1.Traceflow
 	var err error
 	timeout := 15 * time.Second
-	if err = wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
+	if err = wait.PollImmediate(defaultInterval, timeout, func() (bool, error) {
 		tf, err = data.crdClient.OpsV1alpha1().Traceflows().Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil || tf.Status.Phase != phase {
 			return false, nil


### PR DESCRIPTION
* Fixed bugs in AntreaProxy IPv6 support
  * HarpinIPv6 address is changed to a unique local address instead of a link local one. An automatically generated IPv6 link local address will be allocated to a device. Then, the device considers itself in the same subnet as the IPv6 link local address. As a result, traffic fails. As a reserved IP address, a unique local address works.
  * ServiceLearnFlow: Use MatchLearnedSrcIPv6 and MatchLearnedDstIPv6 to replace IPv4 ones. IPv6 specific fields (NXM_NX_IPV6_SRC and NXM_NX_IPV6_DST) should be used.
  * MatchTransportDst: wrong OXM_OF_XXX_DST field for IPv6. In original logic, protocol name is put into OXM field name but IPv6 protocol has "v6" in its name, which lead s to flow table addition failure.
* Modified and enabled AntreaProxy e2e tests to support IPv6 only and Dual-stack environment
* Refactored interval in e2e tests