### PR TITLE
Remove the run dir and CNI socket file permissions for non-root users

### DIFF
--- a/build/images/scripts/install_cni
+++ b/build/images/scripts/install_cni
@@ -29,3 +29,6 @@ install -m 755 /opt/cni/bin/bandwidth /host/opt/cni/bin/bandwidth
 
 # Load the OVS kernel module
 modprobe openvswitch || (echo "Failed to load the OVS kernel module from the container, try running 'modprobe openvswitch' on your Nodes"; exit 1)
+
+# Change the default permissions of the run directory.
+chmod 0750 /var/run/antrea

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1787,6 +1787,8 @@ spec:
         - mountPath: /lib/modules
           name: host-lib-modules
           readOnly: true
+        - mountPath: /var/run/antrea
+          name: host-var-run-antrea
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1789,6 +1789,8 @@ spec:
         - mountPath: /lib/modules
           name: host-lib-modules
           readOnly: true
+        - mountPath: /var/run/antrea
+          name: host-var-run-antrea
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1787,6 +1787,8 @@ spec:
         - mountPath: /lib/modules
           name: host-lib-modules
           readOnly: true
+        - mountPath: /var/run/antrea
+          name: host-var-run-antrea
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1836,6 +1836,8 @@ spec:
         - mountPath: /lib/modules
           name: host-lib-modules
           readOnly: true
+        - mountPath: /var/run/antrea
+          name: host-var-run-antrea
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1792,6 +1792,8 @@ spec:
         - mountPath: /lib/modules
           name: host-lib-modules
           readOnly: true
+        - mountPath: /var/run/antrea
+          name: host-var-run-antrea
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical

--- a/build/yamls/base/agent.yml
+++ b/build/yamls/base/agent.yml
@@ -57,6 +57,9 @@ spec:
           - name: host-lib-modules
             mountPath: /lib/modules
             readOnly: true
+          # For changing the default permissions of the run directory.
+          - name: host-var-run-antrea
+            mountPath: /var/run/antrea
       containers:
         - name: antrea-agent
           image: antrea

--- a/docs/security.md
+++ b/docs/security.md
@@ -19,7 +19,9 @@ particular during an upgrade. All these files are located under
 `/var/run/antrea/openvswitch/conf.db`, which stores the Open vSwitch
 database. Prior to Antrea v0.10, any user had read access to the file on the
 host (permissions were set to `0644`). Starting with v0.10, this is no longer
-the case (permissions are now set to `0640`).
+the case (permissions are now set to `0640`). Starting with v0.13, we further
+remove access to the `/var/run/antrea/` directory for non-root users
+(permissions are set to `0750`).
 
 If a malicious Pod can gain read access to this file, or, prior to Antrea v0.10,
 if an attacker can gain access to the host, they can potentially access

--- a/pkg/agent/util/net_linux.go
+++ b/pkg/agent/util/net_linux.go
@@ -168,10 +168,18 @@ func ListenLocalSocket(address string) (net.Listener, error) {
 	// remove before bind to avoid "address already in use" errors
 	_ = os.Remove(address)
 
-	if err := os.MkdirAll(filepath.Dir(address), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(address), 0750); err != nil {
 		klog.Fatalf("Failed to create directory %s: %v", filepath.Dir(address), err)
 	}
-	return listenUnix(address)
+	listener, err := listenUnix(address)
+	if err != nil {
+		return nil, err
+	}
+	err = os.Chmod(address, 0750)
+	if err != nil {
+		klog.Fatalf("Failed to change permissions for socket file %s: %v", address, err)
+	}
+	return listener, nil
 }
 
 // DialLocalSocket connects to a Unix domain socket.

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -130,13 +130,12 @@ func (data *TestData) testDeletePod(t *testing.T, podName string, nodeName strin
 	}
 
 	doesIPAllocationExist := func(podIP string) bool {
-		cmd := fmt.Sprintf("test -f /var/run/antrea/cni/networks/antrea/%s", podIP)
-		if rc, _, _, err := RunCommandOnNode(nodeName, cmd); err != nil {
-			t.Fatalf("Error when running ip command on Node '%s': %v", nodeName, err)
-		} else {
-			return rc == 0
+		cmd := []string{"test", "-f", "/var/run/antrea/cni/networks/antrea/" + podIP}
+		_, _, err := data.runCommandFromPod(antreaNamespace, antreaPodName, agentContainerName, cmd)
+		if err != nil {
+			return false
 		}
-		return false
+		return true
 	}
 
 	t.Logf("Checking that the veth interface and the OVS port exist")


### PR DESCRIPTION
This commit changes the permissions of the /var/run/antrea directory
and the CNI UNIX socket file, to disallow access from non-root users.
The /var/run/antrea directory is created on the host filesystem through
Pod volume mount, and its default permissions allow access from all
users.