### PR TITLE
Improvements / bug fixes in NPL Controller code

### DIFF
--- a/pkg/agent/nodeportlocal/k8s/npl_controller.go
+++ b/pkg/agent/nodeportlocal/k8s/npl_controller.go
@@ -369,7 +369,7 @@ func (c *NPLController) handleAddUpdatePod(key string, obj interface{}) error {
 
 	podIP := newPod.Status.PodIP
 	if podIP == "" {
-		klog.Infof("IP address not set for Pod: %s/%s", newPod.Namespace, newPod.Name)
+		klog.Infof("IP address not set for Pod: %s", key)
 		return nil
 	}
 	c.addPodIPToCache(key, podIP)
@@ -384,7 +384,7 @@ func (c *NPLController) handleAddUpdatePod(key string, obj interface{}) error {
 		}
 		return nil
 	}
-	klog.V(2).Infof("Pod %s/%s is selected by a Service for which NodePortLocal is enabled", newPod.Namespace, newPod.Name)
+	klog.V(2).Infof("Pod %s is selected by a Service for which NodePortLocal is enabled", key)
 
 	var err error
 	var updatePodAnnotation bool
@@ -398,7 +398,7 @@ func (c *NPLController) handleAddUpdatePod(key string, obj interface{}) error {
 			if !c.portTable.RuleExists(podIP, int(cport.ContainerPort)) {
 				nodePort, err = c.portTable.AddRule(podIP, port)
 				if err != nil {
-					return fmt.Errorf("failed to add rule for Pod %s/%s: %s", newPod.Namespace, newPod.Name, err.Error())
+					return fmt.Errorf("failed to add rule for Pod %s: %v", key, err)
 				}
 				assignPodAnnotation(newPod, newPod.Status.HostIP, port, nodePort)
 				updatePodAnnotation = true


### PR DESCRIPTION
* keys were never deleted from the Pod IP cache
* log verbosity was too high for for add / update / delete events
* handleRemovePod was called for Pod update events when the Pod was not
  selected by a Service with NPL enabled. This didn't really make sense
  and led to some misleading log messages.
* controller.go file renamed to npl_controller.go so that the NPL log
  messages are easier to locate in Agent logs.