### PR TITLE
Conditionally pull base image for "make ubuntu" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,11 @@ codegen:
 .PHONY: ubuntu
 ubuntu:
 	@echo "===> Building antrea/antrea-ubuntu Docker image <==="
+ifneq ($(DOCKER_REGISTRY),"")
+	docker build -t antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.ubuntu .
+else
 	docker build --pull -t antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.ubuntu .
+endif
 	docker tag antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) antrea/antrea-ubuntu
 	docker tag antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/antrea-ubuntu
 	docker tag antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION)


### PR DESCRIPTION
It is not always appropriate to pull the base image when building the Antrea Docker image with the "make ubuntu" target. In particular, when using a Docker registry other than docker.io, we may not want to pull the base image. Other targets already consider the "DOCKER_REGISTRY" variable and only pull the base image if the variable is not set. We do the same for the "make ubuntu" target. Other variables may be used in the future to make this decision if appropriate.