### PR TITLE
Avoid warning about 'flow-restore-wait' config with netdev datapath

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -90,7 +90,8 @@ func run(o *Options) error {
 	}
 	defer ovsdbConnection.Close()
 
-	ovsBridgeClient := ovsconfig.NewOVSBridge(o.config.OVSBridge, o.config.OVSDatapathType, ovsdbConnection)
+	ovsDatapathType := ovsconfig.OVSDatapathType(o.config.OVSDatapathType)
+	ovsBridgeClient := ovsconfig.NewOVSBridge(o.config.OVSBridge, ovsDatapathType, ovsdbConnection)
 	ovsBridgeMgmtAddr := ofconfig.GetMgmtAddress(o.config.OVSRunDir, o.config.OVSBridge)
 	ofClient := openflow.NewClient(o.config.OVSBridge, ovsBridgeMgmtAddr,
 		features.DefaultFeatureGate.Enabled(features.AntreaProxy),
@@ -214,7 +215,7 @@ func run(o *Options) error {
 		isChaining,
 		routeClient,
 		networkReadyCh)
-	err = cniServer.Initialize(ovsBridgeClient, ofClient, ifaceStore, o.config.OVSDatapathType, entityUpdates)
+	err = cniServer.Initialize(ovsBridgeClient, ofClient, ifaceStore, entityUpdates)
 	if err != nil {
 		return fmt.Errorf("error initializing CNI server: %v", err)
 	}
@@ -338,7 +339,7 @@ func run(o *Options) error {
 		v6Enabled := config.IsIPv6Enabled(nodeConfig, networkConfig.TrafficEncapMode)
 
 		connStore := connections.NewConnectionStore(
-			connections.InitializeConnTrackDumper(nodeConfig, serviceCIDRNet, serviceCIDRNetv6, o.config.OVSDatapathType, features.DefaultFeatureGate.Enabled(features.AntreaProxy)),
+			connections.InitializeConnTrackDumper(nodeConfig, serviceCIDRNet, serviceCIDRNetv6, ovsDatapathType, features.DefaultFeatureGate.Enabled(features.AntreaProxy)),
 			ifaceStore,
 			v4Enabled,
 			v6Enabled,

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -110,7 +110,7 @@ func (o *Options) validate(args []string) error {
 	if o.config.EnableIPSecTunnel && o.config.TunnelType != ovsconfig.GRETunnel {
 		return fmt.Errorf("IPSec encyption is supported only for GRE tunnel")
 	}
-	if o.config.OVSDatapathType != ovsconfig.OVSDatapathSystem && o.config.OVSDatapathType != ovsconfig.OVSDatapathNetdev {
+	if o.config.OVSDatapathType != string(ovsconfig.OVSDatapathSystem) && o.config.OVSDatapathType != string(ovsconfig.OVSDatapathNetdev) {
 		return fmt.Errorf("OVS datapath type %s is not supported", o.config.OVSDatapathType)
 	}
 	ok, encapMode := config.GetTrafficEncapModeFromStr(o.config.TrafficEncapMode)
@@ -163,7 +163,7 @@ func (o *Options) setDefaults() {
 		o.config.OVSBridge = defaultOVSBridge
 	}
 	if o.config.OVSDatapathType == "" {
-		o.config.OVSDatapathType = ovsconfig.OVSDatapathSystem
+		o.config.OVSDatapathType = string(ovsconfig.OVSDatapathSystem)
 	}
 	if o.config.OVSRunDir == "" {
 		o.config.OVSRunDir = ovsconfig.DefaultOVSRunDir

--- a/cmd/antrea-agent/options_windows.go
+++ b/cmd/antrea-agent/options_windows.go
@@ -38,7 +38,7 @@ func (o *Options) checkUnsupportedFeatures() error {
 		}
 	}
 
-	if o.config.OVSDatapathType != ovsconfig.OVSDatapathSystem {
+	if o.config.OVSDatapathType != string(ovsconfig.OVSDatapathSystem) {
 		unsupported = append(unsupported, "OVSDatapathType: "+o.config.OVSDatapathType)
 	}
 	_, encapMode := config.GetTrafficEncapModeFromStr(o.config.TrafficEncapMode)

--- a/cmd/antrea-agent/options_windows_test.go
+++ b/cmd/antrea-agent/options_windows_test.go
@@ -51,7 +51,7 @@ func TestCheckUnsupportedFeatures(t *testing.T) {
 		},
 		{
 			"netdev datapath",
-			AgentConfig{OVSDatapathType: ovsconfig.OVSDatapathNetdev},
+			AgentConfig{OVSDatapathType: string(ovsconfig.OVSDatapathNetdev)},
 			false,
 		},
 		{

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -366,6 +366,11 @@ func (i *Initializer) initOpenFlowPipeline() error {
 			i.ofClient.ReplayFlows()
 			klog.Info("Flow replay completed")
 
+			if i.ovsBridgeClient.GetOVSDatapathType() == ovsconfig.OVSDatapathNetdev {
+				// we don't set flow-restore-wait when using the OVS netdev datapath
+				return
+			}
+
 			// ofClient and ovsBridgeClient have their own mechanisms to restore connections with OVS, and it could
 			// happen that ovsBridgeClient's connection is not ready when ofClient completes flow replay. We retry it
 			// with a timeout that is longer time than ovsBridgeClient's maximum connecting retry interval (8 seconds)

--- a/pkg/agent/cniserver/interface_configuration_linux.go
+++ b/pkg/agent/cniserver/interface_configuration_linux.go
@@ -44,11 +44,11 @@ const (
 )
 
 type ifConfigurator struct {
-	ovsDatapathType             string
+	ovsDatapathType             ovsconfig.OVSDatapathType
 	isOvsHardwareOffloadEnabled bool
 }
 
-func newInterfaceConfigurator(ovsDatapathType string, isOvsHardwareOffloadEnabled bool) (*ifConfigurator, error) {
+func newInterfaceConfigurator(ovsDatapathType ovsconfig.OVSDatapathType, isOvsHardwareOffloadEnabled bool) (*ifConfigurator, error) {
 	return &ifConfigurator{ovsDatapathType: ovsDatapathType, isOvsHardwareOffloadEnabled: isOvsHardwareOffloadEnabled}, nil
 }
 

--- a/pkg/agent/cniserver/interface_configuration_windows.go
+++ b/pkg/agent/cniserver/interface_configuration_windows.go
@@ -48,7 +48,7 @@ type ifConfigurator struct {
 	ifCache    *sync.Map
 }
 
-func newInterfaceConfigurator(ovsDataPathType string, isOvsHardwareOffloadEnabled bool) (*ifConfigurator, error) {
+func newInterfaceConfigurator(ovsDatapathType ovsconfig.OVSDatapathType, isOvsHardwareOffloadEnabled bool) (*ifConfigurator, error) {
 	eps, err := hcsshim.HNSListEndpointRequest()
 	if err != nil {
 		return nil, err

--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -81,7 +81,7 @@ func newPodConfigurator(
 	routeClient route.Interface,
 	ifaceStore interfacestore.InterfaceStore,
 	gatewayMAC net.HardwareAddr,
-	ovsDatapathType string,
+	ovsDatapathType ovsconfig.OVSDatapathType,
 	isOvsHardwareOffloadEnabled bool,
 	entityUpdates chan<- types.EntityReference,
 ) (*podConfigurator, error) {

--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -551,12 +551,13 @@ func (s *CNIServer) Initialize(
 	ovsBridgeClient ovsconfig.OVSBridgeClient,
 	ofClient openflow.Client,
 	ifaceStore interfacestore.InterfaceStore,
-	ovsDatapathType string,
 	entityUpdates chan<- types.EntityReference,
 ) error {
 	var err error
-	s.podConfigurator, err = newPodConfigurator(ovsBridgeClient, ofClient, s.routeClient, ifaceStore, s.nodeConfig.GatewayConfig.MAC,
-		ovsDatapathType, ovsBridgeClient.IsHardwareOffloadEnabled(), entityUpdates)
+	s.podConfigurator, err = newPodConfigurator(
+		ovsBridgeClient, ofClient, s.routeClient, ifaceStore, s.nodeConfig.GatewayConfig.MAC,
+		ovsBridgeClient.GetOVSDatapathType(), ovsBridgeClient.IsHardwareOffloadEnabled(), entityUpdates,
+	)
 	if err != nil {
 		return fmt.Errorf("error during initialize podConfigurator: %v", err)
 	}

--- a/pkg/agent/flowexporter/connections/conntrack.go
+++ b/pkg/agent/flowexporter/connections/conntrack.go
@@ -25,7 +25,7 @@ import (
 )
 
 // InitializeConnTrackDumper initializes the ConnTrackDumper interface for different OS and datapath types.
-func InitializeConnTrackDumper(nodeConfig *config.NodeConfig, serviceCIDRv4 *net.IPNet, serviceCIDRv6 *net.IPNet, ovsDatapathType string, isAntreaProxyEnabled bool) ConnTrackDumper {
+func InitializeConnTrackDumper(nodeConfig *config.NodeConfig, serviceCIDRv4 *net.IPNet, serviceCIDRv6 *net.IPNet, ovsDatapathType ovsconfig.OVSDatapathType, isAntreaProxyEnabled bool) ConnTrackDumper {
 	var connTrackDumper ConnTrackDumper
 	if ovsDatapathType == ovsconfig.OVSDatapathSystem {
 		connTrackDumper = NewConnTrackSystem(nodeConfig, serviceCIDRv4, serviceCIDRv6, isAntreaProxyEnabled)

--- a/pkg/ovs/ovsconfig/interfaces.go
+++ b/pkg/ovs/ovsconfig/interfaces.go
@@ -16,14 +16,16 @@ package ovsconfig
 
 type TunnelType string
 
+type OVSDatapathType string
+
 const (
 	GeneveTunnel = "geneve"
 	VXLANTunnel  = "vxlan"
 	GRETunnel    = "gre"
 	STTTunnel    = "stt"
 
-	OVSDatapathSystem = "system"
-	OVSDatapathNetdev = "netdev"
+	OVSDatapathSystem OVSDatapathType = "system"
+	OVSDatapathNetdev OVSDatapathType = "netdev"
 )
 
 type OVSBridgeClient interface {
@@ -51,4 +53,5 @@ type OVSBridgeClient interface {
 	DeleteOVSOtherConfig(configs map[string]interface{}) Error
 	GetBridgeName() string
 	IsHardwareOffloadEnabled() bool
+	GetOVSDatapathType() OVSDatapathType
 }

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -31,7 +31,7 @@ const defaultOVSDBFile = "db.sock"
 type OVSBridge struct {
 	ovsdb                    *ovsdb.OVSDB
 	name                     string
-	datapathType             string
+	datapathType             OVSDatapathType
 	uuid                     string
 	isHardwareOffloadEnabled bool
 }
@@ -94,7 +94,7 @@ func NewOVSDBConnectionUDS(address string) (*ovsdb.OVSDB, Error) {
 }
 
 // NewOVSBridge creates and returns a new OVSBridge struct.
-func NewOVSBridge(bridgeName string, ovsDatapathType string, ovsdb *ovsdb.OVSDB) *OVSBridge {
+func NewOVSBridge(bridgeName string, ovsDatapathType OVSDatapathType, ovsdb *ovsdb.OVSDB) *OVSBridge {
 	return &OVSBridge{ovsdb, bridgeName, ovsDatapathType, "", false}
 }
 
@@ -172,7 +172,7 @@ func (br *OVSBridge) create() Error {
 		// Use Openflow protocol version 1.0 and 1.3.
 		Protocols: makeOVSDBSetFromList([]string{openflowProtoVersion10,
 			openflowProtoVersion13}),
-		DatapathType: br.datapathType,
+		DatapathType: string(br.datapathType),
 	}
 	namedUUID := tx.Insert(dbtransaction.Insert{
 		Table: "Bridge",
@@ -895,4 +895,8 @@ func (br *OVSBridge) getHardwareOffload() (bool, Error) {
 		}
 	}
 	return false, nil
+}
+
+func (br *OVSBridge) GetOVSDatapathType() OVSDatapathType {
+	return br.datapathType
 }

--- a/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
+++ b/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Antrea Authors
+// Copyright 2021 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -264,6 +264,20 @@ func (m *MockOVSBridgeClient) GetOFPort(arg0 string) (int32, ovsconfig.Error) {
 func (mr *MockOVSBridgeClientMockRecorder) GetOFPort(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOFPort", reflect.TypeOf((*MockOVSBridgeClient)(nil).GetOFPort), arg0)
+}
+
+// GetOVSDatapathType mocks base method
+func (m *MockOVSBridgeClient) GetOVSDatapathType() ovsconfig.OVSDatapathType {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOVSDatapathType")
+	ret0, _ := ret[0].(ovsconfig.OVSDatapathType)
+	return ret0
+}
+
+// GetOVSDatapathType indicates an expected call of GetOVSDatapathType
+func (mr *MockOVSBridgeClientMockRecorder) GetOVSDatapathType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOVSDatapathType", reflect.TypeOf((*MockOVSBridgeClient)(nil).GetOVSDatapathType))
 }
 
 // GetOVSOtherConfig mocks base method

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -573,7 +573,7 @@ func newTester() *cmdAddDelTester {
 		false,
 		nil,
 		tester.networkReadyCh)
-	tester.server.Initialize(ovsServiceMock, ofServiceMock, ifaceStore, "", make(chan antreatypes.EntityReference, 100))
+	tester.server.Initialize(ovsServiceMock, ofServiceMock, ifaceStore, make(chan antreatypes.EntityReference, 100))
 	ctx := context.Background()
 	tester.ctx = ctx
 	return tester
@@ -670,6 +670,7 @@ func TestAntreaServerFunc(t *testing.T) {
 
 		ovsServiceMock.EXPECT().GetPortList().Return([]ovsconfig.OVSPortData{}, nil).AnyTimes()
 		ovsServiceMock.EXPECT().IsHardwareOffloadEnabled().Return(false).AnyTimes()
+		ovsServiceMock.EXPECT().GetOVSDatapathType().Return(ovsconfig.OVSDatapathSystem).AnyTimes()
 	}
 
 	teardown := func() {
@@ -790,7 +791,8 @@ func TestCNIServerChaining(t *testing.T) {
 			ofServiceMock = openflowtest.NewMockClient(controller)
 			ifaceStore := interfacestore.NewInterfaceStore()
 			ovsServiceMock.EXPECT().IsHardwareOffloadEnabled().Return(false).AnyTimes()
-			err = server.Initialize(ovsServiceMock, ofServiceMock, ifaceStore, "", make(chan antreatypes.EntityReference, 100))
+			ovsServiceMock.EXPECT().GetOVSDatapathType().Return(ovsconfig.OVSDatapathSystem).AnyTimes()
+			err = server.Initialize(ovsServiceMock, ofServiceMock, ifaceStore, make(chan antreatypes.EntityReference, 100))
 			testRequire.Nil(err)
 		}
 


### PR DESCRIPTION
'flow-restore-wait' is not set for netdev datapath