### PR TITLE
Fix NPLController unit test failure

### DIFF
--- a/pkg/agent/nodeportlocal/k8s/annotations_test.go
+++ b/pkg/agent/nodeportlocal/k8s/annotations_test.go
@@ -1,0 +1,89 @@
+// +build !windows
+
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func BenchmarkCompareNPLAnnotationLists(b *testing.B) {
+	const nodeIP = "127.0.0.1"
+	a1 := NPLAnnotation{
+		PodPort:  80,
+		NodeIP:   nodeIP,
+		NodePort: 40000,
+	}
+	a2 := NPLAnnotation{
+		PodPort:  8080,
+		NodeIP:   nodeIP,
+		NodePort: 40001,
+	}
+	a3 := NPLAnnotation{
+		PodPort:  81,
+		NodeIP:   nodeIP,
+		NodePort: 40002,
+	}
+	a4 := NPLAnnotation{
+		PodPort:  8081,
+		NodeIP:   nodeIP,
+		NodePort: 40003,
+	}
+	benchmarkCases := []struct {
+		name         string
+		annotations1 []NPLAnnotation
+		annotations2 []NPLAnnotation
+		equal        bool
+	}{
+		{
+			"EqualSameOrder",
+			[]NPLAnnotation{a2, a1, a3},
+			[]NPLAnnotation{a2, a1, a3},
+			true,
+		},
+		{
+			"EqualDifferentOrder",
+			[]NPLAnnotation{a1, a2, a3},
+			[]NPLAnnotation{a3, a2, a1},
+			true,
+		},
+		{
+			"NotEqualSameLength",
+			[]NPLAnnotation{a1, a2, a3},
+			[]NPLAnnotation{a3, a2, a4},
+			false,
+		},
+		{
+			"NotEqualDifferentLength",
+			[]NPLAnnotation{a1, a2, a3},
+			[]NPLAnnotation{a1, a2, a3, a4},
+			false,
+		},
+	}
+
+	for _, bc := range benchmarkCases {
+		bc := bc
+		b.Run(bc.name, func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				result := compareNPLAnnotationLists(bc.annotations1, bc.annotations2)
+				assert.Equal(b, bc.equal, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The newly added unit test (TestInitInvalidPod) was failing, for the
following reason:
* first the Pod is patched to remove the invalid annotation
* second the Pod is handled by the Controller for the first time (add /
  update event handler) and the correct NPL annotation is generated,
  which needs to be apply with another patch
* but, because the local cache has not been updated yet to reflect the
  result of the previous patch operation, the object used in the handler
  still includes the invalid annotation. This leads to the "final" Pod
  object having 2 annotations (correct + invalid) instead of only 1
  (correct).

The test is not always failing, as sometimes the cache is updated fast
enough.

To avoid this issue we update the Controller logic:
* patches are no longer applied during the initial reconciliation phase,
  all patches are applied by handler calls
* the handler logic is simplified: we compute the expected annotation,
  compare it with the existing one, and decide if a patch is required