### PR TITLE
Use NamespacedName KeyFunc for ClusterGroups

### DIFF
--- a/pkg/controller/networkpolicy/clustergroup_test.go
+++ b/pkg/controller/networkpolicy/clustergroup_test.go
@@ -191,7 +191,7 @@ func TestAddClusterGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, npc := newController()
 			npc.addClusterGroup(tt.inputGroup)
-			key := string(tt.inputGroup.UID)
+			key := tt.inputGroup.Name
 			actualGroupObj, _, _ := npc.internalGroupStore.Get(key)
 			actualGroup := actualGroupObj.(*antreatypes.Group)
 			assert.Equal(t, tt.expectedGroup, actualGroup)
@@ -282,7 +282,7 @@ func TestUpdateClusterGroup(t *testing.T) {
 	}
 	_, npc := newController()
 	npc.addClusterGroup(&testCG)
-	key := string(testCG.UID)
+	key := testCG.Name
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			npc.updateClusterGroup(&testCG, tt.updatedGroup)
@@ -301,7 +301,7 @@ func TestDeleteCG(t *testing.T) {
 			NamespaceSelector: &selectorA,
 		},
 	}
-	key := string(testCG.UID)
+	key := testCG.Name
 	_, npc := newController()
 	npc.addClusterGroup(&testCG)
 	npc.deleteClusterGroup(&testCG)
@@ -326,18 +326,22 @@ func TestFilterInternalGroupsForPod(t *testing.T) {
 	}
 	grp1 := &antreatypes.Group{
 		UID:      "uid1",
+		Name:     "cgA",
 		Selector: *toGroupSelector("", &selectorSpec, nil, nil),
 	}
 	grp2 := &antreatypes.Group{
 		UID:      "uid2",
+		Name:     "cgB",
 		Selector: *toGroupSelector("", nil, nil, nil),
 	}
 	grp3 := &antreatypes.Group{
 		UID:      "uid3",
+		Name:     "cgC",
 		Selector: *toGroupSelector("", nil, &selectorSpec, nil),
 	}
 	grp4 := &antreatypes.Group{
 		UID:      "uid4",
+		Name:     "cgD",
 		Selector: *toGroupSelector("", &selectorSpec, &selectorSpec, nil),
 	}
 
