### PR TITLE
Fix incorrect use of 'uniq' in golicense run.sh script

### DIFF
--- a/.github/workflows/golicense.yml
+++ b/.github/workflows/golicense.yml
@@ -44,7 +44,7 @@ jobs:
         cache-name: cache-lichen-deps-licensing-info
       with:
         path: license-reports
-        key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/go.sum', 'ci/golicense/**') }}
     - run: mkdir antrea-bins
     - name: Build assets
       run: |

--- a/ci/golicense/run.sh
+++ b/ci/golicense/run.sh
@@ -28,7 +28,7 @@ done
 echo "Merging all files as $REPORTS_DIR/ALL.deps.txt"
 echo "****************"
 # The 'grep -v' is to remove the dependency of the Antrea Octant plugin to Antrea
-cat "$REPORTS_DIR"/*.deps.txt | grep -v "\.\./\.\." | uniq | tee "$REPORTS_DIR/ALL.deps.txt"
+cat "$REPORTS_DIR"/*.deps.txt | grep -v "\.\./\.\." | sort | uniq | tee "$REPORTS_DIR/ALL.deps.txt"
 echo "****************"
 
 if [ -z "$failed_binaries" ]; then


### PR DESCRIPTION
uniq only works on sorted inputs; as a result the command was not
removing duplicates as expected.
Before the fix, the dependency manifest had 975 entries and now it has
171 entries.