### PR TITLE
Support building Antrea docker images for arm/v7 and arm64

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -76,6 +76,9 @@ jobs:
   bin:
     name: Build Antrea binaries
     runs-on: [ubuntu-latest]
+    strategy:
+      matrix:
+        arch: [amd64, arm64, arm]
     steps:
 
     - name: Set up Go 1.15
@@ -87,7 +90,20 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Build Antrea binaries
-      run: make bin
+      run: GOARCH=${{ matrix.arch }} make bin
+
+  windows-bin:
+    name: Build Antrea Windows binaries
+    runs-on: [ubuntu-latest]
+    steps:
+
+    - name: Set up Go 1.15
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.15
+
+    - name: Check-out code
+      uses: actions/checkout@v2
 
     - name: Build Antrea windows binaries
       run: make windows-bin

--- a/.github/workflows/update_ovs_image.yml
+++ b/.github/workflows/update_ovs_image.yml
@@ -21,9 +21,9 @@ jobs:
         docker pull antrea/openvswitch-debs:$OVS_VERSION || true
         docker pull antrea/openvswitch:$OVS_VERSION || true
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        ./build_and_push.sh
+        ./build.sh --pull --push
         cd ../base/
-        ./build_and_push.sh
+        ./build.sh --pull --push
   skip:
     if: github.repository != 'vmware-tanzu/antrea'
     runs-on: [ubuntu-latest]

--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -7,8 +7,17 @@ RUN apt-get update && \
 # Leading dot is required for the tar command below
 ENV CNI_PLUGINS="./host-local ./loopback ./portmap ./bandwidth"
 
-RUN mkdir -p /opt/cni/bin && \
-    wget -q -O - https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
+# Download containernetworking plugin binaries for the correct architecture
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+         amd64) pluginsArch='amd64' ;; \
+	 armhf) pluginsArch='arm' ;; \
+	 arm64) pluginsArch='arm64' ;; \
+         *) pluginsArch=''; echo >&2; echo >&2 "unsupported architecture '$dpkgArch'"; echo >&2 ; exit 1 ;; \
+    esac; \
+    mkdir -p /opt/cni/bin; \
+    wget -q -O - https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${pluginsArch}-v0.8.7.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
 
 
 FROM antrea/openvswitch:${OVS_VERSION}

--- a/build/images/base/build.sh
+++ b/build/images/base/build.sh
@@ -23,24 +23,79 @@ function echoerr {
     >&2 echo "$@"
 }
 
+_usage="Usage: OVS_VERSION=<VERSION> $0 [--pull] [--push] [--platform <PLATFORM>]
+Build the antrea/base-ubuntu:<VERSION> image.
+        --pull                  Always attempt to pull a newer version of the base images
+        --push                  Push the built image to the registry
+        --platform <PLATFORM>   Target platform for the image if server is multi-platform capable"
+
+function print_usage {
+    echoerr "$_usage"
+}
+
+PULL=false
+PUSH=false
+PLATFORM=""
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    --push)
+    PUSH=true
+    shift
+    ;;
+    --pull)
+    PULL=true
+    shift
+    ;;
+    --platform)
+    PLATFORM="$2"
+    shift 2
+    ;;
+    -h|--help)
+    print_usage
+    exit 0
+    ;;
+    *)    # unknown option
+    echoerr "Unknown option $1"
+    exit 1
+    ;;
+esac
+done
+
 if [ -z "$OVS_VERSION" ]; then
     echoerr "The OVS_VERSION env variable must be set to a valid value (e.g. 2.14.0)"
     exit 1
+fi
+
+if [ "$PLATFORM" != "" ] && $PUSH; then
+    echoerr "Cannot use --platform with --push"
+    exit 1
+fi
+
+PLATFORM_ARG=""
+if [ "$PLATFORM" != "" ]; then
+    PLATFORM_ARG="--platform $PLATFORM"
 fi
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 pushd $THIS_DIR > /dev/null
 
-docker pull ubuntu:20.04
+if $PULL; then
+    docker pull $PLATFORM_ARG ubuntu:20.04
+    docker pull $PLATFORM_ARG antrea/openvswitch:$OVS_VERSION
+fi
 
-docker pull antrea/openvswitch:$OVS_VERSION
-
-docker build \
+docker build $PLATFORM_ARG \
        -t antrea/base-ubuntu:$OVS_VERSION \
        -f Dockerfile \
        --build-arg OVS_VERSION=$OVS_VERSION .
 
-docker push antrea/base-ubuntu:$OVS_VERSION
+if $PUSH; then
+    docker push antrea/base-ubuntu:$OVS_VERSION
+fi
 
 popd > /dev/null

--- a/build/images/ovs/README.md
+++ b/build/images/ovs/README.md
@@ -14,12 +14,12 @@ reason, you can follow the instructions below.
 ## Manually building the image and pushing it to Dockerhub
 
 Choose the version of OVS you want to build by setting the `OVS_VERSION`
