### PR TITLE
Fix Traceflow implementation for external IPs and gateway IP

### DIFF
--- a/pkg/agent/controller/traceflow/packetin.go
+++ b/pkg/agent/controller/traceflow/packetin.go
@@ -224,6 +224,8 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*opsv1alpha1.Tracefl
 			ob.Action = opsv1alpha1.Delivered
 		} else if c.networkConfig.TrafficEncapMode.SupportsEncap() && outputPort == config.HostGatewayOFPort {
 			ob.Action = opsv1alpha1.ForwardedOutOfOverlay
+		} else if outputPort == config.HostGatewayOFPort { // noEncap
+			ob.Action = opsv1alpha1.Forwarded
 		} else {
 			// Output port is Pod port, packet is delivered.
 			ob.Action = opsv1alpha1.Delivered

--- a/pkg/agent/controller/traceflow/packetin.go
+++ b/pkg/agent/controller/traceflow/packetin.go
@@ -213,11 +213,17 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*opsv1alpha1.Tracefl
 				return nil, nil, err
 			}
 		}
-		if (c.networkConfig.TrafficEncapMode.SupportsEncap() && outputPort == config.DefaultTunOFPort) || outputPort == config.HostGatewayOFPort {
-			// Output port is Tunnel/Gateway port, packet is forwarded.
-			// tunnelDstIP is valid IP in encapMode, and empty string in other modes.
+		gatewayIP := c.nodeConfig.GatewayConfig.IPv4
+		if pktIn.Data.Ethertype == protocol.IPv6_MSG {
+			gatewayIP = c.nodeConfig.GatewayConfig.IPv6
+		}
+		if c.networkConfig.TrafficEncapMode.SupportsEncap() && outputPort == config.DefaultTunOFPort {
 			ob.TunnelDstIP = tunnelDstIP
 			ob.Action = opsv1alpha1.Forwarded
+		} else if ipDst == gatewayIP.String() && outputPort == config.HostGatewayOFPort {
+			ob.Action = opsv1alpha1.Delivered
+		} else if c.networkConfig.TrafficEncapMode.SupportsEncap() && outputPort == config.HostGatewayOFPort {
+			ob.Action = opsv1alpha1.ForwardedOutOfOverlay
 		} else {
 			// Output port is Pod port, packet is delivered.
 			ob.Action = opsv1alpha1.Delivered

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -854,7 +854,9 @@ func (c *client) traceflowL2ForwardOutputFlows(dataplaneTag uint8, category cook
 				Action().SendToController(uint8(PacketInReasonTF)).
 				Cookie(c.cookieAllocator.Request(category).Raw()).
 				Done())
-			// Only SendToController if output port is local gateway.
+			// Only SendToController if output port is local gateway. In encapMode, a
+			// Traceflow packet going out of the gateway port (i.e. exiting the overlay)
+			// essentially means that the Traceflow request is complete.
 			flows = append(flows, c.pipeline[L2ForwardingOutTable].BuildFlow(priorityNormal+2).
 				MatchReg(int(PortCacheReg), config.HostGatewayOFPort).
 				MatchIPDscp(dataplaneTag).
@@ -865,7 +867,9 @@ func (c *client) traceflowL2ForwardOutputFlows(dataplaneTag uint8, category cook
 				Cookie(c.cookieAllocator.Request(category).Raw()).
 				Done())
 		} else {
-			// SendToController and Output if output port is local gateway.
+			// SendToController and Output if output port is local gateway. Unlike in
+			// encapMode, inter-Node Pod-to-Pod traffic is expected to go out of the
+			// gateway port on the way to its destination.
 			flows = append(flows, c.pipeline[L2ForwardingOutTable].BuildFlow(priorityNormal+2).
 				MatchReg(int(PortCacheReg), config.HostGatewayOFPort).
 				MatchIPDscp(dataplaneTag).

--- a/pkg/apis/ops/v1alpha1/types.go
+++ b/pkg/apis/ops/v1alpha1/types.go
@@ -44,6 +44,9 @@ const (
 	Received  TraceflowAction = "Received"
 	Forwarded TraceflowAction = "Forwarded"
 	Dropped   TraceflowAction = "Dropped"
+	// ForwardedOutOfOverlay indicates that the packet has been forwarded out of the network
+	// managed by Antrea. This indicates that the Traceflow request can be considered complete.
+	ForwardedOutOfOverlay TraceflowAction = "ForwardedOutOfOverlay"
 )
 
 // List the supported protocols and their codes in traceflow.

--- a/pkg/controller/traceflow/controller.go
+++ b/pkg/controller/traceflow/controller.go
@@ -288,7 +288,7 @@ func (c *Controller) checkTraceflowStatus(tf *opsv1alpha1.Traceflow) error {
 			if ob.Component == opsv1alpha1.SpoofGuard {
 				sender = true
 			}
-			if ob.Action == opsv1alpha1.Delivered || ob.Action == opsv1alpha1.Dropped {
+			if ob.Action == opsv1alpha1.Delivered || ob.Action == opsv1alpha1.Dropped || ob.Action == opsv1alpha1.ForwardedOutOfOverlay {
 				receiver = true
 			}
 			if ob.TranslatedDstIP != "" {

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 )
 
 func skipIfNotBenchmarkTest(tb testing.TB) {
@@ -78,6 +80,16 @@ func skipIfMissingKernelModule(tb testing.TB, nodeName string, requiredModules [
 		}
 	}
 	tb.Logf("The following modules have been found on Node '%s': %v", nodeName, requiredModules)
+}
+
+func skipIfEncapModeIsNot(tb testing.TB, data *TestData, encapMode config.TrafficEncapModeType) {
+	currentEncapMode, err := data.GetEncapMode()
+	if err != nil {
+		tb.Fatalf("Failed to get encap mode: %v", err)
+	}
+	if currentEncapMode != encapMode {
+		tb.Skipf("Skipping test for encap mode '%s', test requires '%s'", currentEncapMode.String(), encapMode.String())
+	}
 }
 
 func ensureAntreaRunning(tb testing.TB, data *TestData) error {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -231,7 +231,7 @@ func nodeName(idx int) string {
 	}
 }
 
-// nodeName returns an empty string if there is no Node with the provided idx. If idx is 0, the IP
+// nodeIP returns an empty string if there is no Node with the provided idx. If idx is 0, the IP
 // of the control-plane Node will be returned.
 func nodeIP(idx int) string {
 	if node, ok := clusterInfo.nodes[idx]; !ok {


### PR DESCRIPTION
PR #1883 fixes a panic in libOpenflow triggered when OVS receives reply
traffic for a Traceflow request with a valid dataplane tag as the ToS
field and the Linux packet mark set. However, it should be noted that
reply packets for Traceflow requests are generally meaningless and
should be ignored. In encapMode, The Traceflow implementation should
also not timeout when a Traceflow request leaves the overlay: as soon as
the request is forwarded through the gateway port, we should consider
the request complete, and ignore any potential reply packet. So we
include the following changes:

* add a new "ForwardedOutOfOverlay" Traceflow action when a request is
  forwarded out of the network managed by Antrea in encapMode. The
  Controller can then mark the request as "succeeded". In theory,
  something similar could be done for other traffic modes, but it would
  be much more complex.
* add support for Traceflow requests for which the destination is the
  gateway's IP, by reporting a "Delivered" action.
* add an OVS flow in charge of dropping reply traffic for Traceflow
  requests (using the conntrack state to match this traffic), thus
  ensuring it is not sent to the Agent. In our testing, this is
  especially useful when the destination IP is the local Node's IP, as
  the IP ToS field seems to be preseved in that case, causing the reply
  packet to be treated as a Traceflow request.

We add end-to-end tests for both cases (external destination IP and
Antrea gateway destination IP).

See #1878