### PR TITLE
Use Ubuntu 20.04 more consistently instead of Ubuntu 18.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   check-changes:
     name: Check whether tests need to be run based on diff
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -30,7 +30,7 @@ jobs:
   build:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name == 'push' }}
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Build Antrea Docker image
@@ -47,7 +47,7 @@ jobs:
   build-scale:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name == 'push' }}
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Build Antrea Agent Simulator Docker image
@@ -82,7 +82,7 @@ jobs:
   build-octant-antrea-ubuntu:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name == 'push' }}
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Build octant-antrea-ubuntu Docker image
@@ -99,7 +99,7 @@ jobs:
   build-netpol-tmp:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name == 'push' }}
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Build netpol Docker image
@@ -119,7 +119,7 @@ jobs:
   build-flow-aggregator:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name == 'push' }}
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Build flow-aggregator Docker image

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Build Antrea Docker image and push to registry
@@ -37,7 +37,7 @@ jobs:
       shell: bash
 
   build-octant-antrea-ubuntu:
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
       - name: Build octant-antrea-ubuntu Docker image and push to registry
@@ -51,7 +51,7 @@ jobs:
           docker push antrea/octant-antrea-ubuntu:"${TAG:10}"
 
   build-flow-aggregator:
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Build flow-aggregator Docker image and push to registry

--- a/.github/workflows/clair.yml
+++ b/.github/workflows/clair.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     if: github.repository == 'vmware-tanzu/antrea'
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1
@@ -23,7 +23,7 @@ jobs:
         ./run.sh
   skip:
     if: github.repository != 'vmware-tanzu/antrea'
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
       - name: Skip
         run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
     name: Unit test
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-2019]
+        os: [ubuntu-latest, windows-2019]
     runs-on: ${{ matrix.os }}
     steps:
 
@@ -45,7 +45,7 @@ jobs:
     name: Golangci-lint
     strategy:
       matrix:
-        platform: [ubuntu-18.04, macos-latest]
+        platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Set up Go 1.15
@@ -60,7 +60,7 @@ jobs:
 
   golangci-lint-netpol-tmp:
     name: Golangci-lint for netpol code
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - name: Set up Go 1.15
       uses: actions/setup-go@v1
@@ -75,7 +75,7 @@ jobs:
 
   bin:
     name: Build Antrea binaries
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
 
     - name: Set up Go 1.15
@@ -94,7 +94,7 @@ jobs:
 
   antctl:
     name: Build antctl for macOS, Linux and Windows
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
 
       - name: Set up Go 1.15
@@ -111,7 +111,7 @@ jobs:
 
   codegen:
     name: Check code generation
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
 
     - name: Set up Go 1.15
@@ -128,7 +128,7 @@ jobs:
 
   manifest:
     name: Check manifest
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
 
     - name: Set up Go 1.15
@@ -145,7 +145,7 @@ jobs:
 
   tidy:
     name: Check go.mod tidy
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
 
     - name: Set up Go 1.15
@@ -161,7 +161,7 @@ jobs:
 
   verify:
     name: Verify docs and spelling
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
 
     - name: Set up Go 1.15

--- a/.github/workflows/golicense.yml
+++ b/.github/workflows/golicense.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   check-changes:
     name: Check whether tests need to be run based on diff
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   check-changes:
     name: Check whether tests need to be run based on diff
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -33,7 +33,7 @@ jobs:
     name: Build Antrea image to be used for Kind e2e tests
     needs: check-changes
     if: ${{ needs.check-changes.outputs.has_changes == 'yes' }}
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
     - run: make build-ubuntu-coverage
@@ -50,7 +50,7 @@ jobs:
     name: Build Flow Aggregator image to be used for Kind e2e tests
     needs: check-changes
     if: ${{ needs.check-changes.outputs.has_changes == 'yes' }}
-    runs-on: [ ubuntu-18.04 ]
+    runs-on: [ ubuntu-latest ]
     steps:
     - uses: actions/checkout@v2
     - run: make flow-aggregator-ubuntu
@@ -66,7 +66,7 @@ jobs:
   test-e2e-encap:
     name: E2e tests on a Kind cluster on Linux
     needs: [build-antrea-coverage-image, build-flow-aggregator-image]
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - name: Free disk space
       # https://github.com/actions/virtual-environments/issues/709
@@ -131,7 +131,7 @@ jobs:
   test-e2e-encap-no-proxy:
     name: E2e tests on a Kind cluster on Linux with AntreaProxy disabled
     needs: [build-antrea-coverage-image, build-flow-aggregator-image]
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - name: Free disk space
       # https://github.com/actions/virtual-environments/issues/709
@@ -194,7 +194,7 @@ jobs:
   test-e2e-noencap:
     name: E2e tests on a Kind cluster on Linux (noEncap)
     needs: [build-antrea-coverage-image, build-flow-aggregator-image]
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - name: Free disk space
       # https://github.com/actions/virtual-environments/issues/709
@@ -257,7 +257,7 @@ jobs:
   test-e2e-hybrid:
     name: E2e tests on a Kind cluster on Linux (hybrid)
     needs: [build-antrea-coverage-image, build-flow-aggregator-image]
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - name: Free disk space
       # https://github.com/actions/virtual-environments/issues/709
