### PR TITLE
Reject action support

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -172,6 +172,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:
@@ -227,6 +228,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:
@@ -419,6 +421,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:
@@ -471,6 +474,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -172,6 +172,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:
@@ -227,6 +228,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:
@@ -419,6 +421,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:
@@ -471,6 +474,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -172,6 +172,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:
@@ -227,6 +228,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:
@@ -419,6 +421,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:
@@ -471,6 +474,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -172,6 +172,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:
@@ -227,6 +228,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:
@@ -419,6 +421,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:
@@ -471,6 +474,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -172,6 +172,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:
@@ -227,6 +228,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:
@@ -419,6 +421,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:
@@ -471,6 +474,7 @@ spec:
                       enum:
                       - Allow
                       - Drop
+                      - Reject
                       type: string
                     appliedTo:
                       items:

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -343,10 +343,10 @@ spec:
                               x-kubernetes-preserve-unknown-fields: true
                             group:
                               type: string
-                      # Ensure that Action field allows only ALLOW and DROP values
+                      # Ensure that Action field allows only ALLOW, DROP and REJECT values
                       action:
                         type: string
-                        enum: ['Allow', 'Drop']
+                        enum: ['Allow', 'Drop', 'Reject']
                       ports:
                         type: array
                         items:
@@ -398,10 +398,10 @@ spec:
                               x-kubernetes-preserve-unknown-fields: true
                             group:
                               type: string
-                      # Ensure that Action field allows only ALLOW and DROP values
+                      # Ensure that Action field allows only ALLOW, DROP and REJECT values
                       action:
                         type: string
-                        enum: ['Allow', 'Drop']
+                        enum: ['Allow', 'Drop', 'Reject']
                       ports:
                         type: array
                         items:
@@ -533,10 +533,10 @@ spec:
                             podSelector:
                               type: object
                               x-kubernetes-preserve-unknown-fields: true
-                      # Ensure that Action field allows only ALLOW and DROP values
+                      # Ensure that Action field allows only ALLOW, DROP and REJECT values
                       action:
                         type: string
-                        enum: ['Allow', 'Drop']
+                        enum: ['Allow', 'Drop', 'Reject']
                       ports:
                         type: array
                         items:
@@ -585,10 +585,10 @@ spec:
                             podSelector:
                               type: object
                               x-kubernetes-preserve-unknown-fields: true
-                      # Ensure that Action field allows only ALLOW and DROP values
+                      # Ensure that Action field allows only ALLOW, DROP and REJECT values
                       action:
                         type: string
-                        enum: ['Allow', 'Drop']
+                        enum: ['Allow', 'Drop', 'Reject']
                       ports:
                         type: array
                         items:

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -87,6 +87,7 @@ type Controller struct {
 	appliedToGroupWatcher *watcher
 	addressGroupWatcher   *watcher
 	fullSyncGroup         sync.WaitGroup
+	ifaceStore            interfacestore.InterfaceStore
 }
 
 // NewNetworkPolicyController returns a new *Controller.
@@ -310,6 +311,7 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 		fullSyncWaitGroup: &c.fullSyncGroup,
 		fullSynced:        false,
 	}
+	c.ifaceStore = ifaceStore
 	return c, nil
 }
 

--- a/pkg/agent/controller/networkpolicy/packetin.go
+++ b/pkg/agent/controller/networkpolicy/packetin.go
@@ -300,7 +300,7 @@ func getTCPHeaderData(ipPkt util.Message) (TCPSrcPort uint16, TCPDstPort uint16,
 	return tcpIn.PortDst, tcpIn.PortSrc, 0, tcpIn.SeqNum + 1, nil
 }
 
-// getBasePacketOutBuilder gets a base IP packetOutBuilder with src&dst MAC, IP and OFPort settled.
+// getBasePacketOutBuilder gets a base IP packetOutBuilder with src&dst MAC, IP and OFPort set.
 func (c *Controller) getBasePacketOutBuilder(srcMAC string, dstMAC string, srcIP string, dstIP string) (binding.PacketOutBuilder, error) {
 
 	// Get the OpenFlow ports of src Pod and dst Pod.

--- a/pkg/agent/controller/networkpolicy/packetin_test.go
+++ b/pkg/agent/controller/networkpolicy/packetin_test.go
@@ -86,10 +86,10 @@ func TestGetTCPHeaderData(t *testing.T) {
 					SeqNum:  0,
 					AckNum:  0,
 				},
-				expectTCPSrcPort: 80,
-				expectTCPDstPort: 1080,
+				expectTCPSrcPort: 1080,
+				expectTCPDstPort: 80,
 				expectTCPSeqNum:  0,
-				expectTCPAckNum:  1,
+				expectTCPAckNum:  0,
 			},
 			wantErr: false,
 		},
