### PR TITLE
Delete IPTABLES rules for NodePortLocal when nplPortRange is updated

### DIFF
--- a/pkg/agent/nodeportlocal/k8s/npl_controller.go
+++ b/pkg/agent/nodeportlocal/k8s/npl_controller.go
@@ -509,10 +509,8 @@ func (c *NPLController) GetPodsAndGenRules() error {
 		}
 	}
 
-	if len(allNPLPorts) > 0 {
-		if err := c.addRulesForNPLPorts(allNPLPorts); err != nil {
-			return err
-		}
+	if err := c.addRulesForNPLPorts(allNPLPorts); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
If we change nplPortRange and Antrea Agent is rebooted, rules with Node Port outside
current port range are supposed to be deleted. But we face a problem if all rules
have to be deleted from NPL chain. In that case we were skipping IPTABLES update -
because length of allNPLPorts in GetPodsAndGenRules function was getting set to zero.

Removed this length check so that even if all rules have to be deleted, the function
addRulesForNPLPorts is executed.