### PR TITLE
[CI] Fix wrong trigger phrase in integration-manual job

### DIFF
--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -190,7 +190,7 @@
           - ${{sha1}}
           builders:
           - builder-integration
-          trigger_phrase: ^(?!Thanks for your PR).*/test-integration).*
+          trigger_phrase: ^(?!Thanks for your PR).*/test-integration.*
           white_list_target_branches: []
           allow_whitelist_orgs_as_admins: true
           admin_list: '{antrea_admin_list}'


### PR DESCRIPTION
There is a extra ")" in current trigger phrase in integration-manual job.
As a result, triggering will fail and it leads to error below:
```
Failed to compile pattern ^(?!Thanks for your PR).*/test-integration).*
java.util.regex.PatternSyntaxException: Unmatched closing ')' near index 41
^(?!Thanks for your PR).*/test-integration).*
```