@@ -103,15 +103,15 @@ func TestGetTCPHeaderData(t *testing.T) {
 			bf.UnmarshalBinary(bytes)
 			pktIn.Data = bf
 
-			TCPSrcPort, TCPDstPort, TCPSeqNum, TCPAckNum, err := getTCPHeaderData(pktIn)
+			tcpSrcPort, tcpDstPort, tcpSeqNum, tcpAckNum, err := getTCPHeaderData(pktIn)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getPacketInfo() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			assert.Equal(t, tt.args.expectTCPSrcPort, TCPSrcPort, "Expect to retrieve exact TCP src port while differed")
-			assert.Equal(t, tt.args.expectTCPDstPort, TCPDstPort, "Expect to retrieve exact TCP dst port while differed")
-			assert.Equal(t, tt.args.expectTCPSeqNum, TCPSeqNum, "Expect to retrieve exact TCP seq num while differed")
-			assert.Equal(t, tt.args.expectTCPAckNum, TCPAckNum, "Expect to retrieve exact TCP ack num while differed")
+			assert.Equal(t, tt.args.expectTCPSrcPort, tcpSrcPort, "Expect to retrieve exact TCP src port while differed")
+			assert.Equal(t, tt.args.expectTCPDstPort, tcpDstPort, "Expect to retrieve exact TCP dst port while differed")
+			assert.Equal(t, tt.args.expectTCPSeqNum, tcpSeqNum, "Expect to retrieve exact TCP seq num while differed")
+			assert.Equal(t, tt.args.expectTCPAckNum, tcpAckNum, "Expect to retrieve exact TCP ack num while differed")
 		})
 	}
 }

--- a/pkg/agent/controller/networkpolicy/packetin_test.go
+++ b/pkg/agent/controller/networkpolicy/packetin_test.go
@@ -63,3 +63,55 @@ func TestGetPacketInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestGetTCPHeaderData(t *testing.T) {
+	type args struct {
+		tcp              protocol.TCP
+		expectTCPSrcPort uint16
+		expectTCPDstPort uint16
+		expectTCPSeqNum  uint32
+		expectTCPAckNum  uint32
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "ipv4",
+			args: args{
+				tcp: protocol.TCP{
+					PortSrc: 1080,
+					PortDst: 80,
+					SeqNum:  0,
+					AckNum:  0,
+				},
+				expectTCPSrcPort: 80,
+				expectTCPDstPort: 1080,
+				expectTCPSeqNum:  0,
+				expectTCPAckNum:  1,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tcp := tt.args.tcp
+			pktIn := new(protocol.IPv4)
+			bytes, _ := tcp.MarshalBinary()
+			bf := new(util.Buffer)
+			bf.UnmarshalBinary(bytes)
+			pktIn.Data = bf
+
+			TCPSrcPort, TCPDstPort, TCPSeqNum, TCPAckNum, err := getTCPHeaderData(pktIn)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getPacketInfo() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equal(t, tt.args.expectTCPSrcPort, TCPSrcPort, "Expect to retrieve exact TCP src port while differed")
+			assert.Equal(t, tt.args.expectTCPDstPort, TCPDstPort, "Expect to retrieve exact TCP dst port while differed")
+			assert.Equal(t, tt.args.expectTCPSeqNum, TCPSeqNum, "Expect to retrieve exact TCP seq num while differed")
+			assert.Equal(t, tt.args.expectTCPAckNum, TCPAckNum, "Expect to retrieve exact TCP ack num while differed")
+		})
+	}
+}

