### PR TITLE
Support creating IPv6-only Vagrant-based K8s cluster

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -55,6 +55,23 @@ Use the following Bash scripts to manage the Kubernetes Nodes with Vagrant:
 Note that `./infra/vagrant/provision.sh` can take a while to complete but it
 only needs to be run once.
 
+##### IPv6 cluster
+
+To test Antrea IPv6 support, an IPv6-only cluster can be created, by
+provisioning a private IPv6 network to connect Kubernetes Nodes, instead of a
+private IPv4 network. You simply need to invoke `./infra/vagrant/provision.sh`
+with `--ip-family v6`. This option can be used even if the host machine does not
+support IPv6 itself. Note however that the Nodes do not have public IPv6
+connectivity; they can still connect to the Internet using IPv4, which means
+that Docker images can be pulled without issue. Similarly, Pods (which only
+support IPv6) cannot connect to the Internet. To avoid issues when running
+Kubernetes conformance tests, we configure a proxy on the control-plane Node for
+all DNS traffic. While CoreDNS will reply to cluster local DNS queries directly,
+all other queries will be forwarded to the proxy over IPv6, and the proxy will
+then forward them to the default resolver for the Node (this time over
+IPv4). This means that all DNS queries from the Pods should succeed, even though
+the returned public IP addresses (IPv4 and / or IPv6) are no accessible.
+
 #### Debugging
 
 You can SSH into any of the Node VMs using `vagrant ssh [Node name]` (must be

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -70,7 +70,15 @@ all DNS traffic. While CoreDNS will reply to cluster local DNS queries directly,
 all other queries will be forwarded to the proxy over IPv6, and the proxy will
 then forward them to the default resolver for the Node (this time over
 IPv4). This means that all DNS queries from the Pods should succeed, even though
-the returned public IP addresses (IPv4 and / or IPv6) are no accessible.
+the returned public IP addresses (IPv4 and / or IPv6) are not accessible.
+
+You may need more recent versions of the dependencies (virtualbox, vagrant,
+ansible) than the ones listed above when creating an IPv6 cluster. The following
+versions were tested successfully:
+
+* `vagrant 2.2.14`
+* `ansible 2.9.18`
+* `virtualbox 5.2`
 
 #### Debugging
 

--- a/test/e2e/infra/vagrant/Vagrantfile
+++ b/test/e2e/infra/vagrant/Vagrantfile
@@ -2,7 +2,26 @@ VAGRANTFILE_API_VERSION = "2"
 
 NUM_WORKERS = 1
 
-K8S_POD_NETWORK_CIDR = "10.10.0.0/16"
+MODE = ENV['K8S_IP_FAMILY'] || "v4"
+if MODE != "v4" && MODE != "v6"
+  raise "K8S_IP_FAMILY env variable should be one of 'v4' or 'v6'"
+end
+
+K8S_POD_NETWORK_V4_CIDR = "10.10.0.0/16"
+K8S_POD_NETWORK_V6_CIDR = "fd02::/48"
+K8S_POD_NETWORK_CIDR = (MODE == "v4") ? K8S_POD_NETWORK_V4_CIDR : K8S_POD_NETWORK_V6_CIDR
+
+# Only used for IPv6 clusters
+K8S_NODE_CP_GW_V4_IP = "10.10.0.1"
+K8S_NODE_CP_GW_V6_IP = "fd02::1"
+K8S_NODE_CP_GW_IP = (MODE == "v4") ? K8S_NODE_CP_GW_V4_IP : K8S_NODE_CP_GW_V6_IP
+
+K8S_SERVICE_NETWORK_V4_CIDR = "10.96.0.0/12"
+K8S_SERVICE_NETWORK_V6_CIDR = "fd03::/112"
+K8S_SERVICE_NETWORK_CIDR = (MODE == "v4") ? K8S_SERVICE_NETWORK_V4_CIDR : K8S_SERVICE_NETWORK_V6_CIDR
+
+NODE_NETWORK_V4_PREFIX = "192.168.77."
+NODE_NETWORK_V6_PREFIX = "fd3b:fcf5:3e92:d732::"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/focal64"
@@ -20,8 +39,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define "k8s-node-control-plane" do |node|
     node.vm.hostname = "k8s-node-control-plane"
-    node_ip = "192.168.77.100"
+    node_ipv4 = NODE_NETWORK_V4_PREFIX + "100"
+    node_ipv6 = NODE_NETWORK_V6_PREFIX + "100"
+    node_ip = (MODE == "v4") ? node_ipv4 : node_ipv6
     node.vm.network "private_network", ip: node_ip
+
+    if MODE == "v6"
+      # add a fake default route for IPv6: required for ClusterIP traffic even though it is DNATed
+      node.vm.provision :shell, privileged: true, inline: "ip -6 route replace default via " + NODE_NETWORK_V6_PREFIX + "200"
+    end
 
     node.vm.provision :ansible  do |ansible|
       ansible.playbook = "playbook/k8s.yml"
@@ -32,7 +58,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         node_ip: node_ip,
         node_name: "k8s-node-control-plane",
         k8s_pod_network_cidr: K8S_POD_NETWORK_CIDR,
+        k8s_service_network_cidr: K8S_SERVICE_NETWORK_CIDR,
         k8s_api_server_ip: node_ip,
+        k8s_ip_family: MODE,
+        k8s_antrea_gw_ip: K8S_NODE_CP_GW_IP,
       }
     end
   end
