### PR TITLE
Fix CG validation

### DIFF
--- a/pkg/controller/networkpolicy/validate.go
+++ b/pkg/controller/networkpolicy/validate.go
@@ -610,7 +610,7 @@ func (t *tierValidator) deleteValidate(oldObj interface{}, userInfo authenticati
 // podSelector.
 func validateAntreaGroupSelectors(s corev1a2.GroupSpec) (string, bool) {
 	if s.IPBlock != nil {
-		if s.NamespaceSelector != nil && s.PodSelector != nil {
+		if s.NamespaceSelector != nil || s.PodSelector != nil {
 			return fmt.Sprint("cluster group IPBlock cannot be set with other selectors"), false
 		}
 	}

--- a/test/e2e/clustergroup_test.go
+++ b/test/e2e/clustergroup_test.go
@@ -1,0 +1,64 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	secv1alpha1 "github.com/vmware-tanzu/antrea/pkg/apis/security/v1alpha1"
+)
+
+func testInvalidCGIPBlockWithPodSelector(t *testing.T) {
+	invalidErr := fmt.Errorf("clustergroup created with ipblock and pod selector")
+	cgName := "ipb-pod"
+	pSel := &metav1.LabelSelector{MatchLabels: map[string]string{"pod": "x"}}
+	cidr := "10.0.0.10/32"
+	ipb := &secv1alpha1.IPBlock{CIDR: cidr}
+	if _, err := k8sUtils.CreateOrUpdateCG(cgName, pSel, nil, ipb); err == nil {
+		// Above creation of CG must fail as it is an invalid spec.
+		failOnError(invalidErr, t)
+	}
+}
+
+func testInvalidCGIPBlockWithNSSelector(t *testing.T) {
+	invalidErr := fmt.Errorf("clustergroup created with ipblock and namespace selector")
+	cgName := "ipb-ns"
+	nSel := &metav1.LabelSelector{MatchLabels: map[string]string{"pod": "x"}}
+	cidr := "10.0.0.10/32"
+	ipb := &secv1alpha1.IPBlock{CIDR: cidr}
+	if _, err := k8sUtils.CreateOrUpdateCG(cgName, nil, nSel, ipb); err == nil {
+		// Above creation of CG must fail as it is an invalid spec.
+		failOnError(invalidErr, t)
+	}
+}
+
+func TestClusterGroup(t *testing.T) {
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+	skipIfAntreaPolicyDisabled(t, data)
+	initialize(t, data)
+
+	t.Run("TestGroupClusterGroupValidate", func(t *testing.T) {
+		t.Run("Case=IPBlockWithPodSelectorDenied", func(t *testing.T) { testInvalidCGIPBlockWithPodSelector(t) })
+		t.Run("Case=IPBlockWithNamespaceSelectorDenied", func(t *testing.T) { testInvalidCGIPBlockWithNSSelector(t) })
+	})
+	failOnError(k8sUtils.CleanCGs(), t)
+}

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -311,6 +311,7 @@ func (k *KubernetesUtils) CreateOrUpdateCG(name string, pSelector, nSelector *me
 		cgr, err := k.crdClient.CoreV1alpha2().ClusterGroups().Create(context.TODO(), cg, metav1.CreateOptions{})
 		if err != nil {
 			log.Infof("unable to create cluster group %s: %v", name, err)
+			return nil, err
 		}
 		return cgr, nil
 	} else if cgReturned.Name != "" {


### PR DESCRIPTION
Do not allow CG to be created with IPBlock set with either PodSelector and/or NamespaceSelector.