@@ -320,7 +320,7 @@ jobs:
   test-e2e-encap-np:
     name: E2e tests on a Kind cluster on Linux with Antrea NetworkPolicies enabled
     needs: [build-antrea-coverage-image, build-flow-aggregator-image]
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - name: Free disk space
       # https://github.com/actions/virtual-environments/issues/709
@@ -384,7 +384,7 @@ jobs:
     name: Build Antrea image to be used for Kind netpol tests
     needs: check-changes
     if: ${{ needs.check-changes.outputs.has_changes == 'yes' }}
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
     - run: make
@@ -400,7 +400,7 @@ jobs:
   test-netpol-tmp:
     name: Run experimental network policy tests (netpol) on Kind cluster
     needs: build-antrea-image
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - name: Free disk space
       # https://github.com/actions/virtual-environments/issues/709
@@ -432,7 +432,7 @@ jobs:
   validate-prometheus-metrics-doc:
     name: Validate metrics in Prometheus document match running deployment's
     needs: build-antrea-image
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
       - name: Free disk space
         # https://github.com/actions/virtual-environments/issues/709
@@ -466,7 +466,7 @@ jobs:
     name: Delete uploaded images
     needs: [build-antrea-coverage-image, build-flow-aggregator-image, build-antrea-image, test-e2e-encap, test-e2e-encap-no-proxy, test-e2e-noencap, test-e2e-hybrid, test-e2e-encap-np, test-netpol-tmp, validate-prometheus-metrics-doc]
     if: ${{ always() }}
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - name: Delete antrea-ubuntu-cov
       if: ${{ needs.build-antrea-coverage-image.result == 'success' }}

--- a/.github/workflows/kind_upgrade.yml
+++ b/.github/workflows/kind_upgrade.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   check-changes:
     name: Check whether tests need to be run based on diff
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -33,7 +33,7 @@ jobs:
     name: Build Antrea image to be used for Kind upgrade test
     needs: check-changes
     if: ${{ needs.check-changes.outputs.has_changes == 'yes' }}
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
     - run: make
@@ -51,7 +51,7 @@ jobs:
   from-N-1:
     name: Upgrade from Antrea version N-1
     needs: build-antrea-image
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - name: Free disk space
       # https://github.com/actions/virtual-environments/issues/709
@@ -91,7 +91,7 @@ jobs:
   from-N-2:
     name: Upgrade from Antrea version N-2
     needs: build-antrea-image
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - name: Free disk space
       # https://github.com/actions/virtual-environments/issues/709
@@ -131,7 +131,7 @@ jobs:
   compatible-N-1:
     name: API compatible with client version N-1
     needs: build-antrea-image
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
       - name: Free disk space
         # https://github.com/actions/virtual-environments/issues/709
@@ -171,7 +171,7 @@ jobs:
   compatible-N-2:
     name: API compatible with client version N-2
     needs: build-antrea-image
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
       - name: Free disk space
         # https://github.com/actions/virtual-environments/issues/709
@@ -216,7 +216,7 @@ jobs:
     name: Delete uploaded images
     needs: [build-antrea-image, from-N-1, from-N-2, compatible-N-1, compatible-N-2]
     if: ${{ always() }}
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - name: Delete antrea-ubuntu
       if: ${{ needs.build-antrea-image.result == 'success' }}

--- a/.github/workflows/update_ovs_image.yml
+++ b/.github/workflows/update_ovs_image.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     if: github.repository == 'vmware-tanzu/antrea'
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Build antrea/openvswitch Docker image and push to registry
@@ -26,7 +26,7 @@ jobs:
         ./build_and_push.sh
   skip:
     if: github.repository != 'vmware-tanzu/antrea'
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
       - name: Skip
         run: |

--- a/.github/workflows/upload_release_assets.yml
+++ b/.github/workflows/upload_release_assets.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Build assets

--- a/build/images/Dockerfile.octant.ubuntu
+++ b/build/images/Dockerfile.octant.ubuntu
@@ -7,7 +7,7 @@ WORKDIR /antrea/plugins/octant
 RUN make octant-plugins
 
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A docker image to deploy octant and antrea related octant plugins."

--- a/build/images/codegen/Dockerfile
+++ b/build/images/codegen/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 as protoc
+FROM ubuntu:20.04 as protoc
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget ca-certificates unzip

--- a/build/images/ethtool/Dockerfile
+++ b/build/images/ethtool/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A Docker image based on Ubuntu 18.04 which includes ethtool, ip tools and iptables."

--- a/build/images/perftool/Dockerfile
+++ b/build/images/perftool/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A Docker image based on Ubuntu 18.04 which is used for performance tests."

--- a/test/e2e/infra/vagrant/Vagrantfile
+++ b/test/e2e/infra/vagrant/Vagrantfile
@@ -5,7 +5,7 @@ NUM_WORKERS = 1
 K8S_POD_NETWORK_CIDR = "10.10.0.0/16"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ubuntu/bionic64"
+  config.vm.box = "ubuntu/focal64"
 
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048


### PR DESCRIPTION
* use Ubuntu 20.04 for Antrea Octant Docker image
* use Ubuntu 20.04 for ethtool, perfitool and codegen utility Docker
  images
* use Ubuntu 20.04 for K8s Nodes in Vagrant testbed
* use ubuntu-latest instead of ubuntu-18.04 for Github runners; Github
  has started rolling out Ubuntu 20.04 as the default version (see
  https://github.com/actions/virtual-environments/issues/1816)