### PR TITLE
Unify the writting of containerd

### DIFF
--- a/pkg/agent/cniserver/interface_configuration_windows.go
+++ b/pkg/agent/cniserver/interface_configuration_windows.go
@@ -176,7 +176,7 @@ func (ic *ifConfigurator) createContainerLink(endpointName string, result *curre
 	}
 	// Save interface config to HNSEndpoint. It's used for creating missing OVS
 	// ports during antrea-agent boot stage. The change is introduced mainly for
-	// ContainerD support. When working with ContainerD runtime, antrea-agent creates
+	// Containerd support. When working with Containerd runtime, antrea-agent creates
 	// OVS ports in an asynchronous way. So the OVS ports can be lost if antrea-agent
 	// gets stopped/restarted before port creation completes.
 	//
@@ -256,7 +256,7 @@ func parseOVSPortInterfaceConfigFromHNSEndpoint(ep *hcsshim.HNSEndpoint) *interf
 // addresses and routes to the interface.
 // For different CRI runtimes we need to use the appropriate Windows container API:
 //   - Docker runtime: HNS API
-//   - ContainerD runtime: HCS API
+//   - Containerd runtime: HCS API
 func attachContainerLink(ep *hcsshim.HNSEndpoint, containerID, sandbox, containerIFDev string) (*current.Interface, error) {
 	var attached bool
 	var err error
@@ -268,7 +268,7 @@ func attachContainerLink(ep *hcsshim.HNSEndpoint, containerID, sandbox, containe
 			return nil, err
 		}
 	} else {
-		// ContainerD runtime
+		// Containerd runtime
 		if hcnEp, err = hcn.GetEndpointByID(ep.Id); err != nil {
 			return nil, err
 		}
@@ -295,7 +295,7 @@ func attachContainerLink(ep *hcsshim.HNSEndpoint, containerID, sandbox, containe
 				}
 			}
 		} else {
-			// ContainerD runtime
+			// Containerd runtime
 			if err := hcnEp.NamespaceAttach(sandbox); err != nil {
 				return nil, err
 			}

--- a/pkg/agent/cniserver/pod_configuration_windows.go
+++ b/pkg/agent/cniserver/pod_configuration_windows.go
@@ -30,7 +30,7 @@ import (
 )
 
 // connectInterfaceToOVSAsync waits for an interface to be created and connects it to OVS br-int asynchronously
-// in another goroutine. The function is for ContainerD runtime. The host interface is created after
+// in another goroutine. The function is for Containerd runtime. The host interface is created after
 // CNI call completes.
 func (pc *podConfigurator) connectInterfaceToOVSAsync(ifConfig *interfacestore.InterfaceConfig, containerAccess *containerAccessArbitrator) error {
 	if containerAccess == nil {
@@ -86,11 +86,11 @@ func (pc *podConfigurator) connectInterfaceToOVS(
 	ovsPortName := hostIface.Name
 	containerConfig := buildContainerConfig(ovsPortName, containerID, podName, podNameSpace, containerIface, ips)
 	hostIfAlias := fmt.Sprintf("%s (%s)", util.ContainerVNICPrefix, ovsPortName)
-	// - For ContainerD runtime, the container interface is created after CNI replying the network setup result.
+	// - For Containerd runtime, the container interface is created after CNI replying the network setup result.
 	//   So for such case we need to use asynchronous way to wait for interface to be created.
 	// - For Docker runtime, antrea-agent still creates OVS port synchronously.
 	// - Here antrea-agent determines the way of OVS port creation by checking if container interface is yet created.
-	//   If one day ContainerD runtime changes the behavior and container interface can be created when attaching
+	//   If one day Containerd runtime changes the behavior and container interface can be created when attaching
 	//   HNSEndpoint/HostComputeEndpoint, the current implementation will still work. It will choose the synchronized
 	//   way to create OVS port.
 	if util.HostInterfaceExists(hostIfAlias) {

--- a/pkg/agent/cniserver/server_windows.go
+++ b/pkg/agent/cniserver/server_windows.go
@@ -49,7 +49,7 @@ func (s *CNIServer) hostNetNsPath(netNS string) string {
 // isInfraContainer returns true if a container is infra container according to the network namespace path.
 // On Windows platform:
 //   - When using Docker as CRI runtime, the network namespace of infra container is "none".
-//   - When using ContainerD as CRI runtime, the network namespace of infra container is
+//   - When using Containerd as CRI runtime, the network namespace of infra container is
 //     a string which does not contains ":".
 func isInfraContainer(netNS string) bool {
 	return netNS == dockerInfraContainerNetNS || !strings.Contains(netNS, ":")


### PR DESCRIPTION
It's written as ContainerD only in a few windows documentation. Use
Containerd to align with the official documentation.