@@ -353,12 +357,12 @@ func TestFilterInternalGroupsForPod(t *testing.T) {
 		{
 			"pod-match-selector-match-ns",
 			pod1,
-			sets.NewString("uid1", "uid3", "uid4"),
+			sets.NewString("cgA", "cgC", "cgD"),
 		},
 		{
 			"pod-unmatch-selector-match-ns",
 			pod2,
-			sets.NewString("uid3"),
+			sets.NewString("cgC"),
 		},
 		{
 			"pod-unmatch-selector-unmatch-ns",
@@ -399,18 +403,22 @@ func TestFilterInternalGroupsForNamespace(t *testing.T) {
 	}
 	grp1 := &antreatypes.Group{
 		UID:      "uid1",
+		Name:     "cgA",
 		Selector: *toGroupSelector("", &selectorSpec, nil, nil),
 	}
 	grp2 := &antreatypes.Group{
 		UID:      "uid2",
+		Name:     "cgB",
 		Selector: *toGroupSelector("", nil, nil, nil),
 	}
 	grp3 := &antreatypes.Group{
 		UID:      "uid3",
+		Name:     "cgC",
 		Selector: *toGroupSelector("", nil, &selectorSpec, nil),
 	}
 	grp4 := &antreatypes.Group{
 		UID:      "uid4",
+		Name:     "cgD",
 		Selector: *toGroupSelector("", &selectorSpec, &selectorSpec, nil),
 	}
 
@@ -422,7 +430,7 @@ func TestFilterInternalGroupsForNamespace(t *testing.T) {
 		{
 			"ns-match-selector",
 			ns1,
-			sets.NewString("uid3", "uid4"),
+			sets.NewString("cgC", "cgD"),
 		},
 		{
 			"ns-unmatch-selector",

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -1602,7 +1602,7 @@ func internalNetworkPolicyKeyFunc(obj metav1.Object) string {
 }
 
 // internalGroupKeyFunc knows how to generate the key for an internal Group based on the object metadata
-// of the corresponding ClusterGroup resource. Currently the UID of the ClusterGroup is used to ensure uniqueness.
+// of the corresponding ClusterGroup resource. Currently the Name of the ClusterGroup is used to ensure uniqueness.
 func internalGroupKeyFunc(obj metav1.Object) string {
-	return string(obj.GetUID())
+	return obj.GetName()
 }

--- a/pkg/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_test.go
@@ -1235,7 +1235,7 @@ func TestAddPod(t *testing.T) {
 	}
 	_, npc := newController()
 	npc.addNetworkPolicy(testNPObj)
-	groupKey := string(testCG.UID)
+	groupKey := testCG.Name
 	npc.addClusterGroup(testCG)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1316,7 +1316,7 @@ func TestDeletePod(t *testing.T) {
 			PodSelector: &selectorGroup,
 		},
 	}
-	groupKey := string(testCG.UID)
+	groupKey := testCG.Name
 	p1IP := "1.1.1.1"
 	p2IP := "2.2.2.2"
 	p1 := getPod("p1", ns, "", p1IP, false)
@@ -1479,7 +1479,7 @@ func TestAddNamespace(t *testing.T) {
 	_, npc := newController()
 	npc.addNetworkPolicy(testNPObj)
 	npc.addClusterGroup(testCG)
-	groupKey := string(testCG.UID)
+	groupKey := testCG.Name
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			npc.namespaceStore.Add(tt.addedNamespace)
@@ -1636,7 +1636,7 @@ func TestDeleteNamespace(t *testing.T) {
 	_, npc := newController()
 	npc.addNetworkPolicy(testNPObj)
 	npc.addClusterGroup(testCG)
-	groupKey := string(testCG.UID)
+	groupKey := testCG.Name
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p1 := getPod("p1", "nsA", "", "1.1.1.1", false)
@@ -2848,7 +2848,7 @@ func TestDeleteFinalStateUnknownNetworkPolicy(t *testing.T) {
 }
 
 func TestInternalGroupKeyFunc(t *testing.T) {
-	expValue := "uid-a"
+	expValue := "cgA"
 	cg := v1alpha2.ClusterGroup{
 		ObjectMeta: metav1.ObjectMeta{Name: "cgA", UID: "uid-a"},
 		Spec: v1alpha2.GroupSpec{

--- a/pkg/controller/networkpolicy/store/group.go
+++ b/pkg/controller/networkpolicy/store/group.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/apiserver/storage"
 	"github.com/vmware-tanzu/antrea/pkg/apiserver/storage/ram"
 	antreatypes "github.com/vmware-tanzu/antrea/pkg/controller/types"
+	"github.com/vmware-tanzu/antrea/pkg/k8s"
 )
 
 // groupEvent implements storage.InternalEvent.
@@ -101,6 +102,7 @@ func genGroupEvent(key string, prevObj, currObj interface{}, rv uint64) (storage
 // If includeBody is true, GroupMembers will be copied.
 func ToGroupMsg(in *antreatypes.Group, out *controlplane.Group, includeBody bool) {
 	out.UID = in.UID
+	out.Name = in.Name
 	if !includeBody {
 		return
 	}
@@ -115,7 +117,8 @@ func GroupKeyFunc(obj interface{}) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("object is not *types.Group: %v", obj)
 	}
-	return string(group.UID), nil
+	// Replace empty Namespace with Group.Namespace once Namespaced Groups are introduced.
+	return k8s.NamespacedName("", group.Name), nil
 }
 
 // NewGroupStore creates a store of Group.


### PR DESCRIPTION
Instead of using the UID, use the namespace/name to uniquely identify ClusterGroups and internal Group objects.
Additionally, move the IPBlock nil check for ClusterGroup processing to sync handler.