### PR TITLE
Add liveness probe to Antrea Controller

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1543,6 +1543,15 @@ spec:
               fieldPath: spec.serviceAccountName
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            host: 127.0.0.1
+            path: /livez
+            port: api
+            scheme: HTTPS
+          periodSeconds: 10
+          timeoutSeconds: 5
         name: antrea-controller
         ports:
         - containerPort: 10349
@@ -1552,7 +1561,7 @@ spec:
           failureThreshold: 5
           httpGet:
             host: 127.0.0.1
-            path: /healthz
+            path: /readyz
             port: api
             scheme: HTTPS
           initialDelaySeconds: 5
@@ -1734,7 +1743,7 @@ spec:
           failureThreshold: 5
           httpGet:
             host: 127.0.0.1
-            path: /healthz
+            path: /readyz
             port: api
             scheme: HTTPS
           initialDelaySeconds: 5

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1543,6 +1543,15 @@ spec:
               fieldPath: spec.serviceAccountName
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            host: 127.0.0.1
+            path: /livez
+            port: api
+            scheme: HTTPS
+          periodSeconds: 10
+          timeoutSeconds: 5
         name: antrea-controller
         ports:
         - containerPort: 10349
@@ -1552,7 +1561,7 @@ spec:
           failureThreshold: 5
           httpGet:
             host: 127.0.0.1
-            path: /healthz
+            path: /readyz
             port: api
             scheme: HTTPS
           initialDelaySeconds: 5
@@ -1736,7 +1745,7 @@ spec:
           failureThreshold: 5
           httpGet:
             host: 127.0.0.1
-            path: /healthz
+            path: /readyz
             port: api
             scheme: HTTPS
           initialDelaySeconds: 5

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1543,6 +1543,15 @@ spec:
               fieldPath: spec.serviceAccountName
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            host: 127.0.0.1
+            path: /livez
+            port: api
+            scheme: HTTPS
+          periodSeconds: 10
+          timeoutSeconds: 5
         name: antrea-controller
         ports:
         - containerPort: 10349
@@ -1552,7 +1561,7 @@ spec:
           failureThreshold: 5
           httpGet:
             host: 127.0.0.1
-            path: /healthz
+            path: /readyz
             port: api
             scheme: HTTPS
           initialDelaySeconds: 5
@@ -1734,7 +1743,7 @@ spec:
           failureThreshold: 5
           httpGet:
             host: 127.0.0.1
-            path: /healthz
+            path: /readyz
             port: api
             scheme: HTTPS
           initialDelaySeconds: 5

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1557,6 +1557,15 @@ spec:
               fieldPath: spec.serviceAccountName
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            host: 127.0.0.1
+            path: /livez
+            port: api
+            scheme: HTTPS
+          periodSeconds: 10
+          timeoutSeconds: 5
         name: antrea-controller
         ports:
         - containerPort: 10349
@@ -1566,7 +1575,7 @@ spec:
           failureThreshold: 5
           httpGet:
             host: 127.0.0.1
-            path: /healthz
+            path: /readyz
             port: api
             scheme: HTTPS
           initialDelaySeconds: 5
@@ -1783,7 +1792,7 @@ spec:
           failureThreshold: 5
           httpGet:
             host: 127.0.0.1
-            path: /healthz
+            path: /readyz
             port: api
             scheme: HTTPS
           initialDelaySeconds: 5

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1548,6 +1548,15 @@ spec:
               fieldPath: spec.serviceAccountName
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            host: 127.0.0.1
+            path: /livez
+            port: api
+            scheme: HTTPS
+          periodSeconds: 10
+          timeoutSeconds: 5
         name: antrea-controller
         ports:
         - containerPort: 10349
@@ -1557,7 +1566,7 @@ spec:
           failureThreshold: 5
           httpGet:
             host: 127.0.0.1
-            path: /healthz
+            path: /readyz
             port: api
             scheme: HTTPS
           initialDelaySeconds: 5
@@ -1739,7 +1748,7 @@ spec:
           failureThreshold: 5
           httpGet:
             host: 127.0.0.1
-            path: /healthz
+            path: /readyz
             port: api
             scheme: HTTPS
           initialDelaySeconds: 5

--- a/build/yamls/base/agent.yml
+++ b/build/yamls/base/agent.yml
@@ -100,7 +100,7 @@ spec:
           readinessProbe:
             httpGet:
               host: 127.0.0.1
-              path: /healthz
+              path: /readyz
               port: api
               scheme: HTTPS
             initialDelaySeconds: 5

--- a/build/yamls/base/controller.yml
+++ b/build/yamls/base/controller.yml
@@ -249,10 +249,19 @@ spec:
           readinessProbe:
             httpGet:
               host: 127.0.0.1
-              path: /healthz
+              path: /readyz
               port: api
               scheme: HTTPS
             initialDelaySeconds: 5
