### PR TITLE
Fix AddressGroup memberKey not updated on pod IP update

### DIFF
--- a/pkg/agent/controller/networkpolicy/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/reconciler.go
@@ -541,8 +541,8 @@ func (r *reconciler) update(lastRealized *lastRealized, newRule *CompletedRule, 
 	if newRule.Direction == v1beta2.DirectionIn {
 		from1 := groupMembersToOFAddresses(newRule.FromAddresses)
 		from2 := ipBlocksToOFAddresses(newRule.From.IPBlocks, r.ipv4Enabled, r.ipv6Enabled)
-		addedFrom := groupMembersToOFAddresses(newRule.FromAddresses.Difference(lastRealized.FromAddresses))
-		deletedFrom := groupMembersToOFAddresses(lastRealized.FromAddresses.Difference(newRule.FromAddresses))
+		addedFrom := ipsToOFAddresses(newRule.FromAddresses.IPDifference(lastRealized.FromAddresses))
+		deletedFrom := ipsToOFAddresses(lastRealized.FromAddresses.IPDifference(newRule.FromAddresses))
 
 		membersByServicesMap, servicesMap := groupMembersByServices(newRule.Services, newRule.TargetMembers)
 		for svcKey, members := range membersByServicesMap {

--- a/pkg/apis/controlplane/sets.go
+++ b/pkg/apis/controlplane/sets.go
@@ -25,7 +25,9 @@ type groupMemberKey string
 type GroupMemberSet map[groupMemberKey]*GroupMember
 
 // normalizeGroupMember calculates the groupMemberKey of the provided
-// GroupMember based on the Pod's namespaced name or IP.
+// GroupMember based on the Pod/ExternalEntity's namespaced name and IPs.
+// For GroupMembers in appliedToGroups, the IPs are not set, so the
+// generated key does not contain IP information.
 func normalizeGroupMember(member *GroupMember) groupMemberKey {
 	// "/" is illegal in Namespace and name so is safe as the delimiter.
 	const delimiter = "/"
@@ -38,10 +40,9 @@ func normalizeGroupMember(member *GroupMember) groupMemberKey {
 		b.WriteString(member.ExternalEntity.Namespace)
 		b.WriteString(delimiter)
 		b.WriteString(member.ExternalEntity.Name)
-	} else if len(member.IPs) != 0 {
-		for _, ip := range member.IPs {
-			b.Write(ip)
-		}
+	}
+	for _, ip := range member.IPs {
+		b.Write(ip)
 	}
 	return groupMemberKey(b.String())
 }

--- a/pkg/apis/controlplane/sets.go
+++ b/pkg/apis/controlplane/sets.go
@@ -14,7 +14,12 @@
 
 package controlplane
 
-import "strings"
+import (
+	"net"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
 
 // groupMemberKey is used to uniquely identify GroupMember.
 type groupMemberKey string
@@ -83,6 +88,22 @@ func (s GroupMemberSet) Difference(o GroupMemberSet) GroupMemberSet {
 		}
 	}
 	return result
+}
+
+// IPDifference returns a String set of GroupMember IPs that are not in o.
+func (s GroupMemberSet) IPDifference(o GroupMemberSet) sets.String {
+	sIPs, oIPs := sets.NewString(), sets.NewString()
+	for _, m := range s {
+		for _, ip := range m.IPs {
+			sIPs.Insert(net.IP(ip).String())
+		}
+	}
+	for _, m := range o {
+		for _, ip := range m.IPs {
+			oIPs.Insert(net.IP(ip).String())
+		}
+	}
+	return sIPs.Difference(oIPs)
 }
 
 // Union returns a new set which includes items in either m or o.

--- a/pkg/apis/controlplane/v1beta2/sets.go
+++ b/pkg/apis/controlplane/v1beta2/sets.go
@@ -15,7 +15,10 @@
 package v1beta2
 
 import (
+	"net"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // groupMemberKey is used to uniquely identify GroupMember.
@@ -85,6 +88,22 @@ func (s GroupMemberSet) Difference(o GroupMemberSet) GroupMemberSet {
 		}
 	}
 	return result
+}
+
+// IPDifference returns a String set of GroupMember IPs that are not in o.
+func (s GroupMemberSet) IPDifference(o GroupMemberSet) sets.String {
+	sIPs, oIPs := sets.NewString(), sets.NewString()
+	for _, m := range s {
+		for _, ip := range m.IPs {
+			sIPs.Insert(net.IP(ip).String())
+		}
+	}
+	for _, m := range o {
+		for _, ip := range m.IPs {
+			oIPs.Insert(net.IP(ip).String())
+		}
+	}
+	return sIPs.Difference(oIPs)
 }
 
 // Union returns a new set which includes items in either m or o.

--- a/pkg/apis/controlplane/v1beta2/sets.go
+++ b/pkg/apis/controlplane/v1beta2/sets.go
@@ -27,7 +27,9 @@ type groupMemberKey string
 type GroupMemberSet map[groupMemberKey]*GroupMember
 
 // normalizeGroupMember calculates the groupMemberKey of the provided
-// GroupMember based on the Pod's namespaced name or IP.
+// GroupMember based on the Pod/ExternalEntity's namespaced name and IPs.
+// For GroupMembers in appliedToGroups, the IPs are not set, so the
+// generated key does not contain IP information.
 func normalizeGroupMember(member *GroupMember) groupMemberKey {
 	// "/" is illegal in Namespace and name so is safe as the delimiter.
 	const delimiter = "/"
@@ -40,10 +42,9 @@ func normalizeGroupMember(member *GroupMember) groupMemberKey {
 		b.WriteString(member.ExternalEntity.Namespace)
 		b.WriteString(delimiter)
 		b.WriteString(member.ExternalEntity.Name)
-	} else if len(member.IPs) != 0 {
-		for _, ip := range member.IPs {
-			b.Write(ip)
-		}
+	}
+	for _, ip := range member.IPs {
+		b.Write(ip)
 	}
 	return groupMemberKey(b.String())
 }

--- a/pkg/controller/networkpolicy/antreanetworkpolicy_test.go
+++ b/pkg/controller/networkpolicy/antreanetworkpolicy_test.go
@@ -309,8 +309,8 @@ func TestProcessAntreaNetworkPolicy(t *testing.T) {
 					},
 				},
 				AppliedToGroups: []string{
-					getNormalizedUID(toGroupSelector("ns3", &selectorA, nil, nil).NormalizedName),
 					getNormalizedUID(toGroupSelector("ns3", &selectorB, nil, nil).NormalizedName),
+					getNormalizedUID(toGroupSelector("ns3", &selectorA, nil, nil).NormalizedName),
 				},
 				AppliedToPerRule: true,
 			},

