### PR TITLE
[CI] Enable prometheus e2e test on dual-stack and IPv6 testbeds

### DIFF
--- a/build/yamls/antrea-prometheus.yml
+++ b/build/yamls/antrea-prometheus.yml
@@ -126,7 +126,7 @@ spec:
     spec:
       containers:
         - name: prometheus
-          image: prom/prometheus:v2.19.3
+          image: projects.registry.vmware.com/antrea/prom-prometheus:v2.19.3
           args:
             - "--config.file=/etc/prometheus/prometheus.yml"
             - "--storage.tsdb.path=/prometheus/"

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -305,6 +305,10 @@ function deliver_antrea {
         fi
     done
 
+    echo  "=== Append antrea-prometheus.yml to antrea.yml ==="
+    echo "---" >> build/yamls/antrea.yml
+    cat build/yamls/antrea-prometheus.yml >> build/yamls/antrea.yml
+
     cp -f build/yamls/*.yml $WORKDIR
     docker save -o antrea-ubuntu.tar projects.registry.vmware.com/antrea/antrea-ubuntu:latest
 
@@ -332,7 +336,7 @@ function run_e2e {
 
     set +e
     mkdir -p `pwd`/antrea-test-logs
-    go test -v github.com/vmware-tanzu/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs -timeout=50m
+    go test -v github.com/vmware-tanzu/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs -timeout=50m --prometheus
     if [[ "$?" != "0" ]]; then
         TEST_FAILURE=true
     fi

--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -292,9 +292,9 @@ func (p *proxier) syncProxyRules() {
 	defer func() {
 		delta := time.Since(start)
 		if p.isIPv6 {
-			metrics.SyncProxyDuration.Observe(delta.Seconds())
-		} else {
 			metrics.SyncProxyDurationV6.Observe(delta.Seconds())
+		} else {
+			metrics.SyncProxyDuration.Observe(delta.Seconds())
 		}
 		klog.V(4).Infof("syncProxyRules took %v", time.Since(start))
 	}()

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -156,6 +157,7 @@ func testPrometheusMetricsOnPods(t *testing.T, data *TestData, component string,
 
 	var hostIP = ""
 	var hostPort int32 = 0
+	var address = ""
 	var parser expfmt.TextParser
 
 	// Find Pods' API endpoints, check for metrics existence on each of them
@@ -166,8 +168,9 @@ func testPrometheusMetricsOnPods(t *testing.T, data *TestData, component string,
 		for _, container := range pod.Spec.Containers {
 			for _, port := range container.Ports {
 				hostPort = port.HostPort
-				t.Logf("Found %s %d", hostIP, hostPort)
-				respBody := getMetricsFromApiServer(t, fmt.Sprintf("https://%s:%d/metrics", hostIP, hostPort), token)
+				address := net.JoinHostPort(hostIP, fmt.Sprint(hostPort))
+				t.Logf("Found %s", address)
+				respBody := getMetricsFromApiServer(t, fmt.Sprintf("https://%s/metrics", address), token)
 
 				parsed, err := parser.TextToMetricFamilies(strings.NewReader(respBody))
 				if err != nil {
@@ -184,13 +187,13 @@ func testPrometheusMetricsOnPods(t *testing.T, data *TestData, component string,
 				for _, metric := range metrics {
 					if !testMap[metric] {
 						metricsFound = false
-						t.Errorf("Metric %s not found on %s:%d", metric, hostIP, hostPort)
+						t.Errorf("Metric %s not found on %s", metric, address)
 					}
 				}
 			}
 		}
 		if !metricsFound {
-			t.Fatalf("Some metrics do not exist in pods on %s:%d", hostIP, hostPort)
+			t.Fatalf("Some metrics do not exist in pods on %s", address)
 		}
 	}
 }
@@ -264,7 +267,8 @@ func testMetricsFromPrometheusServer(t *testing.T, data *TestData, prometheusJob
 	// Target metadata API(/api/v1/targets/metadata) has been available since Prometheus v2.4.0.
 	// This API is still experimental in Prometheus v2.19.3.
 	path := url.PathEscape("match_target={job=\"" + prometheusJob + "\"}")
-	queryUrl := fmt.Sprintf("http://%s:%d/api/v1/targets/metadata?%s", hostIP, nodePort, path)
+	address := net.JoinHostPort(hostIP, fmt.Sprint(nodePort))
+	queryUrl := fmt.Sprintf("http://%s/api/v1/targets/metadata?%s", address, path)
 
 	client := &http.Client{}
 	resp, err := client.Get(queryUrl)
@@ -304,7 +308,7 @@ func testMetricsFromPrometheusServer(t *testing.T, data *TestData, prometheusJob
 	}
 }
 
-func TestControllerMetricsOnPrometheusServer(t *testing.T) {
+func TestPrometheusServerControllerMetrics(t *testing.T) {
 	skipIfPrometheusDisabled(t)
 
 	data, err := setupTest(t)
@@ -316,7 +320,7 @@ func TestControllerMetricsOnPrometheusServer(t *testing.T) {
 	testMetricsFromPrometheusServer(t, data, "antrea-controllers", antreaControllerMetrics)
 }
 
-func TestAgentMetricsOnPrometheusServer(t *testing.T) {
+func TestPrometheusServerAgentMetrics(t *testing.T) {
 	skipIfPrometheusDisabled(t)
 
 	data, err := setupTest(t)


### PR DESCRIPTION
* Used Harbor prom/prometheus image link
* Enabled prometheus test on IPv6 testbeds
* Fixed a bug in proxier.go that SyncProxyDurationV6 should be Observed when p.isIPv6 is true
* Refactored some code in prometheus_test.go to better support IPv6 URL
* Renamed tests in prometheus_test.go so prometheus tests have same prefix