### PR TITLE
Move go-ipfix to v0.4.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/ti-mo/conntrack v0.3.0
 	github.com/vishvananda/netlink v1.1.0
-	github.com/vmware/go-ipfix v0.4.4
+	github.com/vmware/go-ipfix v0.4.5
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
 	golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495
 	golang.org/x/mod v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -407,8 +407,8 @@ github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYp
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/vmware/go-ipfix v0.4.4 h1:WxbijNZH6F4W9czZ7O/4yWJo3B49MX93NR5dBwJwqiI=
-github.com/vmware/go-ipfix v0.4.4/go.mod h1:lQz3f4r2pZWo0q8s8BtZ0xo5fPSOYsYteqJgBASP69o=
+github.com/vmware/go-ipfix v0.4.5 h1:EwG2bQXKT72IzMOsCcbvP1Po2PncLoSoPuYrHf3YrsI=
+github.com/vmware/go-ipfix v0.4.5/go.mod h1:lQz3f4r2pZWo0q8s8BtZ0xo5fPSOYsYteqJgBASP69o=
 github.com/wenyingd/ofnet v0.0.0-20210205051801-5a4f247248d4 h1:HwolNov6r/aM4zwA3MiSzxJKUTi3MypPOR6PRCTg1sA=
 github.com/wenyingd/ofnet v0.0.0-20210205051801-5a4f247248d4/go.mod h1:8mMMWAYBNUeTGXYKizOLETfN3WIbu3P5DgvS2jiXKdI=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=

--- a/pkg/agent/flowexporter/exporter/exporter_test.go
+++ b/pkg/agent/flowexporter/exporter/exporter_test.go
@@ -62,6 +62,7 @@ func testFlowExporter_sendTemplateSet(t *testing.T, v4Enabled bool, v6Enabled bo
 		0,
 		testTemplateIDv4,
 		testTemplateIDv6,
+		ipfixtest.NewMockIPFIXSet(ctrl),
 		mockIPFIXRegistry,
 		v4Enabled,
 		v6Enabled,
@@ -169,6 +170,7 @@ func testFlowExporter_sendDataSet(t *testing.T, v4Enabled bool, v6Enabled bool) 
 		0,
 		testTemplateIDv4,
 		testTemplateIDv6,
+		mockDataSet,
 		mockIPFIXRegistry,
 		v4Enabled,
 		v6Enabled,
@@ -190,7 +192,7 @@ func testFlowExporter_sendDataSet(t *testing.T, v4Enabled bool, v6Enabled bool) 
 		)
 		mockDataSet.EXPECT().GetSet().Return(dataSet)
 		mockIPFIXExpProc.EXPECT().SendSet(dataSet).Return(0, nil)
-		err := flowExp.addRecordToSet(mockDataSet, record)
+		err := flowExp.addRecordToSet(record)
 		assert.NoError(t, err, "Error when adding record to data set")
 		_, err = flowExp.sendDataSet(mockDataSet)
 		assert.NoError(t, err, "Error in sending data set")

--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -53,6 +53,7 @@ func TestFlowAggregator_sendTemplateSet(t *testing.T) {
 		mockIPFIXExpProc,
 		testTemplateID,
 		mockIPFIXRegistry,
+		ipfixtest.NewMockIPFIXSet(ctrl),
 		"",
 		nil,
 	}

--- a/pkg/ipfix/ipfix_set.go
+++ b/pkg/ipfix/ipfix_set.go
@@ -22,6 +22,8 @@ var _ IPFIXSet = new(ipfixSet)
 
 // IPFIXSet interface is added to facilitate unit testing without involving the code from go-ipfix library.
 type IPFIXSet interface {
+	PrepareSet(setType ipfixentities.ContentType, templateID uint16) error
+	ResetSet()
 	AddRecord(elements []*ipfixentities.InfoElementWithValue, templateID uint16) error
 	GetSet() ipfixentities.Set
 }
@@ -30,9 +32,16 @@ type ipfixSet struct {
 	set ipfixentities.Set
 }
 
-func NewSet(setType ipfixentities.ContentType, templateID uint16, isDecoding bool) *ipfixSet {
-	s := ipfixentities.NewSet(setType, templateID, isDecoding)
-	return &ipfixSet{set: s}
+func NewSet(isDecoding bool) *ipfixSet {
+	return &ipfixSet{set: ipfixentities.NewSet(isDecoding)}
+}
+
+func (s *ipfixSet) PrepareSet(setType ipfixentities.ContentType, templateID uint16) error {
+	return s.set.PrepareSet(setType, templateID)
+}
+
+func (s *ipfixSet) ResetSet() {
+	s.set.ResetSet()
 }
 
 func (s *ipfixSet) AddRecord(elements []*ipfixentities.InfoElementWithValue, templateID uint16) error {

--- a/pkg/ipfix/testing/mock_ipfix.go
+++ b/pkg/ipfix/testing/mock_ipfix.go
@@ -141,6 +141,32 @@ func (mr *MockIPFIXSetMockRecorder) GetSet() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSet", reflect.TypeOf((*MockIPFIXSet)(nil).GetSet))
 }
 
+// PrepareSet mocks base method
+func (m *MockIPFIXSet) PrepareSet(arg0 entities.ContentType, arg1 uint16) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PrepareSet", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PrepareSet indicates an expected call of PrepareSet
+func (mr *MockIPFIXSetMockRecorder) PrepareSet(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareSet", reflect.TypeOf((*MockIPFIXSet)(nil).PrepareSet), arg0, arg1)
+}
+
+// ResetSet mocks base method
+func (m *MockIPFIXSet) ResetSet() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ResetSet")
+}
+
+// ResetSet indicates an expected call of ResetSet
+func (mr *MockIPFIXSetMockRecorder) ResetSet() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetSet", reflect.TypeOf((*MockIPFIXSet)(nil).ResetSet))
+}
+
 // MockIPFIXRegistry is a mock of IPFIXRegistry interface
 type MockIPFIXRegistry struct {
 	ctrl     *gomock.Controller

--- a/plugins/octant/go.sum
+++ b/plugins/octant/go.sum
@@ -591,7 +591,7 @@ github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmF
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vmware-tanzu/octant v0.16.1 h1:fkofB9oZ4yTqOaKf0JEhdibnIGBEOJ4OYOZL4Kli74A=
 github.com/vmware-tanzu/octant v0.16.1/go.mod h1:FhWXp2v0bgOQEwuOMOE49DXUu+uwWt8lXh7aOHtrA8A=
-github.com/vmware/go-ipfix v0.4.4/go.mod h1:lQz3f4r2pZWo0q8s8BtZ0xo5fPSOYsYteqJgBASP69o=
+github.com/vmware/go-ipfix v0.4.5/go.mod h1:lQz3f4r2pZWo0q8s8BtZ0xo5fPSOYsYteqJgBASP69o=
 github.com/wenyingd/ofnet v0.0.0-20201109024835-6fd225d8c8d1/go.mod h1:8mMMWAYBNUeTGXYKizOLETfN3WIbu3P5DgvS2jiXKdI=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSfTONNIgpN5RA8prR7fF8nkF6cTWTcNerRO8=


### PR DESCRIPTION
This commit adds changes in go-ipfix v0.4.5. It modifies the set interface: add PrepareSet and ResetSet methods to support re-use of set and better unit tests. 
It also simplifies the input consumption for exporting and collecting process, which also solves the issue in the slack channel https://kubernetes.slack.com/archives/CR2J23M0X/p1613742315130500

fixes #1893 
