### PR TITLE
Stop mounting the host's kmod to the Antrea initContainer

### DIFF
--- a/build/images/scripts/install_cni
+++ b/build/images/scripts/install_cni
@@ -28,4 +28,4 @@ install -m 755 /opt/cni/bin/portmap /host/opt/cni/bin/portmap
 install -m 755 /opt/cni/bin/bandwidth /host/opt/cni/bin/bandwidth
 
 # Load the OVS kernel module
-modprobe openvswitch
+modprobe openvswitch || (echo "Failed to load the OVS kernel module from the container, try running 'modprobe openvswitch' on your Nodes"; exit 1)

--- a/build/images/scripts/install_cni_chaining
+++ b/build/images/scripts/install_cni_chaining
@@ -28,4 +28,4 @@ install -m 755 /usr/local/bin/antrea-cni /host/opt/cni/bin/antrea
 
 id
 # Load the OVS kernel module
-modprobe openvswitch
+modprobe openvswitch || (echo "Failed to load the OVS kernel module from the container, try running 'modprobe openvswitch' on your Nodes"; exit 1)

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1787,9 +1787,6 @@ spec:
         - mountPath: /lib/modules
           name: host-lib-modules
           readOnly: true
-        - mountPath: /sbin/depmod
-          name: host-depmod
-          readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
@@ -1828,9 +1825,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: host-lib-modules
-      - hostPath:
-          path: /sbin/depmod
-        name: host-depmod
       - hostPath:
           path: /run/xtables.lock
           type: FileOrCreate

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1789,9 +1789,6 @@ spec:
         - mountPath: /lib/modules
           name: host-lib-modules
           readOnly: true
-        - mountPath: /sbin/depmod
-          name: host-depmod
-          readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
@@ -1830,9 +1827,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: host-lib-modules
-      - hostPath:
-          path: /sbin/depmod
-        name: host-depmod
       - hostPath:
           path: /run/xtables.lock
           type: FileOrCreate

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1787,9 +1787,6 @@ spec:
         - mountPath: /lib/modules
           name: host-lib-modules
           readOnly: true
-        - mountPath: /sbin/depmod
-          name: host-depmod
-          readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
@@ -1828,9 +1825,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: host-lib-modules
-      - hostPath:
-          path: /sbin/depmod
-        name: host-depmod
       - hostPath:
           path: /run/xtables.lock
           type: FileOrCreate

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1836,9 +1836,6 @@ spec:
         - mountPath: /lib/modules
           name: host-lib-modules
           readOnly: true
-        - mountPath: /sbin/depmod
-          name: host-depmod
-          readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
@@ -1877,9 +1874,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: host-lib-modules
-      - hostPath:
-          path: /sbin/depmod
-        name: host-depmod
       - hostPath:
           path: /run/xtables.lock
           type: FileOrCreate

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1792,9 +1792,6 @@ spec:
         - mountPath: /lib/modules
           name: host-lib-modules
           readOnly: true
-        - mountPath: /sbin/depmod
-          name: host-depmod
-          readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
@@ -1833,9 +1830,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: host-lib-modules
-      - hostPath:
-          path: /sbin/depmod
-        name: host-depmod
       - hostPath:
           path: /run/xtables.lock
           type: FileOrCreate

--- a/build/yamls/base/agent.yml
+++ b/build/yamls/base/agent.yml
@@ -57,11 +57,6 @@ spec:
           - name: host-lib-modules
             mountPath: /lib/modules
             readOnly: true
-          # depmod is required by modprobe when the Node OS is different from
-          # that of the Antrea Docker image.
-          - name: host-depmod
-            mountPath: /sbin/depmod
-            readOnly: true
       containers:
         - name: antrea-agent
           image: antrea
@@ -208,9 +203,6 @@ spec:
         - name: host-lib-modules
           hostPath:
             path: /lib/modules
-        - name: host-depmod
-          hostPath:
-            path: /sbin/depmod
         - name: xtables-lock
           hostPath:
             path: /run/xtables.lock


### PR DESCRIPTION
The host's binary may depend on shared libraries not available in the
container image.

Additionally, if 'modprobe openvswitch' fails in the initContainer, we
use a log message to suggest to the user to try running the command on
each Kubernetes Node. While this is not ideal, the rationale is that if
the Kernel module format is not supported by the container's kmod,
loading it from the host will ensure that requirements are met and also
bypass the error as the initContainer will not attempt to load the
module if it is already loaded (normal modprobe behavior)..

Fixes #1776