### PR TITLE
[CI] Improve e2e tests and scripts

### DIFF
--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -185,7 +185,7 @@ function deliver_antrea_windows {
 
     git show --numstat
     make clean
-    docker images | grep 'antrea-ubuntu' | awk '{print $3}' | xargs -r docker rmi || true
+    docker images | grep 'antrea-ubuntu' | awk '{print $3}' | xargs -r docker rmi -f || true
     docker images | grep '<none>' | awk '{print $3}' | xargs -r docker rmi || true
     if [[ "$DOCKER_REGISTRY" != "" ]]; then
         pull_antrea_ubuntu_image
@@ -281,7 +281,7 @@ function deliver_antrea {
 
     git show --numstat
     make clean
-    docker images | grep 'antrea-ubuntu' | awk '{print $3}' | xargs -r docker rmi || true
+    docker images | grep 'antrea-ubuntu' | awk '{print $3}' | xargs -r docker rmi -f || true
     docker images | grep '<none>' | awk '{print $3}' | xargs -r docker rmi || true
     if [[ "${DOCKER_REGISTRY}" != "" ]]; then
         pull_antrea_ubuntu_image

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -16,6 +16,7 @@ package e2e
 
 import (
 	"fmt"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -119,7 +120,7 @@ func (data *TestData) testHostPortPodConnectivity(t *testing.T) {
 	}
 
 	if err = data.runNetcatCommandFromTestPod(clientName, hpPodHostIP, hpPodPort); err != nil {
-		t.Fatalf("Pod %s should be able to connect %s:%d, but was not able to connect", clientName, hpPodHostIP, hpPodPort)
+		t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", clientName, net.JoinHostPort(hpPodHostIP, fmt.Sprint(hpPodPort)))
 	}
 }
 

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -199,10 +199,10 @@ func (data *TestData) setupDifferentNamedPorts(t *testing.T) (checkFn func(), cl
 		// Both clients can connect to both servers.
 		for _, clientName := range []string{client0Name, client1Name} {
 			if err := data.runNetcatCommandFromTestPod(clientName, server0IP, server0Port); err != nil {
-				t.Fatalf("Pod %s should be able to connect %s:%d, but was not able to connect", clientName, server0IP, server0Port)
+				t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", clientName, net.JoinHostPort(server0IP, fmt.Sprint(server0Port)))
 			}
 			if err := data.runNetcatCommandFromTestPod(clientName, server1IP, server1Port); err != nil {
-				t.Fatalf("Pod %s should be able to connect %s:%d, but was not able to connect", clientName, server1IP, server1Port)
+				t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", clientName, net.JoinHostPort(server1IP, fmt.Sprint(server1Port)))
 			}
 		}
 	}
@@ -258,19 +258,21 @@ func (data *TestData) setupDifferentNamedPorts(t *testing.T) (checkFn func(), cl
 	})
 
 	npCheck := func(server0IP, server1IP string) {
+		server0Address := net.JoinHostPort(server0IP, fmt.Sprint(server0Port))
+		server1Address := net.JoinHostPort(server1IP, fmt.Sprint(server1Port))
 		// client0 can connect to both servers.
 		if err = data.runNetcatCommandFromTestPod(client0Name, server0IP, server0Port); err != nil {
-			t.Fatalf("Pod %s should be able to connect %s:%d, but was not able to connect", client0Name, server0IP, server0Port)
+			t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", client0Name, server0Address)
 		}
 		if err = data.runNetcatCommandFromTestPod(client0Name, server1IP, server1Port); err != nil {
-			t.Fatalf("Pod %s should be able to connect %s:%d, but was not able to connect", client0Name, server1IP, server1Port)
+			t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", client0Name, server1Address)
 		}
 		// client1 cannot connect to both servers.
 		if err = data.runNetcatCommandFromTestPod(client1Name, server0IP, server0Port); err == nil {
-			t.Fatalf("Pod %s should not be able to connect %s:%d, but was able to connect", client1Name, server0IP, server0Port)
+			t.Fatalf("Pod %s should not be able to connect %s, but was able to connect", client1Name, server0Address)
 		}
 		if err = data.runNetcatCommandFromTestPod(client1Name, server1IP, server1Port); err == nil {
-			t.Fatalf("Pod %s should not be able to connect %s:%d, but was able to connect", client1Name, server1IP, server1Port)
+			t.Fatalf("Pod %s should not be able to connect %s, but was able to connect", client1Name, server1Address)
 		}
 	}
 
@@ -304,7 +306,7 @@ func TestDefaultDenyEgressPolicy(t *testing.T) {
 
 	preCheckFunc := func(serverIP string) {
 		if err = data.runNetcatCommandFromTestPod(clientName, serverIP, serverPort); err != nil {
-			t.Fatalf("Pod %s should be able to connect %s:%d, but was not able to connect", clientName, serverIP, serverPort)
+			t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", clientName, net.JoinHostPort(serverIP, fmt.Sprint(serverPort)))
 		}
 	}
 	if clusterInfo.podV4NetworkCIDR != "" {
@@ -331,7 +333,7 @@ func TestDefaultDenyEgressPolicy(t *testing.T) {
 
 	npCheck := func(serverIP string) {
 		if err = data.runNetcatCommandFromTestPod(clientName, serverIP, serverPort); err == nil {
-			t.Fatalf("Pod %s should not be able to connect %s:%d, but was able to connect", clientName, serverIP, serverPort)
+			t.Fatalf("Pod %s should not be able to connect %s, but was able to connect", clientName, net.JoinHostPort(serverIP, fmt.Sprint(serverPort)))
 		}
 	}
 
@@ -629,7 +631,7 @@ func TestIngressPolicyWithoutPortNumber(t *testing.T) {
 		// Both clients can connect to server.
 		for _, clientName := range []string{client0Name, client1Name} {
 			if err = data.runNetcatCommandFromTestPod(clientName, serverIP, serverPort); err != nil {
-				t.Fatalf("Pod %s should be able to connect %s:%d, but was not able to connect", clientName, serverIP, serverPort)
+				t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", clientName, net.JoinHostPort(serverIP, fmt.Sprint(serverPort)))
 			}
 		}
 	}
@@ -673,13 +675,14 @@ func TestIngressPolicyWithoutPortNumber(t *testing.T) {
 	}()
 
 	npCheck := func(serverIP string) {
+		serverAddress := net.JoinHostPort(serverIP, fmt.Sprint(serverPort))
 		// Client0 can access server.
 		if err = data.runNetcatCommandFromTestPod(client0Name, serverIP, serverPort); err != nil {
-			t.Fatalf("Pod %s should be able to connect %s:%d, but was not able to connect", client0Name, serverIP, serverPort)
+			t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", client0Name, serverAddress)
 		}
 		// Client1 can't access server.
 		if err = data.runNetcatCommandFromTestPod(client1Name, serverIP, serverPort); err == nil {
-			t.Fatalf("Pod %s should not be able to connect %s:%d, but was able to connect", client1Name, serverIP, serverPort)
+			t.Fatalf("Pod %s should not be able to connect %s, but was able to connect", client1Name, serverAddress)
 		}
 	}
 

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -17,6 +17,7 @@ package e2e
 import (
 	"encoding/hex"
 	"fmt"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -178,11 +179,7 @@ func testProxyEndpointLifeCycle(ipFamily *corev1.IPFamily, data *TestData, t *te
 	}
 
 	keywords := make(map[int]string)
-	if *ipFamily == corev1.IPv6Protocol {
-		keywords[42] = fmt.Sprintf("nat(dst=[%s]:80)", nginxIP) // endpointNATTable
-	} else {
-		keywords[42] = fmt.Sprintf("nat(dst=%s:80)", nginxIP) // endpointNATTable
-	}
+	keywords[42] = fmt.Sprintf("nat(dst=%s)", net.JoinHostPort(nginxIP, "80")) // endpointNATTable
 
 	for tableID, keyword := range keywords {
 		tableOutput, _, err := data.runCommandFromPod(metav1.NamespaceSystem, agentName, "antrea-agent", []string{"ovs-ofctl", "dump-flows", defaultBridgeName, fmt.Sprintf("table=%d", tableID)})

--- a/test/e2e/security_test.go
+++ b/test/e2e/security_test.go
@@ -175,11 +175,7 @@ func testCert(t *testing.T, data *TestData, expectedCABundle string, restartPod 
 		trans, _ := restclient.TransportFor(&clientConfig)
 		hc := &http.Client{Transport: trans, Timeout: 5 * time.Second}
 		var reqURL string
-		if net.ParseIP(antreaController.Status.PodIP).To4() != nil {
-			reqURL = fmt.Sprintf("https://%s:%d/healthz", antreaController.Status.PodIP, apis.AntreaControllerAPIPort)
-		} else {
-			reqURL = fmt.Sprintf("https://[%s]:%d/healthz", antreaController.Status.PodIP, apis.AntreaControllerAPIPort)
-		}
+		reqURL = fmt.Sprintf("https://%s/healthz", net.JoinHostPort(antreaController.Status.PodIP, fmt.Sprint(apis.AntreaControllerAPIPort)))
 		req, err := http.NewRequest("GET", reqURL, nil)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
* antctl
  - There is no need to log antctl output(stdout and stderr) when tests are successful.
     It makes console output unnecessarily long.
  - proxyPort should be used as value of option "--port" in runAntctProxy().
* IP and Port combination
  - Use net.JoinHostPort to avoid if statement.
  - Turn "%s:%d" to net.JoinHostPort(ip, port) in log info becauses it
    only considers IPv4 before
 - Remove old antrea-ubuntu images with "-f" in IPv6/Windows tests. "-f" is
   needed because "image is referenced in multiple repositories":
   - antrea/antrea-ubuntu
   - projects.registry.vmware.com/antrea/antrea-ubuntu