### PR TITLE
Add Antrea Proxy metrics to tests, add stability

### DIFF
--- a/pkg/agent/proxy/metrics/metrics.go
+++ b/pkg/agent/proxy/metrics/metrics.go
@@ -18,93 +18,103 @@ var (
 
 	SyncProxyDuration = kmetrics.NewHistogram(
 		&kmetrics.HistogramOpts{
-			Namespace:   metricNamespaceAntrea,
-			Subsystem:   metricSubsystemProxy,
-			ConstLabels: map[string]string{"ip_family": "v4"},
-			Name:        "sync_proxy_rules_duration_seconds",
-			Help:        "SyncProxyRules duration of AntreaProxy in seconds",
+			Namespace:      metricNamespaceAntrea,
+			Subsystem:      metricSubsystemProxy,
+			ConstLabels:    map[string]string{"ip_family": "v4"},
+			StabilityLevel: kmetrics.ALPHA,
+			Name:           "sync_proxy_rules_duration_seconds",
+			Help:           "SyncProxyRules duration of AntreaProxy in seconds",
 		},
 	)
 	ServicesInstalledTotal = kmetrics.NewGauge(
 		&kmetrics.GaugeOpts{
-			Namespace:   metricNamespaceAntrea,
-			Subsystem:   metricSubsystemProxy,
-			ConstLabels: map[string]string{"ip_family": "v4"},
-			Name:        "total_services_installed",
-			Help:        "The number of Services installed by AntreaProxy",
+			Namespace:      metricNamespaceAntrea,
+			Subsystem:      metricSubsystemProxy,
+			ConstLabels:    map[string]string{"ip_family": "v4"},
+			StabilityLevel: kmetrics.ALPHA,
+			Name:           "total_services_installed",
+			Help:           "The number of Services installed by AntreaProxy",
 		},
 	)
 	EndpointsInstalledTotal = kmetrics.NewGauge(
 		&kmetrics.GaugeOpts{
-			Namespace:   metricNamespaceAntrea,
-			Subsystem:   metricSubsystemProxy,
-			ConstLabels: map[string]string{"ip_family": "v4"},
-			Name:        "total_endpoints_installed",
-			Help:        "The number of Endpoints installed by AntreaProxy",
+			Namespace:      metricNamespaceAntrea,
+			Subsystem:      metricSubsystemProxy,
+			ConstLabels:    map[string]string{"ip_family": "v4"},
+			StabilityLevel: kmetrics.ALPHA,
+			Name:           "total_endpoints_installed",
+			Help:           "The number of Endpoints installed by AntreaProxy",
 		},
 	)
 	ServicesUpdatesTotal = kmetrics.NewCounter(
 		&kmetrics.CounterOpts{
-			Namespace:   metricNamespaceAntrea,
-			Subsystem:   metricSubsystemProxy,
-			ConstLabels: map[string]string{"ip_family": "v4"},
-			Name:        "total_services_updates",
-			Help:        "The cumulative number of Service updates received by AntreaProxy",
+			Namespace:      metricNamespaceAntrea,
+			Subsystem:      metricSubsystemProxy,
+			ConstLabels:    map[string]string{"ip_family": "v4"},
+			StabilityLevel: kmetrics.ALPHA,
+			Name:           "total_services_updates",
+			Help:           "The cumulative number of Service updates received by AntreaProxy",
 		},
 	)
 	EndpointsUpdatesTotal = kmetrics.NewCounter(
 		&kmetrics.CounterOpts{
-			Namespace:   metricNamespaceAntrea,
-			Subsystem:   metricSubsystemProxy,
-			ConstLabels: map[string]string{"ip_family": "v4"},
-			Name:        "total_endpoints_updates",
-			Help:        "The cumulative number of Endpoint updates received by AntreaProxy",
+			Namespace:      metricNamespaceAntrea,
+			Subsystem:      metricSubsystemProxy,
+			ConstLabels:    map[string]string{"ip_family": "v4"},
+			StabilityLevel: kmetrics.ALPHA,
+			Name:           "total_endpoints_updates",
+			Help:           "The cumulative number of Endpoint updates received by AntreaProxy",
 		},
 	)
 
 	SyncProxyDurationV6 = kmetrics.NewHistogram(
 		&kmetrics.HistogramOpts{
-			Namespace:   metricNamespaceAntrea,
-			Subsystem:   metricSubsystemProxy,
-			ConstLabels: map[string]string{"ip_family": "v6"},
-			Name:        "sync_proxy_rules_duration_seconds",
-			Help:        "SyncProxyRules duration of AntreaProxy in seconds",
+			Namespace:      metricNamespaceAntrea,
+			Subsystem:      metricSubsystemProxy,
+			ConstLabels:    map[string]string{"ip_family": "v6"},
+			StabilityLevel: kmetrics.ALPHA,
+			Name:           "sync_proxy_rules_duration_seconds",
+			Help:           "SyncProxyRules duration of AntreaProxy in seconds",
 		},
 	)
 	ServicesInstalledTotalV6 = kmetrics.NewGauge(
 		&kmetrics.GaugeOpts{
-			Namespace:   metricNamespaceAntrea,
-			Subsystem:   metricSubsystemProxy,
-			ConstLabels: map[string]string{"ip_family": "v6"},
-			Name:        "total_services_installed",
-			Help:        "The number of Services installed by AntreaProxy",
+			Namespace:      metricNamespaceAntrea,
+			Subsystem:      metricSubsystemProxy,
+			ConstLabels:    map[string]string{"ip_family": "v6"},
+			StabilityLevel: kmetrics.ALPHA,
+			Name:           "total_services_installed",
+			Help:           "The number of Services installed by AntreaProxy",
 		},
 	)
 	EndpointsInstalledTotalV6 = kmetrics.NewGauge(
 		&kmetrics.GaugeOpts{
-			Namespace:   metricNamespaceAntrea,
-			Subsystem:   metricSubsystemProxy,
-			ConstLabels: map[string]string{"ip_family": "v6"},
-			Name:        "total_endpoints_installed",
-			Help:        "The number of Endpoints installed by AntreaProxy",
+			Namespace:      metricNamespaceAntrea,
+			Subsystem:      metricSubsystemProxy,
+			ConstLabels:    map[string]string{"ip_family": "v6"},
+			StabilityLevel: kmetrics.ALPHA,
+			Name:           "total_endpoints_installed",
+			Help:           "The number of Endpoints installed by AntreaProxy",
 		},
 	)
 	ServicesUpdatesTotalV6 = kmetrics.NewCounter(
 		&kmetrics.CounterOpts{
-			Namespace:   metricNamespaceAntrea,
-			Subsystem:   metricSubsystemProxy,
-			ConstLabels: map[string]string{"ip_family": "v6"},
-			Name:        "total_services_updates",
-			Help:        "The cumulative number of Service updates received by AntreaProxy",
+			Namespace:      metricNamespaceAntrea,
+			Subsystem:      metricSubsystemProxy,
+			ConstLabels:    map[string]string{"ip_family": "v6"},
+			StabilityLevel: kmetrics.ALPHA,
+			Name:           "total_services_updates",
+			Help:           "The cumulative number of Service updates received by AntreaProxy",
 		},
 	)
 	EndpointsUpdatesTotalV6 = kmetrics.NewCounter(
 		&kmetrics.CounterOpts{
-			Namespace:   metricNamespaceAntrea,
-			Subsystem:   metricSubsystemProxy,
-			ConstLabels: map[string]string{"ip_family": "v6"},
-			Name:        "total_endpoints_updates",
-			Help:        "The cumulative number of Endpoint updates received by AntreaProxy",
+			Namespace:      metricNamespaceAntrea,
+			Subsystem:      metricSubsystemProxy,
+			ConstLabels:    map[string]string{"ip_family": "v6"},
+			StabilityLevel: kmetrics.ALPHA,
+			Name:           "total_endpoints_updates",
+			Help:           "The cumulative number of Endpoint updates received by AntreaProxy",
 		},
 	)
 )

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -45,6 +45,11 @@ var antreaAgentMetrics = []string{
 	"antrea_agent_conntrack_total_connection_count",
 	"antrea_agent_conntrack_antrea_connection_count",
 	"antrea_agent_conntrack_max_connection_count",
+	"antrea_proxy_sync_proxy_rules_duration_seconds",
+	"antrea_proxy_total_endpoints_installed",
+	"antrea_proxy_total_endpoints_updates",
+	"antrea_proxy_total_services_installed",
+	"antrea_proxy_total_services_updates",
 }
 
 // Controller metrics to validate


### PR DESCRIPTION
Add explicit stability info to Antrea Proxy metrics, also add to the
Prometheus tests.