### PR TITLE
Add code coverage for flow aggregator

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -44,26 +44,26 @@ jobs:
         path: antrea-ubuntu.tar
         retention-days: 1 # minimum value, in case artifact deletion by 'artifact-cleanup' job fails
 
-  build-flow-aggregator-image:
+  build-flow-aggregator-coverage-image:
     name: Build Flow Aggregator image to be used for Kind e2e tests
     needs: check-changes
     if: ${{ needs.check-changes.outputs.has_changes == 'yes' }}
     runs-on: [ ubuntu-latest ]
     steps:
     - uses: actions/checkout@v2
-    - run: make flow-aggregator-ubuntu
+    - run: make flow-aggregator-ubuntu-coverage
     - name: Save Flow Aggregator image to tarball
-      run: docker save -o flow-aggregator.tar projects.registry.vmware.com/antrea/flow-aggregator:latest
+      run: docker save -o flow-aggregator.tar antrea/flow-aggregator-coverage:latest
     - name: Upload Flow Aggregator image for subsequent jobs
       uses: actions/upload-artifact@v2
       with:
-        name: flow-aggregator
+        name: flow-aggregator-cov
         path: flow-aggregator.tar
         retention-days: 1 # minimum value, in case artifact deletion by 'artifact-cleanup' job fails
 
   test-e2e-encap:
     name: E2e tests on a Kind cluster on Linux
