### PR TITLE
Service annotation based pod selection for NodePortLocal

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -244,7 +244,11 @@ func run(o *Options) error {
 
 	// Start the NPL agent.
 	if features.DefaultFeatureGate.Enabled(features.NodePortLocal) {
-		nplController, err := npl.InitializeNPLAgent(k8sClient, o.config.NPLPortRange, nodeConfig.Name)
+		nplController, err := npl.InitializeNPLAgent(
+			k8sClient,
+			informerFactory,
+			o.config.NPLPortRange,
+			nodeConfig.Name)
 		if err != nil {
 			return fmt.Errorf("failed to start NPL agent: %v", err)
 		}

--- a/pkg/agent/nodeportlocal/k8s/annotations.go
+++ b/pkg/agent/nodeportlocal/k8s/annotations.go
@@ -89,7 +89,7 @@ func assignPodAnnotation(pod *corev1.Pod, nodeIP string, containerPort, nodePort
 }
 
 func removePodAnnotation(pod *corev1.Pod) {
-	klog.V(2).Infof("Removing all NodePortLocal annotation from Pod: %s/%s", pod.Namespace, pod.Name)
+	klog.V(2).Infof("Removing entire NodePortLocal annotation from Pod: %s/%s", pod.Namespace, pod.Name)
 	delete(pod.Annotations, NPLAnnotationKey)
 }
 
@@ -97,7 +97,7 @@ func removeFromPodAnnotation(pod *corev1.Pod, containerPort int) {
 	var err error
 	current := pod.Annotations
 
-	klog.V(2).Infof("Removing annotation from Pod: %v\tport: %v", pod.Name, containerPort)
+	klog.V(2).Infof("Removing NodePortLocal annotation from Pod: %s/%s\tport: %v", pod.Namespace, pod.Name, containerPort)
 	var annotations []NPLAnnotation
 	if err = json.Unmarshal([]byte(current[NPLAnnotationKey]), &annotations); err != nil {
 		klog.Warningf("Unable to unmarshal NodePortLocal annotation: %v", current[NPLAnnotationKey])

--- a/pkg/agent/nodeportlocal/k8s/annotations.go
+++ b/pkg/agent/nodeportlocal/k8s/annotations.go
@@ -134,7 +134,7 @@ func (c *NPLController) RemoveNPLAnnotationFromPods() {
 		if _, exists := pod.Annotations[NPLAnnotationKey]; !exists {
 			continue
 		}
-		removePodAnnotation(&pod)
+		removePodAnnotation(&podList.Items[i])
 		c.updatePodAnnotation(&podList.Items[i])
 	}
 	klog.Infof("Removed all NodePortLocal annotations from all Pods")

--- a/pkg/agent/nodeportlocal/k8s/annotations.go
+++ b/pkg/agent/nodeportlocal/k8s/annotations.go
@@ -89,7 +89,7 @@ func assignPodAnnotation(pod *corev1.Pod, nodeIP string, containerPort, nodePort
 }
 
 func removePodAnnotation(pod *corev1.Pod) {
-	klog.V(2).Infof("Removing annotation from Pod: %v", pod.Name)
+	klog.V(2).Infof("Removing all NodePortLocal annotation from Pod: %s/%s", pod.Namespace, pod.Name)
 	delete(pod.Annotations, NPLAnnotationKey)
 }
 
@@ -131,16 +131,10 @@ func (c *NPLController) RemoveNPLAnnotationFromPods() {
 		return
 	}
 	for i, pod := range podList.Items {
-		podAnnotation := pod.GetAnnotations()
-		if podAnnotation == nil {
+		if _, exists := pod.Annotations[NPLAnnotationKey]; !exists {
 			continue
 		}
-		if _, exists := podAnnotation[NPLAnnotationKey]; !exists {
-			continue
-		}
-		klog.V(2).Infof("Removing all NodePortLocal annotation from Pod: %s, ns: %s", pod.Name, pod.Namespace)
-		delete(podAnnotation, NPLAnnotationKey)
-		pod.Annotations = podAnnotation
+		removePodAnnotation(&pod)
 		c.updatePodAnnotation(&podList.Items[i])
 	}
 	klog.Infof("Removed all NodePortLocal annotations from all Pods")

--- a/pkg/agent/nodeportlocal/k8s/annotations.go
+++ b/pkg/agent/nodeportlocal/k8s/annotations.go
@@ -33,7 +33,7 @@ const (
 	NPLEnabledAnnotationIndex = "nplEnabledAnnotation"
 )
 
-// NPLAnnotation is the structure used for setting NodePortLocal annotation on the Pods
+// NPLAnnotation is the structure used for setting NodePortLocal annotation on the Pods.
 type NPLAnnotation struct {
 	PodPort  int    `json:"podPort"`
 	NodeIP   string `json:"nodeIP"`
@@ -122,7 +122,7 @@ func (c *NPLController) RemoveNPLAnnotationFromPods() {
 		klog.Warningf("Failed to get Node's name, NodePortLocal annotation cannot be removed for Pods scheduled to this Node")
 		return
 	}
-	podList, err := c.kubeClient.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{
+	podList, err := c.kubeClient.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{
 		FieldSelector:   "spec.nodeName=" + nodeName,
 		ResourceVersion: "0",
 	})

--- a/pkg/agent/nodeportlocal/k8s/annotations.go
+++ b/pkg/agent/nodeportlocal/k8s/annotations.go
@@ -28,6 +28,7 @@ import (
 )
 
 const NPLAnnotationStr = "nodeportlocal.antrea.io"
+const NPLServiceAnnotation = "nodeportlocal.antrea.io/enabled"
 
 // NPLAnnotation is the structure used for setting NodePortLocal annotation on the Pods
 type NPLAnnotation struct {
@@ -81,6 +82,14 @@ func assignPodAnnotation(pod *corev1.Pod, nodeIP string, containerPort, nodePort
 	}
 
 	current[NPLAnnotationStr] = toJSON(annotations)
+	pod.Annotations = current
+}
+
+func removePodAnnotation(pod *corev1.Pod) {
+	current := pod.Annotations
+
+	klog.V(2).Infof("Removing annotation from pod: %v", pod.Name)
+	delete(current, NPLAnnotationStr)
 	pod.Annotations = current
 }
 

--- a/pkg/agent/nodeportlocal/k8s/controller.go
+++ b/pkg/agent/nodeportlocal/k8s/controller.go
@@ -151,7 +151,7 @@ func (c *NPLController) syncPod(key string) error {
 func (c *NPLController) checkDeletedPod(obj interface{}) (*corev1.Pod, error) {
 	deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 	if !ok {
-		return nil, fmt.Errorf("Received unexpected object: %v", obj)
+		return nil, fmt.Errorf("received unexpected object: %v", obj)
 
 	}
 	pod, ok := deletedState.Obj.(*corev1.Pod)
@@ -178,7 +178,7 @@ func (c *NPLController) enqueuePod(obj interface{}) {
 func (c *NPLController) checkDeletedSvc(obj interface{}) (*corev1.Service, error) {
 	deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 	if !ok {
-		return nil, fmt.Errorf("Received unexpected object: %v", obj)
+		return nil, fmt.Errorf("received unexpected object: %v", obj)
 	}
 	svc, ok := deletedState.Obj.(*corev1.Service)
 	if !ok {
@@ -267,7 +267,7 @@ func (c *NPLController) isNPLEnabledForServiceOfPod(obj interface{}) bool {
 	pod := obj.(*corev1.Pod)
 	services, err := c.svcInformer.GetIndexer().ByIndex(NPLEnabledAnnotationIndex, "true")
 	if err != nil {
-		klog.Errorf("Got error while listing Services with annotation: %v", err)
+		klog.Errorf("Got error while listing Services with annotation %s: %v", NPLEnabledAnnotationKey, err)
 		return false
 	}
 

--- a/pkg/agent/nodeportlocal/k8s/controller.go
+++ b/pkg/agent/nodeportlocal/k8s/controller.go
@@ -344,8 +344,9 @@ func (c *NPLController) handleRemovePod(key string, obj interface{}) error {
 	}
 
 	if obj != nil {
-		newPod := obj.(*corev1.Pod).DeepCopy()
-		if _, exists := newPod.Annotations[NPLAnnotationKey]; exists {
+		pod := obj.(*corev1.Pod)
+		if _, exists := pod.Annotations[NPLAnnotationKey]; exists {
+			newPod := pod.DeepCopy()
 			removePodAnnotation(newPod)
 			return c.updatePodAnnotation(newPod)
 		}

--- a/pkg/agent/nodeportlocal/k8s/controller.go
+++ b/pkg/agent/nodeportlocal/k8s/controller.go
@@ -17,6 +17,7 @@
 package k8s
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -25,6 +26,9 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/nodeportlocal/portcache"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -39,13 +43,16 @@ const (
 )
 
 type Controller struct {
-	portTable  *portcache.PortTable
-	kubeClient clientset.Interface
-	queue      workqueue.RateLimitingInterface
-	Ctrl       cache.Controller
-	CacheStore cache.Store
-	PodToIP    map[string]string
-	podIPLock  sync.RWMutex
+	NodeName      string
+	portTable     *portcache.PortTable
+	kubeClient    clientset.Interface
+	queue         workqueue.RateLimitingInterface
+	PodController cache.Controller
+	PodCacheStore cache.Store
+	SvcController cache.Controller
+	SvcCacheStore cache.Store
+	PodToIP       map[string]string
+	podIPLock     sync.RWMutex
 }
 
 func NewNPLController(kubeClient clientset.Interface, pt *portcache.PortTable) *Controller {
@@ -69,19 +76,22 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	for i := 0; i < numWorkers; i++ {
 		go wait.Until(c.Worker, time.Second, stopCh)
 	}
-	c.Ctrl.Run(stopCh)
-	cache.WaitForCacheSync(stopCh, c.Ctrl.HasSynced)
+
+	go c.PodController.Run(stopCh)
+	go c.SvcController.Run(stopCh)
+	cache.WaitForCacheSync(stopCh, c.PodController.HasSynced)
+	cache.WaitForCacheSync(stopCh, c.SvcController.HasSynced)
 	<-stopCh
 }
 
 func (c *Controller) syncPod(key string) error {
-	obj, exists, err := c.CacheStore.GetByKey(key)
+	obj, exists, err := c.PodCacheStore.GetByKey(key)
 	if err != nil {
 		return err
-	} else if exists {
+	} else if exists && c.isNPLEnabledForServiceOfPod(obj) {
 		return c.handleAddUpdatePod(key, obj)
 	} else {
-		return c.handleDeletePod(key)
+		return c.handleRemovePod(key, obj)
 	}
 }
 
@@ -98,7 +108,7 @@ func (c *Controller) checkDeletedPod(obj interface{}) (*corev1.Pod, error) {
 	return pod, nil
 }
 
-func (c *Controller) EnqueueObj(obj interface{}) {
+func (c *Controller) EnqueuePod(obj interface{}) {
 	pod, isPod := obj.(*corev1.Pod)
 	if !isPod {
 		var err error
@@ -110,6 +120,107 @@ func (c *Controller) EnqueueObj(obj interface{}) {
 	}
 	podKey := podKeyFunc(pod)
 	c.queue.Add(podKey)
+}
+
+func (c *Controller) checkDeletedSvc(obj interface{}) (*corev1.Service, error) {
+	deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+	if !ok {
+		return nil, fmt.Errorf("Received unexpected object: %v", obj)
+	}
+	svc, ok := deletedState.Obj.(*corev1.Service)
+	if !ok {
+		return nil, fmt.Errorf("DeletedFinalStateUnknown object is not of type Service: %v", deletedState.Obj)
+	}
+	return svc, nil
+}
+
+func (c *Controller) EnqueueSvcUpdate(oldObj, newObj interface{}) {
+	// In case where the app selector in Service gets updated from one valid selector to another
+	// both set of pods (corresponding to old and new selector) need to be considered
+	newSvc, isSvc := newObj.(*corev1.Service)
+	if !isSvc {
+		var err error
+		newSvc, err = c.checkDeletedSvc(newObj)
+		if err != nil {
+			klog.Errorf("Got error while processing event update: %v", err)
+			return
+		}
+	}
+
+	oldSvc := oldObj.(*corev1.Service)
+	if oldSvc.ResourceVersion == newSvc.ResourceVersion {
+		return
+	}
+
+	podKeys := append(c.getPodsFromService(oldSvc), c.getPodsFromService(newSvc)...)
+	for _, podKey := range podKeys {
+		c.queue.Add(podKey)
+	}
+}
+
+func (c *Controller) EnqueueSvc(obj interface{}) {
+	svc, isSvc := obj.(*corev1.Service)
+	if !isSvc {
+		var err error
+		svc, err = c.checkDeletedSvc(obj)
+		if err != nil {
+			klog.Errorf("Got error while processing event update: %v", err)
+			return
+		}
+	}
+
+	for _, podKey := range c.getPodsFromService(svc) {
+		c.queue.Add(podKey)
+	}
+}
+
+func (c *Controller) getPodsFromService(svc *corev1.Service) []string {
+	var pods []string
+	annotations := svc.GetAnnotations()
+	if val, ok := annotations[NPLServiceAnnotation]; !ok || (ok && val != "true") {
+		return pods
+	}
+
+	appSelectorValue, ok := svc.Spec.Selector["app"]
+	if !ok {
+		return pods
+	}
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set{"app": appSelectorValue}).String(),
+		FieldSelector: fields.OneTermEqualSelector("spec.nodeName", c.NodeName).String(),
+	}
+	podList, err := c.kubeClient.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), listOptions)
+	if err != nil {
+		klog.Errorf("Got error while listing pods: %v", err)
+		return pods
+	}
+	for i := range podList.Items {
+		pods = append(pods, podKeyFunc(&podList.Items[i]))
+	}
+	return pods
+}
+
+func (c *Controller) isNPLEnabledForServiceOfPod(obj interface{}) bool {
+	pod := obj.(*corev1.Pod)
+	appLabelValue, ok := pod.GetLabels()["app"]
+	if !ok {
+		return false
+	}
+
+	for _, service := range c.SvcCacheStore.List() {
+		svc, isSvc := service.(*corev1.Service)
+		// selecting services NOT of type NodePort, with matching app selector (with pod),
+		// having appropriate annotation for enabling NPL
+		if isSvc && svc.Spec.Type != corev1.ServiceTypeNodePort {
+			if appSelectorVal, ok := svc.Spec.Selector["app"]; ok && appSelectorVal == appLabelValue {
+				if val, ok := svc.GetAnnotations()[NPLServiceAnnotation]; ok && val == "true" {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func (c *Controller) Worker() {
@@ -151,9 +262,10 @@ func (c *Controller) addPodIPToCache(key, podIP string) {
 	c.PodToIP[key] = podIP
 }
 
-// handleDeletePod removes rules from port table and
+// handleRemovePod removes rules from port table and
 // rules programmed in the system based on implementation type (e.g. IPTABLES)
-func (c *Controller) handleDeletePod(key string) error {
+// this also removes pod annotation from pods that are not selected by service annotation
+func (c *Controller) handleRemovePod(key string, obj interface{}) error {
 	klog.Infof("Got delete event for Pod: %s", key)
 	podIP, found := c.getPodIPFromCache(key)
 	if !found {
@@ -166,6 +278,12 @@ func (c *Controller) handleDeletePod(key string) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if obj != nil {
+		newPod := obj.(*corev1.Pod).DeepCopy()
+		removePodAnnotation(newPod)
+		return c.updatePodAnnotation(newPod)
 	}
 	return nil
 }

--- a/pkg/agent/nodeportlocal/k8s/controller.go
+++ b/pkg/agent/nodeportlocal/k8s/controller.go
@@ -187,10 +187,10 @@ func (c *NPLController) checkDeletedSvc(obj interface{}) (*corev1.Service, error
 
 func (c *NPLController) enqueueSvcUpdate(oldObj, newObj interface{}) {
 	// In case where the app selector in Service gets updated from one valid selector to another
-	// both sets of Pods (corresponding to old and new selector) need to be considered
+	// both sets of Pods (corresponding to old and new selector) need to be considered.
 
 	// Donot push to queue if 1) Service ResourceVersions don't change OR
-	// 2) Service spec selectors AND 3) NPLEnabledAnnotationKey values don't change
+	// 2) Service spec selectors AND 3) NPLEnabledAnnotationKey values don't change.
 	newSvc := newObj.(*corev1.Service)
 	oldSvc := oldObj.(*corev1.Service)
 	if oldSvc.ResourceVersion == newSvc.ResourceVersion ||
@@ -199,7 +199,7 @@ func (c *NPLController) enqueueSvcUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	// disjunctive union of Pods from both Service sets
+	// Disjunctive union of Pods from both Service sets.
 	oldPodSet := sets.NewString(c.getPodsFromService(oldSvc)...)
 	newPodSet := sets.NewString(c.getPodsFromService(newSvc)...)
 	podKeys := oldPodSet.Difference(newPodSet).Union(newPodSet.Difference(oldPodSet))
@@ -231,7 +231,7 @@ func (c *NPLController) getPodsFromService(svc *corev1.Service) []string {
 		return pods
 	}
 
-	// handling Service without selectors
+	// Handling Service without selectors.
 	if len(svc.Spec.Selector) == 0 {
 		return pods
 	}
@@ -257,7 +257,7 @@ func (c *NPLController) isNPLEnabledForServiceOfPod(obj interface{}) bool {
 
 	for _, service := range services {
 		svc, isSvc := service.(*corev1.Service)
-		// selecting Services NOT of type NodePort, with Service selector matching Pod labels
+		// Selecting Services NOT of type NodePort, with Service selector matching Pod labels.
 		if isSvc && svc.Spec.Type != corev1.ServiceTypeNodePort {
 			if matchSvcSelectorPodLabels(svc.Spec.Selector, pod.GetLabels()) {
 				return true
@@ -268,9 +268,9 @@ func (c *NPLController) isNPLEnabledForServiceOfPod(obj interface{}) bool {
 }
 
 // matchSvcSelectorPodLabels verifies that all key/value pairs present in Service's selector
-// are also present in Pod's labels
+// are also present in Pod's labels.
 func matchSvcSelectorPodLabels(svcSelector, podLabel map[string]string) bool {
-	// handling Service without selectors
+	// Handling Service without selectors.
 	if len(svcSelector) == 0 {
 		return false
 	}
@@ -323,8 +323,8 @@ func (c *NPLController) addPodIPToCache(key, podIP string) {
 }
 
 // handleRemovePod removes rules from port table and
-// rules programmed in the system based on implementation type (e.g. IPTABLES)
-// this also removes pod annotation from pods that are not selected by service annotation
+// rules programmed in the system based on implementation type (e.g. IPTABLES).
+// This also removes pod annotation from pods that are not selected by service annotation.
 func (c *NPLController) handleRemovePod(key string, obj interface{}) error {
 	klog.Infof("Got delete event for Pod: %s", key)
 	podIP, found := c.getPodIPFromCache(key)
@@ -348,7 +348,7 @@ func (c *NPLController) handleRemovePod(key string, obj interface{}) error {
 	return nil
 }
 
-// handleAddUpdatePod handles Pod Add, Update events and updates annotation if required
+// handleAddUpdatePod handles Pod Add, Update events and updates annotation if required.
 func (c *NPLController) handleAddUpdatePod(key string, obj interface{}) error {
 	newPod := obj.(*corev1.Pod).DeepCopy()
 	klog.Infof("Got add/update event for pod: %s", key)

--- a/pkg/agent/nodeportlocal/npl_agent_init.go
+++ b/pkg/agent/nodeportlocal/npl_agent_init.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-const resyncPeriod = 60 * time.Minute
+const resyncPeriod = 0 * time.Minute
 
 // InitializeNPLAgent initializes the NodePortLocal (NPL) agent.
 // It initializes the port table cache to keep track of Node ports available for use by NPL,

--- a/pkg/agent/nodeportlocal/npl_agent_init.go
+++ b/pkg/agent/nodeportlocal/npl_agent_init.go
@@ -71,7 +71,7 @@ func InitController(kubeClient clientset.Interface, informerFactory informers.Sh
 		listOptions,
 	)
 
-	svcInformer := informerFactory.Core().V1().Services()
+	svcInformer := informerFactory.Core().V1().Services().Informer()
 
 	c := k8s.NewNPLController(kubeClient,
 		podInformer,

--- a/pkg/agent/nodeportlocal/npl_agent_init.go
+++ b/pkg/agent/nodeportlocal/npl_agent_init.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/vmware-tanzu/antrea/pkg/agent/nodeportlocal/k8s"
+	nplk8s "github.com/vmware-tanzu/antrea/pkg/agent/nodeportlocal/k8s"
 	"github.com/vmware-tanzu/antrea/pkg/agent/nodeportlocal/portcache"
 	"github.com/vmware-tanzu/antrea/pkg/agent/nodeportlocal/util"
 
@@ -39,7 +39,7 @@ const resyncPeriod = 60 * time.Minute
 // It initializes the port table cache to keep track of Node ports available for use by NPL,
 // sets up event handlers to handle Pod add, update and delete events.
 // When a Pod gets created, a free Node port is obtained from the port table cache and a DNAT rule is added to NAT traffic to the Pod's ip:port.
-func InitializeNPLAgent(kubeClient clientset.Interface, informerFactory informers.SharedInformerFactory, portRange, nodeName string) (*k8s.NPLController, error) {
+func InitializeNPLAgent(kubeClient clientset.Interface, informerFactory informers.SharedInformerFactory, portRange, nodeName string) (*nplk8s.NPLController, error) {
 	start, end, err := util.ParsePortsRange(portRange)
 	if err != nil {
 		return nil, fmt.Errorf("something went wrong while fetching port range: %v", err)
@@ -58,8 +58,8 @@ func InitializeNPLAgent(kubeClient clientset.Interface, informerFactory informer
 
 // InitController initializes the NPLController with appropriate Pod and Service Informers.
 // This function can be used independently while unit testing without using InitializeNPLAgent function.
-func InitController(kubeClient clientset.Interface, informerFactory informers.SharedInformerFactory, portTable *portcache.PortTable, nodeName string) (*k8s.NPLController, error) {
-	// Watch only the Pods which belong to the Node where the agent is running
+func InitController(kubeClient clientset.Interface, informerFactory informers.SharedInformerFactory, portTable *portcache.PortTable, nodeName string) (*nplk8s.NPLController, error) {
+	// Watch only the Pods which belong to the Node where the agent is running.
 	listOptions := func(options *metav1.ListOptions) {
 		options.FieldSelector = fields.OneTermEqualSelector("spec.nodeName", nodeName).String()
 	}
@@ -73,7 +73,7 @@ func InitController(kubeClient clientset.Interface, informerFactory informers.Sh
 
 	svcInformer := informerFactory.Core().V1().Services().Informer()
 
-	c := k8s.NewNPLController(kubeClient,
+	c := nplk8s.NewNPLController(kubeClient,
 		podInformer,
 		svcInformer,
 		resyncPeriod,

--- a/pkg/agent/nodeportlocal/npl_agent_init.go
+++ b/pkg/agent/nodeportlocal/npl_agent_init.go
@@ -33,6 +33,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// Set resyncPeriod to 0 to disable resyncing.
+// UpdateFunc event handler will be called only when the object is actually updated.
 const resyncPeriod = 0 * time.Minute
 
 // InitializeNPLAgent initializes the NodePortLocal (NPL) agent.

--- a/pkg/agent/nodeportlocal/npl_agent_init_windows.go
+++ b/pkg/agent/nodeportlocal/npl_agent_init_windows.go
@@ -19,12 +19,13 @@ package nodeportlocal
 import (
 	"errors"
 
+	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 )
 
 // InitializeNPLAgent starts NodePortLocal (NPL) agent.
 // Currently NPL is disabled for windows.
-func InitializeNPLAgent(kubeClient clientset.Interface, portRange, nodeName string) (*windowsCtrl, error) {
+func InitializeNPLAgent(kubeClient clientset.Interface, informerFactory informers.SharedInformerFactory, portRange, nodeName string) (*windowsCtrl, error) {
 	return nil, errors.New("Windows Platform not supported for NPL")
 }
 

--- a/pkg/agent/nodeportlocal/nplagent_test.go
+++ b/pkg/agent/nodeportlocal/nplagent_test.go
@@ -184,7 +184,6 @@ func TestSvcUpdateAnnotation(t *testing.T) {
 
 	// Update Service with bad annotation value.
 	testSvc.Annotations = map[string]string{k8s.NPLEnabledAnnotationKey: "false"}
-	testSvc.ResourceVersion = "2"
 	s, err = kubeClient.CoreV1().Services(defaultNS).Update(context.TODO(), &testSvc, metav1.UpdateOptions{})
 	r.Nil(err, "Service update failed")
 	t.Logf("successfully updated Service: %s", s.Name)
@@ -207,7 +206,6 @@ func TestSvcRemoveAnnotation(t *testing.T) {
 	testSvc.Name = servicePodName
 	testSvc.Annotations = map[string]string{k8s.NPLEnabledAnnotationKey: "true"}
 	testSvc.Spec.Selector[defaultAppSelectorKey] = servicePodName
-	testSvc.ResourceVersion = "3"
 	s, err := kubeClient.CoreV1().Services(defaultNS).Update(context.TODO(), &testSvc, metav1.UpdateOptions{})
 	r.Nil(err, "Service update failed")
 	t.Logf("successfully updated Service: %s", s.Name)
@@ -217,7 +215,6 @@ func TestSvcRemoveAnnotation(t *testing.T) {
 	a.Equal(portTable.RuleExists(defaultPodIP, defaultPort), true)
 
 	testSvc.Annotations = make(map[string]string)
-	testSvc.ResourceVersion = "4"
 	s, err = kubeClient.CoreV1().Services(defaultNS).Update(context.TODO(), &testSvc, metav1.UpdateOptions{})
 	r.Nil(err, "Service update failed")
 	t.Logf("successfully updated Service: %v", s)
@@ -237,7 +234,6 @@ func TestSvcUpdateSelector(t *testing.T) {
 	testSvc.Name = servicePodName
 	testSvc.Annotations = map[string]string{k8s.NPLEnabledAnnotationKey: "true"}
 	testSvc.Spec.Selector[defaultAppSelectorKey] = servicePodName
-	testSvc.ResourceVersion = "5"
 	s, err := kubeClient.CoreV1().Services(defaultNS).Update(context.TODO(), &testSvc, metav1.UpdateOptions{})
 	r.Nil(err, "Service update failed")
 	t.Logf("successfully updated Service: %s", s.Name)
@@ -247,7 +243,6 @@ func TestSvcUpdateSelector(t *testing.T) {
 	a.Equal(portTable.RuleExists(defaultPodIP, defaultPort), true)
 
 	testSvc.Spec.Selector = map[string]string{"foo": "invalid-selector"}
-	testSvc.ResourceVersion = "6"
 	s, err = kubeClient.CoreV1().Services(defaultNS).Update(context.TODO(), &testSvc, metav1.UpdateOptions{})
 	r.Nil(err, "Service update failed")
 	t.Logf("successfully updated Service: %v", s)
@@ -267,7 +262,6 @@ func TestPodUpdateSelectorLabel(t *testing.T) {
 	testSvc.Name = servicePodName
 	testSvc.Annotations = map[string]string{k8s.NPLEnabledAnnotationKey: "true"}
 	testSvc.Spec.Selector[defaultAppSelectorKey] = servicePodName
-	testSvc.ResourceVersion = "7"
 	s, err := kubeClient.CoreV1().Services(defaultNS).Update(context.TODO(), &testSvc, metav1.UpdateOptions{})
 	r.Nil(err, "Service update failed")
 	t.Logf("successfully updated Service: %s", s.Name)
@@ -279,7 +273,6 @@ func TestPodUpdateSelectorLabel(t *testing.T) {
 	testPod := getTestPod()
 	testPod.Name = servicePodName
 	testPod.Labels["invalid-label-key"] = servicePodName
-	testPod.ResourceVersion = "2"
 	p, err := kubeClient.CoreV1().Pods(defaultNS).Update(context.TODO(), &testPod, metav1.UpdateOptions{})
 	r.Nil(err, "Pod update failed")
 	t.Logf("successfully updated Pod: %v", p)
@@ -301,7 +294,6 @@ func TestDeleteSvc(t *testing.T) {
 	testSvc.Name = servicePodName
 	testSvc.Annotations = map[string]string{k8s.NPLEnabledAnnotationKey: "true"}
 	testSvc.Spec.Selector[defaultAppSelectorKey] = servicePodName
-	testSvc.ResourceVersion = "7"
 	s, err := kubeClient.CoreV1().Services(defaultNS).Update(context.TODO(), &testSvc, metav1.UpdateOptions{})
 	r.Nil(err, "Service update failed")
 	t.Logf("successfully updated Service: %s", s.Name)
@@ -309,7 +301,6 @@ func TestDeleteSvc(t *testing.T) {
 	testPod := getTestPod()
 	testPod.Name = servicePodName
 	testPod.Labels[defaultAppSelectorKey] = servicePodName
-	testPod.ResourceVersion = "3"
 	p, err := kubeClient.CoreV1().Pods(defaultNS).Update(context.TODO(), &testPod, metav1.UpdateOptions{})
 	r.Nil(err, "Pod update failed")
 	t.Logf("successfully updated Pod: %v", p)
@@ -367,7 +358,6 @@ func TestPodUpdate(t *testing.T) {
 
 	testPod := getTestPod()
 	testPod.Spec.Containers[0].Ports[0].ContainerPort = 8080
-	testPod.ResourceVersion = "2"
 	p, err := kubeClient.CoreV1().Pods(defaultNS).Update(context.TODO(), &testPod, metav1.UpdateOptions{})
 	r.Nil(err, "Pod creation failed")
 	t.Logf("successfully created Pod: %v", p)

--- a/pkg/agent/nodeportlocal/nplagent_test.go
+++ b/pkg/agent/nodeportlocal/nplagent_test.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/nodeportlocal/k8s"
@@ -118,7 +119,8 @@ func TestMain(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	portTable = NewPortTable(mockCtrl)
 
-	c, _ := InitController(kubeClient, portTable, defaultNodeName)
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, resyncPeriod)
+	c, _ := InitController(kubeClient, informerFactory, portTable, defaultNodeName)
 	stopCh := signals.RegisterSignalHandlers()
 	go c.Run(stopCh)
 }

--- a/pkg/agent/nodeportlocal/nplagent_test.go
+++ b/pkg/agent/nodeportlocal/nplagent_test.go
@@ -51,7 +51,6 @@ func NewPortTable(c *gomock.Controller) *portcache.PortTable {
 }
 
 const (
-	controllerName        = "AntreaAgentNPLController"
 	defaultPodName        = "test-pod"
 	defaultSvcName        = "test-svc"
 	defaultNS             = "default"

--- a/pkg/agent/nodeportlocal/nplagent_test.go
+++ b/pkg/agent/nodeportlocal/nplagent_test.go
@@ -161,8 +161,9 @@ func TestSvcUpdateAnnotation(t *testing.T) {
 	testSvc.Name = servicePodName
 	testSvc.Spec.Selector[defaultAppSelectorKey] = servicePodName
 	testSvc.Annotations = map[string]string{k8s.NPLEnabledAnnotationKey: "true"}
-	_, err := kubeClient.CoreV1().Services(defaultNS).Create(context.TODO(), &testSvc, metav1.CreateOptions{})
+	s, err := kubeClient.CoreV1().Services(defaultNS).Create(context.TODO(), &testSvc, metav1.CreateOptions{})
 	r.Nil(err, "Service creation failed")
+	t.Logf("successfully created Service: %v", s)
 
 	testPod := getTestPod()
 	testPod.Name = servicePodName
@@ -184,7 +185,7 @@ func TestSvcUpdateAnnotation(t *testing.T) {
 	// Update Service with bad annotation value.
 	testSvc.Annotations = map[string]string{k8s.NPLEnabledAnnotationKey: "false"}
 	testSvc.ResourceVersion = "2"
-	s, err := kubeClient.CoreV1().Services(defaultNS).Update(context.TODO(), &testSvc, metav1.UpdateOptions{})
+	s, err = kubeClient.CoreV1().Services(defaultNS).Update(context.TODO(), &testSvc, metav1.UpdateOptions{})
 	r.Nil(err, "Service update failed")
 	t.Logf("successfully updated Service: %s", s.Name)
 

--- a/pkg/agent/nodeportlocal/nplagent_test.go
+++ b/pkg/agent/nodeportlocal/nplagent_test.go
@@ -147,8 +147,8 @@ func pollForPodAnnotation(r *require.Assertions, podName string, found bool) (st
 	return data, err
 }
 
-// Add a service (proper annotation) and pod pair, update service with bad
-// annotation value and check for pod annotation and port cache entry removal
+// Add a Service (proper annotation) and Pod pair, update Service with bad
+// annotation value and check for Pod annotation and port cache entry removal.
 func TestSvcUpdateAnnotation(t *testing.T) {
 	var data string
 
@@ -162,7 +162,7 @@ func TestSvcUpdateAnnotation(t *testing.T) {
 	testSvc.Spec.Selector[defaultAppSelectorKey] = servicePodName
 	testSvc.Annotations = map[string]string{k8s.NPLEnabledAnnotationKey: "true"}
 	_, err := kubeClient.CoreV1().Services(defaultNS).Create(context.TODO(), &testSvc, metav1.CreateOptions{})
-	r.Nil(err, "Svc creation failed")
+	r.Nil(err, "Service creation failed")
 
 	testPod := getTestPod()
 	testPod.Name = servicePodName
@@ -181,21 +181,21 @@ func TestSvcUpdateAnnotation(t *testing.T) {
 	a.Equal(nplData[0].NodeIP, defaultHostIP)
 	a.Equal(portTable.RuleExists(defaultPodIP, defaultPort), true)
 
-	// update svc with bad annotation value
+	// Update Service with bad annotation value.
 	testSvc.Annotations = map[string]string{k8s.NPLEnabledAnnotationKey: "false"}
 	testSvc.ResourceVersion = "2"
 	s, err := kubeClient.CoreV1().Services(defaultNS).Update(context.TODO(), &testSvc, metav1.UpdateOptions{})
-	r.Nil(err, "Svc update failed")
-	t.Logf("successfully updated Svc: %s", s.Name)
+	r.Nil(err, "Service update failed")
+	t.Logf("successfully updated Service: %s", s.Name)
 
-	// check that annotation is removed and the rule is removed
+	// Check that annotation and the rule is removed.
 	_, err = pollForPodAnnotation(r, servicePodName, false)
 	r.Nil(err, "Poll for annotation check failed")
 	a.Equal(portTable.RuleExists(defaultPodIP, defaultPort), false)
 }
 
-// Update existing service with proper annotation to get pod annotation and port
-// cache entry back, remove annotation from service
+// Update existing Service with proper annotation to get Pod annotation and port
+// cache entry back, remove annotation from Service.
 func TestSvcRemoveAnnotation(t *testing.T) {
 	a := assert.New(t)
 	r := require.New(t)
@@ -208,8 +208,8 @@ func TestSvcRemoveAnnotation(t *testing.T) {
 	testSvc.Spec.Selector[defaultAppSelectorKey] = servicePodName
 	testSvc.ResourceVersion = "3"
 	s, err := kubeClient.CoreV1().Services(defaultNS).Update(context.TODO(), &testSvc, metav1.UpdateOptions{})
-	r.Nil(err, "Svc update failed")
-	t.Logf("successfully updated Svc: %s", s.Name)
+	r.Nil(err, "Service update failed")
+	t.Logf("successfully updated Service: %s", s.Name)
 
 	_, err = pollForPodAnnotation(r, servicePodName, true)
 	r.Nil(err, "Poll for annotation check failed")
@@ -218,8 +218,8 @@ func TestSvcRemoveAnnotation(t *testing.T) {
 	testSvc.Annotations = make(map[string]string)
 	testSvc.ResourceVersion = "4"
 	s, err = kubeClient.CoreV1().Services(defaultNS).Update(context.TODO(), &testSvc, metav1.UpdateOptions{})
-	r.Nil(err, "Svc update failed")
-	t.Logf("successfully updated Svc: %v", s)
+	r.Nil(err, "Service update failed")
+	t.Logf("successfully updated Service: %v", s)
 
 	_, err = pollForPodAnnotation(r, servicePodName, false)
 	r.Nil(err, "Poll for annotation check failed")
@@ -238,8 +238,8 @@ func TestSvcUpdateSelector(t *testing.T) {
 	testSvc.Spec.Selector[defaultAppSelectorKey] = servicePodName
 	testSvc.ResourceVersion = "5"
 	s, err := kubeClient.CoreV1().Services(defaultNS).Update(context.TODO(), &testSvc, metav1.UpdateOptions{})
-	r.Nil(err, "Svc update failed")
-	t.Logf("successfully updated Svc: %s", s.Name)
+	r.Nil(err, "Service update failed")
+	t.Logf("successfully updated Service: %s", s.Name)
 
 	_, err = pollForPodAnnotation(r, servicePodName, true)
 	r.Nil(err, "Poll for annotation check failed")
@@ -248,8 +248,8 @@ func TestSvcUpdateSelector(t *testing.T) {
 	testSvc.Spec.Selector = map[string]string{"foo": "invalid-selector"}
 	testSvc.ResourceVersion = "6"
 	s, err = kubeClient.CoreV1().Services(defaultNS).Update(context.TODO(), &testSvc, metav1.UpdateOptions{})
-	r.Nil(err, "Svc update failed")
-	t.Logf("successfully updated Svc: %v", s)
+	r.Nil(err, "Service update failed")
+	t.Logf("successfully updated Service: %v", s)
 
 	_, err = pollForPodAnnotation(r, servicePodName, false)
 	r.Nil(err, "Poll for annotation check failed")
@@ -268,8 +268,8 @@ func TestPodUpdateSelectorLabel(t *testing.T) {
 	testSvc.Spec.Selector[defaultAppSelectorKey] = servicePodName
 	testSvc.ResourceVersion = "7"
 	s, err := kubeClient.CoreV1().Services(defaultNS).Update(context.TODO(), &testSvc, metav1.UpdateOptions{})
-	r.Nil(err, "Svc update failed")
-	t.Logf("successfully updated Svc: %s", s.Name)
+	r.Nil(err, "Service update failed")
+	t.Logf("successfully updated Service: %s", s.Name)
 
 	_, err = pollForPodAnnotation(r, servicePodName, true)
 	r.Nil(err, "Poll for annotation check failed")
@@ -288,8 +288,8 @@ func TestPodUpdateSelectorLabel(t *testing.T) {
 	a.Equal(portTable.RuleExists(defaultPodIP, defaultPort), false)
 }
 
-// Update existing service with proper annotation to get pod annotation and port
-// cache entry back, delete service
+// Update existing Service with proper annotation to get Pod annotation and port
+// cache entry back, delete Service.
 func TestDeleteSvc(t *testing.T) {
 	a := assert.New(t)
 	r := require.New(t)
@@ -302,8 +302,8 @@ func TestDeleteSvc(t *testing.T) {
 	testSvc.Spec.Selector[defaultAppSelectorKey] = servicePodName
 	testSvc.ResourceVersion = "7"
 	s, err := kubeClient.CoreV1().Services(defaultNS).Update(context.TODO(), &testSvc, metav1.UpdateOptions{})
-	r.Nil(err, "Svc update failed")
-	t.Logf("successfully updated Svc: %s", s.Name)
+	r.Nil(err, "Service update failed")
+	t.Logf("successfully updated Service: %s", s.Name)
 
 	testPod := getTestPod()
 	testPod.Name = servicePodName
@@ -318,16 +318,16 @@ func TestDeleteSvc(t *testing.T) {
 	a.Equal(portTable.RuleExists(defaultPodIP, defaultPort), true)
 
 	err = kubeClient.CoreV1().Services(defaultNS).Delete(context.TODO(), servicePodName, metav1.DeleteOptions{})
-	r.Nil(err, "Svc deletion failed")
-	t.Logf("successfully deleted Svc: %s", servicePodName)
+	r.Nil(err, "Service deletion failed")
+	t.Logf("successfully deleted Service: %s", servicePodName)
 
 	_, err = pollForPodAnnotation(r, servicePodName, false)
 	r.Nil(err, "Poll for annotation check failed")
 	a.Equal(portTable.RuleExists(defaultPodIP, defaultPort), false)
 }
 
-// Add a new Pod with fake k8s client and verify that npl annotation gets updated
-// and an entry gets added in the local port cache
+// Add a new Pod with fake k8s client and verify that NPL annotation gets updated
+// and an entry gets added in the local port cache.
 func TestPodAdd(t *testing.T) {
 	var data string
 
@@ -337,7 +337,7 @@ func TestPodAdd(t *testing.T) {
 	testSvc := getTestSvc()
 	testSvc.Annotations = map[string]string{k8s.NPLEnabledAnnotationKey: "true"}
 	_, err := kubeClient.CoreV1().Services(defaultNS).Create(context.TODO(), &testSvc, metav1.CreateOptions{})
-	r.Nil(err, "Svc creation failed")
+	r.Nil(err, "Service creation failed")
 
 	testPod := getTestPod()
 	p, err := kubeClient.CoreV1().Pods(defaultNS).Create(context.TODO(), &testPod, metav1.CreateOptions{})
@@ -355,7 +355,7 @@ func TestPodAdd(t *testing.T) {
 	a.Equal(portTable.RuleExists(defaultPodIP, defaultPort), true)
 }
 
-// Test that any update in the Pod container port is reflected in Pod annotation and local port cache
+// Test that any update in the Pod container port is reflected in Pod annotation and local port cache.
 func TestPodUpdate(t *testing.T) {
 	var ann map[string]string
 	var nplData []k8s.NPLAnnotation
@@ -377,7 +377,7 @@ func TestPodUpdate(t *testing.T) {
 		ann = updatedPod.GetAnnotations()
 		data, _ = ann[k8s.NPLAnnotationKey]
 		json.Unmarshal([]byte(data), &nplData)
-		t.Logf("pod annotation: %v", nplData)
+		t.Logf("Pod annotation: %v", nplData)
 		if len(nplData) != 1 {
 			return false, nil
 		}
@@ -392,7 +392,7 @@ func TestPodUpdate(t *testing.T) {
 	a.Equal(portTable.RuleExists(defaultPodIP, 8080), true)
 }
 
-// Make sure that when a pod gets deleted, corresponding entry gets deleted from local port cache also
+// Make sure that when a Pod gets deleted, corresponding entry gets deleted from local port cache also
 func TestPodDel(t *testing.T) {
 	r := require.New(t)
 

--- a/pkg/agent/nodeportlocal/nplagent_test.go
+++ b/pkg/agent/nodeportlocal/nplagent_test.go
@@ -119,10 +119,14 @@ func TestMain(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	portTable = NewPortTable(mockCtrl)
 
+	// informerFactory is initialised and started from cmd/antrea-agent/agent.go
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, resyncPeriod)
+
 	c, _ := InitController(kubeClient, informerFactory, portTable, defaultNodeName)
 	stopCh := signals.RegisterSignalHandlers()
+
 	go c.Run(stopCh)
+	informerFactory.Start(stopCh)
 }
 
 func pollForPodAnnotation(r *require.Assertions, podName string, found bool) (string, error) {


### PR DESCRIPTION
Currently the NPLController in antrea-agent watches for all pods on the node, and exposes all pods to the external network using nodeip:nodeport.
This PR introduces pod selection/filtering for NodePortLocal based on an annotation to be provided in the Service objects. The Service objects can be of any type but `NodePort`. The proposed annotation NPLController will watch for is:
`nodeportlocal.antrea.io/enabled: "true"`

**Note**: The value "true" is case sensitive here
This makes the selection and implementation of NodePortLocal much more controlled.
