### PR TITLE
Clean up stale IP addresses on Antrea host gateway

### DIFF
--- a/pkg/agent/util/net_linux.go
+++ b/pkg/agent/util/net_linux.go
@@ -130,36 +130,68 @@ func SetLinkUp(name string) (net.HardwareAddr, int, error) {
 	return mac, index, nil
 }
 
-func ConfigureLinkAddress(idx int, gwIPNet *net.IPNet) error {
+func ConfigureLinkAddresses(idx int, ipNets []*net.IPNet) error {
 	// No need to check the error here, since the link is found in previous steps.
 	link, _ := netlink.LinkByIndex(idx)
-	gwAddr := &netlink.Addr{IPNet: gwIPNet, Label: ""}
-
-	var addrFamily int
-	if gwIPNet.IP.To4() != nil {
-		addrFamily = netlink.FAMILY_V4
-	} else {
-		addrFamily = netlink.FAMILY_V6
+	ifaceName := link.Attrs().Name
+	var newAddrs []netlink.Addr
+	for _, ipNet := range ipNets {
+		newAddrs = append(newAddrs, netlink.Addr{IPNet: ipNet, Label: ""})
 	}
 
-	if addrs, err := netlink.AddrList(link, addrFamily); err != nil {
-		klog.Errorf("Failed to query address list for interface %s: %v", link.Attrs().Name, err)
-		return err
-	} else if addrs != nil {
-		for _, addr := range addrs {
-			klog.V(4).Infof("Found address %s for interface %s", addr.IP.String(), link.Attrs().Name)
-			if addr.IP.Equal(gwAddr.IPNet.IP) {
-				klog.V(2).Infof("Address %s already assigned to interface %s", addr.IP.String(), link.Attrs().Name)
-				return nil
-			}
+	allAddrs, err := netlink.AddrList(link, netlink.FAMILY_ALL)
+	if err != nil {
+		return fmt.Errorf("failed to query address list for interface %s: %v", ifaceName, err)
+	}
+	// Remove link-local address from list
+	addrs := make([]netlink.Addr, 0, len(allAddrs))
+	for _, addr := range allAddrs {
+		if !addr.IP.IsLinkLocalUnicast() {
+			addrs = append(addrs, addr)
 		}
 	}
 
-	klog.V(2).Infof("Adding address %v to gateway interface %s", gwAddr, link.Attrs().Name)
-	if err := netlink.AddrAdd(link, gwAddr); err != nil {
-		klog.Errorf("Failed to set gateway interface %s with address %v: %v", link.Attrs().Name, gwAddr, err)
-		return err
+	addrSliceDifference := func(s1, s2 []netlink.Addr) []*netlink.Addr {
+		var diff []*netlink.Addr
+
+		for i, e1 := range s1 {
+			found := false
+			for _, e2 := range s2 {
+				if e1.Equal(e2) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				diff = append(diff, &s1[i])
+			}
+		}
+
+		return diff
 	}
+
+	addrsToAdd := addrSliceDifference(newAddrs, addrs)
+	addrsToRemove := addrSliceDifference(addrs, newAddrs)
+
+	if len(addrsToAdd) == 0 && len(addrsToRemove) == 0 {
+		klog.V(2).Infof("IP configuration for interface %s does not need to change", ifaceName)
+		return nil
+	}
+
+	for _, addr := range addrsToRemove {
+		klog.V(2).Infof("Removing address %v from interface %s", addr, ifaceName)
+		if err := netlink.AddrDel(link, addr); err != nil {
+			return fmt.Errorf("failed to remove address %v from interface %s: %v", addr, ifaceName, err)
+		}
+	}
+
+	for _, addr := range addrsToAdd {
+		klog.V(2).Infof("Adding address %v to interface %s", addr, ifaceName)
+		if err := netlink.AddrAdd(link, addr); err != nil {
+			return fmt.Errorf("failed to add address %v to interface %s: %v", addr, ifaceName, err)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/agent/util/net_windows.go
+++ b/pkg/agent/util/net_windows.go
@@ -95,6 +95,17 @@ func ConfigureInterfaceAddress(ifaceName string, ipConfig *net.IPNet) error {
 	return nil
 }
 
+// RemoveInterfaceAddress removes IPAddress from the specified interface.
+func RemoveInterfaceAddress(ifaceName string, ipAddr net.IP) error {
+	cmd := fmt.Sprintf(`Remove-NetIPAddress -InterfaceAlias "%s" -IPAddress %s -Confirm:$false`, ifaceName, ipAddr.String())
+	err := InvokePSCommand(cmd)
+	// If the address does not exist, ignore the error.
+	if err != nil && !strings.Contains(err.Error(), "No matching") {
+		return err
+	}
+	return nil
+}
+
 // ConfigureInterfaceAddressWithDefaultGateway adds IPAddress on the specified interface and sets the default gateway
 // for the host.
 func ConfigureInterfaceAddressWithDefaultGateway(ifaceName string, ipConfig *net.IPNet, gateway string) error {
@@ -270,34 +281,73 @@ func SetLinkUp(name string) (net.HardwareAddr, int, error) {
 	return mac, index, nil
 }
 
-func ConfigureLinkAddress(idx int, gwIPNet *net.IPNet) error {
-	if gwIPNet.IP.To4() == nil {
-		klog.Warningf("Windows only supports IPv4 addresses. Skip this address %s", gwIPNet.String())
-		return nil
-	}
-
+func ConfigureLinkAddresses(idx int, ipNets []*net.IPNet) error {
 	iface, _ := net.InterfaceByIndex(idx)
-	gwIP := gwIPNet.IP
-	name := iface.Name
-	if addrs, err := iface.Addrs(); err != nil {
-		klog.Errorf("Failed to query IPv4 address list for interface %s: %v", name, err)
-		return err
-	} else if addrs != nil {
-		for _, addr := range addrs {
-			// Check with IPv4 address.
+	ifaceName := iface.Name
+	var addrs []*net.IPNet
+	if ifaceAddrs, err := iface.Addrs(); err != nil {
+		return fmt.Errorf("failed to query IPv4 address list for interface %s: %v", ifaceName, err)
+	} else {
+		for _, addr := range ifaceAddrs {
 			if ipNet, ok := addr.(*net.IPNet); ok {
-				if ipNet.IP.To4() != nil && ipNet.IP.Equal(gwIPNet.IP) {
-					return nil
+				if ipNet.IP.To4() != nil && !ipNet.IP.IsLinkLocalUnicast() {
+					addrs = append(addrs, ipNet)
 				}
 			}
 		}
 	}
 
-	klog.V(2).Infof("Adding address %v to gateway interface %s", gwIP, name)
-	if err := ConfigureInterfaceAddress(iface.Name, gwIPNet); err != nil {
-		klog.Errorf("Failed to set gateway interface %v with address %v: %v", iface, gwIP, err)
-		return err
+	addrEqual := func(addr1, addr2 *net.IPNet) bool {
+		size1, _ := addr1.Mask.Size()
+		size2, _ := addr2.Mask.Size()
+		return addr1.IP.Equal(addr2.IP) && size1 == size2
 	}
+
+	addrSliceDifference := func(s1, s2 []*net.IPNet) []*net.IPNet {
+		var diff []*net.IPNet
+
+		for _, e1 := range s1 {
+			found := false
+			for _, e2 := range s2 {
+				if addrEqual(e1, e2) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				diff = append(diff, e1)
+			}
+		}
+
+		return diff
+	}
+
+	addrsToAdd := addrSliceDifference(ipNets, addrs)
+	addrsToRemove := addrSliceDifference(addrs, ipNets)
+
+	if len(addrsToAdd) == 0 && len(addrsToRemove) == 0 {
+		klog.V(2).Infof("IP configuration for interface %s does not need to change", ifaceName)
+		return nil
+	}
+
+	for _, addr := range addrsToRemove {
+		klog.V(2).Infof("Removing address %v from interface %s", addr, ifaceName)
+		if err := RemoveInterfaceAddress(ifaceName, addr.IP); err != nil {
+			return fmt.Errorf("failed to remove address %v from interface %s: %v", addr, ifaceName, err)
+		}
+	}
+
+	for _, addr := range addrsToAdd {
+		klog.V(2).Infof("Adding address %v to interface %s", addr, ifaceName)
+		if addr.IP.To4() == nil {
+			klog.Warningf("Windows only supports IPv4 addresses, skipping this address %v", addr)
+			return nil
+		}
+		if err := ConfigureInterfaceAddress(ifaceName, addr); err != nil {
+			return fmt.Errorf("failed to add address %v to interface %s: %v", addr, ifaceName, err)
+		}
+	}
+
 	return nil
 }
 

--- a/test/integration/agent/net_test.go
+++ b/test/integration/agent/net_test.go
@@ -1,0 +1,82 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/util"
+)
+
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+}
+
+func addrEqual(addr1, addr2 *net.IPNet) bool {
+	size1, _ := addr1.Mask.Size()
+	size2, _ := addr2.Mask.Size()
+	return addr1.IP.Equal(addr2.IP) && size1 == size2
+}
+
+func TestConfigureLinkAddresses(t *testing.T) {
+	// #nosec G404: random number generator not used for security purposes
+	suffix := rand.Uint32()
+	ifaceName := fmt.Sprintf("test%x", suffix)
+	createTestInterface(t, ifaceName)
+	defer deleteTestInterface(t, ifaceName)
+	ifaceIdx := setTestInterfaceUp(t, ifaceName)
+
+	addrs := getTestInterfaceAddresses(t, ifaceName)
+	t.Logf("Found the following initial addresses: %v", addrs)
+	nAddrs := len(addrs)
+	// there can be up to one IPv6 link-local address and one IPv4
+	// link-local address (on Windows)
+	assert.LessOrEqual(t, nAddrs, 2)
+
+	_, dummyAddr, _ := net.ParseCIDR("192.0.2.0/24")
+
+	addTestInterfaceAddress(t, ifaceName, dummyAddr)
+	addrs2 := getTestInterfaceAddresses(t, ifaceName)
+	nAddrs2 := len(addrs2)
+	assert.Equal(t, nAddrs+1, nAddrs2)
+
+	_, ipAddr, _ := net.ParseCIDR("192.0.3.0/24")
+	err := util.ConfigureLinkAddresses(ifaceIdx, []*net.IPNet{ipAddr})
+	require.NoError(t, err)
+
+	addrs3 := getTestInterfaceAddresses(t, ifaceName)
+	nAddrs3 := len(addrs3)
+	assert.Equal(t, nAddrs+1, nAddrs3)
+
+	foundDummy := false
+	foundActual := false
+	for _, addr := range addrs3 {
+		switch {
+		case addrEqual(addr, dummyAddr):
+			foundDummy = true
+		case addrEqual(addr, ipAddr):
+			foundActual = true
+		}
+	}
+	assert.True(t, foundActual, "IP address was not assigned to test interface")
+	assert.False(t, foundDummy, "Dummy IP address should have been removed from test interface")
+}

--- a/test/integration/agent/net_test_linux.go
+++ b/test/integration/agent/net_test_linux.go
@@ -1,0 +1,64 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/util"
+)
+
+func createTestInterface(t *testing.T, name string) string {
+	t.Logf("Creating dummy test interface '%s'", name)
+	gwLink := &netlink.Dummy{}
+	gwLink.Name = name
+	require.NoError(t, netlink.LinkAdd(gwLink))
+	link, _ := netlink.LinkByName(name)
+	require.NoError(t, netlink.LinkSetUp(link))
+	return name
+}
+
+func setTestInterfaceUp(t *testing.T, name string) int {
+	_, ifaceIdx, err := util.SetLinkUp(name)
+	require.NoError(t, err)
+	return ifaceIdx
+}
+
+func deleteTestInterface(t *testing.T, name string) {
+	t.Logf("Deleting dummy test interface '%s'", name)
+	link, _ := netlink.LinkByName(name)
+	assert.NoError(t, netlink.LinkDel(link))
+}
+
+func getTestInterfaceAddresses(t *testing.T, name string) []*net.IPNet {
+	link, _ := netlink.LinkByName(name)
+	addrs, err := netlink.AddrList(link, netlink.FAMILY_ALL)
+	require.NoError(t, err)
+	var result []*net.IPNet
+	for _, addr := range addrs {
+		result = append(result, addr.IPNet)
+	}
+	return result
+}
+
+func addTestInterfaceAddress(t *testing.T, name string, addr *net.IPNet) {
+	link, _ := netlink.LinkByName(name)
+	require.NoError(t, netlink.AddrAdd(link, &netlink.Addr{IPNet: addr}))
+}

--- a/test/integration/agent/net_test_windows.go
+++ b/test/integration/agent/net_test_windows.go
@@ -1,0 +1,76 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent/util"
+)
+
+func adapterName(name string) string {
+	return fmt.Sprintf("vEthernet (%s)", name)
+}
+
+func createTestInterface(t *testing.T, name string) string {
+	t.Logf("Checking if Hyper-V feature is enabled")
+	enabled, err := util.WindowsHyperVEnabled()
+	require.NoError(t, err)
+	if !enabled {
+		t.Skipf("Skipping test as it requires the Hyper-V feature to be enabled")
+	}
+	t.Logf("Creating test vSwitch and adapter '%s'", name)
+	cmd := fmt.Sprintf("New-VMSwitch %s -SwitchType Internal", name)
+	require.NoError(t, util.InvokePSCommand(cmd))
+	return adapterName(name)
+}
+
+func setTestInterfaceUp(t *testing.T, name string) int {
+	_, ifaceIdx, err := util.SetLinkUp(adapterName(name))
+	require.NoError(t, err)
+	return ifaceIdx
+}
+
+func deleteTestInterface(t *testing.T, name string) {
+	t.Logf("Deleting test vSwitch '%s'", name)
+	cmd := fmt.Sprintf(`Remove-VMSwitch "%s" -Force`, name)
+	assert.NoError(t, util.InvokePSCommand(cmd))
+}
+
+func getTestInterfaceAddresses(t *testing.T, name string) []*net.IPNet {
+	iface, err := net.InterfaceByName(adapterName(name))
+	require.NoError(t, err)
+	addrs, err := iface.Addrs()
+	require.NoError(t, err)
+	var result []*net.IPNet
+	for _, addr := range addrs {
+		if ipNet, ok := addr.(*net.IPNet); ok {
+			result = append(result, ipNet)
+		}
+	}
+	return result
+}
+
+func addTestInterfaceAddress(t *testing.T, name string, addr *net.IPNet) {
+	ipStr := strings.Split(addr.String(), "/")
+	cmd := fmt.Sprintf(`New-NetIPAddress -InterfaceAlias "%s" -IPAddress %s -PrefixLength %s`, adapterName(name), ipStr[0], ipStr[1])
+	require.NoError(t, util.InvokePSCommand(cmd))
+}


### PR DESCRIPTION
When a Node leaves a K8s cluster and joins it again later, it is likely
that it will receive a different Pod CIDR. If we simply add the new
gateway IP (first IP in the CIDR) to the host gateway interface without
removing the previous one, we have observed that it can lead to
connectivity issues. This commit ensures that all stale IPs are removed
when configuring the gateway interface on an Agent restart. Link-local
addresses are left untouched. An integration test is added for both
Linux & Windows.

Fixes #1685