### PR TITLE
Update file list used to determine if a PR is a documentation PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: vmware-tanzu/antrea/ci/gh-actions/has-changes@main
       id: check_diff
       with:
-        args: docs/* ci/jenkins/* *.md
+        args: docs/* ci/jenkins/* *.md hack/.notableofcontents
     outputs:
       has_changes: ${{ steps.check_diff.outputs.has_changes }}
 

--- a/.github/workflows/golicense.yml
+++ b/.github/workflows/golicense.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: vmware-tanzu/antrea/ci/gh-actions/has-changes@main
       id: check_diff
       with:
-        args: docs/* ci/jenkins/* *.md
+        args: docs/* ci/jenkins/* *.md hack/.notableofcontents
     outputs:
       has_changes: ${{ steps.check_diff.outputs.has_changes }}
 

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: vmware-tanzu/antrea/ci/gh-actions/has-changes@main
       id: check_diff
       with:
-        args: docs/* ci/jenkins/* *.md
+        args: docs/* ci/jenkins/* *.md hack/.notableofcontents
     outputs:
       has_changes: ${{ steps.check_diff.outputs.has_changes }}
 

--- a/.github/workflows/kind_upgrade.yml
+++ b/.github/workflows/kind_upgrade.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: vmware-tanzu/antrea/ci/gh-actions/has-changes@main
       id: check_diff
       with:
-        args: docs/* ci/jenkins/* *.md
+        args: docs/* ci/jenkins/* *.md hack/.notableofcontents
     outputs:
       has_changes: ${{ steps.check_diff.outputs.has_changes }}
 


### PR DESCRIPTION
Add .hack/notableofcontents to the file list. It is frequent to update
this file in documentation PRs which add a new Markdown documentation
file, and changes to this file should not trigger expensive CI tests
(notably Kind tests).