### PR TITLE
[Windows] Update the way to check the state of required Windows feature

### DIFF
--- a/pkg/agent/util/net_windows_test.go
+++ b/pkg/agent/util/net_windows_test.go
@@ -30,7 +30,7 @@ import (
 var hypervInstalled = false
 
 func TestWindowsHyperVInstalled(t *testing.T) {
-	installed, err := WindowsHyperVInstalled()
+	installed, err := WindowsHyperVEnabled()
 	require.Nil(t, err)
 	t.Logf("HyperV installed: %v", installed)
 	hypervInstalled = installed


### PR DESCRIPTION
Hyper-V feature contains multiple components/sub-features. According to
the test, OVS requires "Microsoft-Hyper-V" feature to be enabled.

Signed-off-by: Rui Cao <rcao@vmware.com>