### PR TITLE
Increase kind e2e test timeout to 40m

### DIFF
--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -120,7 +120,7 @@ function run_test {
   $FLOWAGGREGATOR_YML_CMD | docker exec -i kind-control-plane dd of=/root/flow-aggregator.yml
   sleep 1
   if $coverage; then
-      go test -v -timeout=35m github.com/vmware-tanzu/antrea/test/e2e -provider=kind --logs-export-dir=$ANTREA_LOG_DIR --coverage --coverage-dir $ANTREA_COV_DIR
+      go test -v -timeout=40m github.com/vmware-tanzu/antrea/test/e2e -provider=kind --logs-export-dir=$ANTREA_LOG_DIR --coverage --coverage-dir $ANTREA_COV_DIR
   else
       go test -v -timeout=30m github.com/vmware-tanzu/antrea/test/e2e -provider=kind --logs-export-dir=$ANTREA_LOG_DIR
   fi

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -1705,6 +1705,11 @@ func TestAntreaPolicy(t *testing.T) {
 		t.Run("Case=ACNPAllowXBtoA", func(t *testing.T) { testACNPAllowXBtoA(t) })
 		t.Run("Case=ACNPAllowXBtoYA", func(t *testing.T) { testACNPAllowXBtoYA(t) })
 		t.Run("Case=ACNPPriorityOverrideDefaultDeny", func(t *testing.T) { testACNPPriorityOverrideDefaultDeny(t) })
+		// The test group cleans up ACNP/ANPs before executing a test case. However, cleanupDefaultDenyNPs() validates
+		// that all Pod to Pod traffic is allowed without cleaning up Antrea-native policies, which fails if there is
+		// a lingering policy from a previous test run. Clean up all Antrea-native policies before exiting the group.
+		failOnError(k8sUtils.CleanACNPs(), t)
+		failOnError(k8sUtils.CleanANPs(namespaces), t)
 		cleanupDefaultDenyNPs(k8sUtils, namespaces)
 	})
 

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -1705,11 +1705,6 @@ func TestAntreaPolicy(t *testing.T) {
 		t.Run("Case=ACNPAllowXBtoA", func(t *testing.T) { testACNPAllowXBtoA(t) })
 		t.Run("Case=ACNPAllowXBtoYA", func(t *testing.T) { testACNPAllowXBtoYA(t) })
 		t.Run("Case=ACNPPriorityOverrideDefaultDeny", func(t *testing.T) { testACNPPriorityOverrideDefaultDeny(t) })
-		// The test group cleans up ACNP/ANPs before executing a test case. However, cleanupDefaultDenyNPs() validates
-		// that all Pod to Pod traffic is allowed without cleaning up Antrea-native policies, which fails if there is
-		// a lingering policy from a previous test run. Clean up all Antrea-native policies before exiting the group.
-		failOnError(k8sUtils.CleanACNPs(), t)
-		failOnError(k8sUtils.CleanANPs(namespaces), t)
 		cleanupDefaultDenyNPs(k8sUtils, namespaces)
 	})
 


### PR DESCRIPTION
Increase the timeout for e2e tests to 40m (previously 35m) to accommodate new tests.