### PR TITLE
Fail golicense Github workflow if license check fails

### DIFF
--- a/.github/workflows/golicense.yml
+++ b/.github/workflows/golicense.yml
@@ -58,6 +58,7 @@ jobs:
         mkdir license-reports
         ./ci/golicense/run.sh ./antrea-bins ./license-reports
     - name: Upload licensing information
+      if: ${{ always() }}
       uses: actions/upload-artifact@v2
       with:
         name: licenses.deps

--- a/ci/golicense/run.sh
+++ b/ci/golicense/run.sh
@@ -31,10 +31,14 @@ echo "****************"
 cat "$REPORTS_DIR"/*.deps.txt | grep -v "\.\./\.\." | sort | uniq | tee "$REPORTS_DIR/ALL.deps.txt"
 echo "****************"
 
+rc=
 if [ -z "$failed_binaries" ]; then
   echo "#### SUCCESS ####"
+  rc=0
 else
   echo "#### FAILURE ####"
   echo "Scan failed for the following binaries: $failed_binaries"
   echo "Check $REPORTS_DIR/ALL.deps.txt for more info"
+  rc=1
 fi
+exit $rc


### PR DESCRIPTION
Until now, the workflow would actually succeed even if the lichen run
failed, and one would have needed to look at the logs to detect issues.