### PR TITLE
Update Github workflows ahead of default branch renaming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,12 @@ name: Build and push latest image if needed
 on:
   pull_request:
     branches:
+      - main
       - master
       - release-*
   push:
     branches:
+      - main
       - master
       - release-*
 
@@ -18,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: vmware-tanzu/antrea/ci/gh-actions/has-changes@master
+    - uses: vmware-tanzu/antrea/ci/gh-actions/has-changes@v0.12.0 # TODO: change to main after default branch renaming
       id: check_diff
       with:
         args: docs/* ci/jenkins/* *.md
@@ -34,7 +36,7 @@ jobs:
     - name: Build Antrea Docker image
       run: make
     - name: Push Antrea Docker image to registry
-      if: ${{ github.repository == 'vmware-tanzu/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      if: ${{ github.repository == 'vmware-tanzu/antrea' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -51,7 +53,7 @@ jobs:
     - name: Build Antrea Agent Simulator Docker image
       run: make build-scale-simulator
     - name: Push Antrea Agent Simulator Docker image to registry
-      if: ${{ github.repository == 'vmware-tanzu/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      if: ${{ github.repository == 'vmware-tanzu/antrea' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -68,7 +70,7 @@ jobs:
     - name: Build Antrea Windows Docker image
       run: make build-windows
     - name: Push Antrea Windows Docker image to registry
-      if: ${{ github.repository == 'vmware-tanzu/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      if: ${{ github.repository == 'vmware-tanzu/antrea' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -86,7 +88,7 @@ jobs:
     - name: Build octant-antrea-ubuntu Docker image
       run: make octant-antrea-ubuntu
     - name: Push octant-antrea-ubuntu Docker image to registry
-      if: ${{ github.repository == 'vmware-tanzu/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      if: ${{ github.repository == 'vmware-tanzu/antrea' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -104,7 +106,7 @@ jobs:
       working-directory: hack/netpol
       run: make build
     - name: Push netpol Docker image to registry
-      if: ${{ github.repository == 'vmware-tanzu/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      if: ${{ github.repository == 'vmware-tanzu/antrea' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -123,7 +125,7 @@ jobs:
     - name: Build flow-aggregator Docker image
       run: make flow-aggregator-ubuntu
     - name: Push flow-aggregator Docker image to registry
-      if: ${{ github.repository == 'vmware-tanzu/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      if: ${{ github.repository == 'vmware-tanzu/antrea' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,10 +2,12 @@ name: Go
 on:
   pull_request:
     branches:
+    - main
     - master
     - release-*
   push:
     branches:
+    - main
     - master
     - release-*
 jobs:

--- a/.github/workflows/golicense.yml
+++ b/.github/workflows/golicense.yml
@@ -2,10 +2,12 @@ name: Golicense
 on:
   pull_request:
     branches:
+    - main
     - master
     - release-*
   push:
     branches:
+    - main
     - master
     - release-*
   release:
@@ -20,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: vmware-tanzu/antrea/ci/gh-actions/has-changes@master
+    - uses: vmware-tanzu/antrea/ci/gh-actions/has-changes@v0.12.0 # TODO: change to main after default branch renaming
       id: check_diff
       with:
         args: docs/* ci/jenkins/* *.md

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -2,10 +2,12 @@ name: Kind
 on:
   pull_request:
     branches:
+    - main
     - master
     - release-*
   push:
     branches:
+    - main
     - master
     - release-*
 
@@ -20,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: vmware-tanzu/antrea/ci/gh-actions/has-changes@master
+    - uses: vmware-tanzu/antrea/ci/gh-actions/has-changes@v0.12.0 # TODO: change to main after default branch renaming
       id: check_diff
       with:
         args: docs/* ci/jenkins/* *.md

--- a/.github/workflows/kind_upgrade.yml
+++ b/.github/workflows/kind_upgrade.yml
@@ -2,10 +2,12 @@ name: Antrea upgrade
 on:
   pull_request:
     branches:
+    - main
     - master
     - release-*
   push:
     branches:
+    - main
     - master
     - release-*
 
@@ -20,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: vmware-tanzu/antrea/ci/gh-actions/has-changes@master
+    - uses: vmware-tanzu/antrea/ci/gh-actions/has-changes@v0.12.0 # TODO: change to main after default branch renaming
       id: check_diff
       with:
         args: docs/* ci/jenkins/* *.md


### PR DESCRIPTION
Getting ready to rename default branch from "master" to "main".
By making these changes ahead of time, we ensure that workflows will not
break, including for existing PRs.

Jenkins YAML files will need to be updated right after renaming the
branch. Jenkins jobs for PRs should not be affected.

See #1675