+            timeoutSeconds: 5
+            periodSeconds: 10
+            failureThreshold: 5
+          livenessProbe:
+            httpGet:
+              host: 127.0.0.1
+              path: /livez
+              port: api
+              scheme: HTTPS
             timeoutSeconds: 5
             periodSeconds: 10
             failureThreshold: 5

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -71,6 +71,8 @@ const (
 
 var allowedPaths = []string{
 	"/healthz",
+	"/livez",
+	"/readyz",
 	"/mutate/acnp",
 	"/mutate/anp",
 	"/validate/tier",

--- a/pkg/agent/apiserver/apiserver.go
+++ b/pkg/agent/apiserver/apiserver.go
@@ -113,7 +113,7 @@ func New(aq agentquerier.AgentQuerier, npq querier.AgentNetworkPolicyInfoQuerier
 func newConfig(bindPort int, enableMetrics bool, kubeconfig string) (*genericapiserver.CompletedConfig, error) {
 	secureServing := genericoptions.NewSecureServingOptions().WithLoopback()
 	authentication := genericoptions.NewDelegatingAuthenticationOptions()
-	authorization := genericoptions.NewDelegatingAuthorizationOptions().WithAlwaysAllowPaths("/healthz")
+	authorization := genericoptions.NewDelegatingAuthorizationOptions().WithAlwaysAllowPaths("/healthz", "/livez", "/readyz")
 
 	// kubeconfig file is useful when antrea-agent isn't not running as a pod
 	if len(kubeconfig) > 0 {

--- a/pkg/controller/querier/querier.go
+++ b/pkg/controller/querier/querier.go
@@ -29,7 +29,7 @@ const (
 var _ ControllerQuerier = new(controllerQuerier)
 
 type ControllerQuerier interface {
-	GetControllerInfo(controllInfo *v1beta1.AntreaControllerInfo, partial bool)
+	GetControllerInfo(controllerInfo *v1beta1.AntreaControllerInfo, partial bool)
 }
 
 type controllerQuerier struct {
@@ -72,16 +72,16 @@ func (cq controllerQuerier) getControllerConditions() []v1beta1.ControllerCondit
 }
 
 // GetControllerInfo gets current info of controller.
-func (cq controllerQuerier) GetControllerInfo(controllInfo *v1beta1.AntreaControllerInfo, partial bool) {
-	controllInfo.NetworkPolicyControllerInfo = cq.getNetworkPolicyControllerInfo()
-	controllInfo.ConnectedAgentNum = int32(cq.getNetworkPolicyInfoQuerier().GetConnectedAgentNum())
-	controllInfo.ControllerConditions = cq.getControllerConditions()
+func (cq controllerQuerier) GetControllerInfo(controllerInfo *v1beta1.AntreaControllerInfo, partial bool) {
+	controllerInfo.NetworkPolicyControllerInfo = cq.getNetworkPolicyControllerInfo()
+	controllerInfo.ConnectedAgentNum = int32(cq.getNetworkPolicyInfoQuerier().GetConnectedAgentNum())
+	controllerInfo.ControllerConditions = cq.getControllerConditions()
 
 	if !partial {
-		controllInfo.Version = querier.GetVersion()
-		controllInfo.PodRef = querier.GetSelfPod()
-		controllInfo.NodeRef = querier.GetSelfNode(false, "")
-		controllInfo.ServiceRef = cq.getService()
-		controllInfo.APIPort = cq.apiPort
+		controllerInfo.Version = querier.GetVersion()
+		controllerInfo.PodRef = querier.GetSelfPod()
+		controllerInfo.NodeRef = querier.GetSelfNode(false, "")
+		controllerInfo.ServiceRef = cq.getService()
+		controllerInfo.APIPort = cq.apiPort
 	}
 }

--- a/pkg/monitor/controller.go
+++ b/pkg/monitor/controller.go
@@ -108,7 +108,7 @@ func (monitor *controllerMonitor) syncControllerCRD() {
 }
 
 // getControllerCRD is used to check the existence of controller monitoring CRD.
-// So when the pod restarts, it will update this monitoring CRD instead of creating a new one.
+// So when the Pod restarts, it will update this monitoring CRD instead of creating a new one.
 func (monitor *controllerMonitor) getControllerCRD(crdName string) (*v1beta1.AntreaControllerInfo, error) {
 	return monitor.client.ClusterinformationV1beta1().AntreaControllerInfos().Get(context.TODO(), crdName, metav1.GetOptions{})
 }

--- a/test/e2e/security_test.go
+++ b/test/e2e/security_test.go
@@ -175,7 +175,7 @@ func testCert(t *testing.T, data *TestData, expectedCABundle string, restartPod 
 		trans, _ := restclient.TransportFor(&clientConfig)
 		hc := &http.Client{Transport: trans, Timeout: 5 * time.Second}
 		var reqURL string
-		reqURL = fmt.Sprintf("https://%s/healthz", net.JoinHostPort(antreaController.Status.PodIP, fmt.Sprint(apis.AntreaControllerAPIPort)))
+		reqURL = fmt.Sprintf("https://%s/readyz", net.JoinHostPort(antreaController.Status.PodIP, fmt.Sprint(apis.AntreaControllerAPIPort)))
 		req, err := http.NewRequest("GET", reqURL, nil)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
This is motivated by #1837, in which the Antrea Controller got in a bad
state (presubmably because of a bug in the apiserver library), and
didn't recover. The endpoint was marked as non-Ready for the Antrea
Service, which means the APIService became broken, since the Antrea
Service has a single Endpoint (single Controller replica). With the
liveness probe, the Antrea Controller would have been restarted by
kubelet and the APIService would hopefully have recovered.

The /healthz endpoint is deprecated since K8s v1.16, so we switch to
/readyz and /livez.