### PR TITLE
Fix Traceflow implementation for external IPs and gateway IP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,9 @@ replace (
 	// hcshim repo is modifed to add "AdditionalParams" field to HNSEndpoint struct.
 	// We will use this replace before pushing the change to hcshim upstream repo.
 	github.com/Microsoft/hcsshim v0.8.9 => github.com/ruicao93/hcsshim v0.8.10-0.20210114035434-63fe00c1b9aa
+	// temporary replacement to avoid Antrea Agent panics for some Traceflow requests
+	// see https://github.com/vmware-tanzu/antrea/issues/1878
+	github.com/contiv/libOpenflow => github.com/antoninbas/libOpenflow v0.0.0-20210218001059-32f2e57d0435
 	// antrea/plugins/octant/go.mod also has this replacement since replace statement in dependencies
 	// were ignored. We need to change antrea/plugins/octant/go.mod if there is any change here.
 	github.com/contiv/ofnet => github.com/wenyingd/ofnet v0.0.0-20210205051801-5a4f247248d4

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/antoninbas/go-powershell v0.1.0 h1:LKwuZJt3loyr++Y2Qc+FZoUt8TwbrTWB3H
 github.com/antoninbas/go-powershell v0.1.0/go.mod h1:01pgKhz1CJxGnCWqXVDgvmp/QmHgWgEdxdYP+1azopE=
 github.com/antoninbas/gonetsh v0.1.2 h1:twRwmATT+Xnj/0JD0UBY4tWeW0D4vcEWITlj8nItJbI=
 github.com/antoninbas/gonetsh v0.1.2/go.mod h1:CMmmf/2dAGQRmgWUDXf4Om/MBof1Emt1V0UH/sgw85c=
+github.com/antoninbas/libOpenflow v0.0.0-20210218001059-32f2e57d0435 h1:vVl9f3eDJm14Cyu9ye0ENw6j1Q++XYLEshV4KYBc9ac=
+github.com/antoninbas/libOpenflow v0.0.0-20210218001059-32f2e57d0435/go.mod h1:KqprRw1Mp8VGnGj0NzPeZQojUvT5X26DV7suLSM1iqM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/awalterschulze/gographviz v2.0.1+incompatible h1:XIECBRq9VPEQqkQL5pw2OtjCAdrtIgFKoJU8eT98AS8=
 github.com/awalterschulze/gographviz v2.0.1+incompatible/go.mod h1:GEV5wmg4YquNw7v1kkyoX9etIk8yVmXj+AkDHuuETHs=
@@ -80,9 +82,6 @@ github.com/containernetworking/cni v0.8.0 h1:BT9lpgGoH4jw3lFC7Odz2prU5ruiYKcgAjM
 github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/plugins v0.8.7 h1:bU7QieuAp+sACI2vCzESJ3FoT860urYP+lThyZkb/2M=
 github.com/containernetworking/plugins v0.8.7/go.mod h1:R7lXeZaBzpfqapcAbHRW8/CYwm0dHzbz0XEjofx0uB0=
-github.com/contiv/libOpenflow v0.0.0-20201014051314-c1702744526c/go.mod h1:DtsPlJOByJZ+MO9YITEGUlbJ/jfh/ef0qeNyBYaeNR4=
-github.com/contiv/libOpenflow v0.0.0-20201116154255-01db743640b1 h1:Dx2zj9vXbBivPzmikhvHA5b7Kl3k/SKApMYw9aUF3oE=
-github.com/contiv/libOpenflow v0.0.0-20201116154255-01db743640b1/go.mod h1:DtsPlJOByJZ+MO9YITEGUlbJ/jfh/ef0qeNyBYaeNR4=
 github.com/contiv/libovsdb v0.0.0-20170227191248-d0061a53e358 h1:AiA9SKyNXulsU7aAnyka3UFHYOIH00A9HvdIRnDXlg0=
 github.com/contiv/libovsdb v0.0.0-20170227191248-d0061a53e358/go.mod h1:+qKEHaNVPj+wrn5st7TEFH9wcUWCJq5ZBvVKPQwzAeg=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/pkg/agent/controller/traceflow/packetin.go
+++ b/pkg/agent/controller/traceflow/packetin.go
@@ -213,11 +213,17 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*opsv1alpha1.Tracefl
 				return nil, nil, err
 			}
 		}
