### PR TITLE
[Windows] Lock container by ID to prevent concurrent modification

### DIFF
--- a/pkg/agent/cniserver/pod_configuration_windows.go
+++ b/pkg/agent/cniserver/pod_configuration_windows.go
@@ -46,6 +46,8 @@ func (pc *podConfigurator) connectInterfaceToOVSAsync(ifConfig *interfacestore.I
 	go func() {
 		klog.Infof("Waiting for interface %s to be created", hostIfAlias)
 		err := wait.PollImmediate(time.Second, 60*time.Second, func() (bool, error) {
+			containerAccess.lockContainer(containerID)
+			defer containerAccess.unlockContainer(containerID)
 			curEp, ok := pc.ifConfigurator.getEndpoint(ovsPortName)
 			if !ok {
 				return true, fmt.Errorf("failed to find HNSEndpoint %s", ovsPortName)


### PR DESCRIPTION
When working with ContainerD runtime, antrea creates OVS port
for Pod asynchronously. Lock needs to be used to prevent
concurrent modification on the same container.

Signed-off-by: Rui Cao <rcao@vmware.com>