### PR TITLE
[IPv6] Use localhost and add IPv6 loopback addresses

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1574,7 +1574,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
-            host: 127.0.0.1
+            host: localhost
             path: /livez
             port: api
             scheme: HTTPS
@@ -1588,7 +1588,7 @@ spec:
         readinessProbe:
           failureThreshold: 5
           httpGet:
-            host: 127.0.0.1
+            host: localhost
             path: /readyz
             port: api
             scheme: HTTPS
@@ -1770,7 +1770,7 @@ spec:
         readinessProbe:
           failureThreshold: 5
           httpGet:
-            host: 127.0.0.1
+            host: localhost
             path: /readyz
             port: api
             scheme: HTTPS

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1574,7 +1574,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
-            host: 127.0.0.1
+            host: localhost
             path: /livez
             port: api
             scheme: HTTPS
@@ -1588,7 +1588,7 @@ spec:
         readinessProbe:
           failureThreshold: 5
           httpGet:
-            host: 127.0.0.1
+            host: localhost
             path: /readyz
             port: api
             scheme: HTTPS
@@ -1772,7 +1772,7 @@ spec:
         readinessProbe:
           failureThreshold: 5
           httpGet:
-            host: 127.0.0.1
+            host: localhost
             path: /readyz
             port: api
             scheme: HTTPS

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1574,7 +1574,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
-            host: 127.0.0.1
+            host: localhost
             path: /livez
             port: api
             scheme: HTTPS
@@ -1588,7 +1588,7 @@ spec:
         readinessProbe:
           failureThreshold: 5
           httpGet:
-            host: 127.0.0.1
+            host: localhost
             path: /readyz
             port: api
             scheme: HTTPS
@@ -1770,7 +1770,7 @@ spec:
         readinessProbe:
           failureThreshold: 5
           httpGet:
-            host: 127.0.0.1
+            host: localhost
             path: /readyz
             port: api
             scheme: HTTPS

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1588,7 +1588,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
-            host: 127.0.0.1
+            host: localhost
             path: /livez
             port: api
             scheme: HTTPS
@@ -1602,7 +1602,7 @@ spec:
         readinessProbe:
           failureThreshold: 5
           httpGet:
-            host: 127.0.0.1
+            host: localhost
             path: /readyz
             port: api
             scheme: HTTPS
@@ -1819,7 +1819,7 @@ spec:
         readinessProbe:
           failureThreshold: 5
           httpGet:
-            host: 127.0.0.1
+            host: localhost
             path: /readyz
             port: api
             scheme: HTTPS

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1579,7 +1579,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
-            host: 127.0.0.1
+            host: localhost
             path: /livez
             port: api
             scheme: HTTPS
@@ -1593,7 +1593,7 @@ spec:
         readinessProbe:
           failureThreshold: 5
           httpGet:
-            host: 127.0.0.1
+            host: localhost
             path: /readyz
             port: api
             scheme: HTTPS
@@ -1775,7 +1775,7 @@ spec:
         readinessProbe:
           failureThreshold: 5
           httpGet:
-            host: 127.0.0.1
+            host: localhost
             path: /readyz
             port: api
             scheme: HTTPS

--- a/build/yamls/base/agent.yml
+++ b/build/yamls/base/agent.yml
@@ -99,7 +99,7 @@ spec:
             failureThreshold: 5
           readinessProbe:
             httpGet:
-              host: 127.0.0.1
+              host: localhost
               path: /readyz
               port: api
               scheme: HTTPS

--- a/build/yamls/base/controller.yml
+++ b/build/yamls/base/controller.yml
@@ -248,7 +248,7 @@ spec:
               protocol: TCP
           readinessProbe:
             httpGet:
-              host: 127.0.0.1
+              host: localhost
               path: /readyz
               port: api
               scheme: HTTPS
@@ -258,7 +258,7 @@ spec:
             failureThreshold: 5
           livenessProbe:
             httpGet:
-              host: 127.0.0.1
+              host: localhost
               path: /livez
               port: api
               scheme: HTTPS

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -249,7 +249,7 @@ func createAPIServerConfig(kubeconfig string,
 	}
 
 	secureServing.BindPort = bindPort
-	secureServing.BindAddress = net.ParseIP("0.0.0.0")
+	secureServing.BindAddress = net.IPv4zero
 	// kubeconfig file is useful when antrea-controller isn't not running as a pod, like during development.
 	if len(kubeconfig) > 0 {
 		authentication.RemoteKubeConfigFile = kubeconfig

--- a/pkg/agent/apiserver/apiserver.go
+++ b/pkg/agent/apiserver/apiserver.go
@@ -124,10 +124,10 @@ func newConfig(bindPort int, enableMetrics bool, kubeconfig string) (*genericapi
 	// Set the PairName but leave certificate directory blank to generate in-memory by default.
 	secureServing.ServerCert.CertDirectory = ""
 	secureServing.ServerCert.PairName = Name
-	secureServing.BindAddress = net.ParseIP("0.0.0.0")
+	secureServing.BindAddress = net.IPv4zero
 	secureServing.BindPort = bindPort
 
-	if err := secureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
+	if err := secureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
 	serverConfig := genericapiserver.NewConfig(codecs)

--- a/pkg/apiserver/certificate/certificate.go
+++ b/pkg/apiserver/certificate/certificate.go
@@ -130,7 +130,7 @@ func generateSelfSignedCertificate(secureServing *options.SecureServingOptionsWi
 	secureServing.ServerCert.CertDirectory = selfSignedCertDir
 	secureServing.ServerCert.PairName = "antrea-controller"
 
-	if err := secureServing.MaybeDefaultWithSelfSignedCerts("antrea", GetAntreaServerNames(), []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
+	if err := secureServing.MaybeDefaultWithSelfSignedCerts("antrea", GetAntreaServerNames(), []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
 
@@ -192,7 +192,7 @@ func rotateSelfSignedCertificates(c *CACertController, secureServing *options.Se
 }
 
 func generateNewServingCertificate(secureServing *options.SecureServingOptionsWithLoopback) error {
-	cert, key, err := certutil.GenerateSelfSignedCertKeyWithFixtures("antrea", []net.IP{net.ParseIP("127.0.0.1")}, GetAntreaServerNames(), secureServing.ServerCert.FixtureDirectory)
+	cert, key, err := certutil.GenerateSelfSignedCertKeyWithFixtures("antrea", []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback}, GetAntreaServerNames(), secureServing.ServerCert.FixtureDirectory)
 	if err != nil {
 		return fmt.Errorf("unable to generate self signed cert: %v", err)
 	}

--- a/pkg/apiserver/certificate/certificate_test.go
+++ b/pkg/apiserver/certificate/certificate_test.go
@@ -28,7 +28,6 @@ import (
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/keyutil"
-
 	fakeaggregatorclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
 )
 


### PR DESCRIPTION
* Used "localhost" instead of "127.0.0.1" in antrea.yml
* Added IPv6 loopback address in alternate IPs
* Replaced some net IPs with pre-defined vars.