### PR TITLE
add simulator to run scale test without large number of nodes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,23 @@ jobs:
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         docker push antrea/antrea-ubuntu:latest
 
+  build-scale:
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name == 'push' }}
+    runs-on: [ubuntu-18.04]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build Antrea Docker image
+      run: make build-scale-simulator
+    - name: Push Antrea Agent Simulator Docker image to registry
+      if: ${{ github.repository == 'vmware-tanzu/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      run: |
+        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        docker push antrea/antrea-ubuntu-simulator:latest
+
   build-windows:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name == 'push' }}

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,11 @@ antrea-agent:
 	@mkdir -p $(BINDIR)
 	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' github.com/vmware-tanzu/antrea/cmd/antrea-agent
 
+.PHONY: antrea-agent-simulator
+antrea-agent-simulator:
+	@mkdir -p $(BINDIR)
+	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' github.com/vmware-tanzu/antrea/cmd/antrea-agent-simulator
+
 .PHONY: antrea-agent-instr-binary
 antrea-agent-instr-binary:
 	@mkdir -p $(BINDIR)

--- a/Makefile
+++ b/Makefile
@@ -303,10 +303,8 @@ endif
 .PHONY: build-scale-simulator
 build-scale-simulator:
 	@echo "===> Building simulator bin and antrea-ubuntu-simulator image"
-	docker build -t harbor-repo.vmware.com/dockerhub-proxy-cache/antrea/antrea-ubuntu-simulator:$(DOCKER_IMG_VERSION) \
-	    -f build/images/Dockerfile.simulator.build.ubuntu .
-	docker tag harbor-repo.vmware.com/dockerhub-proxy-cache/antrea/antrea-ubuntu-simulator:$(DOCKER_IMG_VERSION) \
-	    harbor-repo.vmware.com/dockerhub-proxy-cache/antrea/antrea-ubuntu-simulator
+	docker build -t antrea/antrea-ubuntu-simulator:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.simulator.build.ubuntu .
+	docker tag antrea/antrea-ubuntu-simulator:$(DOCKER_IMG_VERSION) antrea/antrea-ubuntu-simulator
 
 .PHONY: manifest
 manifest:

--- a/Makefile
+++ b/Makefile
@@ -300,6 +300,14 @@ else
 endif
 	docker tag antrea/antrea-ubuntu-coverage:$(DOCKER_IMG_VERSION) antrea/antrea-ubuntu-coverage
 
+.PHONY: build-scale-simulator
+build-scale-simulator:
+	@echo "===> Building simulator bin and antrea-ubuntu-simulator image"
+	docker build -t harbor-repo.vmware.com/dockerhub-proxy-cache/antrea/antrea-ubuntu-simulator:$(DOCKER_IMG_VERSION) \
+	    -f build/images/Dockerfile.simulator.build.ubuntu .
+	docker tag harbor-repo.vmware.com/dockerhub-proxy-cache/antrea/antrea-ubuntu-simulator:$(DOCKER_IMG_VERSION) \
+	    harbor-repo.vmware.com/dockerhub-proxy-cache/antrea/antrea-ubuntu-simulator
+
 .PHONY: manifest
 manifest:
 	@echo "===> Generating dev manifest for Antrea <==="
@@ -312,6 +320,7 @@ manifest:
 	$(CURDIR)/hack/generate-manifest-windows.sh --mode dev > build/yamls/antrea-windows.yml
 	$(CURDIR)/hack/generate-manifest-flow-aggregator.sh --mode dev > build/yamls/flow-aggregator.yml
 
+.PHONY: manifest-scale
 manifest-scale:
 	@echo "===> Generating simulator manifest for Antrea <==="
 	$(CURDIR)/hack/generate-manifest.sh --mode dev --simulator > build/yamls/antrea-scale.yml

--- a/Makefile
+++ b/Makefile
@@ -312,6 +312,10 @@ manifest:
 	$(CURDIR)/hack/generate-manifest-windows.sh --mode dev > build/yamls/antrea-windows.yml
 	$(CURDIR)/hack/generate-manifest-flow-aggregator.sh --mode dev > build/yamls/flow-aggregator.yml
 
