### PR TITLE
Enhance Traceflow IPv6 e2e test and fix Traceflow IPv6 issues

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -634,10 +634,6 @@ spec:
                     type: string
                 type: object
               packet:
-                not:
-                  required:
-                  - ipHeader
-                  - ipv6Header
                 properties:
                   ipHeader:
                     properties:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -634,10 +634,6 @@ spec:
                     type: string
                 type: object
               packet:
-                not:
-                  required:
-                  - ipHeader
-                  - ipv6Header
                 properties:
                   ipHeader:
                     properties:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -634,10 +634,6 @@ spec:
                     type: string
                 type: object
               packet:
-                not:
-                  required:
-                  - ipHeader
-                  - ipv6Header
                 properties:
                   ipHeader:
                     properties:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -634,10 +634,6 @@ spec:
                     type: string
                 type: object
               packet:
-                not:
-                  required:
-                  - ipHeader
-                  - ipv6Header
                 properties:
                   ipHeader:
                     properties:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -634,10 +634,6 @@ spec:
                     type: string
                 type: object
               packet:
-                not:
-                  required:
-                  - ipHeader
-                  - ipv6Header
                 properties:
                   ipHeader:
                     properties:

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -165,8 +165,6 @@ spec:
                               type: integer
                             flags:
                               type: integer
-                  not:
-                    required: ["ipHeader", "ipv6Header"]
             status:
               type: object
               properties:

--- a/pkg/apis/ops/v1alpha1/types.go
+++ b/pkg/apis/ops/v1alpha1/types.go
@@ -180,6 +180,7 @@ type TCPHeader struct {
 
 // Packet includes header info.
 type Packet struct {
+	// TODO: change type IPHeader to *IPHeader and correct all internal references
 	IPHeader        IPHeader        `json:"ipHeader,omitempty"`
 	IPv6Header      *IPv6Header     `json:"ipv6Header,omitempty"`
 	TransportHeader TransportHeader `json:"transportHeader,omitempty"`

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -1156,8 +1156,11 @@ func (data *TestData) createService(serviceName string, port, targetPort int, se
 }
 
 // createNginxClusterIPService create a nginx service with the given name.
-func (data *TestData) createNginxClusterIPService(affinity bool, ipFamily *corev1.IPFamily) (*corev1.Service, error) {
-	return data.createService("nginx", 80, 80, map[string]string{"app": "nginx"}, affinity, corev1.ServiceTypeClusterIP, ipFamily)
+func (data *TestData) createNginxClusterIPService(name string, affinity bool, ipFamily *corev1.IPFamily) (*corev1.Service, error) {
+	if name == "" {
+		name = "nginx"
+	}
+	return data.createService(name, 80, 80, map[string]string{"app": "nginx"}, affinity, corev1.ServiceTypeClusterIP, ipFamily)
 }
 
 func (data *TestData) createNginxLoadBalancerService(affinity bool, ingressIPs []string, ipFamily *corev1.IPFamily) (*corev1.Service, error) {

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -70,7 +70,7 @@ func testProxyServiceSessionAffinity(ipFamily *corev1.IPFamily, ingressIPs []str
 	defer data.deletePodAndWait(defaultTimeout, nginx)
 	require.NoError(t, err)
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, nginx, testNamespace))
-	svc, err := data.createNginxClusterIPService(true, ipFamily)
+	svc, err := data.createNginxClusterIPService("", true, ipFamily)
 	defer data.deleteServiceAndWait(defaultTimeout, nginx)
 	require.NoError(t, err)
 	_, err = data.createNginxLoadBalancerService(true, ingressIPs, ipFamily)
@@ -166,7 +166,7 @@ func testProxyEndpointLifeCycle(ipFamily *corev1.IPFamily, data *TestData, t *te
 	require.NoError(t, data.createNginxPod(nginx, nodeName))
 	nginxIPs, err := data.podWaitForIPs(defaultTimeout, nginx, testNamespace)
 	require.NoError(t, err)
-	_, err = data.createNginxClusterIPService(false, ipFamily)
+	_, err = data.createNginxClusterIPService("", false, ipFamily)
 	defer data.deleteServiceAndWait(defaultTimeout, nginx)
 	require.NoError(t, err)
 	agentName, err := data.getAntreaPodOnNode(nodeName)
@@ -228,7 +228,7 @@ func testProxyServiceLifeCycle(ipFamily *corev1.IPFamily, ingressIPs []string, d
 	} else {
 		nginxIP = nginxIPs.ipv4.String()
 	}
-	svc, err := data.createNginxClusterIPService(false, ipFamily)
+	svc, err := data.createNginxClusterIPService("", false, ipFamily)
 	defer data.deleteServiceAndWait(defaultTimeout, nginx)
 	require.NoError(t, err)
 	_, err = data.createNginxLoadBalancerService(false, ingressIPs, ipFamily)


### PR DESCRIPTION
This PR enhanced Traceflow e2e test and fixed 4 Traceflow IPv6 issues:

1. Failure if create Traceflow with ipHeader and ipv6Header (The type of ipHeader defined in pkg/apis/ops/v1alpha1/types.go is ipHeader. If we use this definition to create Traceflow CRD, it will always create ipHeader section. This section will be changed to *ipHeader in future.)
2. IPv6 packet is not handled by packetin.go
3. Unexpected LB observation exists in ICMPv6 Traceflow
4. Wrong ICMPv6 echo request type