--- a/pkg/agent/controller/traceflow/packetin.go
+++ b/pkg/agent/controller/traceflow/packetin.go
@@ -179,12 +179,12 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*opsv1alpha1.Tracefl
 	// Get drop table.
 	if tableID == uint8(openflow.EgressMetricTable) || tableID == uint8(openflow.IngressMetricTable) {
 		ob := getNetworkPolicyObservation(tableID, tableID == uint8(openflow.IngressMetricTable))
-		if match = getMatchRegField(matchers, uint32(openflow.CNPDropConjunctionIDReg)); match != nil {
-			dropConjInfo, err := getRegValue(match, nil)
+		if match = getMatchRegField(matchers, uint32(openflow.CNPNotAllowConjIDReg)); match != nil {
+			notAllowConjInfo, err := getRegValue(match, nil)
 			if err != nil {
 				return nil, nil, err
 			}
-			npRef := c.networkPolicyQuerier.GetNetworkPolicyByRuleFlowID(dropConjInfo)
+			npRef := c.networkPolicyQuerier.GetNetworkPolicyByRuleFlowID(notAllowConjInfo)
 			if npRef != nil {
 				ob.NetworkPolicy = npRef.ToString()
 			}

--- a/pkg/agent/controller/traceflow/packetin.go
+++ b/pkg/agent/controller/traceflow/packetin.go
@@ -179,7 +179,7 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*opsv1alpha1.Tracefl
 	// Get drop table.
 	if tableID == uint8(openflow.EgressMetricTable) || tableID == uint8(openflow.IngressMetricTable) {
 		ob := getNetworkPolicyObservation(tableID, tableID == uint8(openflow.IngressMetricTable))
-		if match = getMatchRegField(matchers, uint32(openflow.CNPNotAllowConjIDReg)); match != nil {
+		if match = getMatchRegField(matchers, uint32(openflow.CNPDenyConjIDReg)); match != nil {
 			notAllowConjInfo, err := getRegValue(match, nil)
 			if err != nil {
 				return nil, nil, err

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -480,7 +480,7 @@ func prepareTraceflowFlow(ctrl *gomock.Controller) *client {
 	mFlow.EXPECT().FlowProtocol().Return(ofconfig.Protocol("ip"))
 	mFlow.EXPECT().CopyToBuilder(priorityNormal+2, false).Return(c.pipeline[EgressDefaultTable].BuildFlow(priorityNormal + 2)).Times(1)
 	c.globalConjMatchFlowCache["mockContext"] = ctx
-	c.policyCache.Add(&policyRuleConjunction{metricFlows: []ofconfig.Flow{c.notAllowRuleMetricFlow(123, false)}})
+	c.policyCache.Add(&policyRuleConjunction{metricFlows: []ofconfig.Flow{c.denyRuleMetricFlow(123, false)}})
 	return c
 }
 

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -480,7 +480,7 @@ func prepareTraceflowFlow(ctrl *gomock.Controller) *client {
 	mFlow.EXPECT().FlowProtocol().Return(ofconfig.Protocol("ip"))
 	mFlow.EXPECT().CopyToBuilder(priorityNormal+2, false).Return(c.pipeline[EgressDefaultTable].BuildFlow(priorityNormal + 2)).Times(1)
 	c.globalConjMatchFlowCache["mockContext"] = ctx
-	c.policyCache.Add(&policyRuleConjunction{metricFlows: []ofconfig.Flow{c.dropRuleMetricFlow(123, false)}})
+	c.policyCache.Add(&policyRuleConjunction{metricFlows: []ofconfig.Flow{c.notAllowRuleMetricFlow(123, false)}})
 	return c
 }
 
@@ -488,6 +488,93 @@ func prepareSendTraceflowPacket(ctrl *gomock.Controller, success bool) *client {
 	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, true, false)
 	c := ofClient.(*client)
 	c.nodeConfig = nodeConfig
+	m := ovsoftest.NewMockBridge(ctrl)
+	c.bridge = m
+	bridge := ofconfig.OFBridge{}
+	m.EXPECT().BuildPacketOut().Return(bridge.BuildPacketOut()).Times(1)
+	if success {
+		m.EXPECT().SendPacketOut(gomock.Any()).Times(1)
+	}
+	return c
+}
+
+func Test_client_GenBasePacketOutBuilder(t *testing.T) {
+	type args struct {
+		srcMAC  string
+		dstMAC  string
+		srcIP   string
+		dstIP   string
+		inPort  uint32
+		outPort uint32
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "err invalidSrcMAC",
+			args: args{
+				srcMAC: "invalidMAC",
+				dstMAC: "11:22:33:44:55:66",
+			},
+			wantErr: true,
+		},
+		{
+			name: "err invalidDstMAC",
+			args: args{
+				srcMAC: "11:22:33:44:55:66",
+				dstMAC: "invalidMAC",
+			},
+			wantErr: true,
+		},
+		{
+			name: "err invalidSrcIP",
+			args: args{
+				srcMAC: "11:22:33:44:55:66",
+				dstMAC: "11:22:33:44:55:77",
+				srcIP:  "invalidIP",
+				dstIP:  "1.2.3.4",
+			},
+			wantErr: true,
+		},
+		{
+			name: "err invalidDstIP",
+			args: args{
+				srcMAC: "11:22:33:44:55:66",
+				dstMAC: "11:22:33:44:55:77",
+				srcIP:  "1.2.3.4",
+				dstIP:  "invalidIP",
+			},
+			wantErr: true,
+		},
+		{
+			name: "err IPVersionMismatch",
+			args: args{
+				srcMAC: "11:22:33:44:55:66",
+				dstMAC: "11:22:33:44:55:77",
+				srcIP:  "1.2.3.4",
+				dstIP:  "1111::5555",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			c := prepareSendRejectPacket(ctrl, !tt.wantErr)
+			_, err := c.GenBasePacketOutBuilder(tt.args.srcMAC, tt.args.dstMAC, tt.args.srcIP, tt.args.dstIP, tt.args.inPort, tt.args.outPort)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SendRejectPacket() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func prepareSendRejectPacket(ctrl *gomock.Controller, success bool) *client {
+	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, true)
+	c := ofClient.(*client)
 	m := ovsoftest.NewMockBridge(ctrl)
 	c.bridge = m
 	bridge := ofconfig.OFBridge{}

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -498,14 +498,14 @@ func prepareSendTraceflowPacket(ctrl *gomock.Controller, success bool) *client {
 	return c
 }
 
-func Test_client_GenBasePacketOutBuilder(t *testing.T) {
+func Test_client_setBasePacketOutBuilder(t *testing.T) {
 	type args struct {
 		srcMAC  string
 		dstMAC  string
 		srcIP   string
 		dstIP   string
 		inPort  uint32
-		outPort uint32
+		outPort int32
 	}
 	tests := []struct {
 		name    string
@@ -563,17 +563,17 @@ func Test_client_GenBasePacketOutBuilder(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			c := prepareSendRejectPacket(ctrl, !tt.wantErr)
-			_, err := c.GenBasePacketOutBuilder(tt.args.srcMAC, tt.args.dstMAC, tt.args.srcIP, tt.args.dstIP, tt.args.inPort, tt.args.outPort)
+			c := prepareSetBasePacketOutBuilder(ctrl, !tt.wantErr)
+			_, err := setBasePacketOutBuilder(c.bridge.BuildPacketOut(), tt.args.srcMAC, tt.args.dstMAC, tt.args.srcIP, tt.args.dstIP, tt.args.inPort, tt.args.outPort)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("SendRejectPacket() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("setBasePacketOutBuilder() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
 }
 
-func prepareSendRejectPacket(ctrl *gomock.Controller, success bool) *client {
-	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, true)
+func prepareSetBasePacketOutBuilder(ctrl *gomock.Controller, success bool) *client {
+	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, true, false)
 	c := ofClient.(*client)
 	m := ovsoftest.NewMockBridge(ctrl)
 	c.bridge = m

--- a/pkg/agent/openflow/network_policy.go
+++ b/pkg/agent/openflow/network_policy.go
@@ -868,10 +868,10 @@ func (c *client) calculateActionFlowChangesForRule(rule *types.PolicyRule) *poli
 		var actionFlows []binding.Flow
 		var metricFlows []binding.Flow
 		if rule.IsAntreaNetworkPolicyRule() && *rule.Action == secv1alpha1.RuleActionDrop {
-			metricFlows = append(metricFlows, c.notAllowRuleMetricFlow(ruleOfID, isIngress))
+			metricFlows = append(metricFlows, c.denyRuleMetricFlow(ruleOfID, isIngress))
 			actionFlows = append(actionFlows, c.conjunctionActionDropFlow(ruleOfID, ruleTable.GetID(), rule.Priority, rule.EnableLogging))
 		} else if rule.IsAntreaNetworkPolicyRule() && *rule.Action == secv1alpha1.RuleActionReject {
-			metricFlows = append(metricFlows, c.notAllowRuleMetricFlow(ruleOfID, isIngress))
+			metricFlows = append(metricFlows, c.denyRuleMetricFlow(ruleOfID, isIngress))
 			actionFlows = append(actionFlows, c.conjunctionActionRejectFlow(ruleOfID, ruleTable.GetID(), rule.Priority, rule.EnableLogging))
 		} else {
 			metricFlows = append(metricFlows, c.allowRulesMetricFlows(ruleOfID, isIngress)...)

--- a/pkg/agent/openflow/network_policy.go
+++ b/pkg/agent/openflow/network_policy.go
@@ -868,8 +868,11 @@ func (c *client) calculateActionFlowChangesForRule(rule *types.PolicyRule) *poli
 		var actionFlows []binding.Flow
 		var metricFlows []binding.Flow
 		if rule.IsAntreaNetworkPolicyRule() && *rule.Action == secv1alpha1.RuleActionDrop {
-			metricFlows = append(metricFlows, c.dropRuleMetricFlow(ruleOfID, isIngress))
+			metricFlows = append(metricFlows, c.notAllowRuleMetricFlow(ruleOfID, isIngress))
 			actionFlows = append(actionFlows, c.conjunctionActionDropFlow(ruleOfID, ruleTable.GetID(), rule.Priority, rule.EnableLogging))
+		} else if rule.IsAntreaNetworkPolicyRule() && *rule.Action == secv1alpha1.RuleActionReject {
+			metricFlows = append(metricFlows, c.notAllowRuleMetricFlow(ruleOfID, isIngress))
+			actionFlows = append(actionFlows, c.conjunctionActionRejectFlow(ruleOfID, ruleTable.GetID(), rule.Priority, rule.EnableLogging))
 		} else {
 			metricFlows = append(metricFlows, c.allowRulesMetricFlows(ruleOfID, isIngress)...)
 			actionFlows = append(actionFlows, c.conjunctionActionFlow(ruleOfID, ruleTable.GetID(), dropTable.GetNext(), rule.Priority, rule.EnableLogging)...)

--- a/pkg/agent/openflow/network_policy.go
+++ b/pkg/agent/openflow/network_policy.go
@@ -869,10 +869,10 @@ func (c *client) calculateActionFlowChangesForRule(rule *types.PolicyRule) *poli
 		var metricFlows []binding.Flow
 		if rule.IsAntreaNetworkPolicyRule() && *rule.Action == secv1alpha1.RuleActionDrop {
 			metricFlows = append(metricFlows, c.denyRuleMetricFlow(ruleOfID, isIngress))
-			actionFlows = append(actionFlows, c.conjunctionActionDropFlow(ruleOfID, ruleTable.GetID(), rule.Priority, rule.EnableLogging))
+			actionFlows = append(actionFlows, c.conjunctionActionDenyFlow(ruleOfID, ruleTable.GetID(), rule.Priority, DispositionDrop, rule.EnableLogging))
 		} else if rule.IsAntreaNetworkPolicyRule() && *rule.Action == secv1alpha1.RuleActionReject {
 			metricFlows = append(metricFlows, c.denyRuleMetricFlow(ruleOfID, isIngress))
-			actionFlows = append(actionFlows, c.conjunctionActionRejectFlow(ruleOfID, ruleTable.GetID(), rule.Priority, rule.EnableLogging))
+			actionFlows = append(actionFlows, c.conjunctionActionDenyFlow(ruleOfID, ruleTable.GetID(), rule.Priority, DispositionRej, rule.EnableLogging))
 		} else {
 			metricFlows = append(metricFlows, c.allowRulesMetricFlows(ruleOfID, isIngress)...)
 			actionFlows = append(actionFlows, c.conjunctionActionFlow(ruleOfID, ruleTable.GetID(), dropTable.GetNext(), rule.Priority, rule.EnableLogging)...)

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -123,6 +123,21 @@ func (mr *MockClientMockRecorder) Disconnect() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Disconnect", reflect.TypeOf((*MockClient)(nil).Disconnect))
 }
 
+// GenBasePacketOutBuilder mocks base method
+func (m *MockClient) GenBasePacketOutBuilder(arg0, arg1, arg2, arg3 string, arg4, arg5 uint32) (openflow.PacketOutBuilder, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GenBasePacketOutBuilder", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret0, _ := ret[0].(openflow.PacketOutBuilder)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GenBasePacketOutBuilder indicates an expected call of GenBasePacketOutBuilder
+func (mr *MockClientMockRecorder) GenBasePacketOutBuilder(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenBasePacketOutBuilder", reflect.TypeOf((*MockClient)(nil).GenBasePacketOutBuilder), arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
 // GetFlowTableStatus mocks base method
 func (m *MockClient) GetFlowTableStatus() []openflow.TableStatus {
 	m.ctrl.T.Helper()
@@ -525,6 +540,34 @@ func (m *MockClient) ReplayFlows() {
 func (mr *MockClientMockRecorder) ReplayFlows() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplayFlows", reflect.TypeOf((*MockClient)(nil).ReplayFlows))
+}
+
+// SendICMPReject mocks base method
+func (m *MockClient) SendICMPReject(arg0 openflow.PacketOutBuilder, arg1 []byte, arg2 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendICMPReject", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendICMPReject indicates an expected call of SendICMPReject
+func (mr *MockClientMockRecorder) SendICMPReject(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendICMPReject", reflect.TypeOf((*MockClient)(nil).SendICMPReject), arg0, arg1, arg2)
+}
+
+// SendTCPReject mocks base method
+func (m *MockClient) SendTCPReject(arg0 openflow.PacketOutBuilder, arg1, arg2 uint16, arg3, arg4 uint32, arg5 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendTCPReject", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendTCPReject indicates an expected call of SendTCPReject
+func (mr *MockClientMockRecorder) SendTCPReject(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTCPReject", reflect.TypeOf((*MockClient)(nil).SendTCPReject), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // SendTraceflowPacket mocks base method

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -123,21 +123,6 @@ func (mr *MockClientMockRecorder) Disconnect() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Disconnect", reflect.TypeOf((*MockClient)(nil).Disconnect))
 }
 
-// GenBasePacketOutBuilder mocks base method
-func (m *MockClient) GenBasePacketOutBuilder(arg0, arg1, arg2, arg3 string, arg4, arg5 uint32) (openflow.PacketOutBuilder, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenBasePacketOutBuilder", arg0, arg1, arg2, arg3, arg4, arg5)
-	ret0, _ := ret[0].(openflow.PacketOutBuilder)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GenBasePacketOutBuilder indicates an expected call of GenBasePacketOutBuilder
-func (mr *MockClientMockRecorder) GenBasePacketOutBuilder(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenBasePacketOutBuilder", reflect.TypeOf((*MockClient)(nil).GenBasePacketOutBuilder), arg0, arg1, arg2, arg3, arg4, arg5)
-}
-
 // GetFlowTableStatus mocks base method
 func (m *MockClient) GetFlowTableStatus() []openflow.TableStatus {
 	m.ctrl.T.Helper()
@@ -542,32 +527,32 @@ func (mr *MockClientMockRecorder) ReplayFlows() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplayFlows", reflect.TypeOf((*MockClient)(nil).ReplayFlows))
 }
 
-// SendICMPReject mocks base method
-func (m *MockClient) SendICMPReject(arg0 openflow.PacketOutBuilder, arg1 []byte, arg2 bool) error {
+// SendICMPPacketOut mocks base method
+func (m *MockClient) SendICMPPacketOut(arg0, arg1, arg2, arg3 string, arg4 uint32, arg5 int32, arg6 bool, arg7, arg8 byte, arg9 []byte, arg10 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendICMPReject", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SendICMPPacketOut", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SendICMPReject indicates an expected call of SendICMPReject
-func (mr *MockClientMockRecorder) SendICMPReject(arg0, arg1, arg2 interface{}) *gomock.Call {
+// SendICMPPacketOut indicates an expected call of SendICMPPacketOut
+func (mr *MockClientMockRecorder) SendICMPPacketOut(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendICMPReject", reflect.TypeOf((*MockClient)(nil).SendICMPReject), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendICMPPacketOut", reflect.TypeOf((*MockClient)(nil).SendICMPPacketOut), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
 }
 
-// SendTCPReject mocks base method
-func (m *MockClient) SendTCPReject(arg0 openflow.PacketOutBuilder, arg1, arg2 uint16, arg3, arg4 uint32, arg5 bool) error {
+// SendTCPPacketOut mocks base method
+func (m *MockClient) SendTCPPacketOut(arg0, arg1, arg2, arg3 string, arg4 uint32, arg5 int32, arg6 bool, arg7, arg8 uint16, arg9 uint32, arg10 byte, arg11 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendTCPReject", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "SendTCPPacketOut", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SendTCPReject indicates an expected call of SendTCPReject
-func (mr *MockClientMockRecorder) SendTCPReject(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+// SendTCPPacketOut indicates an expected call of SendTCPPacketOut
+func (mr *MockClientMockRecorder) SendTCPPacketOut(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTCPReject", reflect.TypeOf((*MockClient)(nil).SendTCPReject), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTCPPacketOut", reflect.TypeOf((*MockClient)(nil).SendTCPPacketOut), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)
 }
 
 // SendTraceflowPacket mocks base method

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -30,6 +30,19 @@ const (
 
 	FamilyIPv4 uint8 = 4
 	FamilyIPv6 uint8 = 6
+
+	TCPUrg uint8 = 0b100000
+	TCPAck uint8 = 0b010000
+	TCPPsh uint8 = 0b001000
+	TCPRst uint8 = 0b000100
+	TCPSyn uint8 = 0b000010
+	TCPFin uint8 = 0b000001
+
+	ICMPDstUnreachableType         uint8 = 3
+	ICMPDstHostAdminProhibitedCode uint8 = 10
+
+	ICMPv6DstUnreachableType     uint8 = 1
+	ICMPv6DstAdminProhibitedCode uint8 = 1
 )
 
 func generateInterfaceName(key string, name string, useHead bool) string {

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -30,19 +30,6 @@ const (
 
 	FamilyIPv4 uint8 = 4
 	FamilyIPv6 uint8 = 6
-
-	TCPUrg uint8 = 0b100000
-	TCPAck uint8 = 0b010000
-	TCPPsh uint8 = 0b001000
-	TCPRst uint8 = 0b000100
-	TCPSyn uint8 = 0b000010
-	TCPFin uint8 = 0b000001
-
-	ICMPDstUnreachableType         uint8 = 3
-	ICMPDstHostAdminProhibitedCode uint8 = 10
-
-	ICMPv6DstUnreachableType     uint8 = 1
-	ICMPv6DstAdminProhibitedCode uint8 = 1
 )
 
 func generateInterfaceName(key string, name string, useHead bool) string {

--- a/pkg/apis/ops/v1alpha1/types.go
+++ b/pkg/apis/ops/v1alpha1/types.go
@@ -55,6 +55,7 @@ const (
 	ICMPProtocol int32 = 1
 	TCPProtocol  int32 = 6
 	UDPProtocol  int32 = 17
+	SCTPProtocol int32 = 132
 )
 
 var SupportedProtocols = map[string]int32{
@@ -67,6 +68,7 @@ var ProtocolsToString = map[int32]string{
 	TCPProtocol:  "TCP",
 	UDPProtocol:  "UDP",
 	ICMPProtocol: "ICMP",
+	SCTPProtocol: "SCTP",
 }
 
 // List the supported destination types in traceflow.

--- a/pkg/apis/security/v1alpha1/types.go
+++ b/pkg/apis/security/v1alpha1/types.go
@@ -181,10 +181,13 @@ type NetworkPolicyPort struct {
 type RuleAction string
 
 const (
-	// RuleActionAllow describes that rule matching traffic must be allowed.
+	// RuleActionAllow describes that the traffic matching the rule must be allowed.
 	RuleActionAllow RuleAction = "Allow"
-	// RuleActionDrop describes that rule matching traffic must be dropped.
+	// RuleActionDrop describes that the traffic matching the rule must be dropped.
 	RuleActionDrop RuleAction = "Drop"
+	// RuleActionReject indicates that the traffic matching the rule must be rejected and the
+	// client will receive a response.
+	RuleActionReject RuleAction = "Reject"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -322,12 +322,15 @@ type PacketOutBuilder interface {
 	SetTCPSrcPort(port uint16) PacketOutBuilder
 	SetTCPDstPort(port uint16) PacketOutBuilder
 	SetTCPFlags(flags uint8) PacketOutBuilder
+	SetTCPSeqNum(seqNum uint32) PacketOutBuilder
+	SetTCPAckNum(ackNum uint32) PacketOutBuilder
 	SetUDPSrcPort(port uint16) PacketOutBuilder
 	SetUDPDstPort(port uint16) PacketOutBuilder
 	SetICMPType(icmpType uint8) PacketOutBuilder
 	SetICMPCode(icmpCode uint8) PacketOutBuilder
 	SetICMPID(id uint16) PacketOutBuilder
 	SetICMPSequence(seq uint16) PacketOutBuilder
+	SetICMPData(data []byte) PacketOutBuilder
 	SetInport(inPort uint32) PacketOutBuilder
 	SetOutport(outport uint32) PacketOutBuilder
 	AddLoadAction(name string, data uint64, rng Range) PacketOutBuilder

--- a/test/e2e/reachability.go
+++ b/test/e2e/reachability.go
@@ -55,16 +55,17 @@ func (pod Pod) PodName() string {
 	return podName
 }
 
-type PodConnectivityMark uint8
+type PodConnectivityMark string
 
 const (
-	Connected     PodConnectivityMark = 0
-	UnknownStatus PodConnectivityMark = 1
-	Dropped       PodConnectivityMark = 2
-	Rejected      PodConnectivityMark = 3
+	Connected PodConnectivityMark = "Con"
+	Error     PodConnectivityMark = "Err"
+	Dropped   PodConnectivityMark = "Drp"
+	Rejected  PodConnectivityMark = "Rej"
 
-	RejectProbeReturn string = "Connection refused."
-	DropProbeReturn   string = "Operation timed out."
+	TCPRejectProbeReturn string = "Connection refused."
+	UDPRejectProbeReturn string = "Host is unreachable."
+	DropProbeReturn      string = "Operation timed out."
 )
 
 type Connectivity struct {
@@ -184,7 +185,7 @@ func (ct *ConnectivityTable) PrettyPrint(indent string) string {
 	for _, from := range ct.Items {
 		line := []string{from}
 		for _, to := range ct.Items {
-			val := fmt.Sprintf("%d", ct.Values[from][to])
+			val := fmt.Sprintf("%s", ct.Values[from][to])
 			line = append(line, val)
 		}
 		lines = append(lines, indent+strings.Join(line, "\t"))
@@ -252,7 +253,7 @@ func (r *Reachability) ExpectSelf(allPods []Pod, connectivity PodConnectivityMar
 	}
 }
 
-// ExpectAllIngress defines that any traffic going into the pod will be allowed/dropped/rejected (0/1/2)
+// ExpectAllIngress defines that any traffic going into the pod will be allowed/dropped/rejected
 func (r *Reachability) ExpectAllIngress(pod Pod, connectivity PodConnectivityMark) {
 	r.Expected.SetAllTo(string(pod), connectivity)
 	if connectivity != Connected {
@@ -260,7 +261,7 @@ func (r *Reachability) ExpectAllIngress(pod Pod, connectivity PodConnectivityMar
 	}
 }
 
-// ExpectAllEgress defines that any traffic going out of the pod will be allowed/dropped/rejected (0/1/2)
+// ExpectAllEgress defines that any traffic going out of the pod will be allowed/dropped/rejected
 func (r *Reachability) ExpectAllEgress(pod Pod, connectivity PodConnectivityMark) {
 	r.Expected.SetAllFrom(string(pod), connectivity)
 	if connectivity != Connected {


### PR DESCRIPTION
Reject action is quite similar to the Drop action. Reject action not only drop the request packet, but also send a response to the requesting client to indicate the rejection.
1. Add `Reject` to the YAML.
2. Use register to carry more information in packet-in. Mark the packet-in need logging, rejection or other operations.
3. OpenFlow controller sends reject packet-out to the requesting client.