@@ -40,8 +69,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   (1..NUM_WORKERS).each do |node_id|
     config.vm.define "k8s-node-worker-#{node_id}" do |node|
       node.vm.hostname = "k8s-node-worker-#{node_id}"
-      node_ip = "192.168.77.#{100 + node_id}"
+      node_ipv4 = NODE_NETWORK_V4_PREFIX + "#{100 + node_id}"
+      node_ipv6 = NODE_NETWORK_V6_PREFIX + "#{100 + node_id}"
+      node_ip = (MODE == "v4") ? node_ipv4 : node_ipv6
       node.vm.network "private_network", ip: node_ip
+
+      if MODE == "v6"
+        # add a fake default route for IPv6: required for ClusterIP traffic even though it is DNATed
+        node.vm.provision :shell, privileged: true, inline: "ip -6 route replace default via " + NODE_NETWORK_V6_PREFIX + "200"
+      end
 
       node.vm.provision :ansible do |ansible|
         ansible.playbook = "playbook/k8s.yml"

--- a/test/e2e/infra/vagrant/destroy.sh
+++ b/test/e2e/infra/vagrant/destroy.sh
@@ -5,3 +5,4 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 pushd $THIS_DIR
 
 vagrant destroy -f
+rm -rf playbook/kube

--- a/test/e2e/infra/vagrant/playbook/roles/common/tasks/enable-forwarding.yml
+++ b/test/e2e/infra/vagrant/playbook/roles/common/tasks/enable-forwarding.yml
@@ -1,0 +1,31 @@
+- name: Configure IPv4 forwarding (net.ipv4.conf.default.forwarding)
+  sysctl:
+    name: net.ipv4.conf.default.forwarding
+    value: '1'
+    sysctl_set: yes
+    state: present
+    reload: yes
+
+- name: Configure IPv4 forwarding (net.ipv4.conf.all.forwarding)
+  sysctl:
+    name: net.ipv4.conf.all.forwarding
+    value: '1'
+    sysctl_set: yes
+    state: present
+    reload: yes
+
+- name: Configure IPv6 forwarding (net.ipv6.conf.default.forwarding)
+  sysctl:
+    name: net.ipv6.conf.default.forwarding
+    value: '1'
+    sysctl_set: yes
+    state: present
+    reload: yes
+
+- name: Configure IPv6 forwarding (net.ipv6.conf.all.forwarding)
+  sysctl:
+    name: net.ipv6.conf.all.forwarding
+    value: '1'
+    sysctl_set: yes
+    state: present
+    reload: yes

--- a/test/e2e/infra/vagrant/playbook/roles/common/tasks/main.yml
+++ b/test/e2e/infra/vagrant/playbook/roles/common/tasks/main.yml
@@ -13,4 +13,7 @@
 # Kubelet will not start if the system has swap enabled
 - import_tasks: disable-swap.yml
 
+# Kubeadm may fail pre-flight checks without this
+- import_tasks: enable-forwarding.yml
+
 - import_tasks: kube.yml

--- a/test/e2e/infra/vagrant/playbook/roles/control-plane/tasks/main.yml
+++ b/test/e2e/infra/vagrant/playbook/roles/control-plane/tasks/main.yml
@@ -68,6 +68,50 @@
         flat: yes
   when: kubeadm_init.changed
 
+- name: Create CoreDNS ConfigMap file from template (IPv6)
+  template:
+    src: templates/coreDNS-cm.yml.j2
+    dest: /tmp/coreDNS-cm.yml
+  when: k8s_ip_family == "v6"
+
+- name: Edit CoreDNS ConfigMap (IPv6)
+  environment:
+    KUBECONFIG: /etc/kubernetes/admin.conf
+  command: kubectl apply -f /tmp/coreDNS-cm.yml
+  when: (k8s_ip_family == "v6") and kubeadm_init.changed
+
+- name: Restart CoreDNS Pods (IPv6)
+  environment:
+    KUBECONFIG: /etc/kubernetes/admin.conf
+  command: kubectl delete pods --namespace=kube-system -l k8s-app=kube-dns
+  when: (k8s_ip_family == "v6") and kubeadm_init.changed
+
+- name: Install socat DNS proxy UDP as service (IPv6)
+  template:
+    src: templates/socat-dns-proxy-udp.service.j2
+    dest: /etc/systemd/system/socat-dns-proxy-udp.service
+  when: k8s_ip_family == "v6"
+
+- name: Start socat DNS proxy UDP service (IPv6)
+  systemd:
+    name: socat-dns-proxy-udp
+    state: started
+    daemon_reload: yes
+  when: k8s_ip_family == "v6"
+
+- name: Install socat DNS proxy TCP as service (IPv6)
+  template:
+    src: templates/socat-dns-proxy-tcp.service.j2
+    dest: /etc/systemd/system/socat-dns-proxy-tcp.service
+  when: k8s_ip_family == "v6"
+
+- name: Start socat DNS proxy TCP service (IPv6)
+  systemd:
+    name: socat-dns-proxy-tcp
+    state: started
+    daemon_reload: yes
+  when: k8s_ip_family == "v6"
+
 # We copy the config file last, as we use it to determine whether the cluster
 # was setup correctly and with the appropriate configguration in future runs.
 - name: Copy kubeadm configuration to test user's home

