### PR TITLE
Fix flaky test TestControllerWithDuplicatePodCIDR

### DIFF
--- a/pkg/agent/controller/noderoute/node_route_controller_test.go
+++ b/pkg/agent/controller/noderoute/node_route_controller_test.go
@@ -83,6 +83,10 @@ func TestControllerWithDuplicatePodCIDR(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	c.informerFactory.Start(stopCh)
+	// Must wait for cache sync, otherwise resource creation events will be missing if the resources are created
+	// in-between list and watch call of an informer. This is because fake clientset doesn't support watching with
+	// resourceVersion. A watcher of fake clientset only gets events that happen after the watcher is created.
+	c.informerFactory.WaitForCacheSync(stopCh)
 
 	node1 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
The test must wait for cache sync first, otherwise resource creation
events will be missing if the resources are created in-between list and
watch call of an informer. This is because fake clientset doesn't
support watching with resourceVersion. A watcher of fake clientset only
gets events that happen after the watcher is created.

Fixes #1562