--- a/pkg/controller/networkpolicy/clustergroup.go
+++ b/pkg/controller/networkpolicy/clustergroup.go
@@ -189,7 +189,7 @@ func (n *NetworkPolicyController) syncInternalGroup(key string) error {
 		pods, _ := n.processSelector(groupSelector)
 		memberSet := controlplane.GroupMemberSet{}
 		for _, pod := range pods {
-			if pod.Status.PodIP == "" {
+			if len(pod.Status.PodIPs) == 0 {
 				// No need to insert Pod IPAddress when it is unset.
 				continue
 			}

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -83,9 +83,9 @@ var (
 	// uuidNamespace is a uuid.UUID type generated from a string to be
 	// used to generate uuid.UUID for internal Antrea objects like
 	// AppliedToGroup, AddressGroup etc.
-	// 5a5e7dd9-e3fb-49bb-b263-9bab25c95841 was generated using
+	// e4f24a48-ca1f-4d5b-819c-ea7632b22115 was generated using
 	// uuid.NewV4() function.
-	uuidNamespace = uuid.FromStringOrNil("5a5e7dd9-e3fb-49bb-b263-9bab25c95841")
+	uuidNamespace = uuid.FromStringOrNil("e4f24a48-ca1f-4d5b-819c-ea7632b22115")
 
 	// matchAllPeer is a NetworkPolicyPeer matching all source/destination IP addresses. Both IPv4 Any (0.0.0.0/0) and
 	// IPv6 Any (::/0) are added into the IPBlocks, and Antrea Agent should decide if both two are used according the
@@ -1301,7 +1301,7 @@ func (n *NetworkPolicyController) syncAddressGroup(key string) error {
 	pods, externalEntities := n.processSelector(groupSelector)
 	memberSet := controlplane.GroupMemberSet{}
 	for _, pod := range pods {
-		if pod.Status.PodIP == "" {
+		if len(pod.Status.PodIPs) == 0 {
 			// No need to insert Pod IPAddress when it is unset.
 			continue
 		}

--- a/pkg/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_test.go
@@ -965,6 +965,9 @@ func TestAddPod(t *testing.T) {
 						},
 					},
 					PodIP: "1.2.3.4",
+					PodIPs: []corev1.PodIP{
+						{IP: "1.2.3.4"},
+					},
 				},
 			},
 			appGroupMatch:        false,
@@ -994,6 +997,9 @@ func TestAddPod(t *testing.T) {
 						},
 					},
 					PodIP: "1.2.3.4",
+					PodIPs: []corev1.PodIP{
+						{IP: "1.2.3.4"},
+					},
 				},
 			},
 			appGroupMatch:        false,
@@ -1026,6 +1032,9 @@ func TestAddPod(t *testing.T) {
 						},
 					},
 					PodIP: "1.2.3.4",