--- a/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/coreDNS-cm.yml.j2
+++ b/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/coreDNS-cm.yml.j2
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: kube-system
+  name: coredns
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health {
+           lameduck 5s
+        }
+        ready
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+           pods insecure
+           ttl 30
+        }
+        prometheus :9153
+        forward . [{{ k8s_antrea_gw_ip }}]:5353 {
+           max_concurrent 1000
+        }
+        cache 30
+        reload
+        loadbalance
+    }

--- a/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/kubeadm.conf.j2
+++ b/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/kubeadm.conf.j2
@@ -1,14 +1,15 @@
-apiVersion: kubeadm.k8s.io/v1beta1
+apiVersion: kubeadm.k8s.io/v1beta2
 kind: InitConfiguration
 nodeRegistration:
   name: "{{ node_name }}"
 localAPIEndpoint:
   advertiseAddress: "{{ k8s_api_server_ip }}"
 ---
-apiVersion: kubeadm.k8s.io/v1beta1
+apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration
 networking:
   podSubnet: "{{ k8s_pod_network_cidr }}"
+  serviceSubnet: "{{ k8s_service_network_cidr }}"
 apiServer:
   certSANs:
   - "{{ k8s_api_server_ip }}"

--- a/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/socat-dns-proxy-tcp.service.j2
+++ b/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/socat-dns-proxy-tcp.service.j2
@@ -1,0 +1,8 @@
+[Unit]
+Description=Socat DNS proxy TCP
+
+[Service]
+ExecStart=/usr/bin/socat TCP6-LISTEN:5353,fork TCP4-CONNECT:127.0.0.53:53
+
+[Install]
+WantedBy=multi-user.target

--- a/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/socat-dns-proxy-udp.service.j2
+++ b/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/socat-dns-proxy-udp.service.j2
@@ -1,0 +1,8 @@
+[Unit]
+Description=Socat DNS proxy UDP
+
+[Service]
+ExecStart=/usr/bin/socat UDP6-RECVFROM:5353,fork UDP4-SENDTO:127.0.0.53:53 
+
+[Install]
+WantedBy=multi-user.target

--- a/test/e2e/infra/vagrant/provision.sh
+++ b/test/e2e/infra/vagrant/provision.sh
@@ -1,10 +1,54 @@
 #!/usr/bin/env bash
 
+function usage() {
+    echo "Usage: provision.sh [--ip-family <v4|v6>] [-h|--help]"
+}
+
+K8S_IP_FAMILY="v4"
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    --ip-family)
+    K8S_IP_FAMILY="$2"
+    shift 2
+    ;;
+    -h|--help)
+    usage
+    exit 0
+    ;;
+    *)
+    usage
+    exit 1
+esac
+done
+
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 pushd $THIS_DIR
 
-# With --provision we ensure that we provision the VM again  even if it already
+export K8S_IP_FAMILY
+
+# A few important considerations for IPv6 clusters:
+# * there is no assumption that the host machine supports IPv6.
+# * the network used by K8s is an IPv6 network, but the Nodes still access the
+#   Internet over IPv4.
+# * Pods are IPv6-only and cannot access the Internet.
+# * a dummy default IPv6 route is required on the Nodes for ClusterIP to work
+#   with kube-proxy and for Antrea to access the K8s apiserver. This is because
+#   there is a route lookup before the traffic goes through DNAT in the iptables
+#   OUTPUT chain.
+# * with the default CoreDNS configuration, DNS conformance tests fail. This is
+#   because non-cluster local DNS queries should be forwarded to the upstream
+#   nameservers for the Node, but the CoreDNS Pods (like all other Pods) only
+#   support IPv6, meaning that these nameservers are not accessible. To
+#   workaround this issue, we run a socat proxy on the control-plane Node which
+#   forwards IPv6 DNS queries to the default DNS resolver over IPv4. We modify
+#   the CoreDNS configuration to forward all non-cluster local DNS queries to
+#   the socat proxy, listening on antrea-gw0 on the control-plane Node.
+
+# With --provision we ensure that we provision the VM again even if it already
 # exists and was already provisioned. Our Ansible playbook ensures that we only
 # run tasks that need to be run.
 time vagrant up --provision


### PR DESCRIPTION
provision.sh now supports a new command-line option,
'--ip-family'. Running './provision.sh --ip-family v6' will create an
IPv6-only Kubernetes cluster, even if the host machine does not support
IPv6 itself. While the network used by Kubernetes is IPv6, the Nodes
still access the Internet over IPv4. Pods do not have access to the
Internet. I validated the cluster by running K8s conformance tests.

There will eventually be support for dual-stack clusters as well, when
kubeadm support for dual-stack matures a bit.