+manifest-scale:
+	@echo "===> Generating simulator manifest for Antrea <==="
+	$(CURDIR)/hack/generate-manifest.sh --mode dev --simulator > build/yamls/antrea-scale.yml
+
 .PHONY: manifest-coverage
 manifest-coverage:
 	$(CURDIR)/hack/generate-manifest.sh --mode dev --coverage > build/yamls/antrea-coverage.yml

--- a/build/images/Dockerfile.simulator.build.ubuntu
+++ b/build/images/Dockerfile.simulator.build.ubuntu
@@ -1,0 +1,22 @@
+FROM golang:1.15 as antrea-build
+
+WORKDIR /antrea
+
+COPY go.mod /antrea/go.mod
+
+RUN go mod download
+
+COPY . /antrea
+
+RUN make antrea-agent-simulator
+
+
+FROM antrea/base-ubuntu:2.14.0
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="The Docker image to deploy the Antrea simulator. "
+
+USER root
+
+COPY --from=antrea-build /antrea/bin/* /usr/local/bin/
+

--- a/build/yamls/antrea-agent-simulator.yaml
+++ b/build/yamls/antrea-agent-simulator.yaml
@@ -1,0 +1,144 @@
+---
+apiVersion: v1
+data:
+  content.type: test-cluster
+kind: ConfigMap
+metadata:
+  name: node-configmap
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: antrea-agent-simulator
+  namespace: kube-system
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app: antrea
+      component: antrea-agent-simulator
+  serviceName: antrea-agent-simulator
+  template:
+    metadata:
+      labels:
+        app: antrea
+        component: antrea-agent-simulator
+    spec:
+      serviceAccountName: antrea-agent-simulator
+      initContainers:
+      - name: init-inotify-limit
+        image: projects.registry.vmware.com/library/busybox:latest
+        command: ['sysctl', '-w', 'fs.inotify.max_user_instances=200']
+        securityContext:
+          privileged: true
+      volumes:
+      - name: kubeconfig-volume
+        secret:
+          secretName: kubeconfig
+      - name: logs-volume
+        hostPath:
+          path: /var/log
+      containers:
+      - name: simulator
+        image: harbor-repo.vmware.com/dockerhub-proxy-cache/antrea/antrea-ubuntu-simulator:latest
+        imagePullPolicy: IfNotPresent
+        command: ['/antrea-agent-simulator', '-v', '5']
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        volumeMounts:
+        - name: kubeconfig-volume
+          mountPath: /kubeconfig
+          readOnly: true
+        - name: logs-volume
+          mountPath: /var/log
+      - name: hollow-kubelet
+        image: projects.registry.vmware.com/antrea/kubemark:v1.18.4
+        ports:
+        - containerPort: 4194
+        - containerPort: 10250
+        - containerPort: 10255
+        env:
+        - name: CONTENT_TYPE
+          valueFrom:
+            configMapKeyRef:
+              name: node-configmap
+              key: content.type
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        command: [
+          "/kubemark",
+          "--morph=kubelet",
+          "--name=$(NODE_NAME)",
+          "--kubeconfig=/kubeconfig/admin.conf",
+          "$(CONTENT_TYPE)",
+          "--v=2",
+          "--log-file=/var/log/kubelet-$(NODE_NAME).log",
+          "--node-labels=antrea/instance=simulator",
+        ]
+        volumeMounts:
+        - name: kubeconfig-volume
+          mountPath: /kubeconfig
+          readOnly: true
+        - name: logs-volume
+          mountPath: /var/log
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50M
+        securityContext:
+          privileged: true
+      - name: hollow-proxy
+        image: projects.registry.vmware.com/antrea/kubemark:v1.18.4
+        env:
+        - name: CONTENT_TYPE
+          valueFrom:
+            configMapKeyRef:
+              name: node-configmap
+              key: content.type
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        command: [
+          "/kubemark",
+          "--morph=proxy",
+          "--name=$(NODE_NAME)",
+          "--use-real-proxier=false",
+          "--kubeconfig=/kubeconfig/admin.conf",
+          "$(CONTENT_TYPE)",
+          "--alsologtostderr",
+          "--v=2",
+          "--log-file=/var/log/kubelet-$(NODE_NAME).log"
+        ]
+        volumeMounts:
+        - name: kubeconfig-volume
+          mountPath: /kubeconfig
+          readOnly: true
+        - name: logs-volume
+          mountPath: /var/log
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50M
+      tolerations:
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists

--- a/build/yamls/patches/simulator/agentNodeAffinity.yml
+++ b/build/yamls/patches/simulator/agentNodeAffinity.yml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: antrea-agent
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: antrea/instance
+                    operator: NotIn
+                    values:
+                      - simulator

--- a/build/yamls/patches/simulator/antrea-agent-simulator.yml
+++ b/build/yamls/patches/simulator/antrea-agent-simulator.yml
@@ -51,7 +51,7 @@ spec:
           path: /var/log
       containers:
       - name: simulator
-        image: harbor-repo.vmware.com/dockerhub-proxy-cache/antrea/antrea-ubuntu-simulator:latest
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu-simulator:latest
         imagePullPolicy: IfNotPresent
         command: ['/usr/local/bin/antrea-agent-simulator', '-v', '5']
         env:

--- a/build/yamls/patches/simulator/antrea-agent-simulator.yml
+++ b/build/yamls/patches/simulator/antrea-agent-simulator.yml
@@ -26,7 +26,16 @@ spec:
         app: antrea
         component: antrea-agent-simulator
     spec:
-      serviceAccountName: antrea-agent-simulator
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: antrea/instance
+                    operator: NotIn
+                    values:
+                      - simulator
+      serviceAccountName: antrea-agent
       initContainers:
       - name: init-inotify-limit
         image: projects.registry.vmware.com/library/busybox:latest
@@ -44,7 +53,7 @@ spec:
       - name: simulator
         image: harbor-repo.vmware.com/dockerhub-proxy-cache/antrea/antrea-ubuntu-simulator:latest
         imagePullPolicy: IfNotPresent
-        command: ['/antrea-agent-simulator', '-v', '5']
+        command: ['/usr/local/bin/antrea-agent-simulator', '-v', '5']
         env:
           - name: POD_NAME
             valueFrom:

--- a/build/yamls/patches/simulator/controllerNodeAffinity.yml
+++ b/build/yamls/patches/simulator/controllerNodeAffinity.yml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: antrea-controller
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: antrea/instance
+                    operator: NotIn
+                    values:
+                      - simulator

--- a/cmd/antrea-agent-simulator/main.go
+++ b/cmd/antrea-agent-simulator/main.go
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package main under directory cmd parses and validates user input,
-// instantiates and initializes objects imported from pkg, and runs
-// the process.
+// The simulator binary is responsible to run simulated nodes for antrea agent.
+// It watches NetworkPolicies, AddressGroups and AppliedToGroups from antrea controller
+// and prints the events of these resources to log.
 package main
 
 import (

--- a/cmd/antrea-agent-simulator/main.go
+++ b/cmd/antrea-agent-simulator/main.go
@@ -1,0 +1,67 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main under directory cmd parses and validates user input,
+// instantiates and initializes objects imported from pkg, and runs
+// the process.
+package main
+
+import (
+	"flag"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/component-base/logs"
+	"k8s.io/klog"
+
+	"github.com/vmware-tanzu/antrea/pkg/log"
+	"github.com/vmware-tanzu/antrea/pkg/version"
+)
+
+func main() {
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
+	command := newSimulatorCommand()
+	if err := command.Execute(); err != nil {
+		logs.FlushLogs()
+		os.Exit(1)
+	}
+}
+
+func newSimulatorCommand() *cobra.Command {
+	configFile := ""
+	cmd := &cobra.Command{
+		Use:  "antrea-agent-simulator",
+		Long: "The Antrea agent simulator.",
+		Run: func(cmd *cobra.Command, args []string) {
+			log.InitLogFileLimits(cmd.Flags())
+
+			if err := run(configFile); err != nil {
+				klog.Fatalf("Error running agent: %v", err)
+			}
+		},
+		Version: version.GetFullVersionWithRuntimeInfo(),
+	}
+
+	flags := cmd.Flags()
+	log.AddFlags(flags)
+	flags.StringVar(&configFile, "config", configFile, "The path to the configuration file")
+	if configFile == "" {
+		configFile = "/kubeconfig/kubelet.kubeconfig"
+	}
+	// Install log flags
+	flags.AddGoFlagSet(flag.CommandLine)
+	return cmd
+}

--- a/cmd/antrea-agent-simulator/main.go
+++ b/cmd/antrea-agent-simulator/main.go
@@ -41,14 +41,13 @@ func main() {
 }
 
 func newSimulatorCommand() *cobra.Command {
-	configFile := ""
 	cmd := &cobra.Command{
 		Use:  "antrea-agent-simulator",
 		Long: "The Antrea agent simulator.",
 		Run: func(cmd *cobra.Command, args []string) {
 			log.InitLogFileLimits(cmd.Flags())
 
-			if err := run(configFile); err != nil {
+			if err := run(); err != nil {
 				klog.Fatalf("Error running agent: %v", err)
 			}
 		},
@@ -57,10 +56,7 @@ func newSimulatorCommand() *cobra.Command {
 
 	flags := cmd.Flags()
 	log.AddFlags(flags)
-	flags.StringVar(&configFile, "config", configFile, "The path to the configuration file")
-	if configFile == "" {
-		configFile = "/kubeconfig/kubelet.kubeconfig"
-	}
+
 	// Install log flags
 	flags.AddGoFlagSet(flag.CommandLine)
 	return cmd

--- a/cmd/antrea-agent-simulator/main.go
+++ b/cmd/antrea-agent-simulator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Antrea Authors
+// Copyright 2020 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/antrea-agent-simulator/simulator.go
+++ b/cmd/antrea-agent-simulator/simulator.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent"
+
+	"context"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	componentbaseconfig "k8s.io/component-base/config"
+
+	//"github.com/vmware-tanzu/antrea/pkg/agent/controller/networkpolicy"
+	//"github.com/vmware-tanzu/antrea/pkg/apis/controlplane/v1beta1"
+	crdclientset "github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned"
+	//"github.com/vmware-tanzu/antrea/pkg/features"
+	"github.com/vmware-tanzu/antrea/pkg/signals"
+	"github.com/vmware-tanzu/antrea/pkg/util/env"
+	"github.com/vmware-tanzu/antrea/pkg/version"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
+	aggregatorclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
+)
+
+func createOutClusterCli(configFile string) (clientset.Interface, aggregatorclientset.Interface, crdclientset.Interface, error) {
+	kubeConfig, err := clientcmd.BuildConfigFromFlags("", configFile)
+	if err != nil {
+		klog.Errorf("Failed to get incluster config: %s", err.Error())
+		return nil, nil, nil, err
+	}
+	return createClusterCli(kubeConfig)
+}
+
+func createInClusterCli() (clientset.Interface, aggregatorclientset.Interface, crdclientset.Interface, error) {
+	kubeConfig, err := rest.InClusterConfig()
+	if err != nil {
+		klog.Errorf("Failed to get incluster config: %s", err.Error())
+		return nil, nil, nil, err
+	}
+	return createClusterCli(kubeConfig)
+}
+
+func createClusterCli(kubeConfig *rest.Config) (clientset.Interface, aggregatorclientset.Interface, crdclientset.Interface, error) {
+	client, err := clientset.NewForConfig(kubeConfig)
+	if err != nil {
+		klog.Errorf("Failed to create clientset: %s", err.Error())
+		return nil, nil, nil, err
+	}
+	aggregatorClient, err := aggregatorclientset.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	// Create client for crd operations
+	crdClient, err := crdclientset.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return client, aggregatorClient, crdClient, nil
+}
+
+func run(configFile string) error {
+	klog.Infof("Starting Antrea agent simulator (version %s)", version.GetFullVersion())
+	// Create K8s Clientset, CRD Clientset and SharedInformerFactory for the given config.
+	//k8sClient, _, crdClient, err := k8s.CreateClients(o.config.ClientConnection)
+	//k8sClient, _, _, err := createOutClusterCli(configFile)
+	k8sClient, _, _, err := createInClusterCli()
+	if err != nil {
+		return fmt.Errorf("error creating K8s clients: %v", err)
+	}
+	//informerFactory := informers.NewSharedInformerFactory(k8sClient, informerDefaultResync)
+	//crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, informerDefaultResync)
+
+	nodeName, err := env.GetNodeName()
+	if err != nil {
+		return fmt.Errorf("failed to get hostname: %v", err)
+	}
+	// Create Antrea Clientset for the given config.
+	antreaClientProvider := agent.NewAntreaClientProvider(componentbaseconfig.ClientConnectionConfiguration{}, k8sClient)
+
+	if err = antreaClientProvider.RunOnce(); err != nil {
+		return err
+	}
+
+	//create the stop chan with signals
+	stopCh := signals.RegisterSignalHandlers()
+
+	go antreaClientProvider.Run(stopCh)
+
+	//add loop to check whether client is ready
+	attempts := 0
+	if err := wait.PollImmediateUntil(200*time.Millisecond, func() (bool, error) {
+		if attempts%10 == 0 {
+			klog.Info("Waiting for Antrea client to be ready")
+		}
+		if _, err := antreaClientProvider.GetAntreaClient(); err != nil {
+			attempts++
+			return false, nil
+		}
+		return true, nil
+	}, stopCh); err != nil {
+		klog.Info("Stopped waiting for Antrea client")
+		return err
+	}
+
+	klog.Info("Antrea client is ready")
+
+	options := metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("nodeName", nodeName).String(),
+	}
+	klog.Infof("nodename: %s", nodeName)
+	//get watchers from antrea client
+	fullSyncWaitGroup := sync.WaitGroup{}
+
+	//Wrapper watcher to call watch
+	networkPolicyControllerWatcher := &watchWrapper{
+		func() (watch.Interface, error) {
+			antreaClient, err := antreaClientProvider.GetAntreaClient()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get antrea client: %s", err.Error())
+			}
+			return antreaClient.ControlplaneV1beta1().NetworkPolicies("").Watch(context.TODO(), options)
+		},
+		"networkPolicy",
+		&fullSyncWaitGroup,
+	}
+	addressGroupWatcher := &watchWrapper{
+		func() (watch.Interface, error) {
+			antreaClient, err := antreaClientProvider.GetAntreaClient()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get antrea client: %s", err.Error())
+			}
+			return antreaClient.ControlplaneV1beta1().AddressGroups().Watch(context.TODO(), options)
+		},
+		"addressGroup",
+		&fullSyncWaitGroup,
+	}
+	appliedGroupWatcher := &watchWrapper{
+		func() (watch.Interface, error) {
+			antreaClient, err := antreaClientProvider.GetAntreaClient()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get antrea client: %s", err.Error())
+			}
+			return antreaClient.ControlplaneV1beta1().AppliedToGroups().Watch(context.TODO(), options)
+		},
+		"appliedGroup",
+		&fullSyncWaitGroup,
+	}
+	fullSyncWaitGroup.Add(3)
+
+	//call watch by goroutine with wait.NonSlidingUntil
+	go wait.NonSlidingUntil(networkPolicyControllerWatcher.watch, 5*time.Second, stopCh)
+	go wait.NonSlidingUntil(addressGroupWatcher.watch, 5*time.Second, stopCh)
+	go wait.NonSlidingUntil(appliedGroupWatcher.watch, 5*time.Second, stopCh)
+	fullSyncWaitGroup.Wait()
+
+	<-stopCh
+	klog.Info("Stopping Antrea agent simulator")
+	return nil
+}
+
+type watchWrapper struct {
+	//w                 watch.Interface
+	watchFunc         func() (watch.Interface, error)
+	name              string
+	fullSyncWaitGroup *sync.WaitGroup
+}
+
+type simulator struct {
+	networkPolicyWatcher *watchWrapper
+	addressGroupWatcher  *watchWrapper
+	appliedGroupWatcher  *watchWrapper
+}
+
+func (w *watchWrapper) watch() {
+	klog.Infof("Starting watch for %s", w.name)
+	watcher, err := w.watchFunc()
+	if err != nil {
+		klog.Warningf("Failed to start watch for %s: %v", w.name, err)
+		return
+	}
+	eventCount := 0
+	defer func() {
+		klog.Infof("Stopped watch for %s, total items received %d", w.name, eventCount)
+		watcher.Stop()
+	}()
+	initCount := 0
+	w.fullSyncWaitGroup.Done()
+loop:
+	for {
+		select {
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				klog.Warningf("Result channel for %s was closed", w.name)
+				return
+			}
+			switch event.Type {
+			case watch.Added:
+				klog.V(2).Info("Added %s (%#v)", w.name, event.Object)
+				initCount++
+			case watch.Bookmark:
+				break loop
+			}
+		}
+	}
+	klog.Infof("Received %d init events for %s", initCount, w.name)
+	eventCount += initCount
+
+	for {
+		select {
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				return
+			}
+			switch event.Type {
+			case watch.Added:
+				klog.V(2).Infof("Added %s (%#v)", w.name, event.Object)
+			case watch.Modified:
+				klog.V(2).Infof("Updated %s (%#v)", w.name, event.Object)
+			case watch.Deleted:
+				klog.V(2).Infof("Removed %s (%#v)", w.name, event.Object)
+			default:
+				klog.Errorf("Unknown event: %v", event)
+				return
+			}
+			eventCount++
+		}
+	}
+}

--- a/cmd/antrea-agent-simulator/simulator.go
+++ b/cmd/antrea-agent-simulator/simulator.go
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package main under directory cmd parses and validates user input,
-// instantiates and initializes objects imported from pkg, and runs
-// the process.
+// The simulator binary is responsible to run simulated nodes for antrea agent.
+// It watches NetworkPolicies, AddressGroups and AppliedToGroups from antrea controller
+// and prints the events of these resources to log.
 package main
 
 import (
@@ -26,49 +26,19 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	componentbaseconfig "k8s.io/component-base/config"
 	"k8s.io/klog"
-	aggregatorclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent"
-	crdclientset "github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned"
+	"github.com/vmware-tanzu/antrea/pkg/k8s"
 	"github.com/vmware-tanzu/antrea/pkg/signals"
 	"github.com/vmware-tanzu/antrea/pkg/util/env"
 	"github.com/vmware-tanzu/antrea/pkg/version"
 )
 
-func createClientSet(kubeConfig *rest.Config) (clientset.Interface, aggregatorclientset.Interface, crdclientset.Interface, error) {
-	var err error
-	if kubeConfig == nil {
-		klog.Infof("kubeConfig is not specified, will fallback to incluster")
-		kubeConfig, err = rest.InClusterConfig()
-		if err != nil {
-			klog.Errorf("Failed to get incluster config: %s", err.Error())
-			return nil, nil, nil, err
-		}
-	}
-	client, err := clientset.NewForConfig(kubeConfig)
-	if err != nil {
-		klog.Errorf("Failed to create clientset: %s", err.Error())
-		return nil, nil, nil, err
-	}
-	aggregatorClient, err := aggregatorclientset.NewForConfig(kubeConfig)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	// Create client for crd operations
-	crdClient, err := crdclientset.NewForConfig(kubeConfig)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	return client, aggregatorClient, crdClient, nil
-}
-
 func run() error {
 	klog.Infof("Starting Antrea agent simulator (version %s)", version.GetFullVersion())
-	k8sClient, _, _, err := createClientSet(nil)
+	k8sClient, _, _, err := k8s.CreateClients(componentbaseconfig.ClientConnectionConfiguration{})
 	if err != nil {
 		return fmt.Errorf("error creating K8s clients: %v", err)
 	}
@@ -111,7 +81,7 @@ func run() error {
 	options := metav1.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector("nodeName", nodeName).String(),
 	}
-	klog.Infof("nodename: %s", nodeName)
+	klog.Infof("Nodename: %s", nodeName)
 
 	// Wrapper watcher to call watch
 	networkPolicyControllerWatcher := &watchWrapper{

--- a/docs/antrea-agent-simulator.md
+++ b/docs/antrea-agent-simulator.md
@@ -1,0 +1,46 @@
+# Run Antrea agent simulator
+
+This document describes how to run the Antrea agent simulator. The simulator is useful for Antrea scalability testing, without having to create a very large cluster.
+
+## Build the images
+
+   ```bash
+   make build-scale-simulator
+   ```
+
+## Create the yaml file
+
+This demo uses 1 simulator, this command will create a yaml file build/yamls/antrea-simulator.yml
+
+   ```bash
+   make manifest-scale
+   ```
+
+The above yaml will create one simulated Node/Pod, to change the number of instances, you can modify `spec.replicas` of the StatefulSet `antrea-agent-simulator` in the yaml, or scale it via `kubectl scale statefulset/antrea-agent-simulator -n kube-system --replicas=<COUNT>` after deploying it.
+
+## Taint the simulator node
+
+To prevent Pods from being scheduled on the simulated Node(s), you can use the following taint.
+
+   ```bash
+   kubectl taint -l 'antrea/instance=simulator' node mocknode=true:NoExecute
+   ```
+
+## Create secret for kubemark
+
+   ```bash
+    cp ~/.kube/config admin.conf
+    kubectl create secret generic kubeconfig --type=Opaque --namespace=kube-system --from-file=<path to kubeconfig file>
+   ```
+
+## Apply the yaml file
+
+   ```bash
+   kubectl apply -f build/yamls/antrea-scale.yml
+   ```
+
+check the simulator
+
+   ```bash
+   kubectl get nodes -l 'antrea/instance=simulator'
+   ```

--- a/docs/maintainers/build-kubemark.md
+++ b/docs/maintainers/build-kubemark.md
@@ -1,0 +1,10 @@
+# Build the kubemark image
+  This documentation simply describes how to build kubemark image.
+
+   ```bash
+   cd $KUBERNETES_PATH
+   make WHAT=cmd/kubemark KUBE_BUILD_PLATFORMS=linux/amd64
+   cp ./_output/local/go/bin/linux_amd64/kubemark cluster/images/kubemark
+   cd cluster/images/kubemark
+   docker build -t antrea/kubemark:latest .
+   ```

--- a/hack/.notableofcontents
+++ b/hack/.notableofcontents
@@ -1,5 +1,6 @@
 docs/aks-installation.md
 docs/api.md
+docs/antrea-agent-simulator.md
 docs/assets/README.md
 docs/assets/logo/README.md
 docs/contributors/code-generation.md
@@ -19,6 +20,7 @@ docs/getting-started.md
 docs/gke-installation.md
 docs/ipsec-tunnel.md
 docs/kind.md
+docs/maintainers/build-kubemark.md
 docs/maintainers/getting-started-gif.md
 docs/maintainers/release.md
 docs/octant-plugin-installation.md

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -334,6 +334,7 @@ if $SIMULATOR; then
     $KUSTOMIZE edit add base $BASE
     $KUSTOMIZE edit add patch --path agentNodeAffinity.yml
     $KUSTOMIZE edit add patch --path controllerNodeAffinity.yml
+    $KUSTOMIZE edit add resource antrea-agent-simulator.yml
     BASE=../simulator
     cd ..
 fi

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -38,6 +38,7 @@ Generate a YAML manifest for Antrea using Kustomize and print it to stdout.
         --on-delete                   Generate a manifest with antrea-agent's update strategy set to OnDelete.
                                       This option will work only for Kind clusters (when using '--kind').
         --coverage                    Generates a manifest which supports measuring code coverage of Antrea binaries.
+        --simulator                   Generates a manifest with antrea-agent simulator included
         --help, -h                    Print this message and exit
 
 In 'release' mode, environment variables IMG_NAME and IMG_TAG must be set.
@@ -70,6 +71,7 @@ VERBOSE_LOG=false
 ON_DELETE=false
 COVERAGE=false
 K8S_115=false
+SIMULATOR=false
 
 while [[ $# -gt 0 ]]
 do
@@ -130,6 +132,10 @@ case $key in
     ;;
     --coverage)
     COVERAGE=true
+    shift
+    ;;
+    --simulator)
+    SIMULATOR=true
     shift
     ;;
     -h|--help)
@@ -318,6 +324,17 @@ if [[ $CLOUD == "EKS" ]]; then
     $KUSTOMIZE edit add base $BASE
     $KUSTOMIZE edit add patch --path eksEnv.yml
     BASE=../eks
+    cd ..
+fi
+
+if $SIMULATOR; then
+    mkdir simulator && cd simulator
+    cp ../../patches/simulator/*.yml .
+    touch kustomization.yml
+    $KUSTOMIZE edit add base $BASE
+    $KUSTOMIZE edit add patch --path agentNodeAffinity.yml
+    $KUSTOMIZE edit add patch --path controllerNodeAffinity.yml
+    BASE=../simulator
     cd ..
 fi
 


### PR DESCRIPTION
The binary simulates an antrea-agent in pod for scale test, it works with kubemark which simulates kubelet and kube-proxy. It mainly watches networkPolicies, addressGroups and appliedToGroups.

To run simulator , please refer to docs/antrea-agent-simulator.md

This PR is from #1493