### PR TITLE
Multiple fixes and small improvements for e2e tests

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -374,7 +374,7 @@ jobs:
       uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:
-        name: e2e-kind-hybrid.tar.gz
+        name: e2e-kind-encap-np.tar.gz
         path: log.tar.gz
         retention-days: 30
 

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -130,17 +130,8 @@ func setupTest(tb testing.TB) (*TestData, error) {
 
 func setupTestWithIPFIXCollector(tb testing.TB) (*TestData, error, bool) {
 	// TODO: remove hardcoding to IPv4 after flow aggregator supports IPv6
-	// Also use setupTest.
 	isIPv6 := false
-	if err := testData.setupLogDirectoryForTest(tb.Name()); err != nil {
-		tb.Errorf("Error creating logs directory '%s': %v", testData.logsDirForTestCase, err)
-		return nil, err, isIPv6
-	}
-	tb.Logf("Creating '%s' K8s Namespace", testNamespace)
-	if err := ensureAntreaRunning(tb, testData); err != nil {
-		return nil, err, isIPv6
-	}
-	if err := testData.createTestNamespace(); err != nil {
+	if _, err := setupTest(tb); err != nil {
 		return nil, err, isIPv6
 	}
 
@@ -243,6 +234,9 @@ func exportLogs(tb testing.TB, data *TestData, logsSubDir string, writeNodeLogs 
 
 	// dump the logs for monitoring Pods to disk.
 	data.forAllMatchingPodsInNamespace("", monitoringNamespace, writePodLogs)
+
+	// dump the logs for flow-aggregator Pods to disk.
+	data.forAllMatchingPodsInNamespace("", flowAggregatorNamespace, writePodLogs)
 
 	// dump the output of "kubectl describe" for Antrea pods to disk.
 	data.forAllMatchingPodsInNamespace("app=antrea", antreaNamespace, func(nodeName, podName, nsName string) error {

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -114,8 +114,6 @@ func TestFlowAggregator(t *testing.T) {
 
 	podAIP, podBIP, podCIP, svcB, svcC, err := createPerftestPods(data)
 	if err != nil {
-		teardownFlowAggregator(t, data)
-		teardownTest(t, data)
 		t.Fatalf("Error when creating perftest pods and services: %v", err)
 	}
 

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -214,6 +214,15 @@ func labelNodeRoleControlPlane() string {
 	return labelNodeRoleControlPlane
 }
 
+func controlPlaneNoScheduleToleration() corev1.Toleration {
+	// the Node taint still uses "master" in K8s v1.20
+	return corev1.Toleration{
+		Key:      "node-role.kubernetes.io/master",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+}
+
 func initProvider() error {
 	providerFactory := map[string]func(string) (providers.ProviderInterface, error){
 		"vagrant": providers.NewVagrantProvider,
@@ -741,11 +750,7 @@ func (data *TestData) createPodOnNode(name string, nodeName string, image string
 	}
 	if nodeName == controlPlaneNodeName() {
 		// tolerate NoSchedule taint if we want Pod to run on control-plane Node
-		noScheduleToleration := corev1.Toleration{
-			Key:      labelNodeRoleControlPlane(),
-			Operator: corev1.TolerationOpExists,
-			Effect:   corev1.TaintEffectNoSchedule,
-		}
+		noScheduleToleration := controlPlaneNoScheduleToleration()
 		podSpec.Tolerations = []corev1.Toleration{noScheduleToleration}
 	}
 	pod := &corev1.Pod{

--- a/test/e2e/performance_test.go
+++ b/test/e2e/performance_test.go
@@ -49,12 +49,8 @@ var (
 	httpConcurrency      = flag.Int("perf.http.concurrency", 1, "Number of multiple requests to make at a time")
 	realizeTimeout       = flag.Duration("perf.realize.timeout", 5*time.Minute, "Timeout of the realization of network policies")
 	// tolerate NoSchedule taint to let the Pod run on control-plane Node
-	noScheduleToleration = corev1.Toleration{
-		Key:      labelNodeRoleControlPlane(),
-		Operator: corev1.TolerationOpExists,
-		Effect:   corev1.TaintEffectNoSchedule,
-	}
-	labelSelector = &metav1.LabelSelector{
+	noScheduleToleration = controlPlaneNoScheduleToleration()
+	labelSelector        = &metav1.LabelSelector{
 		MatchLabels: map[string]string{"app": perfTestAppLabel},
 	}
 )


### PR DESCRIPTION
* log artifact was not uploaded with the correct name in Github CI job
  for Kind e2e tests with Antrea policies enabled; as a result it was
  overriding the log archive for one of the other CI jobs.
* export Flow Aggregator logs in e2e test framework in case of test
  failure.
* improve push_antrea.sh script so that "standalone" Flow Aggregator
  (without external Flow Collector) is supported; this is necessary to
  run the e2e tests on a local Vagrant testbed.
* some e2e tests were broken on K8s 1.20 clusters after one of my
  earlier changes (global rename from "master" to "control-plane" as
  part of the inclusive naming inititative). Even though in K8s 1.20
  Nodes are labeled with both "master" and "control-plane" roles, the
  Node taint is still "node-role.kubernetes.io/master:NoSchedule", so
  when scheduling Pods on the control-plane Node, we cannot use
  "node-role.kubernetes.io/control-plane" as the toleration key.