### PR TITLE
Service annotation based pod selection for NodePortLocal

### DIFF
--- a/pkg/agent/nodeportlocal/k8s/annotations.go
+++ b/pkg/agent/nodeportlocal/k8s/annotations.go
@@ -28,6 +28,7 @@ import (
 )
 
 const NPLAnnotationStr = "nodeportlocal.antrea.io"
+const NPLServiceAnnotation = "nodeportlocal.antrea.io/enabled"
 
 // NPLAnnotation is the structure used for setting NodePortLocal annotation on the Pods
 type NPLAnnotation struct {
@@ -81,6 +82,14 @@ func assignPodAnnotation(pod *corev1.Pod, nodeIP string, containerPort, nodePort
 	}
 
 	current[NPLAnnotationStr] = toJSON(annotations)
+	pod.Annotations = current
+}
+
+func removePodAnnotation(pod *corev1.Pod) {
+	current := pod.Annotations
+
+	klog.V(2).Infof("Removing annotation from pod: %v", pod.Name)
+	delete(current, NPLAnnotationStr)
 	pod.Annotations = current
 }
 


### PR DESCRIPTION
Currently the NPLController in antrea-agent watches for all pods on the node, and exposes all pods to the external network using nodeip:nodeport. 
This PR introduces pod selection/filtering for NodePortLocal based on an annotation to be provided in the Service objects. The Service objects must be of type `ClusterIP`. The proposed annotation NPLController will watch for is: 
`nodeportlocal.antrea.io/enabled: "true"`

**Note**:  The value "true" is case sensitive here
This reduces the overall scope of the NodePortLocal and makes the selection and implementation much more controlled.