+					PodIPs: []corev1.PodIP{
+						{IP: "1.2.3.4"},
+					},
 				},
 			},
 			appGroupMatch:        true,
@@ -1055,6 +1064,9 @@ func TestAddPod(t *testing.T) {
 						},
 					},
 					PodIP: "1.2.3.4",
+					PodIPs: []corev1.PodIP{
+						{IP: "1.2.3.4"},
+					},
 				},
 			},
 			appGroupMatch:        false,
@@ -1084,6 +1096,9 @@ func TestAddPod(t *testing.T) {
 						},
 					},
 					PodIP: "1.2.3.4",
+					PodIPs: []corev1.PodIP{
+						{IP: "1.2.3.4"},
+					},
 				},
 			},
 			appGroupMatch:        false,
@@ -1118,6 +1133,9 @@ func TestAddPod(t *testing.T) {
 						},
 					},
 					PodIP: "1.2.3.4",
+					PodIPs: []corev1.PodIP{
+						{IP: "1.2.3.4"},
+					},
 				},
 			},
 			appGroupMatch:        true,
@@ -1203,6 +1221,9 @@ func TestAddPod(t *testing.T) {
 						},
 					},
 					PodIP: "1.2.3.4",
+					PodIPs: []corev1.PodIP{
+						{IP: "1.2.3.4"},
+					},
 				},
 			},
 			appGroupMatch:        false,
@@ -1232,6 +1253,9 @@ func TestAddPod(t *testing.T) {
 						},
 					},
 					PodIP: "1.2.3.4",
+					PodIPs: []corev1.PodIP{
+						{IP: "1.2.3.4"},
+					},
 				},
 			},
 			appGroupMatch:        false,
