### PR TITLE
antrea-agent supports overriding apiserver

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1367,6 +1367,10 @@ data:
     # whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
     # and all Node traffic directed to that port will be forwarded to the Pod.
     #nplPortRange: 40000-41000
+
+    # Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
+    # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
+    #kubeAPIServerOverride: ""
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -1423,7 +1427,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-b8hh7hm486
+  name: antrea-config-7d66b472ff
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1534,7 +1538,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-b8hh7hm486
+          name: antrea-config-7d66b472ff
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1799,7 +1803,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-b8hh7hm486
+          name: antrea-config-7d66b472ff
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1367,6 +1367,10 @@ data:
     # whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
     # and all Node traffic directed to that port will be forwarded to the Pod.
     #nplPortRange: 40000-41000
+
+    # Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
+    # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
+    #kubeAPIServerOverride: ""
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -1423,7 +1427,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-b8hh7hm486
+  name: antrea-config-7d66b472ff
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1534,7 +1538,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-b8hh7hm486
+          name: antrea-config-7d66b472ff
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1801,7 +1805,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-b8hh7hm486
+          name: antrea-config-7d66b472ff
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1367,6 +1367,10 @@ data:
     # whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
     # and all Node traffic directed to that port will be forwarded to the Pod.
     #nplPortRange: 40000-41000
+
+    # Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
+    # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
+    #kubeAPIServerOverride: ""
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -1423,7 +1427,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-hhfkgg2fg5
+  name: antrea-config-8hc5c7g4hb
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1534,7 +1538,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-hhfkgg2fg5
+          name: antrea-config-8hc5c7g4hb
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1802,7 +1806,7 @@ spec:
           path: /home/kubernetes/bin
         name: host-cni-bin
       - configMap:
-          name: antrea-config-hhfkgg2fg5
+          name: antrea-config-8hc5c7g4hb
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1372,6 +1372,10 @@ data:
     # whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
     # and all Node traffic directed to that port will be forwarded to the Pod.
     #nplPortRange: 40000-41000
+
+    # Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
+    # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
+    #kubeAPIServerOverride: ""
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -1428,7 +1432,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-bdc66g4872
+  name: antrea-config-k7574f7tdc
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1548,7 +1552,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-bdc66g4872
+          name: antrea-config-k7574f7tdc
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1848,7 +1852,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-bdc66g4872
+          name: antrea-config-k7574f7tdc
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1372,6 +1372,10 @@ data:
     # whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
     # and all Node traffic directed to that port will be forwarded to the Pod.
     #nplPortRange: 40000-41000
+
+    # Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
+    # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
+    #kubeAPIServerOverride: ""
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -1428,7 +1432,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-9964gfgbb4
+  name: antrea-config-2m4ktcghmf
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1539,7 +1543,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-9964gfgbb4
+          name: antrea-config-2m4ktcghmf
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1804,7 +1808,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-9964gfgbb4
+          name: antrea-config-2m4ktcghmf
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -116,3 +116,7 @@ featureGates:
 # whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
 # and all Node traffic directed to that port will be forwarded to the Pod.
 #nplPortRange: 40000-41000
+
+# Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
+# Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
+#kubeAPIServerOverride: ""

--- a/cmd/antrea-agent-simulator/simulator.go
+++ b/cmd/antrea-agent-simulator/simulator.go
@@ -38,7 +38,7 @@ import (
 
 func run() error {
 	klog.Infof("Starting Antrea agent simulator (version %s)", version.GetFullVersion())
-	k8sClient, _, _, err := k8s.CreateClients(componentbaseconfig.ClientConnectionConfiguration{})
+	k8sClient, _, _, err := k8s.CreateClients(componentbaseconfig.ClientConnectionConfiguration{}, "")
 	if err != nil {
 		return fmt.Errorf("error creating K8s clients: %v", err)
 	}

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -64,7 +64,7 @@ const informerDefaultResync = 12 * time.Hour
 func run(o *Options) error {
 	klog.Infof("Starting Antrea agent (version %s)", version.GetFullVersion())
 	// Create K8s Clientset, CRD Clientset and SharedInformerFactory for the given config.
-	k8sClient, _, crdClient, err := k8s.CreateClients(o.config.ClientConnection)
+	k8sClient, _, crdClient, err := k8s.CreateClients(o.config.ClientConnection, o.config.KubeAPIServerOverride)
 	if err != nil {
 		return fmt.Errorf("error creating K8s clients: %v", err)
 	}

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -124,4 +124,7 @@ type AgentConfig struct {
 	// whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
 	// and all Node traffic directed to that port will be forwarded to the Pod.
 	NPLPortRange string `yaml:"nplPortRange,omitempty"`
+	// Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
+	// Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
+	KubeAPIServerOverride string `yaml:"kubeAPIServerOverride,omitempty"`
 }

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -84,7 +84,7 @@ func run(o *Options) error {
 	// Create K8s Clientset, Aggregator Clientset, CRD Clientset and SharedInformerFactory for the given config.
 	// Aggregator Clientset is used to update the CABundle of the APIServices backed by antrea-controller so that
 	// the aggregator can verify its serving certificate.
-	client, aggregatorClient, crdClient, err := k8s.CreateClients(o.config.ClientConnection)
+	client, aggregatorClient, crdClient, err := k8s.CreateClients(o.config.ClientConnection, "")
 	if err != nil {
 		return fmt.Errorf("error creating K8s clients: %v", err)
 	}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -26,7 +26,7 @@ import (
 )
 
 // CreateClients creates kube clients from the given config.
-func CreateClients(config componentbaseconfig.ClientConnectionConfiguration) (clientset.Interface, aggregatorclientset.Interface, crdclientset.Interface, error) {
+func CreateClients(config componentbaseconfig.ClientConnectionConfiguration, kubeAPIServerOverride string) (clientset.Interface, aggregatorclientset.Interface, crdclientset.Interface, error) {
 	var kubeConfig *rest.Config
 	var err error
 
@@ -38,6 +38,11 @@ func CreateClients(config componentbaseconfig.ClientConnectionConfiguration) (cl
 			&clientcmd.ClientConfigLoadingRules{ExplicitPath: config.Kubeconfig},
 			&clientcmd.ConfigOverrides{}).ClientConfig()
 	}
+
+	if len(kubeAPIServerOverride) != 0 {
+		kubeConfig.Host = kubeAPIServerOverride
+	}
+
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
antrea-agent relies either the following clientConnection or in-cluster
serviceaccount to configure the clientset that talks to apiserver.

```
clientConnection:
  kubeconfig: /home/ubuntu/.kube/config
```

For in-cluster configuration the apiserver host and port are injected
by kubelet, which is normally the apiserver's service vip (e.g.
10.96.0.1). This new option allows override them by `masterOverride`.
It must be a host string, a host:port pair, or a URL to the base of the
apiserver.

For example:
```
masterOverride: 127.0.0.1:43305
```

Fixes #1684