### PR TITLE
Refactor Windows SNAT flows for SNAT policy implementation

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -94,7 +94,8 @@ func run(o *Options) error {
 	ovsBridgeMgmtAddr := ofconfig.GetMgmtAddress(o.config.OVSRunDir, o.config.OVSBridge)
 	ofClient := openflow.NewClient(o.config.OVSBridge, ovsBridgeMgmtAddr, ovsDatapathType,
 		features.DefaultFeatureGate.Enabled(features.AntreaProxy),
-		features.DefaultFeatureGate.Enabled(features.AntreaPolicy))
+		features.DefaultFeatureGate.Enabled(features.AntreaPolicy),
+		false)
 
 	_, serviceCIDRNet, _ := net.ParseCIDR(o.config.ServiceCIDR)
 	var serviceCIDRNetv6 *net.IPNet

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -294,9 +294,9 @@ func (i *Initializer) initOpenFlowPipeline() error {
 		return err
 	}
 
-	// On Windows platform, extra flows are needed to perform SNAT for the
-	// traffic to external network.
-	if err := i.initExternalConnectivityFlows(); err != nil {
+	// Install OpenFlow entries to enable Pod traffic to external IP
+	// addresses.
+	if err := i.ofClient.InstallExternalFlows(); err != nil {
 		klog.Errorf("Failed to install openflow entries for external connectivity: %v", err)
 		return err
 	}

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -188,19 +188,6 @@ func (i *Initializer) initHostNetworkFlows() error {
 	return nil
 }
 
-// initExternalConnectivityFlows installs OpenFlow entries to SNAT Pod traffic
-// using Node IP, and then Pod could communicate to the external IP addresses.
-func (i *Initializer) initExternalConnectivityFlows() error {
-	if i.nodeConfig.PodIPv4CIDR == nil {
-		return fmt.Errorf("Failed to find valid IPv4 PodCIDR")
-	}
-	// Install OpenFlow entries on the OVS to enable Pod traffic to communicate to external IP addresses.
-	if err := i.ofClient.InstallExternalFlows(); err != nil {
-		return err
-	}
-	return nil
-}
-
 // getTunnelLocalIP returns local_ip of tunnel port
 func (i *Initializer) getTunnelPortLocalIP() net.IP {
 	return i.nodeConfig.NodeIPAddr.IP

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -150,10 +150,11 @@ type Client interface {
 	// This function is only used for Windows platform.
 	InstallBridgeUplinkFlows() error
 
-	// InstallExternalFlows sets up flows to enable Pods to communicate to the external IP addresses. The corresponding
-	// OpenFlow entries include: 1) identify the packets from local Pods to the external IP address, 2) mark the traffic
-	// in the connection tracking context, and 3) SNAT the packets with Node IP.
-	// This function is only used for Windows platform.
+	// InstallExternalFlows sets up flows to enable Pods to communicate to
+	// the external IP addresses. The flows identify the packets from local
+	// Pods to the external IP address, and mark the packets to be SNAT'd
+	// with the configured SNAT IPs. On Windows Node, the flows also perform
+	// SNAT with the Openflow NAT action.
 	InstallExternalFlows() error
 
 	// Disconnect disconnects the connection between client and OFSwitch.
@@ -476,22 +477,6 @@ func (c *client) UninstallServiceFlows(svcIP net.IP, svcPort uint16, protocol bi
 	return c.deleteFlows(c.serviceFlowCache, cacheKey)
 }
 
-func (c *client) InstallLoadBalancerServiceFromOutsideFlows(svcIP net.IP, svcPort uint16, protocol binding.Protocol) error {
-	c.replayMutex.RLock()
-	defer c.replayMutex.RUnlock()
-	var flows []binding.Flow
-	flows = append(flows, c.loadBalancerServiceFromOutsideFlow(svcIP, svcPort, protocol))
-	cacheKey := fmt.Sprintf("LoadBalancerService_%s_%d_%s", svcIP, svcPort, protocol)
-	return c.addFlows(c.serviceFlowCache, cacheKey, flows)
-}
-
-func (c *client) UninstallLoadBalancerServiceFromOutsideFlows(svcIP net.IP, svcPort uint16, protocol binding.Protocol) error {
-	c.replayMutex.RLock()
-	defer c.replayMutex.RUnlock()
-	cacheKey := fmt.Sprintf("LoadBalancerService_%s_%d_%s", svcIP, svcPort, protocol)
-	return c.deleteFlows(c.serviceFlowCache, cacheKey)
-}
-
 func (c *client) GetServiceFlowKeys(svcIP net.IP, svcPort uint16, protocol binding.Protocol, endpoints []proxy.Endpoint) []string {
 	cacheKey := generateServicePortFlowCacheKey(svcIP, svcPort, protocol)
 	flowKeys := c.getFlowKeysFromCache(c.serviceFlowCache, cacheKey)
@@ -579,16 +564,6 @@ func (c *client) InstallDefaultTunnelFlows() error {
 	return nil
 }
 
-func (c *client) InstallBridgeUplinkFlows() error {
-	flows := c.hostBridgeUplinkFlows(*c.nodeConfig.PodIPv4CIDR, cookie.Default)
-	c.hostNetworkingFlows = flows
-	if err := c.ofEntryOperations.AddAll(flows); err != nil {
-		return err
-	}
-	c.hostNetworkingFlows = flows
-	return nil
-}
-
 func (c *client) initialize() error {
 	if err := c.ofEntryOperations.AddAll(c.defaultFlows()); err != nil {
 		return fmt.Errorf("failed to install default flows: %v", err)
@@ -655,9 +630,16 @@ func (c *client) Initialize(roundInfo types.RoundInfo, nodeConfig *config.NodeCo
 
 func (c *client) InstallExternalFlows() error {
 	nodeIP := c.nodeConfig.NodeIPAddr.IP
-	podSubnet := c.nodeConfig.PodIPv4CIDR
-	flows := c.uplinkSNATFlows(cookie.SNAT)
-	flows = append(flows, c.snatFlows(nodeIP, *podSubnet, cookie.SNAT)...)
+	localGatewayMAC := c.nodeConfig.GatewayConfig.MAC
+
+	var flows []binding.Flow
+	if c.nodeConfig.PodIPv4CIDR != nil {
+		flows = c.externalFlows(nodeIP, *c.nodeConfig.PodIPv4CIDR, localGatewayMAC)
+	}
+	if c.nodeConfig.PodIPv6CIDR != nil {
+		flows = append(flows, c.externalFlows(nodeIP, *c.nodeConfig.PodIPv6CIDR, localGatewayMAC)...)
+	}
+
 	if err := c.ofEntryOperations.AddAll(flows); err != nil {
 		return fmt.Errorf("failed to install flows for external communication: %v", err)
 	}

--- a/pkg/agent/openflow/client_other.go
+++ b/pkg/agent/openflow/client_other.go
@@ -1,6 +1,7 @@
-// +build linux
+// +build !windows
+// package openflow is needed by antctl which is compiled for macOS too.
 
-// Copyright 2020 Antrea Authors
+// Copyright 2021 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,29 +15,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package agent
+package openflow
 
 import (
 	"net"
+
+	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
 )
 
-// prepareHostNetwork returns immediately on Linux.
-func (i *Initializer) prepareHostNetwork() error {
+func (c *client) InstallBridgeUplinkFlows() error {
 	return nil
 }
 
-// prepareOVSBridge returns immediately on Linux.
-func (i *Initializer) prepareOVSBridge() error {
+func (c *client) InstallLoadBalancerServiceFromOutsideFlows(svcIP net.IP, svcPort uint16, protocol binding.Protocol) error {
 	return nil
 }
 
-// initHostNetworkFlows returns immediately on Linux.
-func (i *Initializer) initHostNetworkFlows() error {
-	return nil
-}
-
-// getTunnelLocalIP returns local_ip of tunnel port.
-// On linux platform, local_ip option is not needed.
-func (i *Initializer) getTunnelPortLocalIP() net.IP {
+func (c *client) UninstallLoadBalancerServiceFromOutsideFlows(svcIP net.IP, svcPort uint16, protocol binding.Protocol) error {
 	return nil
 }

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -101,7 +101,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.ofEntryOperations = m
@@ -129,7 +129,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.ofEntryOperations = m
@@ -170,7 +170,7 @@ func TestFlowInstallationFailed(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.ofEntryOperations = m
@@ -204,7 +204,7 @@ func TestConcurrentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.ofEntryOperations = m
@@ -467,7 +467,7 @@ func Test_client_SendTraceflowPacket(t *testing.T) {
 }
 
 func prepareTraceflowFlow(ctrl *gomock.Controller) *client {
-	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, true)
+	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, true, false)
 	c := ofClient.(*client)
 	c.cookieAllocator = cookie.NewAllocator(0)
 	c.nodeConfig = nodeConfig
@@ -485,7 +485,7 @@ func prepareTraceflowFlow(ctrl *gomock.Controller) *client {
 }
 
 func prepareSendTraceflowPacket(ctrl *gomock.Controller, success bool) *client {
-	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, true)
+	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, true, false)
 	c := ofClient.(*client)
 	c.nodeConfig = nodeConfig
 	m := ovsoftest.NewMockBridge(ctrl)

--- a/pkg/agent/openflow/client_windows.go
+++ b/pkg/agent/openflow/client_windows.go
@@ -1,0 +1,51 @@
+// +build windows
+// package openflow is needed by antctl which is compiled for macOS too.
+
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openflow
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/openflow/cookie"
+	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
+)
+
+func (c *client) InstallBridgeUplinkFlows() error {
+	flows := c.hostBridgeUplinkFlows(*c.nodeConfig.PodIPv4CIDR, cookie.Default)
+	if err := c.ofEntryOperations.AddAll(flows); err != nil {
+		return err
+	}
+	c.hostNetworkingFlows = flows
+	return nil
+}
+
+func (c *client) InstallLoadBalancerServiceFromOutsideFlows(svcIP net.IP, svcPort uint16, protocol binding.Protocol) error {
+	c.replayMutex.RLock()
+	defer c.replayMutex.RUnlock()
+	var flows []binding.Flow
+	flows = append(flows, c.loadBalancerServiceFromOutsideFlow(svcIP, svcPort, protocol))
+	cacheKey := fmt.Sprintf("L%s%s%x", svcIP, protocol, svcPort)
+	return c.addFlows(c.serviceFlowCache, cacheKey, flows)
+}
+
+func (c *client) UninstallLoadBalancerServiceFromOutsideFlows(svcIP net.IP, svcPort uint16, protocol binding.Protocol) error {
+	c.replayMutex.RLock()
+	defer c.replayMutex.RUnlock()
+	cacheKey := fmt.Sprintf("L%s%s%x", svcIP, protocol, svcPort)
+	return c.deleteFlows(c.serviceFlowCache, cacheKey)
+}

--- a/pkg/agent/openflow/pipeline_other.go
+++ b/pkg/agent/openflow/pipeline_other.go
@@ -1,0 +1,33 @@
+// +build !windows
+// package openflow is needed by antctl which is compiled for macOS too.
+
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openflow
+
+import (
+	"net"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/openflow/cookie"
+	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
+)
+
+// externalFlows returns the flows needed to enable SNAT for external traffic.
+func (c *client) externalFlows(nodeIP net.IP, localSubnet net.IPNet, localGatewayMAC net.HardwareAddr) []binding.Flow {
+	if !c.enableEgress {
+		return nil
+	}
+	return c.snatCommonFlows(nodeIP, localSubnet, localGatewayMAC, cookie.SNAT)
+}

--- a/pkg/agent/openflow/pipeline_windows.go
+++ b/pkg/agent/openflow/pipeline_windows.go
@@ -1,0 +1,253 @@
+// +build windows
+
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openflow
+
+import (
+	"net"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/config"
+	"github.com/vmware-tanzu/antrea/pkg/agent/openflow/cookie"
+	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
+)
+
+const (
+	markTrafficFromBridge = 5
+
+	// ctZoneSNAT is only used on Windows and only when AntreaProxy is enabled.
+	// When a Pod access a ClusterIP Service, and the IP of the selected endpoint
+	// is not in "cluster-cidr". The request packets need to be SNAT'd(set src IP to local Node IP)
+	// after have been DNAT'd(set dst IP to endpoint IP).
+	// For example, the endpoint Pod may run in hostNetwork mode and the IP of the endpoint
+	// will is the current Node IP.
+	// We need to use a different ct_zone to track the SNAT'd connection because OVS
+	// does not support doing both DNAT and SNAT in the same ct_zone.
+	//
+	// An example of the connection is a Pod accesses kubernetes API service:
+	// Pod --> DNAT(CtZone) --> SNAT(ctZoneSNAT) --> Endpoint(API server NodeIP)
+	// Pod <-- unDNAT(CtZone) <-- unSNAT(ctZoneSNAT) <-- Endpoint(API server NodeIP)
+	ctZoneSNAT = 0xffdc
+
+	// snatDefaultMark indicates the packet should be SNAT'd with the default
+	// SNAT IP (the Node IP).
+	snatDefaultMark = 0b1
+
+	// snatCTMark indicates SNAT is performed for packets of the connection.
+	snatCTMark = 0x40
+)
+
+var (
+	// snatMarkRange takes the 17th bit of register marksReg to indicate if
+	// the packet needs to be SNATed with Node's IP or not.
+	snatMarkRange = binding.Range{17, 17}
+)
+
+// uplinkSNATFlows installs flows for traffic from the uplink port that help
+// the SNAT implementation of the external traffic.
+func (c *client) uplinkSNATFlows(localSubnet net.IPNet, category cookie.Category) []binding.Flow {
+	ctStateNext := dnatTable
+	if c.enableProxy {
+		ctStateNext = endpointDNATTable
+	}
+	bridgeOFPort := uint32(config.BridgeOFPort)
+	flows := []binding.Flow{
+		// Mark the packet to indicate its destination MAC should be
+		// rewritten to the real MAC in the L3Forwarding table, if the
+		// packet is a reply to a local Pod from an external address.
+		c.pipeline[conntrackStateTable].BuildFlow(priorityHigh).
+			MatchProtocol(binding.ProtocolIP).
+			MatchCTStateNew(false).MatchCTStateTrk(true).
+			MatchCTMark(snatCTMark, nil).
+			MatchRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
+			Action().LoadRegRange(int(marksReg), macRewriteMark, macRewriteMarkRange).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Action().GotoTable(ctStateNext).
+			Done(),
+		// Output the non-SNAT packet to the bridge interface directly
+		// if it is received from the uplink interface.
+		c.pipeline[conntrackStateTable].BuildFlow(priorityNormal).
+			MatchProtocol(binding.ProtocolIP).
+			MatchRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
+			Action().Output(int(bridgeOFPort)).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+	}
+	// Forward the IP packets from the uplink interface to
+	// conntrackTable. This is for unSNAT the traffic from the local
+	// Pod subnet to the external network. Non-SNAT packets will be
+	// output to the bridge port in conntrackStateTable.
+	if c.enableProxy {
+		// For the connection which is both applied DNAT and SNAT, the reply packtets
+		// are received from uplink and need to enter ctZoneSNAT first to do unSNAT.
+		//   Pod --> DNAT(CtZone) --> SNAT(ctZoneSNAT) --> ExternalServer
+		//   Pod <-- unDNAT(CtZone) <-- unSNAT(ctZoneSNAT) <-- ExternalServer
+		flows = append(flows, c.pipeline[uplinkTable].BuildFlow(priorityNormal).
+			MatchProtocol(binding.ProtocolIP).
+			MatchRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
+			Action().CT(false, conntrackTable, ctZoneSNAT).NAT().CTDone().
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done())
+	} else {
+		flows = append(flows, c.pipeline[uplinkTable].BuildFlow(priorityNormal).
+			MatchProtocol(binding.ProtocolIP).
+			MatchRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
+			Action().GotoTable(conntrackTable).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done())
+	}
+	return flows
+}
+
+// snatImplementationFlows installs flows that implement SNAT with OVS NAT.
+func (c *client) snatImplementationFlows(nodeIP net.IP, category cookie.Category) []binding.Flow {
+	snatIPRange := &binding.IPRange{StartIP: nodeIP, EndIP: nodeIP}
+	l3FwdTable := c.pipeline[l3ForwardingTable]
+	nextTable := l3FwdTable.GetNext()
+	ctCommitTable := c.pipeline[conntrackCommitTable]
+	ccNextTable := ctCommitTable.GetNext()
+	flows := []binding.Flow{
+		// Default to using Node IP as the SNAT IP for local Pods.
+		c.pipeline[snatTable].BuildFlow(priorityLow).
+			MatchProtocol(binding.ProtocolIP).
+			MatchCTStateNew(true).MatchCTStateTrk(true).
+			MatchRegRange(int(marksReg), markTrafficFromLocal, binding.Range{0, 15}).
+			Action().LoadRegRange(int(marksReg), snatDefaultMark, snatMarkRange).
+			Action().GotoTable(nextTable).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+		// Force IP packet into the conntrack zone with SNAT. If the connection is SNATed, the reply packet should use
+		// Pod IP as the destination, and then is forwarded to conntrackStateTable.
+		c.pipeline[conntrackTable].BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
+			Action().CT(false, conntrackStateTable, CtZone).NAT().CTDone().
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+		// Perform SNAT with the default SNAT IP (the Node IP). A SNAT
+		// packet has these characteristics: 1) the ct_state is
+		// "+new+trk", 2) reg0[17] is set to 1; 3) ct_mark is set to
+		// 0x40.
+		ctCommitTable.BuildFlow(priorityNormal).
+			MatchProtocol(binding.ProtocolIP).
+			MatchCTStateNew(true).MatchCTStateTrk(true).MatchCTStateDNAT(false).
+			MatchRegRange(int(marksReg), snatDefaultMark, snatMarkRange).
+			Action().CT(true, ccNextTable, CtZone).
+			SNAT(snatIPRange, nil).
+			LoadToMark(snatCTMark).CTDone().
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+	}
+	// The following flows are for both apply DNAT + SNAT for packets.
+	// If AntreaProxy is disabled, no DNAT happens in OVS pipeline.
+	if c.enableProxy {
+		flows = append(flows, []binding.Flow{
+			// If the SNAT is needed after DNAT, mark the
+			// snatDefaultMark even the connection is not new,
+			// because this kind of packets need to enter ctZoneSNAT
+			// to make sure the SNAT can be applied before leaving
+			// the pipeline.
+			l3FwdTable.BuildFlow(priorityLow).
+				MatchProtocol(binding.ProtocolIP).
+				MatchCTStateNew(false).MatchCTStateTrk(true).MatchCTStateDNAT(true).
+				MatchRegRange(int(marksReg), markTrafficFromLocal, binding.Range{0, 15}).
+				Action().LoadRegRange(int(marksReg), snatDefaultMark, snatMarkRange).
+				Action().GotoTable(nextTable).
+				Cookie(c.cookieAllocator.Request(category).Raw()).
+				Done(),
+			// If SNAT is needed after DNAT:
+			//   - For new connection: commit to ctZoneSNAT
+			//   - For existing connection: enter ctZoneSNAT to apply SNAT
+			ctCommitTable.BuildFlow(priorityNormal).
+				MatchProtocol(binding.ProtocolIP).
+				MatchCTStateNew(true).MatchCTStateTrk(true).MatchCTStateDNAT(true).
+				MatchRegRange(int(marksReg), snatDefaultMark, snatMarkRange).
+				Action().CT(true, ccNextTable, ctZoneSNAT).
+				SNAT(snatIPRange, nil).
+				LoadToMark(snatCTMark).CTDone().
+				Cookie(c.cookieAllocator.Request(category).Raw()).
+				Done(),
+			ctCommitTable.BuildFlow(priorityNormal).
+				MatchProtocol(binding.ProtocolIP).
+				MatchCTStateNew(false).MatchCTStateTrk(true).MatchCTStateDNAT(true).
+				MatchRegRange(int(marksReg), snatDefaultMark, snatMarkRange).
+				Action().CT(false, ccNextTable, ctZoneSNAT).NAT().CTDone().
+				Cookie(c.cookieAllocator.Request(category).Raw()).
+				Done(),
+		}...)
+	}
+	return flows
+}
+
+// externalFlows returns the flows needed to enable SNAT for external traffic.
+func (c *client) externalFlows(nodeIP net.IP, localSubnet net.IPNet, localGatewayMAC net.HardwareAddr) []binding.Flow {
+	flows := c.snatCommonFlows(nodeIP, localSubnet, localGatewayMAC, cookie.SNAT)
+	flows = append(flows, c.uplinkSNATFlows(localSubnet, cookie.SNAT)...)
+	flows = append(flows, c.snatImplementationFlows(nodeIP, cookie.SNAT)...)
+	return flows
+}
+
+// hostBridgeUplinkFlows generates the flows that forward traffic between the
+// bridge local port and the uplink port to support the host traffic with
+// outside.
+func (c *client) hostBridgeUplinkFlows(localSubnet net.IPNet, category cookie.Category) (flows []binding.Flow) {
+	bridgeOFPort := uint32(config.BridgeOFPort)
+	flows = []binding.Flow{
+		c.pipeline[ClassifierTable].BuildFlow(priorityNormal).
+			MatchInPort(config.UplinkOFPort).
+			Action().LoadRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
+			Action().GotoTable(uplinkTable).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+		c.pipeline[ClassifierTable].BuildFlow(priorityNormal).
+			MatchInPort(config.BridgeOFPort).
+			Action().LoadRegRange(int(marksReg), markTrafficFromBridge, binding.Range{0, 15}).
+			Action().GotoTable(uplinkTable).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+		// Output non-IP packets to the bridge port directly. IP packets
+		// are redirected to conntrackTable in uplinkSNATFlows() (in
+		// case they need unSNAT).
+		c.pipeline[uplinkTable].BuildFlow(priorityLow).
+			MatchRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
+			Action().Output(int(bridgeOFPort)).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+		// Forward the packet to conntrackTable if it enters the OVS
+		// pipeline from the bridge interface and is sent to the local
+		// Pod subnet. Mark the packet to indicate its destination MAC
+		// should be rewritten to the real MAC in the L3Frowarding
+		// table. This is for the case a Pod accesses a NodePort Service
+		// using the local Node's IP, and then the return traffic after
+		// the kube-proxy processing will enter the bridge from the
+		// bridge interface (but not the gateway interface. This is
+		// probably because we do not enable IP forwarding on the bridge
+		// interface).
+		c.pipeline[uplinkTable].BuildFlow(priorityHigh).
+			MatchProtocol(binding.ProtocolIP).
+			MatchRegRange(int(marksReg), markTrafficFromBridge, binding.Range{0, 15}).
+			MatchDstIPNet(localSubnet).
+			Action().LoadRegRange(int(marksReg), macRewriteMark, macRewriteMarkRange).
+			Action().GotoTable(conntrackTable).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+		// Output other packets from the bridge port to the uplink port
+		// directly.
+		c.pipeline[uplinkTable].BuildFlow(priorityLow).
+			MatchRegRange(int(marksReg), markTrafficFromBridge, binding.Range{0, 15}).
+			Action().Output(config.UplinkOFPort).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done(),
+	}
+	return flows
+}


### PR DESCRIPTION
Separate common flows and Windows only flows for SNAT.
Add a new snatTable(71) between l3ForwardingTable and l3DecTTLTable(72)
for looking up SNAT IPs of the external traffic.

Issue: #667 