@@ -2694,22 +2718,22 @@ func TestPodToGroupMember(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			actualMemberPod := podToGroupMember(tt.inputPod, tt.includeIP)
 			if !reflect.DeepEqual(*(*actualMemberPod).Pod, *(tt.expMemberPod).Pod) {
-				t.Errorf("podToMemberPod() got unexpected PodReference %v, want %v", *(*actualMemberPod).Pod, *(tt.expMemberPod).Pod)
+				t.Errorf("podToGroupMember() got unexpected PodReference %v, want %v", *(*actualMemberPod).Pod, *(tt.expMemberPod).Pod)
 			}
 			// Case where the IPAddress must not be populated.
 			if !tt.includeIP {
 				if len(actualMemberPod.IPs) > 0 {
-					t.Errorf("podToMemberPod() got unexpected IP %v, want nil", actualMemberPod.IPs)
+					t.Errorf("podToGroupMember() got unexpected IP %v, want nil", actualMemberPod.IPs)
 				}
 			} else if !comparePodIPs(actualMemberPod.IPs, tt.expMemberPod.IPs) {
-				t.Errorf("podToMemberPod() got unexpected IP %v, want %v", actualMemberPod.IPs, tt.expMemberPod.IPs)
+				t.Errorf("podToGroupMember() got unexpected IP %v, want %v", actualMemberPod.IPs, tt.expMemberPod.IPs)
 			}
 			if !tt.namedPort {
 				if len(actualMemberPod.Ports) > 0 {
-					t.Errorf("podToMemberPod() got unexpected Ports %v, want []", actualMemberPod.Ports)
+					t.Errorf("podToGroupMember() got unexpected Ports %v, want []", actualMemberPod.Ports)
 				}
 			} else if !reflect.DeepEqual(actualMemberPod.Ports, tt.expMemberPod.Ports) {
-				t.Errorf("podToMemberPod() got unexpected Ports %v, want %v", actualMemberPod.Ports, tt.expMemberPod.Ports)
+				t.Errorf("podToGroupMember() got unexpected Ports %v, want %v", actualMemberPod.Ports, tt.expMemberPod.Ports)
 			}
 		})
 	}


### PR DESCRIPTION
This PR fixes #1807.

PR #1467 unified GroupMemberPod and GroupMember into a single struct. Before the unification, PodReference is not set for GroupMemberPods used in AddressGroups, but set for GroupMemberPods used in AppliedToGroups. In #1467, In order to identify whether a GroupMember contains Pod or EE when converting it to GroupMemberPod (for backward compatibility), PodRef was added to GroupMembers all the time instead. 

This leads to two separate issues. First issue is #1587, where agents running v1beta1 do not expect PodReference in addressGroup members. This was fixed by @tnqn thru not including podRef in addressGroup conversion function #1586. 

Second issue is #1807, where addressGroup updates do not propagate to agents once the Pod IPs are changed after Node restart. This is because if the PodRef is always set for GroupMembers, the memberKey will always be namespaced name, and the key does not change on Pod IP updates.

To fix the second issue, this PR modifies the way `normalizeGroupMember` function is implemented. The new hashed key of a GroupMember will include all the fields in a GroupMember if that field is set. Namely, for GroupMembers used in **AppliedToGroups**, the members will have Pod/ExternalEntityReference set. These members will be identified by namespaced-name. For GroupMembers used in **AddressGroups**,  the members will have BOTH  Pod/ExternalEntityReference and IPs set. These members will be identified by entity reference + IPs. 

For this change to be backward compatible, we need to ensure that across Antrea controller upgrade, all AddressGroups have an updated name. Otherwise, on the old side, AddressGroup update events will not work as expected, since the GroupMember key for the same GroupMembers will be different. This will lead to the same issue pointed out in #1587, where the same addressGroup member IPs gets deleted after being added.

Hence, even if two addressGroups have the same members (different keys) before and after controller upgrade, the Antrea agent needs to treat it as AddressGroup add and delete events, rather than an update. To that end, the controller uses a new `uuidNamespace` to ensure that for the AddressGroups/AppliedToGroups with same members, distinct group names will be generated across the update.

In addition, this PR also fixes a potential issue in Antrea agent in terms of calculating AddressGroup updates in reconciler (this was the issue which led to #1587, but wasn't address then, because in upgrade scenarios agent code cannot be patched). When calculating the added and deleted addresses in an AddressGroup, only IPs should be taken into account. Performing a diff on GroupMembers and then take the diff IPs is error-prone when the agent and controller have different hash functions for GroupMembers.