### PR TITLE
Update the getting started doc about the requirements of Linux Kernel

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,7 +29,7 @@ with the following flags:
 `kube-proxy` should be started with the `--cluster-cidr=<CIDR Range for Pods>`
 flag.
 
-As for OVS, when using the built-in kernel module, kernel version >= 4.4 is
+As for OVS, when using the built-in kernel module, kernel version >= 4.6 is
 required. On the other hand, when building it from OVS sources, OVS
 version >= 2.6.0 is required.
 


### PR DESCRIPTION
docs: updated requirement of Linux Kernel version from 4.4 to 4.6 in 
getting-started.md

For AntreaProxy, the feature that requires OVS ct action to support nat has
been promoted to beta and enabled by default since v0.11. Linux kernel 4.6
is the earliest upstream version that supports it. The PR corrects the 
Linux kernel version requirement in getting-started.md.

Fixes #1652 