### PR TITLE
Handle restartability for Node Port Local

### DIFF
--- a/pkg/agent/nodeportlocal/k8s/annotations.go
+++ b/pkg/agent/nodeportlocal/k8s/annotations.go
@@ -19,6 +19,7 @@ package k8s
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/vmware-tanzu/antrea/pkg/util/env"
 
@@ -40,21 +41,76 @@ type NPLAnnotation struct {
 	NodePort int    `json:"nodePort"`
 }
 
+// ParsePodNPLAnnotations parses a Pod's annotation belonging to NPL and returns
+// a list of NPLAnnotation. Returns an error if no NPL annotation is found for a Pod
+func ParsePodNPLAnnotations(pod corev1.Pod) ([]NPLAnnotation, error) {
+	var result []NPLAnnotation
+	annotations := pod.GetAnnotations()
+	nplAnnotation, ok := annotations[NPLAnnotationKey]
+	if !ok {
+		return result, fmt.Errorf("Pod %s/%s doesn't contain NPL annotation", pod.Namespace, pod.Name)
+	}
+	if err := json.Unmarshal([]byte(nplAnnotation), &result); err != nil {
+		return result, fmt.Errorf("NPL annotations for Pod %s/%s couldn't be parsed with error %s",
+			pod.Namespace, pod.Name, err.Error())
+	}
+	return result, nil
+}
+
+// IsAnnotationDifferent compares two sets of NPL Annotations. If there's any difference, we
+// return true, else false
+func IsAnnotationDifferent(old, new []NPLAnnotation) bool {
+	type NodeIPPort struct {
+		NodeIP   string
+		NodePort int
+	}
+	if len(old) != len(new) {
+		return true
+	}
+	visitedPorts := make(map[int]NodeIPPort)
+	for _, ann := range old {
+		visitedPorts[ann.PodPort] = NodeIPPort{
+			NodeIP:   ann.NodeIP,
+			NodePort: ann.NodePort,
+		}
+	}
+	for _, ann := range new {
+		if np, ok := visitedPorts[ann.PodPort]; ok {
+			if np.NodeIP != ann.NodeIP || np.NodePort != ann.NodePort {
+				return true
+			}
+			continue
+		}
+		return true
+	}
+	return false
+}
+
 func toJSON(serialize interface{}) string {
 	jsonMarshalled, _ := json.Marshal(serialize)
 	return string(jsonMarshalled)
 }
 