-		if (c.networkConfig.TrafficEncapMode.SupportsEncap() && outputPort == config.DefaultTunOFPort) || outputPort == config.HostGatewayOFPort {
-			// Output port is Tunnel/Gateway port, packet is forwarded.
-			// tunnelDstIP is valid IP in encapMode, and empty string in other modes.
+		gatewayIP := c.nodeConfig.GatewayConfig.IPv4
+		if pktIn.Data.Ethertype == protocol.IPv6_MSG {
+			gatewayIP = c.nodeConfig.GatewayConfig.IPv6
+		}
+		if c.networkConfig.TrafficEncapMode.SupportsEncap() && outputPort == config.DefaultTunOFPort {
 			ob.TunnelDstIP = tunnelDstIP
 			ob.Action = opsv1alpha1.Forwarded
+		} else if ipDst == gatewayIP.String() && outputPort == config.HostGatewayOFPort {
+			ob.Action = opsv1alpha1.Delivered
+		} else if c.networkConfig.TrafficEncapMode.SupportsEncap() && outputPort == config.HostGatewayOFPort {
+			ob.Action = opsv1alpha1.ForwardedOutOfOverlay
 		} else {
 			// Output port is Pod port, packet is delivered.
 			ob.Action = opsv1alpha1.Delivered

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -653,12 +653,17 @@ func (c *client) kubeProxyFlows(category cookie.Category) []binding.Flow {
 	return flows
 }
 
-// TODO: Use DuplicateToBuilder or integrate this function into original one to avoid unexpected difference.
-// traceflowConnectionTrackFlows generate Traceflow specific flows that bypass the drop flow in connectionTrackFlows to
-// avoid unexpected packet drop in Traceflow.
-func (c *client) traceflowConnectionTrackFlows(dataplaneTag uint8, category cookie.Category) binding.Flow {
+// TODO: Use DuplicateToBuilder or integrate this function into original one to avoid unexpected
+// difference.
+// traceflowConnectionTrackFlows generates Traceflow specific flows that bypass the drop flow in
+// connectionTrackFlows to avoid unexpected packet drop in Traceflow. It also ensures that if any
+// Traceflow packet has ct_state +rpl, it is dropped. This may happen when the Traceflow request
+// destination is the Node's IP.
+func (c *client) traceflowConnectionTrackFlows(dataplaneTag uint8, category cookie.Category) []binding.Flow {
 	connectionTrackStateTable := c.pipeline[conntrackStateTable]
-	flowBuilder := connectionTrackStateTable.BuildFlow(priorityLow + 2).
+	var flows []binding.Flow
+
+	flowBuilder := connectionTrackStateTable.BuildFlow(priorityLow + 1).
 		MatchProtocol(binding.ProtocolIP).
 		MatchIPDscp(dataplaneTag).
 		SetHardTimeout(300).
@@ -671,7 +676,71 @@ func (c *client) traceflowConnectionTrackFlows(dataplaneTag uint8, category cook
 		flowBuilder = flowBuilder.
 			Action().ResubmitToTable(connectionTrackStateTable.GetNext())
 	}
-	return flowBuilder.Done()
+	flows = append(flows, flowBuilder.Done())
+
+	flows = append(flows, connectionTrackStateTable.BuildFlow(priorityLow+2).
+		MatchProtocol(binding.ProtocolIP).
+		MatchIPDscp(dataplaneTag).
+		MatchCTStateTrk(true).MatchCTStateRpl(true).
+		SetHardTimeout(300).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
+		Action().Drop().
+		Done())
+
+	return flows
+}
+
+func (c *client) traceflowNetworkPolicyFlows(dataplaneTag uint8, category cookie.Category) []binding.Flow {
+	flows := []binding.Flow{}
+	c.conjMatchFlowLock.Lock()
+	defer c.conjMatchFlowLock.Unlock()
+	// Copy default drop rules.
+	for _, ctx := range c.globalConjMatchFlowCache {
+		if ctx.dropFlow != nil {
+			copyFlowBuilder := ctx.dropFlow.CopyToBuilder(priorityNormal+2, false)
+			if ctx.dropFlow.FlowProtocol() == "" {
+				copyFlowBuilderIPv6 := ctx.dropFlow.CopyToBuilder(priorityNormal+2, false)
+				copyFlowBuilderIPv6 = copyFlowBuilderIPv6.MatchProtocol(binding.ProtocolIPv6)
+				flows = append(flows, copyFlowBuilderIPv6.MatchIPDscp(dataplaneTag).
+					SetHardTimeout(300).
+					Cookie(c.cookieAllocator.Request(category).Raw()).
+					Action().SendToController(uint8(PacketInReasonTF)).
+					Done())
+				copyFlowBuilder = copyFlowBuilder.MatchProtocol(binding.ProtocolIP)
+			}
+			flows = append(flows, copyFlowBuilder.MatchIPDscp(dataplaneTag).
+				SetHardTimeout(300).
+				Cookie(c.cookieAllocator.Request(category).Raw()).
+				Action().SendToController(uint8(PacketInReasonTF)).
+				Done())
+		}
+	}
+	// Copy Antrea NetworkPolicy drop rules.
+	for _, conj := range c.policyCache.List() {
+		for _, flow := range conj.(*policyRuleConjunction).metricFlows {
+			if flow.IsDropFlow() {
+				copyFlowBuilder := flow.CopyToBuilder(priorityNormal+2, false)
+				// Generate both IPv4 and IPv6 flows if the original drop flow doesn't match IP/IPv6.
+				// DSCP field is in IP/IPv6 headers so IP/IPv6 match is required in a flow.
+				if flow.FlowProtocol() == "" {
+					copyFlowBuilderIPv6 := flow.CopyToBuilder(priorityNormal+2, false)
+					copyFlowBuilderIPv6 = copyFlowBuilderIPv6.MatchProtocol(binding.ProtocolIPv6)
+					flows = append(flows, copyFlowBuilderIPv6.MatchIPDscp(dataplaneTag).
+						SetHardTimeout(300).
+						Cookie(c.cookieAllocator.Request(category).Raw()).
+						Action().SendToController(uint8(PacketInReasonTF)).
+						Done())
+					copyFlowBuilder = copyFlowBuilder.MatchProtocol(binding.ProtocolIP)
+				}
+				flows = append(flows, copyFlowBuilder.MatchIPDscp(dataplaneTag).
+					SetHardTimeout(300).
+					Cookie(c.cookieAllocator.Request(category).Raw()).
+					Action().SendToController(uint8(PacketInReasonTF)).
+					Done())
+			}
+		}
+	}
+	return flows
 }
 
 // ctRewriteDstMACFlow rewrites the destination MAC address with the local host gateway MAC if the
@@ -768,71 +837,71 @@ func (c *client) l2ForwardCalcFlow(dstMAC net.HardwareAddr, ofPort uint32, skipI
 	// the default flow of L2ForwardingOutTable.
 }
 
-// traceflowL2ForwardOutputFlows generates Traceflow specific flows that outputs traceflow packets to OVS port and Antrea
-// Agent after L2forwarding calculation.
+// traceflowL2ForwardOutputFlows generates Traceflow specific flows that outputs traceflow packets
+// to OVS port and Antrea Agent after L2forwarding calculation.
 func (c *client) traceflowL2ForwardOutputFlows(dataplaneTag uint8, category cookie.Category) []binding.Flow {
 	flows := []binding.Flow{}
-	// Output and SendToController if output port is tunnel or gateway port.
-	// The gw0 IP as Traceflow destination is not supported.
-	if c.encapMode.SupportsEncap() {
+	for _, ipProtocol := range []binding.Protocol{binding.ProtocolIP, binding.ProtocolIPv6} {
+		if c.encapMode.SupportsEncap() {
+			// SendToController and Output if output port is tunnel port.
+			flows = append(flows, c.pipeline[L2ForwardingOutTable].BuildFlow(priorityNormal+3).
+				MatchReg(int(PortCacheReg), config.DefaultTunOFPort).
+				MatchIPDscp(dataplaneTag).
+				SetHardTimeout(300).
+				MatchProtocol(ipProtocol).
+				MatchRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
+				Action().OutputRegRange(int(PortCacheReg), ofPortRegRange).
+				Action().SendToController(uint8(PacketInReasonTF)).
+				Cookie(c.cookieAllocator.Request(category).Raw()).
+				Done())
+			// Only SendToController if output port is local gateway.
+			flows = append(flows, c.pipeline[L2ForwardingOutTable].BuildFlow(priorityNormal+2).
+				MatchReg(int(PortCacheReg), config.HostGatewayOFPort).
+				MatchIPDscp(dataplaneTag).
+				SetHardTimeout(300).
+				MatchProtocol(ipProtocol).
+				MatchRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
+				Action().SendToController(uint8(PacketInReasonTF)).
+				Cookie(c.cookieAllocator.Request(category).Raw()).
+				Done())
+		} else {
+			// SendToController and Output if output port is local gateway.
+			flows = append(flows, c.pipeline[L2ForwardingOutTable].BuildFlow(priorityNormal+2).
+				MatchReg(int(PortCacheReg), config.HostGatewayOFPort).
+				MatchIPDscp(dataplaneTag).
+				SetHardTimeout(300).
+				MatchProtocol(ipProtocol).
+				MatchRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
+				Action().OutputRegRange(int(PortCacheReg), ofPortRegRange).
+				Action().SendToController(uint8(PacketInReasonTF)).
+				Cookie(c.cookieAllocator.Request(category).Raw()).
+				Done())
+		}
+		// Only SendToController if output port is local gateway and destination IP is gateway.
+		gatewayIP := c.nodeConfig.GatewayConfig.IPv4
+		if ipProtocol == binding.ProtocolIPv6 {
+			gatewayIP = c.nodeConfig.GatewayConfig.IPv6
+		}
 		flows = append(flows, c.pipeline[L2ForwardingOutTable].BuildFlow(priorityNormal+3).
-			MatchReg(int(PortCacheReg), config.DefaultTunOFPort).
+			MatchReg(int(PortCacheReg), config.HostGatewayOFPort).
+			MatchDstIP(gatewayIP).
 			MatchIPDscp(dataplaneTag).
 			SetHardTimeout(300).
-			MatchProtocol(binding.ProtocolIP).
+			MatchProtocol(ipProtocol).
 			MatchRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
-			Action().OutputRegRange(int(PortCacheReg), ofPortRegRange).
 			Action().SendToController(uint8(PacketInReasonTF)).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done())
-		flows = append(flows, c.pipeline[L2ForwardingOutTable].BuildFlow(priorityNormal+3).
-			MatchReg(int(PortCacheReg), config.DefaultTunOFPort).
+		// Only SendToController if output port is Pod port.
+		flows = append(flows, c.pipeline[L2ForwardingOutTable].BuildFlow(priorityNormal+2).
 			MatchIPDscp(dataplaneTag).
 			SetHardTimeout(300).
-			MatchProtocol(binding.ProtocolIPv6).
+			MatchProtocol(ipProtocol).
 			MatchRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
-			Action().OutputRegRange(int(PortCacheReg), ofPortRegRange).
 			Action().SendToController(uint8(PacketInReasonTF)).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done())
 	}
-	flows = append(flows, c.pipeline[L2ForwardingOutTable].BuildFlow(priorityNormal+3).
-		MatchReg(int(PortCacheReg), config.HostGatewayOFPort).
-		MatchIPDscp(dataplaneTag).
-		SetHardTimeout(300).
-		MatchProtocol(binding.ProtocolIP).
-		MatchRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
-		Action().OutputRegRange(int(PortCacheReg), ofPortRegRange).
-		Action().SendToController(uint8(PacketInReasonTF)).
-		Cookie(c.cookieAllocator.Request(category).Raw()).
-		Done())
-	flows = append(flows, c.pipeline[L2ForwardingOutTable].BuildFlow(priorityNormal+3).
-		MatchReg(int(PortCacheReg), config.HostGatewayOFPort).
-		MatchIPDscp(dataplaneTag).
-		SetHardTimeout(300).
-		MatchProtocol(binding.ProtocolIPv6).
-		MatchRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
-		Action().OutputRegRange(int(PortCacheReg), ofPortRegRange).
-		Action().SendToController(uint8(PacketInReasonTF)).
-		Cookie(c.cookieAllocator.Request(category).Raw()).
-		Done())
-	// Only SendToController if output port is Pod port.
-	flows = append(flows, c.pipeline[L2ForwardingOutTable].BuildFlow(priorityNormal+2).
-		MatchIPDscp(dataplaneTag).
-		SetHardTimeout(300).
-		MatchProtocol(binding.ProtocolIP).
-		MatchRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
-		Action().SendToController(uint8(PacketInReasonTF)).
-		Cookie(c.cookieAllocator.Request(category).Raw()).
-		Done())
-	flows = append(flows, c.pipeline[L2ForwardingOutTable].BuildFlow(priorityNormal+2).
-		MatchIPDscp(dataplaneTag).
-		SetHardTimeout(300).
-		MatchProtocol(binding.ProtocolIPv6).
-		MatchRegRange(int(marksReg), portFoundMark, ofPortMarkRange).
-		Action().SendToController(uint8(PacketInReasonTF)).
-		Cookie(c.cookieAllocator.Request(category).Raw()).
-		Done())
 	return flows
 }
 

--- a/pkg/apis/ops/v1alpha1/types.go
+++ b/pkg/apis/ops/v1alpha1/types.go
@@ -44,6 +44,9 @@ const (
 	Received  TraceflowAction = "Received"
 	Forwarded TraceflowAction = "Forwarded"
 	Dropped   TraceflowAction = "Dropped"
+	// ForwardedOutOfOverlay indicates that the packet has been forwarded out of the network
+	// managed by Antrea. This indicates that the Traceflow request can be considered complete.
+	ForwardedOutOfOverlay TraceflowAction = "ForwardedOutOfOverlay"
 )
 
 // List the supported protocols and their codes in traceflow.

--- a/pkg/controller/traceflow/controller.go
+++ b/pkg/controller/traceflow/controller.go
@@ -288,7 +288,7 @@ func (c *Controller) checkTraceflowStatus(tf *opsv1alpha1.Traceflow) error {
 			if ob.Component == opsv1alpha1.SpoofGuard {
 				sender = true
 			}
-			if ob.Action == opsv1alpha1.Delivered || ob.Action == opsv1alpha1.Dropped {
+			if ob.Action == opsv1alpha1.Delivered || ob.Action == opsv1alpha1.Dropped || ob.Action == opsv1alpha1.ForwardedOutOfOverlay {
 				receiver = true
 			}
 			if ob.TranslatedDstIP != "" {

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 )
 
 func skipIfNotBenchmarkTest(tb testing.TB) {
@@ -78,6 +80,16 @@ func skipIfMissingKernelModule(tb testing.TB, nodeName string, requiredModules [
 		}
 	}
 	tb.Logf("The following modules have been found on Node '%s': %v", nodeName, requiredModules)
+}
+
+func skipIfEncapModeIsNot(tb testing.TB, data *TestData, encapMode config.TrafficEncapModeType) {
+	currentEncapMode, err := data.GetEncapMode()
+	if err != nil {
+		tb.Fatalf("Failed to get encap mode: %v", err)
+	}
+	if currentEncapMode != encapMode {
+		tb.Skipf("Skipping test for encap mode '%s', test requires '%s'", currentEncapMode.String(), encapMode.String())
+	}
 }
 
 func ensureAntreaRunning(tb testing.TB, data *TestData) error {


### PR DESCRIPTION
libOpenflow panics if a packet-in message is sent by OVS with a
NXM_NX_PKT_MARK match field. Since #1816, it is a possible situation:
Traceflow requests for the Node IP can lead to reply traffic with the
packet mark set, which are sent to the Antrea Agent as a PacketIn
message. To resolve this issue, we first switch temporarily to a patched
libOpenflow version without this issue. When the patch is ported in
upstream libOpenflow, we can remove the replace directive from go.mod.

However, it should be noted that reply packets for Traceflow requests
are generally meaningless and should be ignored. In encapMode, The
Traceflow implementation should also not timeout when a Traceflow
request leaves the overlay: as soon as the request is forwarded through
the gateway port, we should consider the request complete, and ignore
any potential reply packet. So we include the following changes:

* add a new "ForwardedOutOfOverlay" Traceflow action when a request is
  forwarded out of the network managed by Antrea in encapMode. The
  Controller can then mark the request as "succeeded". In theory,
  something similar could be done for other traffic modes, but it would
  be much more complex.
* add support for Traceflow requests for which the destination is the
  gateway's IP, by reporting a "Delivered" action.
* add an OVS flow in charge of dropping reply traffic for Traceflow
  requests (using the conntrack state to match this traffic), thus
  ensuring it is not set to the Agent. In our testing, this is
  especially useful when the destination IP is the local Node's IP, as
  the IP ToS field seems to be preseved in that case, causing the reply
  packet to be treated as a Traceflow request.

We add end-to-end tests for both cases (external destination IP and
Antrea gateway destination IP).

Fixes #1878