-    needs: [build-antrea-coverage-image, build-flow-aggregator-image]
+    needs: [build-antrea-coverage-image, build-flow-aggregator-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
     - name: Free disk space
@@ -84,11 +84,11 @@ jobs:
     - name: Download Flow Aggregator image from previous job
       uses: actions/download-artifact@v1
       with:
-        name: flow-aggregator
+        name: flow-aggregator-cov
     - name: Load Antrea image
       run:  |
         docker load -i antrea-ubuntu-cov/antrea-ubuntu.tar
-        docker load -i flow-aggregator/flow-aggregator.tar
+        docker load -i flow-aggregator-cov/flow-aggregator.tar
     - name: Install Kind
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
@@ -111,7 +111,7 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: '*antrea*'
+        file: '*.cov.out*'
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap
         directory: test-e2e-encap-coverage
@@ -128,7 +128,7 @@ jobs:
 
   test-e2e-encap-no-proxy:
     name: E2e tests on a Kind cluster on Linux with AntreaProxy disabled
-    needs: [build-antrea-coverage-image, build-flow-aggregator-image]
+    needs: [build-antrea-coverage-image, build-flow-aggregator-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
     - name: Free disk space
@@ -147,11 +147,11 @@ jobs:
     - name: Download Flow Aggregator image from previous job
       uses: actions/download-artifact@v1
       with:
-        name: flow-aggregator
+        name: flow-aggregator-cov
     - name: Load Antrea image
       run: |
         docker load -i antrea-ubuntu-cov/antrea-ubuntu.tar
-        docker load -i flow-aggregator/flow-aggregator.tar
+        docker load -i flow-aggregator-cov/flow-aggregator.tar
     - name: Install Kind
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
@@ -174,7 +174,7 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: '*antrea*'
+        file: '*.cov.out*'
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap-no-proxy
         directory: test-e2e-encap-no-proxy-coverage
@@ -191,7 +191,7 @@ jobs:
 
   test-e2e-noencap:
     name: E2e tests on a Kind cluster on Linux (noEncap)
-    needs: [build-antrea-coverage-image, build-flow-aggregator-image]
+    needs: [build-antrea-coverage-image, build-flow-aggregator-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
     - name: Free disk space
@@ -210,11 +210,11 @@ jobs:
     - name: Download Flow Aggregator image from previous job
       uses: actions/download-artifact@v1
       with:
-        name: flow-aggregator
+        name: flow-aggregator-cov
     - name: Load Antrea image
       run: |
         docker load -i antrea-ubuntu-cov/antrea-ubuntu.tar
-        docker load -i flow-aggregator/flow-aggregator.tar
+        docker load -i flow-aggregator-cov/flow-aggregator.tar
     - name: Install Kind
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
@@ -237,7 +237,7 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: '*antrea*'
+        file: '*.cov.out*'
         flags: kind-e2e-tests
         name: codecov-test-e2e-noencap
         directory: test-e2e-noencap-coverage
@@ -254,7 +254,7 @@ jobs:
 
   test-e2e-hybrid:
     name: E2e tests on a Kind cluster on Linux (hybrid)
-    needs: [build-antrea-coverage-image, build-flow-aggregator-image]
+    needs: [build-antrea-coverage-image, build-flow-aggregator-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
     - name: Free disk space
@@ -273,11 +273,11 @@ jobs:
     - name: Download Flow Aggregator image from previous job
       uses: actions/download-artifact@v1
       with:
-        name: flow-aggregator
+        name: flow-aggregator-cov
     - name: Load Antrea image
       run: |
         docker load -i antrea-ubuntu-cov/antrea-ubuntu.tar
-        docker load -i flow-aggregator/flow-aggregator.tar
+        docker load -i flow-aggregator-cov/flow-aggregator.tar
     - name: Install Kind
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
@@ -300,7 +300,7 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: '*antrea*'
+        file: '*.cov.out*'
         flags: kind-e2e-tests
         name: codecov-test-e2e-hybrid
         directory: test-e2e-hybrid-coverage
@@ -317,7 +317,7 @@ jobs:
 
   test-e2e-encap-np:
     name: E2e tests on a Kind cluster on Linux with Antrea NetworkPolicies enabled
-    needs: [build-antrea-coverage-image, build-flow-aggregator-image]
+    needs: [build-antrea-coverage-image, build-flow-aggregator-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
     - name: Free disk space
@@ -336,11 +336,11 @@ jobs:
     - name: Download Flow Aggregator image from previous job
       uses: actions/download-artifact@v1
       with:
-        name: flow-aggregator
+        name: flow-aggregator-cov
     - name: Load Antrea image
       run: |
         docker load -i antrea-ubuntu-cov/antrea-ubuntu.tar
-        docker load -i flow-aggregator/flow-aggregator.tar
+        docker load -i flow-aggregator-cov/flow-aggregator.tar
     - name: Install Kind
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
@@ -363,7 +363,7 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: '*antrea*'
+        file: '*.cov.out*'
         flags: kind-e2e-tests
         name: codecov-test-e2e-np-encap
         directory: test-e2e-encap-np-coverage
@@ -462,7 +462,7 @@ jobs:
   # yet.
   artifact-cleanup:
     name: Delete uploaded images
-    needs: [build-antrea-coverage-image, build-flow-aggregator-image, build-antrea-image, test-e2e-encap, test-e2e-encap-no-proxy, test-e2e-noencap, test-e2e-hybrid, test-e2e-encap-np, test-netpol-tmp, validate-prometheus-metrics-doc]
+    needs: [build-antrea-coverage-image, build-flow-aggregator-coverage-image, build-antrea-image, test-e2e-encap, test-e2e-encap-no-proxy, test-e2e-noencap, test-e2e-hybrid, test-e2e-encap-np, test-netpol-tmp, validate-prometheus-metrics-doc]
     if: ${{ always() }}
     runs-on: [ubuntu-latest]
     steps:
@@ -472,10 +472,10 @@ jobs:
       with:
         name: antrea-ubuntu-cov
     - name: Delete flow-aggregator
-      if: ${{ needs.build-flow-aggregator-image.result == 'success' }}
+      if: ${{ needs.build-flow-aggregator-coverage-image.result == 'success' }}
       uses: geekyeggo/delete-artifact@v1
       with:
-        name: flow-aggregator
+        name: flow-aggregator-cov
     - name: Delete antrea-ubuntu
       if: ${{ needs.build-antrea-image.result == 'success' }}
       uses: geekyeggo/delete-artifact@v1

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,11 @@ flow-aggregator:
 	@mkdir -p $(BINDIR)
 	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' github.com/vmware-tanzu/antrea/cmd/flow-aggregator
 
+.PHONY: flow-aggregator-instr-binary
+flow-aggregator-instr-binary:
+	@mkdir -p $(BINDIR)
+	GOOS=linux $(GO) test -tags testbincover -covermode count -coverpkg=github.com/vmware-tanzu/antrea/pkg/... -c -o $(BINDIR)/flow-aggregator-coverage $(GOFLAGS) -ldflags '$(LDFLAGS)' github.com/vmware-tanzu/antrea/cmd/flow-aggregator
+
 .PHONY: test-unit test-integration
 ifeq ($(UNAME_S),Linux)
 test-unit: .linux-test-unit
@@ -332,6 +337,7 @@ manifest-scale:
 manifest-coverage:
 	$(CURDIR)/hack/generate-manifest.sh --mode dev --coverage > build/yamls/antrea-coverage.yml
 	$(CURDIR)/hack/generate-manifest.sh --mode dev --ipsec --coverage > build/yamls/antrea-ipsec-coverage.yml
+	$(CURDIR)/hack/generate-manifest-flow-aggregator.sh --mode dev --coverage > build/yamls/flow-aggregator-coverage.yml
 
 .PHONY: octant-antrea-ubuntu
 octant-antrea-ubuntu:
@@ -352,6 +358,16 @@ endif
 	docker tag antrea/flow-aggregator:$(DOCKER_IMG_VERSION) antrea/flow-aggregator
 	docker tag antrea/flow-aggregator:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/flow-aggregator
 	docker tag antrea/flow-aggregator:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/flow-aggregator:$(DOCKER_IMG_VERSION)
+
+.PHONY: flow-aggregator-ubuntu-coverage
+flow-aggregator-ubuntu-coverage:
+	@echo "===> Building antrea/flow-aggregator-coverage Docker image <==="
+ifneq ($(DOCKER_REGISTRY),"")
+	docker build -t antrea/flow-aggregator-coverage:$(DOCKER_IMG_VERSION) -f build/images/flow-aggregator/Dockerfile.coverage .
+else
+	docker build --pull -t antrea/flow-aggregator-coverage:$(DOCKER_IMG_VERSION) -f build/images/flow-aggregator/Dockerfile.coverage .
+endif
+	docker tag antrea/flow-aggregator-coverage:$(DOCKER_IMG_VERSION) antrea/flow-aggregator-coverage
 
 .PHONY: verify
 verify:

--- a/build/images/flow-aggregator/Dockerfile.coverage
+++ b/build/images/flow-aggregator/Dockerfile.coverage
@@ -1,0 +1,17 @@
+FROM golang:1.15 as flow-aggregator-build
+
+WORKDIR /antrea
+
+COPY . /antrea
+
+RUN make flow-aggregator flow-aggregator-instr-binary
+
+FROM antrea/base-ubuntu:2.14.0
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="The docker image for the flow aggregator with code coverage measurement enabled for testing purposes."
+
+USER root
+
+COPY --from=flow-aggregator-build /antrea/bin/flow-aggregator* /usr/local/bin/
+COPY --from=flow-aggregator-build /antrea/test/e2e/coverage/flow-aggregator-arg-file /

--- a/build/yamls/flow-aggregator/patches/coverage/startFlowAggCov.yml
+++ b/build/yamls/flow-aggregator/patches/coverage/startFlowAggCov.yml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flow-aggregator
+  namespace: flow-aggregator
+spec:
+  template:
+    spec:
+      containers:
+      - name: flow-aggregator
+        image: antrea/flow-aggregator-coverage:latest
+        command: [ "/bin/sh" ]
+        args: [ "-c", "flow-aggregator-coverage -test.run=TestBincoverRunMain -test.coverprofile=flow-aggregator.cov.out -args-file=/flow-aggregator-arg-file; while true; do sleep 5 & wait $!; done" ]

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -298,7 +298,11 @@ function deliver_antrea {
             VERSION="$CLUSTER" DOCKER_REGISTRY="${DOCKER_REGISTRY}" make && break
         fi
     done
-    VERSION="$CLUSTER" DOCKER_REGISTRY="${DOCKER_REGISTRY}" make flow-aggregator-ubuntu
+    if [[ "$COVERAGE" == true ]]; then
+      VERSION="$CLUSTER" DOCKER_REGISTRY="${DOCKER_REGISTRY}" make flow-aggregator-ubuntu-coverage
+    else
+      VERSION="$CLUSTER" DOCKER_REGISTRY="${DOCKER_REGISTRY}" make flow-aggregator-ubuntu
+    fi
     cd ci/jenkins
 
     if [ "$?" -ne "0" ]; then
@@ -332,10 +336,12 @@ function deliver_antrea {
 
     if [[ "$COVERAGE" == true ]]; then
         docker save -o antrea-ubuntu-coverage.tar antrea/antrea-ubuntu-coverage:${DOCKER_IMG_VERSION}
+        docker save -o flow-aggregator-coverage.tar antrea/flow-aggregator-coverage:${DOCKER_IMG_VERSION}
     else
         docker save -o antrea-ubuntu.tar projects.registry.vmware.com/antrea/antrea-ubuntu:${DOCKER_IMG_VERSION}
+        docker save -o flow-aggregator.tar projects.registry.vmware.com/antrea/flow-aggregator:${DOCKER_IMG_VERSION}
     fi
-    docker save -o flow-aggregator.tar projects.registry.vmware.com/antrea/flow-aggregator:${DOCKER_IMG_VERSION}
+
 
     kubectl get nodes -o wide --no-headers=true | awk -v role="$CONTROL_PLANE_NODE_ROLE" '$3 == role {print $6}' | while read control_plane_ip; do
         scp -q -o StrictHostKeyChecking=no -i ${GIT_CHECKOUT_DIR}/jenkins/key/antrea-ci-key $GIT_CHECKOUT_DIR/build/yamls/*.yml capv@${control_plane_ip}:~
@@ -347,10 +353,11 @@ function deliver_antrea {
         ssh-keygen -f "/var/lib/jenkins/.ssh/known_hosts" -R ${IPs[$i]}
         if [[ "$COVERAGE" == true ]]; then
             copy_image antrea-ubuntu-coverage.tar docker.io/antrea/antrea-ubuntu-coverage ${IPs[$i]} ${DOCKER_IMG_VERSION} true
+            copy_image flow-aggregator-coverage.tar docker.io/antrea/flow-aggregator-coverage ${IPs[$i]} ${DOCKER_IMG_VERSION} true
         else
             copy_image antrea-ubuntu.tar projects.registry.vmware.com/antrea/antrea-ubuntu ${IPs[$i]} ${DOCKER_IMG_VERSION} true
+            copy_image flow-aggregator.tar projects.registry.vmware.com/antrea/flow-aggregator ${IPs[$i]} ${DOCKER_IMG_VERSION} true
         fi
-        copy_image flow-aggregator.tar projects.registry.vmware.com/antrea/flow-aggregator ${IPs[$i]} ${DOCKER_IMG_VERSION} true
     done
 
     if [[ -z $OLD_ANTREA_VERSION ]]; then
@@ -448,7 +455,7 @@ function run_e2e {
     tar -zcf ${GIT_CHECKOUT_DIR}/antrea-test-logs.tar.gz ${GIT_CHECKOUT_DIR}/antrea-test-logs
     if [[ "$COVERAGE" == true ]]; then
         tar -zcf ${GIT_CHECKOUT_DIR}/e2e-coverage.tar.gz ${GIT_CHECKOUT_DIR}/e2e-coverage
-        curl -s https://codecov.io/bash | bash -s -- -c -t ${CODECOV_TOKEN} -F e2e-tests -f '*antrea*' -s ${GIT_CHECKOUT_DIR}/e2e-coverage
+        curl -s https://codecov.io/bash | bash -s -- -c -t ${CODECOV_TOKEN} -F e2e-tests -f '*.cov.out*' -s ${GIT_CHECKOUT_DIR}/e2e-coverage
     fi
 }
 

--- a/cmd/flow-aggregator/bincover_run_main_test.go
+++ b/cmd/flow-aggregator/bincover_run_main_test.go
@@ -1,0 +1,13 @@
+// +build testbincover
+
+package main
+
+import (
+	"testing"
+
+	"github.com/confluentinc/bincover"
+)
+
+func TestBincoverRunMain(t *testing.T) {
+	bincover.RunTest(main)
+}

--- a/pkg/agent/flowexporter/exporter/certificate.go
+++ b/pkg/agent/flowexporter/exporter/certificate.go
@@ -37,7 +37,7 @@ func getCACert(k8sClient kubernetes.Interface) ([]byte, error) {
 		return nil, fmt.Errorf("error getting ConfigMap %s: %v", CAConfigMapName, err)
 	}
 	if caConfigMap.Data == nil || caConfigMap.Data[CAConfigMapKey] == "" {
-		return nil, fmt.Errorf("error getting data from ConfigMap %s: %v", CAConfigMapName, err)
+		return nil, fmt.Errorf("no data in %s ConfigMap", CAConfigMapName)
 	}
 	return []byte(caConfigMap.Data[CAConfigMapKey]), nil
 }

--- a/test/e2e/coverage/flow-aggregator-arg-file
+++ b/test/e2e/coverage/flow-aggregator-arg-file
@@ -1,0 +1,7 @@
+--config
+/etc/flow-aggregator/flow-aggregator.conf
+--logtostderr=false
+--log_dir=/var/log/flowaggregator
+--alsologtostderr
+--log_file_max_size=100
+--log_file_max_num=4

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -305,6 +305,9 @@ func exportLogs(tb testing.TB, data *TestData, logsSubDir string, writeNodeLogs 
 }
 
 func teardownFlowAggregator(tb testing.TB, data *TestData) {
+	if err := testData.gracefulExitFlowAggregator(testOptions.coverageDir); err != nil {
+		tb.Fatalf("Error when gracefully exiting Flow Aggregator: %v", err)
+	}
 	tb.Logf("Deleting '%s' K8s Namespace", flowAggregatorNamespace)
 	if err := data.deleteNamespace(flowAggregatorNamespace, defaultTimeout); err != nil {
 		tb.Logf("Error when tearing down flow aggregator: %v", err)

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -210,7 +210,7 @@ func checkRecordsForFlows(t *testing.T, data *TestData, srcIP string, dstIP stri
 		}
 		return strings.Contains(collectorOutput, srcIP) && strings.Contains(collectorOutput, dstIP), nil
 	})
-	require.NoError(t, err, "IPFIX collector did not receive expected number of data records and timed out.")
+	require.NoErrorf(t, err, "IPFIX collector did not receive the expected records and timed out with error: %v", err)
 
 	rc, collectorOutput, _, err := provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl logs --since=%v ipfix-collector -n antrea-test", time.Since(timeStart).String()))
 	if err != nil || rc != 0 {


### PR DESCRIPTION
Add code coverage for flow aggregator binary when
running end-to-end tests on different platforms
(kind, jenkins, VMC etc.)