-func isNodePortInAnnotation(s []NPLAnnotation, nodeport int) bool {
+func isNodePortInAnnotation(s []NPLAnnotation, nodeport, cport int) bool {
 	for _, i := range s {
 		if i.NodePort == nodeport {
-			return true
+			if i.PodPort == cport {
+				return true
+			}
 		}
 	}
 	return false
 }
 
-func assignPodAnnotation(pod *corev1.Pod, nodeIP string, containerPort, nodePort int) {
+// PodNodePort is a mapping of NodePort assigned for a PodPort.
+type PodNodePort struct {
+	NodePort int
+	PodPort  int
+}
+
+// AssignPodAnnotation creates an annotation for a Pod with the assigned nodePort, and
+// updates it into the Pod, it returns true if an update to the Pod is required
+func AssignPodAnnotation(pod *corev1.Pod, nodeIP string, containerPort, nodePort int) bool {
 	var err error
 	current := pod.Annotations
 	if current == nil {
@@ -69,13 +125,16 @@ func assignPodAnnotation(pod *corev1.Pod, nodeIP string, containerPort, nodePort
 			klog.Warningf("Unable to unmarshal NodePortLocal annotation: %v", current[NPLAnnotationKey])
 		}
 
-		if !isNodePortInAnnotation(annotations, nodePort) {
-			annotations = append(annotations, NPLAnnotation{
-				PodPort:  containerPort,
-				NodeIP:   nodeIP,
-				NodePort: nodePort,
-			})
+		if isNodePortInAnnotation(annotations, nodePort, containerPort) {
+			// no updates required to the pod
+			return false
 		}
+
+		annotations = append(annotations, NPLAnnotation{
+			PodPort:  containerPort,
+			NodeIP:   nodeIP,
+			NodePort: nodePort,
+		})
 	} else {
 		annotations = []NPLAnnotation{{
 			PodPort:  containerPort,
@@ -86,6 +145,7 @@ func assignPodAnnotation(pod *corev1.Pod, nodeIP string, containerPort, nodePort
 
 	current[NPLAnnotationKey] = toJSON(annotations)
 	pod.Annotations = current
+	return true
 }
 
 func removePodAnnotation(pod *corev1.Pod) {

--- a/pkg/agent/nodeportlocal/k8s/annotations.go
+++ b/pkg/agent/nodeportlocal/k8s/annotations.go
@@ -83,14 +83,14 @@ func removeFromNPLAnnotation(annotations []NPLAnnotation, containerPort int) []N
 }
 
 func (c *NPLController) updatePodNPLAnnotation(pod *corev1.Pod, annotations []NPLAnnotation) error {
-	if err := patchPod(annotations, *pod, c.kubeClient); err != nil {
+	if err := patchPod(annotations, pod, c.kubeClient); err != nil {
 		klog.Warningf("Unable to patch NPL annotations for Pod %s/%s: %s", pod.Namespace, pod.Name, err.Error())
 	}
 	klog.V(2).Infof("Successfully updated annotation for Pod %s/%s", pod.Namespace, pod.Name)
 	return nil
 }
 
-func patchPod(value []NPLAnnotation, pod corev1.Pod, kubeClient clientset.Interface) error {
+func patchPod(value []NPLAnnotation, pod *corev1.Pod, kubeClient clientset.Interface) error {
 	payloadValue := make(map[string]*string)
 	if len(value) > 0 {
 		valueStr := string(toJSON(value))
@@ -108,14 +108,14 @@ func patchPod(value []NPLAnnotation, pod corev1.Pod, kubeClient clientset.Interf
 	payloadBytes, _ := json.Marshal(newPayload)
 	if _, err := kubeClient.CoreV1().Pods(pod.Namespace).Patch(context.TODO(), pod.Name, types.MergePatchType,
 		payloadBytes, metav1.PatchOptions{}); err != nil {
-		return fmt.Errorf("unable to update Annotation for Pod %s/%s, %s", pod.Namespace,
+		return fmt.Errorf("unable to update Annotation for Pod %s/%s: %s", pod.Namespace,
 			pod.Name, err.Error())
 	}
 	return nil
 }
 
 // CleanupNPLAnnotationForPod removes the NPL Annotation from the Pod's Annotations map entirely.
-func CleanupNPLAnnotationForPod(kubeClient clientset.Interface, pod corev1.Pod) error {
+func CleanupNPLAnnotationForPod(kubeClient clientset.Interface, pod *corev1.Pod) error {
 	_, ok := pod.Annotations[NPLAnnotationKey]
 	if !ok {
 		return nil

--- a/pkg/agent/nodeportlocal/k8s/annotations.go
+++ b/pkg/agent/nodeportlocal/k8s/annotations.go
@@ -113,12 +113,3 @@ func patchPod(value []NPLAnnotation, pod *corev1.Pod, kubeClient clientset.Inter
 	}
 	return nil
 }
-
-// CleanupNPLAnnotationForPod removes the NodePortLocal annotation from the Pod's annotations map entirely.
-func CleanupNPLAnnotationForPod(kubeClient clientset.Interface, pod *corev1.Pod) error {
-	_, ok := pod.Annotations[NPLAnnotationKey]
-	if !ok {
-		return nil
-	}
-	return patchPod(nil, pod, kubeClient)
-}

--- a/pkg/agent/nodeportlocal/k8s/annotations.go
+++ b/pkg/agent/nodeportlocal/k8s/annotations.go
@@ -19,11 +19,12 @@ package k8s
 import (
 	"context"
 	"encoding/json"
-
-	"github.com/vmware-tanzu/antrea/pkg/util/env"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 )
 
@@ -54,103 +55,75 @@ func isNodePortInAnnotation(s []NPLAnnotation, nodeport, cport int) bool {
 	return false
 }
 
-// AssignPodAnnotation creates an annotation for a Pod with the assigned nodePort, and
-// updates it into the Pod. It returns true if an update to the Pod is required.
-func AssignPodAnnotation(pod *corev1.Pod, nodeIP string, containerPort, nodePort int) bool {
-	var err error
-	current := pod.Annotations
-	if current == nil {
-		current = make(map[string]string)
-	}
-
-	klog.V(2).Infof("Building annotation for Pod: %s\tport: %v --> %v:%v", pod.Name, containerPort, nodeIP, nodePort)
-
-	var annotations []NPLAnnotation
-	if current[NPLAnnotationKey] != "" {
-		if err = json.Unmarshal([]byte(current[NPLAnnotationKey]), &annotations); err != nil {
-			klog.Warningf("Unable to unmarshal NodePortLocal annotation: %v", current[NPLAnnotationKey])
+// IsNPLAnnotationRequired returns true if a new NPL Annotation value is required. It checks
+// for the Container Port, Node Port and the Pod IP in the existing list of the NPL Annotations
+// of the Pod.
+func IsNPLAnnotationRequired(annotations map[string]string, nodeIP string, containerPort, nodePort int) bool {
+	var nplAnnotations []NPLAnnotation
+	if annotations[NPLAnnotationKey] != "" {
+		if err := json.Unmarshal([]byte(annotations[NPLAnnotationKey]), &nplAnnotations); err != nil {
+			klog.Warningf("Unable to unmarshal NodePortLocal annotation: %v", annotations[NPLAnnotationKey])
 		}
-
-		if isNodePortInAnnotation(annotations, nodePort, containerPort) {
-			// no updates required to the pod
-			return false
-		}
-
-		annotations = append(annotations, NPLAnnotation{
-			PodPort:  containerPort,
-			NodeIP:   nodeIP,
-			NodePort: nodePort,
-		})
-	} else {
-		annotations = []NPLAnnotation{{
-			PodPort:  containerPort,
-			NodeIP:   nodeIP,
-			NodePort: nodePort,
-		}}
 	}
-
-	current[NPLAnnotationKey] = toJSON(annotations)
-	pod.Annotations = current
+	if isNodePortInAnnotation(nplAnnotations, nodePort, containerPort) {
+		// no updates required to the Pod
+		return false
+	}
 	return true
 }
 
-func removePodAnnotation(pod *corev1.Pod) {
-	klog.V(2).Infof("Removing entire NodePortLocal annotation from Pod: %s/%s", pod.Namespace, pod.Name)
-	delete(pod.Annotations, NPLAnnotationKey)
-}
-
-func removeFromPodAnnotation(pod *corev1.Pod, containerPort int) {
-	var err error
-	current := pod.Annotations
-
-	klog.V(2).Infof("Removing NodePortLocal annotation from Pod: %s/%s\tport: %v", pod.Namespace, pod.Name, containerPort)
-	var annotations []NPLAnnotation
-	if err = json.Unmarshal([]byte(current[NPLAnnotationKey]), &annotations); err != nil {
-		klog.Warningf("Unable to unmarshal NodePortLocal annotation: %v", current[NPLAnnotationKey])
-		return
-	}
-
+func removeFromNPLAnnotation(annotations []NPLAnnotation, containerPort int) []NPLAnnotation {
 	for i, ann := range annotations {
 		if ann.PodPort == containerPort {
 			annotations = append(annotations[:i], annotations[i+1:]...)
 			break
 		}
 	}
-
-	current[NPLAnnotationKey] = toJSON(annotations)
-	pod.Annotations = current
+	return annotations
 }
 
-// RemoveNPLAnnotationFromPods removes npl annotations from all Pods.
-func (c *NPLController) RemoveNPLAnnotationFromPods() {
-	nodeName, err := env.GetNodeName()
-	if err != nil {
-		klog.Warningf("Failed to get Node's name, NodePortLocal annotation cannot be removed for Pods scheduled to this Node")
-		return
-	}
-	podList, err := c.kubeClient.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{
-		FieldSelector:   "spec.nodeName=" + nodeName,
-		ResourceVersion: "0",
-	})
-	if err != nil {
-		klog.Warningf("Unable to list Pods, err: %v", err)
-		return
-	}
-	for i, pod := range podList.Items {
-		if _, exists := pod.Annotations[NPLAnnotationKey]; !exists {
-			continue
-		}
-		removePodAnnotation(&podList.Items[i])
-		c.updatePodAnnotation(&podList.Items[i])
-	}
-	klog.Infof("Removed all NodePortLocal annotations from all Pods")
-}
-
-func (c *NPLController) updatePodAnnotation(pod *corev1.Pod) error {
-	if _, err := c.kubeClient.CoreV1().Pods(pod.Namespace).Update(context.TODO(), pod, metav1.UpdateOptions{}); err != nil {
-		klog.Warningf("Unable to update annotation for Pod %s/%s, error: %v", pod.Namespace, pod.Name, err)
-		return err
+func (c *NPLController) updatePodNPLAnnotation(pod *corev1.Pod, annotations []NPLAnnotation) error {
+	if err := patchPod(annotations, *pod, c.kubeClient); err != nil {
+		klog.Warningf("Unable to patch NPL annotations for Pod %s/%s: %s", pod.Namespace, pod.Name, err.Error())
 	}
 	klog.V(2).Infof("Successfully updated annotation for Pod %s/%s", pod.Namespace, pod.Name)
 	return nil
+}
+
+func patchPod(value []NPLAnnotation, pod corev1.Pod, kubeClient clientset.Interface) error {
+	type Metadata struct {
+		Annotations map[string]*string `json:"annotations"`
+	}
+	type PatchData struct {
+		Meta Metadata `json:"metadata"`
+	}
+
+	payloadValue := make(map[string]*string)
+	if len(value) > 0 {
+		valueStr := string(toJSON(value))
+		payloadValue[NPLAnnotationKey] = &valueStr
+	} else {
+		payloadValue[NPLAnnotationKey] = nil
+	}
+	payload := PatchData{
+		Meta: Metadata{
+			Annotations: payloadValue,
+		},
+	}
+	payloadBytes, _ := json.Marshal(payload)
+	if _, err := kubeClient.CoreV1().Pods(pod.Namespace).Patch(context.TODO(), pod.Name, types.MergePatchType,
+		payloadBytes, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("unable to update Annotation for Pod %s/%s, %s", pod.Namespace,
+			pod.Name, err.Error())
+	}
+	return nil
+}
+
+// CleanupNPLAnnotationForPod removes the NPL Annotation from the Pod's Annotations map entirely.
+func CleanupNPLAnnotationForPod(kubeClient clientset.Interface, pod corev1.Pod) error {
+	_, ok := pod.Annotations[NPLAnnotationKey]
+	if !ok {
+		return nil
+	}
+	return patchPod(nil, pod, kubeClient)
 }

--- a/pkg/agent/nodeportlocal/k8s/annotations.go
+++ b/pkg/agent/nodeportlocal/k8s/annotations.go
@@ -84,7 +84,7 @@ func removeFromNPLAnnotation(annotations []NPLAnnotation, containerPort int) []N
 
 func (c *NPLController) updatePodNPLAnnotation(pod *corev1.Pod, annotations []NPLAnnotation) error {
 	if err := patchPod(annotations, pod, c.kubeClient); err != nil {
-		klog.Warningf("Unable to patch NodePortLocal annotation for Pod %s/%s: %s", pod.Namespace, pod.Name, err.Error())
+		klog.Warningf("Unable to patch NodePortLocal annotation for Pod %s/%s: %v", pod.Namespace, pod.Name, err)
 	}
 	klog.V(2).Infof("Successfully updated NodePortLocal annotation for Pod %s/%s", pod.Namespace, pod.Name)
 	return nil
@@ -108,8 +108,8 @@ func patchPod(value []NPLAnnotation, pod *corev1.Pod, kubeClient clientset.Inter
 	payloadBytes, _ := json.Marshal(newPayload)
 	if _, err := kubeClient.CoreV1().Pods(pod.Namespace).Patch(context.TODO(), pod.Name, types.MergePatchType,
 		payloadBytes, metav1.PatchOptions{}); err != nil {
-		return fmt.Errorf("unable to update NodePortLocal annotation for Pod %s/%s: %s", pod.Namespace,
-			pod.Name, err.Error())
+		return fmt.Errorf("unable to update NodePortLocal annotation for Pod %s/%s: %v", pod.Namespace,
+			pod.Name, err)
 	}
 	return nil
 }

--- a/pkg/agent/nodeportlocal/k8s/annotations.go
+++ b/pkg/agent/nodeportlocal/k8s/annotations.go
@@ -55,9 +55,9 @@ func isNodePortInAnnotation(s []NPLAnnotation, nodeport, cport int) bool {
 	return false
 }
 
-// IsNPLAnnotationRequired returns true if a new NPL Annotation value is required. It checks
-// for the Container Port, Node Port and the Pod IP in the existing list of the NPL Annotations
-// of the Pod.
+// IsNPLAnnotationRequired returns true if a new NodePortLocal annotation value is required. It
+// checks for the Container Port, Node Port and the Pod IP in the existing list of the
+// NodePortLocal annotation of the Pod.
 func IsNPLAnnotationRequired(annotations map[string]string, nodeIP string, containerPort, nodePort int) bool {
 	var nplAnnotations []NPLAnnotation
 	if annotations[NPLAnnotationKey] != "" {
@@ -84,9 +84,9 @@ func removeFromNPLAnnotation(annotations []NPLAnnotation, containerPort int) []N
 
 func (c *NPLController) updatePodNPLAnnotation(pod *corev1.Pod, annotations []NPLAnnotation) error {
 	if err := patchPod(annotations, pod, c.kubeClient); err != nil {
-		klog.Warningf("Unable to patch NPL annotations for Pod %s/%s: %s", pod.Namespace, pod.Name, err.Error())
+		klog.Warningf("Unable to patch NodePortLocal annotation for Pod %s/%s: %s", pod.Namespace, pod.Name, err.Error())
 	}
-	klog.V(2).Infof("Successfully updated annotation for Pod %s/%s", pod.Namespace, pod.Name)
+	klog.V(2).Infof("Successfully updated NodePortLocal annotation for Pod %s/%s", pod.Namespace, pod.Name)
 	return nil
 }
 
@@ -108,13 +108,13 @@ func patchPod(value []NPLAnnotation, pod *corev1.Pod, kubeClient clientset.Inter
 	payloadBytes, _ := json.Marshal(newPayload)
 	if _, err := kubeClient.CoreV1().Pods(pod.Namespace).Patch(context.TODO(), pod.Name, types.MergePatchType,
 		payloadBytes, metav1.PatchOptions{}); err != nil {
-		return fmt.Errorf("unable to update Annotation for Pod %s/%s: %s", pod.Namespace,
+		return fmt.Errorf("unable to update NodePortLocal annotation for Pod %s/%s: %s", pod.Namespace,
 			pod.Name, err.Error())
 	}
 	return nil
 }
 
-// CleanupNPLAnnotationForPod removes the NPL Annotation from the Pod's Annotations map entirely.
+// CleanupNPLAnnotationForPod removes the NodePortLocal annotation from the Pod's annotations map entirely.
 func CleanupNPLAnnotationForPod(kubeClient clientset.Interface, pod *corev1.Pod) error {
 	_, ok := pod.Annotations[NPLAnnotationKey]
 	if !ok {

--- a/pkg/agent/nodeportlocal/k8s/annotations.go
+++ b/pkg/agent/nodeportlocal/k8s/annotations.go
@@ -47,17 +47,15 @@ func toJSON(serialize interface{}) string {
 
 func isNodePortInAnnotation(s []NPLAnnotation, nodeport, cport int) bool {
 	for _, i := range s {
-		if i.NodePort == nodeport {
-			if i.PodPort == cport {
-				return true
-			}
+		if i.NodePort == nodeport && i.PodPort == cport {
+			return true
 		}
 	}
 	return false
 }
 
 // AssignPodAnnotation creates an annotation for a Pod with the assigned nodePort, and
-// updates it into the Pod, it returns true if an update to the Pod is required
+// updates it into the Pod. It returns true if an update to the Pod is required.
 func AssignPodAnnotation(pod *corev1.Pod, nodeIP string, containerPort, nodePort int) bool {
 	var err error
 	current := pod.Annotations

--- a/pkg/agent/nodeportlocal/k8s/npl_controller.go
+++ b/pkg/agent/nodeportlocal/k8s/npl_controller.go
@@ -379,7 +379,7 @@ func (c *NPLController) handleAddUpdatePod(key string, obj interface{}) error {
 			return err
 		}
 		if _, exists := pod.Annotations[NPLAnnotationKey]; exists {
-			return CleanupNPLAnnotationForPod(c.kubeClient, *pod)
+			return CleanupNPLAnnotationForPod(c.kubeClient, pod)
 		}
 		return nil
 	}

--- a/pkg/agent/nodeportlocal/k8s/npl_controller.go
+++ b/pkg/agent/nodeportlocal/k8s/npl_controller.go
@@ -406,10 +406,10 @@ func (c *NPLController) handleAddUpdatePod(key string, obj interface{}) error {
 	}
 
 	var annotations []NPLAnnotation
-	podAnnotation := newPod.GetAnnotations()
+	podAnnotation, exists := newPod.GetAnnotations()[NPLAnnotationKey]
 	entries := c.portTable.GetDataForPodIP(podIP)
-	if podAnnotation != nil {
-		if err := json.Unmarshal([]byte(podAnnotation[NPLAnnotationKey]), &annotations); err != nil {
+	if exists {
+		if err := json.Unmarshal([]byte(podAnnotation), &annotations); err != nil {
 			klog.Warningf("Unable to unmarshal NodePortLocal annotation")
 			return nil
 		}

--- a/pkg/agent/nodeportlocal/k8s/npl_controller.go
+++ b/pkg/agent/nodeportlocal/k8s/npl_controller.go
@@ -128,7 +128,7 @@ func (c *NPLController) Run(stopCh <-chan struct{}) {
 	klog.Info("Will fetch Pods and generate NodePortLocal rules for these Pods")
 
 	if err := c.GetPodsAndGenRules(); err != nil {
-		klog.Errorf("Error in getting Pods and generating rules: %s", err.Error())
+		klog.Errorf("Error in getting Pods and generating rules: %v", err)
 		return
 	}
 
@@ -438,7 +438,7 @@ func (c *NPLController) handleAddUpdatePod(key string, obj interface{}) error {
 				nplAnnotations = removeFromNPLAnnotation(nplAnnotations, data.PodPort)
 				err := c.portTable.DeleteRule(podIP, int(data.PodPort))
 				if err != nil {
-					return fmt.Errorf("failed to delete rule for Pod IP %s, Pod Port %d: %s", podIP, data.PodPort, err.Error())
+					return fmt.Errorf("failed to delete rule for Pod IP %s, Pod Port %d: %v", podIP, data.PodPort, err)
 				}
 				updatePodAnnotation = true
 			}
@@ -457,7 +457,7 @@ func (c *NPLController) handleAddUpdatePod(key string, obj interface{}) error {
 func (c *NPLController) GetPodsAndGenRules() error {
 	podList, err := c.podLister.List(labels.Everything())
 	if err != nil {
-		return fmt.Errorf("error in fetching the Pods for Node %s: %s", c.nodeName, err.Error())
+		return fmt.Errorf("error in fetching the Pods for Node %s: %v", c.nodeName, err)
 	}
 
 	allNPLPorts := []rules.PodNodePort{}

--- a/pkg/agent/nodeportlocal/k8s/npl_controller.go
+++ b/pkg/agent/nodeportlocal/k8s/npl_controller.go
@@ -400,8 +400,7 @@ func (c *NPLController) handleAddUpdatePod(key string, obj interface{}) error {
 				if err != nil {
 					return fmt.Errorf("failed to add rule for Pod %s: %v", key, err)
 				}
-				assignPodAnnotation(newPod, newPod.Status.HostIP, port, nodePort)
-				updatePodAnnotation = true
+				updatePodAnnotation = AssignPodAnnotation(newPod, newPod.Status.HostIP, port, nodePort)
 			}
 		}
 	}

--- a/pkg/agent/nodeportlocal/npl_agent_init.go
+++ b/pkg/agent/nodeportlocal/npl_agent_init.go
@@ -48,12 +48,12 @@ func InitializeNPLAgent(kubeClient clientset.Interface, informerFactory informer
 	var ok bool
 	portTable, ok := portcache.NewPortTable(start, end)
 	if !ok {
-		return nil, errors.New("error in initializing NodePortLocal port table")
+		return nil, errors.New("error when initializing NodePortLocal port table")
 	}
 
 	err = portTable.PodPortRules.Init()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("NPL rules for pod ports could not be initialized, error: %s", err.Error())
 	}
 
 	return InitController(kubeClient, informerFactory, portTable, nodeName)

--- a/pkg/agent/nodeportlocal/npl_agent_init.go
+++ b/pkg/agent/nodeportlocal/npl_agent_init.go
@@ -85,13 +85,13 @@ func getPodsAndGenRules(kubeClient clientset.Interface, portTable *portcache.Por
 		// check if a valid NPL Annotation exists for this Pod:
 		//   if yes, verifiy validity of the Node port, update the port table and add a rule to the
 		//   rules buffer.
-		podCopy := pod.DeepCopy()
 		annotations := pod.GetAnnotations()
 		nplAnnotation, ok := annotations[nplk8s.NPLAnnotationKey]
 		if !ok {
 			continue
 		}
 		nplData := []nplk8s.NPLAnnotation{}
+		podCopy := pod.DeepCopy()
 		err := json.Unmarshal([]byte(nplAnnotation), &nplData)
 		if err != nil {
 			// if there's an error in this NPL Annotation, clean it up

--- a/pkg/agent/nodeportlocal/npl_agent_init.go
+++ b/pkg/agent/nodeportlocal/npl_agent_init.go
@@ -47,7 +47,7 @@ func addRulesForNPLPorts(portTable *portcache.PortTable, allNPLPorts []rules.Pod
 	}
 
 	if err := portTable.PodPortRules.AddAllRules(allNPLPorts); err != nil {
-		return nil
+		return err
 	}
 	return nil
 }
@@ -80,7 +80,7 @@ func getPodsAndGenRules(kubeClient clientset.Interface, portTable *portcache.Por
 		err := json.Unmarshal([]byte(nplAnnotation), &nplData)
 		if err != nil {
 			// if there's an error in this NPL Annotation, clean it up
-			err := nplk8s.CleanupNPLAnnotationForPod(kubeClient, pod)
+			err := nplk8s.CleanupNPLAnnotationForPod(kubeClient, &pod)
 			if err != nil {
 				return err
 			}
@@ -90,7 +90,7 @@ func getPodsAndGenRules(kubeClient clientset.Interface, portTable *portcache.Por
 		for _, npl := range nplData {
 			if npl.NodePort > portTable.EndPort || npl.NodePort < portTable.StartPort {
 				// invalid port, cleanup the NPL Annotation
-				if err := nplk8s.CleanupNPLAnnotationForPod(kubeClient, pod); err != nil {
+				if err := nplk8s.CleanupNPLAnnotationForPod(kubeClient, &pod); err != nil {
 					return err
 				}
 				break

--- a/pkg/agent/nodeportlocal/npl_agent_init.go
+++ b/pkg/agent/nodeportlocal/npl_agent_init.go
@@ -42,13 +42,13 @@ import (
 // UpdateFunc event handler will be called only when the object is actually updated.
 const resyncPeriod = 0 * time.Minute
 
-func cleanupNPLAnnotationForPod(kubClient clientset.Interface, pod *corev1.Pod) error {
+func cleanupNPLAnnotationForPod(kubeClient clientset.Interface, pod *corev1.Pod) error {
 	_, ok := pod.Annotations[nplk8s.NPLAnnotationKey]
 	if !ok {
 		return nil
 	}
 	delete(pod.Annotations, nplk8s.NPLAnnotationKey)
-	if _, err := kubClient.CoreV1().Pods(pod.Namespace).Update(context.TODO(), pod, metav1.UpdateOptions{}); err != nil {
+	if _, err := kubeClient.CoreV1().Pods(pod.Namespace).Update(context.TODO(), pod, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("unable to update Annotation for Pod %s/%s, %s", pod.Namespace,
 			pod.Name, err.Error())
 	}
@@ -81,10 +81,10 @@ func getPodsAndGenRules(kubeClient clientset.Interface, portTable *portcache.Por
 
 	allNPLPorts := []rules.PodNodePort{}
 	for _, pod := range podList.Items {
-		// for each Pod:
+		// For each Pod:
 		// check if a valid NPL Annotation exists for this Pod:
 		//   if yes, verifiy validity of the Node port, update the port table and add a rule to the
-		//   rules buffer
+		//   rules buffer.
 		podCopy := pod.DeepCopy()
 		annotations := pod.GetAnnotations()
 		nplAnnotation, ok := annotations[nplk8s.NPLAnnotationKey]

--- a/pkg/agent/nodeportlocal/npl_agent_init.go
+++ b/pkg/agent/nodeportlocal/npl_agent_init.go
@@ -53,7 +53,7 @@ func InitializeNPLAgent(kubeClient clientset.Interface, informerFactory informer
 
 	err = portTable.PodPortRules.Init()
 	if err != nil {
-		return nil, fmt.Errorf("NPL rules for pod ports could not be initialized, error: %s", err.Error())
+		return nil, fmt.Errorf("NPL rules for pod ports could not be initialized, error: %v", err)
 	}
 
 	return InitController(kubeClient, informerFactory, portTable, nodeName)

--- a/pkg/agent/nodeportlocal/npl_agent_init.go
+++ b/pkg/agent/nodeportlocal/npl_agent_init.go
@@ -17,6 +17,8 @@
 package nodeportlocal
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -31,11 +33,185 @@ import (
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
 )
 
 // Set resyncPeriod to 0 to disable resyncing.
 // UpdateFunc event handler will be called only when the object is actually updated.
 const resyncPeriod = 0 * time.Minute
+
+func updatePodNodePortCache(cache map[string][]nplk8s.PodNodePort, podIP string, nodePort, podPort int) {
+	v := nplk8s.PodNodePort{
+		NodePort: nodePort,
+		PodPort:  podPort,
+	}
+	_, exists := cache[podIP]
+	if !exists {
+		cache[podIP] = []nplk8s.PodNodePort{v}
+		return
+	}
+	cache[podIP] = append(cache[podIP], v)
+}
+
+// rulesToPodPortMap is responsible for going through the NPL rules and figures out if some of these
+// rules are still needed. To check if a rule is needed, it first checks if the relevant Pod exists,
+// if not, it deletes the rule. This function adds the port rules to the portTable and responds with
+// a list of visited Pods.
+func rulesToPodPortMap(portTable *portcache.PortTable, kubeClient clientset.Interface) (map[string][]nplk8s.PodNodePort, error) {
+	podPortRules, err := portTable.PodPortRules.GetAllRules()
+	if err != nil {
+		klog.Errorf("error in fetching the Pod port rules: %s", err.Error())
+		return nil, errors.New("error in fetching the Pod port rules: " + err.Error())
+	}
+
+	podNodePortCache := make(map[string][]nplk8s.PodNodePort)
+
+	for k, v := range podPortRules {
+		// k: NodePort
+		// v: {PodIP,Pod port}
+		if k > portTable.EndPort || k < portTable.StartPort {
+			// delete this rule, as the Node port falls in an invalid range
+			err := portTable.PodPortRules.DeleteRule(k, v.PodIP)
+			if err != nil {
+				klog.Errorf("error in deleting the rule for port %d and Pod IP %s", k, v.PodIP)
+				continue
+			}
+		}
+		podList, err := kubeClient.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{
+			FieldSelector: "status.podIP=" + v.PodIP,
+		})
+		if err != nil {
+			klog.Infof("error in fetching Pod with IP address %s: %s", v.PodIP, err.Error())
+			continue
+		}
+		if len(podList.Items) == 0 {
+			klog.Infof("couldn't find a Pod for IP address %s, will delete it's entry", v.PodIP)
+			// delete this port's entry from the rules
+			err := portTable.PodPortRules.DeleteRule(k, v.PodIP)
+			if err != nil {
+				// TODO: need to handle this case properly, currently, it would mean that Antrea thinks
+				// this port is free to allocate, however the rule for this port forwards the packets
+				// to a non-existent Pod
+				klog.Errorf("error in deleting the rule for port %d and Pod IP %s: %s", k, v.PodIP, err.Error())
+			}
+			continue
+		}
+		// Pod exists, add it to podPortTable
+		// error is already checked
+		klog.V(2).Infof("adding an entry for Node port %d, Pod %s and Pod port: %d", k, v.PodIP, v.PodPort)
+		portTable.AddUpdateEntry(k, v.PodPort, v.PodIP)
+
+		updatePodNodePortCache(podNodePortCache, v.PodIP, k, v.PodPort)
+	}
+
+	return podNodePortCache, err
+}
+
+// podsToPortMap goes through all the Pods for this node and figures out if there's a need for NPL
+// for each node. If yes, it assigns a port for this Pod and adds that as a rule.
+func podsToPodPortMap(podCache map[string][]nplk8s.PodNodePort, kubeClient clientset.Interface, portTable *portcache.PortTable,
+	nodeName string) error {
+	podList, err := kubeClient.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	if err != nil {
+		klog.Errorf("error in fetching the Pods for Node %s: %s", nodeName, err.Error())
+		return errors.New("error in fetching Pods for the Node" + nodeName)
+	}
+	for _, pod := range podList.Items {
+		// for each Pod:
+		// check if its already part of the podCache, which indicates that the Pod is already
+		// part of a rule
+		// if this Pod doesn't have any rule, compute a rule from the Pod ports, allocate a port
+		// and add it to port table
+		podIP := pod.Status.PodIP
+		if podIP == "" {
+			klog.Infof("IP address not found for Pod %s/%s", pod.Namespace, pod.Name)
+			continue
+		}
+
+		newPod := pod.DeepCopy()
+		// clear out the annotations
+		newPod.SetAnnotations(make(map[string]string))
+		nplAnnotations := []nplk8s.NPLAnnotation{}
+		updatePodAnnotation := false
+		podExists := false
+		var nodePort int
+
+		if _, ok := podCache[podIP]; ok {
+			podExists = true
+			// the rule for this Pod already exists, ensure annotations are right
+			for _, v := range podCache[podIP] {
+				nplAnnotations = append(nplAnnotations, nplk8s.NPLAnnotation{
+					PodPort:  v.PodPort,
+					NodeIP:   pod.Status.HostIP,
+					NodePort: v.NodePort,
+				})
+			}
+		}
+
+		if !podExists {
+			for _, c := range pod.Spec.Containers {
+				for _, cport := range c.Ports {
+					port := int(cport.ContainerPort)
+					if !portTable.RuleExists(podIP, port) {
+						nodePort, err = portTable.AddRule(podIP, port)
+						if err != nil {
+							klog.Errorf("failed to add rule for Pod %s/%s: %s", pod.Namespace, pod.Name, err.Error())
+							continue
+						}
+					}
+					nplAnnotations = append(nplAnnotations, nplk8s.NPLAnnotation{
+						PodPort:  port,
+						NodeIP:   pod.Status.HostIP,
+						NodePort: nodePort,
+					})
+				}
+			}
+		}
+
+		if len(nplAnnotations) > 0 {
+			jsonMarshalled, _ := json.Marshal(nplAnnotations)
+			oldNPLAnnotations, err := nplk8s.ParsePodNPLAnnotations(pod)
+			if err != nil {
+				klog.Warningf("couldn't fetch the NPL annotations %s, will update the annotations", err.Error())
+				newPod.SetAnnotations(map[string]string{
+					nplk8s.NPLAnnotationKey: string(jsonMarshalled),
+				})
+				updatePodAnnotation = true
+			}
+			// check if the annotations differ
+			if nplk8s.IsAnnotationDifferent(oldNPLAnnotations, nplAnnotations) {
+				newPod.SetAnnotations(map[string]string{
+					nplk8s.NPLAnnotationKey: string(jsonMarshalled),
+				})
+				updatePodAnnotation = true
+			}
+		}
+
+		if updatePodAnnotation {
+			if _, err := kubeClient.CoreV1().Pods(pod.Namespace).Update(context.TODO(), newPod, metav1.UpdateOptions{}); err != nil {
+				klog.Warningf("unable to update annotation for Pod %s/%s, error: %s", newPod.Namespace, newPod.Name, err.Error())
+				return err
+			}
+		}
+		klog.V(2).Infof("successfully updated annotation for Pod %s/%s", pod.Namespace, pod.Name)
+	}
+	return nil
+}
+
+func genPodPortMap(portTable *portcache.PortTable, kubeClient clientset.Interface, nodeName string) error {
+	podNodePortCache, err := rulesToPodPortMap(portTable, kubeClient)
+	if err != nil {
+		return err
+	}
+
+	err = podsToPodPortMap(podNodePortCache, kubeClient, portTable, nodeName)
+	if err != nil {
+		return err
+	}
+	return nil
+}
 
 // InitializeNPLAgent initializes the NodePortLocal (NPL) agent.
 // It initializes the port table cache to keep track of Node ports available for use by NPL,
@@ -51,10 +227,17 @@ func InitializeNPLAgent(kubeClient clientset.Interface, informerFactory informer
 	if !ok {
 		return nil, errors.New("NPL port table could not be initialized")
 	}
+
 	err = portTable.PodPortRules.Init()
 	if err != nil {
-		return nil, fmt.Errorf("NPL rules for pod ports could not be initialized, error: %v", err)
+		return nil, err
 	}
+
+	err = genPodPortMap(portTable, kubeClient, nodeName)
+	if err != nil {
+		return nil, err
+	}
+
 	return InitController(kubeClient, informerFactory, portTable, nodeName)
 }
 

--- a/pkg/agent/nodeportlocal/npl_agent_test.go
+++ b/pkg/agent/nodeportlocal/npl_agent_test.go
@@ -372,3 +372,23 @@ func TestMultiplePods(t *testing.T) {
 
 	assert.NotEqual(t, nplData1[0].NodePort, nplData2[0].NodePort)
 }
+
+// TestInitInvalidPod simulates an agent reboot case. A Pod with an invalid NPL annotation is
+// added, this invalid annotation should get cleaned up. And a proper NPL annotation should get
+// added.
+func TestInitInvalidPod(t *testing.T) {
+	testSvc := getTestSvc()
+	testPod := getTestPod()
+	// assign an invalid annotation
+	annotations := map[string]string{
+		nplk8s.NPLAnnotationKey: "[{\"podPort\":53,\"nodeIP\":\"10.10.10.10\", \"nodePort\": 30000}]",
+	}
+	testPod.SetAnnotations(annotations)
+	testData := setUp(t, testSvc, testPod)
+	defer testData.tearDown()
+
+	value, err := testData.pollForPodAnnotation(testPod.Name, true)
+	require.NoError(t, err, "Poll for annotation check failed")
+	testData.checkAnnotationValue(value, defaultPort)
+	assert.True(t, testData.portTable.RuleExists(testPod.Status.PodIP, defaultPort))
+}

--- a/pkg/agent/nodeportlocal/npl_agent_test.go
+++ b/pkg/agent/nodeportlocal/npl_agent_test.go
@@ -47,6 +47,7 @@ func newPortTable(c *gomock.Controller) *portcache.PortTable {
 	mockTable := npltest.NewMockPodPortRules(c)
 	mockTable.EXPECT().AddRule(gomock.Any(), gomock.Any()).AnyTimes()
 	mockTable.EXPECT().DeleteRule(gomock.Any(), gomock.Any()).AnyTimes()
+	mockTable.EXPECT().AddAllRules(gomock.Any()).AnyTimes()
 
 	ptable.PodPortRules = mockTable
 	return &ptable

--- a/pkg/agent/nodeportlocal/portcache/port_table.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table.go
@@ -53,9 +53,7 @@ func NewPortTable(start, end int) (*PortTable, bool) {
 func (pt *PortTable) CleanupAllEntries() {
 	pt.tableLock.Lock()
 	defer pt.tableLock.Unlock()
-	for k := range pt.Table {
-		delete(pt.Table, k)
-	}
+	pt.Table = make(map[int]NodePortData)
 }
 
 func (pt *PortTable) AddUpdateEntry(nodeport, podport int, podip string) {

--- a/pkg/agent/nodeportlocal/portcache/port_table.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table.go
@@ -50,6 +50,14 @@ func NewPortTable(start, end int) (*PortTable, bool) {
 	return &ptable, ok
 }
 
+func (pt *PortTable) CleanupAllEntries() {
+	pt.tableLock.Lock()
+	defer pt.tableLock.Unlock()
+	for k := range pt.Table {
+		delete(pt.Table, k)
+	}
+}
+
 func (pt *PortTable) AddUpdateEntry(nodeport, podport int, podip string) {
 	pt.tableLock.Lock()
 	defer pt.tableLock.Unlock()

--- a/pkg/agent/nodeportlocal/rules/iptable_rule.go
+++ b/pkg/agent/nodeportlocal/rules/iptable_rule.go
@@ -28,13 +28,6 @@ import (
 // NodePortLocalChain is the name of the chain in IPTABLES for Node Port Local
 const NodePortLocalChain = "ANTREA-NODE-PORT-LOCAL"
 
-// PodNodePort contains the Node Port, Pod Port and the Pod IP.
-type PodNodePort struct {
-	NodePort int
-	PodPort  int
-	PodIP    string
-}
-
 // IPTableRules provides a client to perform IPTABLES operations
 type iptablesRules struct {
 	name  string

--- a/pkg/agent/nodeportlocal/rules/iptable_rule.go
+++ b/pkg/agent/nodeportlocal/rules/iptable_rule.go
@@ -36,15 +36,15 @@ type PodNodePort struct {
 }
 
 // IPTableRules provides a client to perform IPTABLES operations
-type IPTableRules struct {
+type iptablesRules struct {
 	name  string
 	table *iptables.Client
 }
 
 // NewIPTableRules retruns a new instance of IPTableRules
-func NewIPTableRules() *IPTableRules {
+func NewIPTableRules() *iptablesRules {
 	iptInstance, _ := iptables.New(true, false)
-	iptRule := IPTableRules{
+	iptRule := iptablesRules{
 		name:  "NPL",
 		table: iptInstance,
 	}
@@ -52,13 +52,13 @@ func NewIPTableRules() *IPTableRules {
 }
 
 // Init initializes IPTABLES rules for NPL. Currently it deletes existing rules to ensure that no stale entries are present.
-func (ipt *IPTableRules) Init() error {
+func (ipt *iptablesRules) Init() error {
 	return ipt.CreateChains()
 }
 
 // CreateChains creates the chain NodePortLocalChain in NAT table.
 // All DNAT rules for NPL would be added in this chain.
-func (ipt *IPTableRules) CreateChains() error {
+func (ipt *iptablesRules) CreateChains() error {
 	err := ipt.table.EnsureChain(iptables.NATTable, NodePortLocalChain)
 	if err != nil {
 		return fmt.Errorf("IPTABLES chain creation in NAT table failed for NPL with error: %v", err)
@@ -74,7 +74,7 @@ func (ipt *IPTableRules) CreateChains() error {
 }
 
 // AddRule appends a DNAT rule in NodePortLocalChain chain of NAT table
-func (ipt *IPTableRules) AddRule(port int, podIP string) error {
+func (ipt *iptablesRules) AddRule(port int, podIP string) error {
 	ruleSpec := []string{
 		"-p", "tcp", "-m", "tcp", "--dport",
 		fmt.Sprint(port), "-j", "DNAT", "--to-destination", podIP,
@@ -89,7 +89,7 @@ func (ipt *IPTableRules) AddRule(port int, podIP string) error {
 
 // AddAllRules constructs a list of iptables rules for the NPL chain and performs a
 // iptables-restore on this chain. It uses --no-flush to keep the previous rules intact.
-func (ipt *IPTableRules) AddAllRules(nplList []PodNodePort) error {
+func (ipt *iptablesRules) AddAllRules(nplList []PodNodePort) error {
 	iptablesData := bytes.NewBuffer(nil)
 	writeLine(iptablesData, "*nat")
 	writeLine(iptablesData, iptables.MakeChainLine(NodePortLocalChain))
@@ -112,7 +112,7 @@ func (ipt *IPTableRules) AddAllRules(nplList []PodNodePort) error {
 }
 
 // DeleteRule deletes a specific NPL rule from NodePortLocalChain chain
-func (ipt *IPTableRules) DeleteRule(port int, podip string) error {
+func (ipt *iptablesRules) DeleteRule(port int, podip string) error {
 	klog.Infof("Deleting rule with port %v and podip %v", port, podip)
 	ruleSpec := []string{
 		"-p", "tcp", "-m", "tcp", "--dport",
@@ -126,7 +126,7 @@ func (ipt *IPTableRules) DeleteRule(port int, podip string) error {
 }
 
 // DeleteAllRules deletes all NPL rules programmed in the node
-func (ipt *IPTableRules) DeleteAllRules() error {
+func (ipt *iptablesRules) DeleteAllRules() error {
 	exists, err := ipt.table.ChainExists(iptables.NATTable, NodePortLocalChain)
 	if err != nil {
 		return fmt.Errorf("failed to check if NodePortLocal chain exists in NAT table: %v", err)

--- a/pkg/agent/nodeportlocal/rules/rules.go
+++ b/pkg/agent/nodeportlocal/rules/rules.go
@@ -21,8 +21,8 @@ type PodPortRules interface {
 	Init() error
 	AddRule(port int, podip string) error
 	DeleteRule(port int, podip string) error
-	GetAllRules() (map[int]DestinationPodIPPort, error)
 	DeleteAllRules() error
+	AddAllRules(nplList []PodNodePort) error
 }
 
 // InitRules initializes rules based on the underlying implementation

--- a/pkg/agent/nodeportlocal/rules/rules.go
+++ b/pkg/agent/nodeportlocal/rules/rules.go
@@ -21,7 +21,7 @@ type PodPortRules interface {
 	Init() error
 	AddRule(port int, podip string) error
 	DeleteRule(port int, podip string) error
-	GetAllRules() (map[int]string, error)
+	GetAllRules() (map[int]DestinationPodIPPort, error)
 	DeleteAllRules() error
 }
 

--- a/pkg/agent/nodeportlocal/rules/testing/mock_rules.go
+++ b/pkg/agent/nodeportlocal/rules/testing/mock_rules.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Antrea Authors
+// Copyright 2021 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ package testing
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	rules "github.com/vmware-tanzu/antrea/pkg/agent/nodeportlocal/rules"
 	reflect "reflect"
 )
 
@@ -90,10 +91,10 @@ func (mr *MockPodPortRulesMockRecorder) DeleteRule(arg0, arg1 interface{}) *gomo
 }
 
 // GetAllRules mocks base method
-func (m *MockPodPortRules) GetAllRules() (map[int]string, error) {
+func (m *MockPodPortRules) GetAllRules() (map[int]rules.DestinationPodIPPort, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllRules")
-	ret0, _ := ret[0].(map[int]string)
+	ret0, _ := ret[0].(map[int]rules.DestinationPodIPPort)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/agent/nodeportlocal/rules/testing/mock_rules.go
+++ b/pkg/agent/nodeportlocal/rules/testing/mock_rules.go
@@ -48,6 +48,20 @@ func (m *MockPodPortRules) EXPECT() *MockPodPortRulesMockRecorder {
 	return m.recorder
 }
 
+// AddAllRules mocks base method
+func (m *MockPodPortRules) AddAllRules(arg0 []rules.PodNodePort) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddAllRules", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddAllRules indicates an expected call of AddAllRules
+func (mr *MockPodPortRulesMockRecorder) AddAllRules(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddAllRules", reflect.TypeOf((*MockPodPortRules)(nil).AddAllRules), arg0)
+}
+
 // AddRule mocks base method
 func (m *MockPodPortRules) AddRule(arg0 int, arg1 string) error {
 	m.ctrl.T.Helper()
@@ -88,21 +102,6 @@ func (m *MockPodPortRules) DeleteRule(arg0 int, arg1 string) error {
 func (mr *MockPodPortRulesMockRecorder) DeleteRule(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRule", reflect.TypeOf((*MockPodPortRules)(nil).DeleteRule), arg0, arg1)
-}
-
-// GetAllRules mocks base method
-func (m *MockPodPortRules) GetAllRules() (map[int]rules.DestinationPodIPPort, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllRules")
-	ret0, _ := ret[0].(map[int]rules.DestinationPodIPPort)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAllRules indicates an expected call of GetAllRules
-func (mr *MockPodPortRulesMockRecorder) GetAllRules() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllRules", reflect.TypeOf((*MockPodPortRules)(nil).GetAllRules))
 }
 
 // Init mocks base method

--- a/pkg/agent/nodeportlocal/rules/types.go
+++ b/pkg/agent/nodeportlocal/rules/types.go
@@ -1,0 +1,22 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+// PodNodePort contains the Node Port, Pod Port and the Pod IP for NodePortLocal.
+type PodNodePort struct {
+	NodePort int
+	PodPort  int
+	PodIP    string
+}


### PR DESCRIPTION
Currently we delete all the iptable rules when the antrea-agent
is restarted. This commit does the following:
- Evaluates the iptable rules in the Node Port Local chain and
  check if a rule is required. If a Pod got deleted while the
  antrea-agent was restarting, we don't need that rule and has
  to be deleted.
- The above evaluation logic also creates a cache for all the
  pods retrived from the iptable rules.
- Evaluates the kubernetes Pods, and for each Pod, it checks if
  its part of the above cache. If yes, only the Pod's annotations
  needs to be verified. If not, a new Node port has to be allocated
  and a rule has to be added.

One of the TODOs as mentioned
[here](https://github.com/vmware-tanzu/antrea/pull/1459).