### PR TITLE
[Windows] Provide workaround to install Hyper-V without CPU check

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -331,10 +331,10 @@ Extension is disabled by default. In this case, the stale OVS bridge and ports
 should be removed. A help script [Clean-AntreaNetwork.ps1](https://raw.githubusercontent.com/vmware-tanzu/antrea/master/hack/windows/Clean-AntreaNetwork.ps1)
 can be used to clean the OVS bridge.
 
-2. Hyper-V feature cannot be installed on Windows node due to the processor not
+2. Hyper-V feature cannot be installed on Windows Node due to the processor not
 having the required virtualization capabilities.
 
-    If the processor of the Windows node does not have the required
+    If the processor of the Windows Node does not have the required
     virtualization capabilities. The installation of Hyper-V feature will fail
     with the following error:
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -45,8 +45,8 @@ and daemons are pre-installed on the Windows Nodes in the demo.
   updates.
 * Deploy a Linux-based Kubernetes cluster.
 * Install [Hyper-V](https://docs.microsoft.com/en-us/windows-server/virtualization/hyper-v/get-started/install-the-hyper-v-role-on-windows-server)
-  with management tools. If the virtualization capabilities on your testbed
-  cannot meet the requirments needed by Hyper-V. You could try the workaround
+  with management tools. If the virtualization capabilities on your Nodes
+  cannot meet the requirements needed by Hyper-V. You could try the workaround
   descried in [Known issues](#Known-issues) section.
 * Install [Docker](https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=Windows-Server).
 * [Install OVS](http://docs.openvswitch.org/en/latest/intro/install/windows/)
@@ -331,46 +331,46 @@ Extension is disabled by default. In this case, the stale OVS bridge and ports
 should be removed. A help script [Clean-AntreaNetwork.ps1](https://raw.githubusercontent.com/vmware-tanzu/antrea/master/hack/windows/Clean-AntreaNetwork.ps1)
 can be used to clean the OVS bridge.
 
-2. Hyper-V feature cannot be installed on Windows node due to the processor does
-not have required virtualization capabilities.
+2. Hyper-V feature cannot be installed on Windows node due to the processor not
+having required virtualization capabilities.
 
-If the processor of the Windows node does not have required virtualization
-capabilities. The installation of Hyper-V feature will be failed with following
-error:
+    If the processor of the Windows node does not have required virtualization
+    capabilities. The installation of Hyper-V feature will fail with the
+    following error:
 
-```powershell
-PS C:\Users\Administrator> Install-WindowsFeature Hyper-V
+    ```powershell
+    PS C:\Users\Administrator> Install-WindowsFeature Hyper-V
 
-Success Restart Needed Exit Code      Feature Result
-------- -------------- ---------      --------------
-False   Maybe          Failed         {}
-Install-WindowsFeature : A prerequisite check for the Hyper-V feature failed.
-1. Hyper-V cannot be installed: The processor does not have required virtualization capabilities.
-At line:1 char:1
-+ Install-WindowsFeature hyper-v
-+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    + CategoryInfo          : InvalidOperation: (Hyper-V:ServerComponentWrapper) [Install-WindowsFeature], Exception
-    + FullyQualifiedErrorId : Alteration_PrerequisiteCheck_Failed,Microsoft.Windows.ServerManager.Commands.AddWindowsF
-   eatureCommand
-```
+    Success Restart Needed Exit Code      Feature Result
+    ------- -------------- ---------      --------------
+    False   Maybe          Failed         {}
+    Install-WindowsFeature : A prerequisite check for the Hyper-V feature failed.
+    1. Hyper-V cannot be installed: The processor does not have required virtualization capabilities.
+    At line:1 char:1
+    + Install-WindowsFeature hyper-v
+    + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        + CategoryInfo          : InvalidOperation: (Hyper-V:ServerComponentWrapper) [Install-WindowsFeature], Exception
+        + FullyQualifiedErrorId : Alteration_PrerequisiteCheck_Failed,Microsoft.Windows.ServerManager.Commands.AddWindowsF
+       eatureCommand
+    ```
 
-The capability is required by the Hyper-V `hypervisor` components to support
-[Hyper-V isolation](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container#hyper-v-isolation)
-. If you only need ues [Process Isolation](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container#process-isolation)
-on the testbed. You could apply following workaround to skip CPU check for
-Hyper-V feature installation.
+    The capabilities are required by the Hyper-V `hypervisor` components to
+    support [Hyper-V isolation](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container#hyper-v-isolation).
+    If you only need uses [Process Isolation](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container#process-isolation)
+    on the testbed. You could apply following workaround to skip CPU check for
+    Hyper-V feature installation.
 
-```powershell
-# 1. Install containers feature
-Install-WindowsFeature containers
+    ```powershell
+    # 1. Install containers feature
+    Install-WindowsFeature containers
 
-# 2. Install Hyper-V management powershell module
-Install-WindowsFeature Hyper-V-Powershell
+    # 2. Install Hyper-V management powershell module
+    Install-WindowsFeature Hyper-V-Powershell
 
-# 3. Install Hyper-V feature without CPU check and disable the "hypervisor"
-dism /online /enable-feature /featurename:Microsoft-Hyper-V /all /NoRestart
-dism /online /disable-feature /featurename:Microsoft-Hyper-V-Online /NoRestart
+    # 3. Install Hyper-V feature without CPU check and disable the "hypervisor"
+    dism /online /enable-feature /featurename:Microsoft-Hyper-V /all /NoRestart
+    dism /online /disable-feature /featurename:Microsoft-Hyper-V-Online /NoRestart
 
-# 4. Restart-Computer to take effect
-Restart-Computer
-```
+    # 4. Restart-Computer to take effect
+    Restart-Computer
+    ```

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -45,9 +45,9 @@ and daemons are pre-installed on the Windows Nodes in the demo.
   updates.
 * Deploy a Linux-based Kubernetes cluster.
 * Install [Hyper-V](https://docs.microsoft.com/en-us/windows-server/virtualization/hyper-v/get-started/install-the-hyper-v-role-on-windows-server)
-  with management tools. If the virtualization capabilities on your Nodes
-  cannot meet the requirements needed by Hyper-V. You could try the workaround
-  descried in [Known issues](#Known-issues) section.
+  with management tools. If your Nodes do not have the virtualization
+  capabilities required by Hyper-V, you could try the workaround
+  described in the [Known issues](#Known-issues) section.
 * Install [Docker](https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=Windows-Server).
 * [Install OVS](http://docs.openvswitch.org/en/latest/intro/install/windows/)
   and configure the daemons as Windows service.
@@ -332,11 +332,11 @@ should be removed. A help script [Clean-AntreaNetwork.ps1](https://raw.githubuse
 can be used to clean the OVS bridge.
 
 2. Hyper-V feature cannot be installed on Windows node due to the processor not
-having required virtualization capabilities.
+having the required virtualization capabilities.
 
-    If the processor of the Windows node does not have required virtualization
-    capabilities. The installation of Hyper-V feature will fail with the
-    following error:
+    If the processor of the Windows node does not have the required
+    virtualization capabilities. The installation of Hyper-V feature will fail
+    with the following error:
 
     ```powershell
     PS C:\Users\Administrator> Install-WindowsFeature Hyper-V
@@ -356,8 +356,8 @@ having required virtualization capabilities.
 
     The capabilities are required by the Hyper-V `hypervisor` components to
     support [Hyper-V isolation](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container#hyper-v-isolation).
-    If you only need uses [Process Isolation](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container#process-isolation)
-    on the testbed. You could apply following workaround to skip CPU check for
+    If you only need [Process Isolation](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container#process-isolation)
+    on the Nodes. You could apply the following workaround to skip CPU check for
     Hyper-V feature installation.
 
     ```powershell


### PR DESCRIPTION
Provide workaround to install Hyper-V without CPU virtualization
capability check. In this way, users could deploy antrea on the
testbed without virtualization capability.

Signed-off-by: Rui Cao <rcao@vmware.com>