### PR TITLE
Fix the formatting of antctl trace-packet output

### DIFF
--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver/handlers/agentinfo"
 	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver/handlers/ovsflows"
-	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver/handlers/ovstracing"
 	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver/handlers/podinterface"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
 	"github.com/vmware-tanzu/antrea/pkg/antctl/raw/proxy"
@@ -30,6 +29,7 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/appliedtogroup"
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/controllerinfo"
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/networkpolicy"
+	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/ovstracing"
 	"github.com/vmware-tanzu/antrea/pkg/antctl/transform/version"
 	cpv1beta "github.com/vmware-tanzu/antrea/pkg/apis/controlplane/v1beta2"
 	systemv1beta1 "github.com/vmware-tanzu/antrea/pkg/apis/system/v1beta1"
@@ -374,9 +374,10 @@ var CommandList = &commandList{
 					},
 					outputType: single,
 				},
+				addonTransform: ovstracing.Transform,
 			},
 			commandGroup:        flat,
-			transformedResponse: reflect.TypeOf(ovstracing.Response{}),
+			transformedResponse: reflect.TypeOf(""),
 		},
 		{ // TODO: implement as a "rawCommand" (see supportbundle) so that the command can be run out-of-cluster
 			use:     "endpoint",

--- a/pkg/antctl/command_definition.go
+++ b/pkg/antctl/command_definition.go
@@ -711,6 +711,14 @@ func (cd *commandDefinition) output(resp io.Reader, writer io.Writer, ft formatt
 		}
 		klog.Infof("After transforming %v", obj)
 	}
+
+	if str, ok := obj.([]byte); ok {
+		// If the transformed response is of type []byte, just output
+		// the raw bytes.
+		_, err = writer.Write(str)
+		return err
+	}
+
 	// Output structure data in format
 	switch ft {
 	case jsonFormatter:

--- a/pkg/antctl/transform/ovstracing/transform.go
+++ b/pkg/antctl/transform/ovstracing/transform.go
@@ -1,0 +1,37 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovstracing
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver/handlers/ovstracing"
+)
+
+func Transform(reader io.Reader, _ bool, _ map[string]string) (interface{}, error) {
+	b, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	resp := new(ovstracing.Response)
+	err = json.Unmarshal(b, resp)
+	if err != nil {
+		return nil, err
+	}
+	// Output the raw bytes of the OVS trace command outputs.
+	return []byte(resp.Result), nil
+}


### PR DESCRIPTION
Transform the "/ovstracing API" response to []byte, and change antctl to
output the raw bytes directly for a []byte type response.