### PR TITLE
Rename Netpol Cyclonus Github workflow

### DIFF
--- a/.github/workflows/netpol_cyclonus.yml
+++ b/.github/workflows/netpol_cyclonus.yml
@@ -1,4 +1,4 @@
-name: Kind
+name: Kind Netpol Cyclonus
 on:
   schedule:
     # run once a day at midnight


### PR DESCRIPTION
The name was the same as for the workflow running the e2e tests on Kind,
causing results of earlier runs to be overwritten.