-environment variable. Then run the `build_and_push.sh` script included in this
+environment variable. Then run the `build.sh` script included in this
 directory. For example:
 
 ```bash
 cd build/images/ovs
-OVS_VERSION=2.14.0 ./build_and_push.sh
+OVS_VERSION=2.14.0 ./build.sh --pull --push
 ```
 
 The image will be pushed to Dockerhub as `antrea/openvswitch:$OVS_VERSION`.

--- a/build/images/ovs/build.sh
+++ b/build/images/ovs/build.sh
@@ -23,9 +23,61 @@ function echoerr {
     >&2 echo "$@"
 }
 
+_usage="Usage: OVS_VERSION=<VERSION> $0 [--pull] [--push] [--platform <PLATFORM>]
+Build the antrea/ovs:<VERSION> image.
+        --pull                  Always attempt to pull a newer version of the base images
+        --push                  Push the built image to the registry
+        --platform <PLATFORM>   Target platform for the image if server is multi-platform capable"
+
+function print_usage {
+    echoerr "$_usage"
+}
+
+PULL=false
+PUSH=false
+PLATFORM=""
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    --push)
+    PUSH=true
+    shift
+    ;;
+    --pull)
+    PULL=true
+    shift
+    ;;
+    --platform)
+    PLATFORM="$2"
+    shift 2
+    ;;
+    -h|--help)
+    print_usage
+    exit 0
+    ;;
+    *)    # unknown option
+    echoerr "Unknown option $1"
+    exit 1
+    ;;
+esac
+done
+
 if [ -z "$OVS_VERSION" ]; then
     echoerr "The OVS_VERSION env variable must be set to a valid value (e.g. 2.14.0)"
     exit 1
+fi
+
+if [ "$PLATFORM" != "" ] && $PUSH; then
+    echoerr "Cannot use --platform with --push"
+    exit 1
+fi
+
+PLATFORM_ARG=""
+if [ "$PLATFORM" != "" ]; then
+    PLATFORM_ARG="--platform $PLATFORM"
 fi
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
@@ -39,20 +91,24 @@ pushd $THIS_DIR > /dev/null
 # locally.
 # See https://github.com/moby/moby/issues/34715.
 
-docker pull ubuntu:20.04
+if $PULL; then
+    docker pull $PLATFORM_ARG ubuntu:20.04
+fi
 
-docker build --target ovs-debs \
+docker build $PLATFORM_ARG --target ovs-debs \
        --cache-from antrea/openvswitch-debs:$OVS_VERSION \
        -t antrea/openvswitch-debs:$OVS_VERSION \
        --build-arg OVS_VERSION=$OVS_VERSION .
 
-docker build \
+docker build $PLATFORM_ARG \
        --cache-from antrea/openvswitch-debs:$OVS_VERSION \
        --cache-from antrea/openvswitch:$OVS_VERSION \
        -t antrea/openvswitch:$OVS_VERSION \
        --build-arg OVS_VERSION=$OVS_VERSION .
 
-docker push antrea/openvswitch-debs:$OVS_VERSION
-docker push antrea/openvswitch:$OVS_VERSION
+if $PUSH; then
+    docker push antrea/openvswitch-debs:$OVS_VERSION
+    docker push antrea/openvswitch:$OVS_VERSION
+fi
 
 popd > /dev/null

--- a/ci/run-k8s-e2e-tests.sh
+++ b/ci/run-k8s-e2e-tests.sh
@@ -32,6 +32,7 @@ DEFAULT_E2E_NETWORKPOLICY_FOCUS="\[Feature:NetworkPolicy\]"
 DEFAULT_E2E_NETWORKPOLICY_SKIP=""
 MODE="report"
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+KUBE_CONFORMANCE_IMAGE=""
 KUBE_CONFORMANCE_IMAGE_VERSION="$(head -n1 $THIS_DIR/k8s-conformance-image-version)"
 IMAGE_PULL_POLICY="Always"
 CONFORMANCE_IMAGE_CONFIG_PATH="${THIS_DIR}/conformance-image-config.yaml"
@@ -49,9 +50,11 @@ using the sonobuoy tool.
         --e2e-focus TestRegex                                     Run only tests matching a specific regex, this is useful to run a single tests for example.
         --e2e-skip TestRegex                                      Skip some tests matching a specific regex.
         --kubeconfig Kubeconfig                                   Explicit path to Kubeconfig file. You may also set the KUBECONFIG environment variable.
+        --kube-conformance-image ConformacneImage                 Container image override for the kube conformance image. Overrides --kube-conformance-image-version.
         --kube-conformance-image-version ConformanceImageVersion  Use specific version of the Conformance tests container image. Default is $KUBE_CONFORMANCE_IMAGE_VERSION.
         --log-mode                                                Use the flag to set either 'report', 'detail', or 'dump' level data for sonobouy results.
         --image-pull-policy                                       The ImagePullPolicy Sonobuoy should use for the aggregators and workers. (default Always)
+        --sonobuoy-image SonobuoyImage                            Sonobuoy image to use. Default is $SONOBUOY_IMAGE.
         --help, -h                                                Print this message and exit
 
 This tool uses sonobuoy (https://github.com/vmware-tanzu/sonobuoy) to run the K8s e2e community
@@ -74,6 +77,10 @@ key="$1"
 case $key in
     --kubeconfig)
     KUBECONFIG_OPTION="--kubeconfig $2"
+    shift 2
+    ;;
+    --kube-conformance-image)
+    KUBE_CONFORMANCE_IMAGE_OPTION="--kube-conformance-image $2"
     shift 2
     ;;
     --kube-conformance-image-version)
@@ -113,6 +120,10 @@ case $key in
     IMAGE_PULL_POLICY="$2"
     shift 2
     ;;
+    --sonobuoy-image)
+    SONOBUOY_IMAGE="$2"
+    shift 2
+    ;;
     -h|--help)
     print_usage
     exit 0
@@ -146,12 +157,14 @@ function run_sonobuoy() {
     if [[ "$focus_regex" == "" && "$skip_regex" == "" ]]; then
         $SONOBUOY run --wait \
                 $KUBECONFIG_OPTION \
+                $KUBE_CONFORMANCE_IMAGE_OPTION \
                 --kube-conformance-image-version $KUBE_CONFORMANCE_IMAGE_VERSION \
                 --mode "certified-conformance" --image-pull-policy ${IMAGE_PULL_POLICY} \
                 --sonobuoy-image ${SONOBUOY_IMAGE} --e2e-repo-config ${CONFORMANCE_IMAGE_CONFIG_PATH}
     else
         $SONOBUOY run --wait \
                 $KUBECONFIG_OPTION \
+                $KUBE_CONFORMANCE_IMAGE_OPTION \
                 --kube-conformance-image-version $KUBE_CONFORMANCE_IMAGE_VERSION \
                 --e2e-focus "$focus_regex" --e2e-skip "$skip_regex" --image-pull-policy ${IMAGE_PULL_POLICY} \
                 --sonobuoy-image ${SONOBUOY_IMAGE} --e2e-repo-config ${CONFORMANCE_IMAGE_CONFIG_PATH}

--- a/ci/verify-sonobuoy.sh
+++ b/ci/verify-sonobuoy.sh
@@ -28,8 +28,18 @@ install_sonobuoy() {
         >&2 echo "Unsupported OS type $OSTYPE"
         return 1
     fi
+    local machinetype=$(uname -m)
+    local arch=""
+    if [[ "$machinetype" == "x86_64" ]]; then
+        arch="amd64"
+    elif [[ "$machinetype" == "aarch64" ]]; then
+        arch="arm64"
+    else
+        >&2 echo "Unsupported machine type $machinetype"
+        return 1
+    fi
     >&2 echo "Installing sonobuoy"
-    local sonobuoy_url="https://github.com/vmware-tanzu/sonobuoy/releases/download/${_MIN_SONOBUOY_VERSION}/sonobuoy_${_MIN_SONOBUOY_VERSION:1}_${ostype}_amd64.tar.gz"
+    local sonobuoy_url="https://github.com/vmware-tanzu/sonobuoy/releases/download/${_MIN_SONOBUOY_VERSION}/sonobuoy_${_MIN_SONOBUOY_VERSION:1}_${ostype}_${arch}.tar.gz"
     curl -sLo "$_SONOBUOY_TARBALL" "${sonobuoy_url}" || return 1
     mkdir -p "$_SONOBUOY_BINDIR" || return 1
     tar -xzf "$_SONOBUOY_TARBALL" -C "$_SONOBUOY_BINDIR" || return 1


### PR DESCRIPTION
* Download containernetworking plugins for correct architecture in the
  "base" image Dockerfile. Inspired by
  https://github.com/docker-library/golang/blob/master/Dockerfile-debian.template.
* Rename build_and_push.sh scripts to build.sh, and add command-line
  options to tweak their behavior. In particular add '--platform' to
  specifiy the target platform. Note that just providing '--platform
  arm64' will not let you build an arm64 image on an amd64 build
  server. However, some build servers can support multiple
  architectures. This is typically the case of arm64 servers, which can
  build images for both 32-bit and 64-bit arm target platforms.
* Update run-k8s-e2e-tests.sh to support arbitrary sonobuoy and
  conformance images, and to install correct sonobuoy binary based on
  the architecture.
* Cross-compile Antrea binaries for arm/v7 and arm64 as part of CI
  (Github actions) to ensure that arm builds are not broken.

We will use self-hosted arm64 runners to build and test the Antrea
Docker images for arm platforms. Note that for security reasons (using
self-hosted runners for public Github repositories is not recommended),
the images will be built and pushed from a separate private Github
respository for now. I believe Github is working on a solution to
improve security, which should enable us to move our arm Github
workflows to the main Antrea repository in the future.

See #450