### PR TITLE
Fix misleading comments about defaultMTU config parameter

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1374,7 +1374,7 @@ data:
     # Default MTU to use for the host gateway interface and the network interface of each Pod.
     # If omitted, antrea-agent will discover the MTU of the Node's primary interface and
     # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
-    #defaultMTU: 1450
+    #defaultMTU: 0
 
     # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
     # for the GRE tunnel type.
@@ -1499,7 +1499,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-mc9bkf47f4
+  name: antrea-config-m6cb2mk6f8
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1619,7 +1619,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-mc9bkf47f4
+          name: antrea-config-m6cb2mk6f8
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1883,7 +1883,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-mc9bkf47f4
+          name: antrea-config-m6cb2mk6f8
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1374,7 +1374,7 @@ data:
     # Default MTU to use for the host gateway interface and the network interface of each Pod.
     # If omitted, antrea-agent will discover the MTU of the Node's primary interface and
     # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
-    #defaultMTU: 1450
+    #defaultMTU: 0
 
     # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
     # for the GRE tunnel type.
@@ -1499,7 +1499,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-mc9bkf47f4
+  name: antrea-config-m6cb2mk6f8
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1619,7 +1619,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-mc9bkf47f4
+          name: antrea-config-m6cb2mk6f8
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1885,7 +1885,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-mc9bkf47f4
+          name: antrea-config-m6cb2mk6f8
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1374,7 +1374,7 @@ data:
     # Default MTU to use for the host gateway interface and the network interface of each Pod.
     # If omitted, antrea-agent will discover the MTU of the Node's primary interface and
     # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
-    #defaultMTU: 1450
+    #defaultMTU: 0
 
     # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
     # for the GRE tunnel type.
@@ -1499,7 +1499,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-bkc6dfdhgt
+  name: antrea-config-mk65mt7755
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1619,7 +1619,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-bkc6dfdhgt
+          name: antrea-config-mk65mt7755
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1886,7 +1886,7 @@ spec:
           path: /home/kubernetes/bin
         name: host-cni-bin
       - configMap:
-          name: antrea-config-bkc6dfdhgt
+          name: antrea-config-mk65mt7755
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1374,7 +1374,7 @@ data:
     # Default MTU to use for the host gateway interface and the network interface of each Pod.
     # If omitted, antrea-agent will discover the MTU of the Node's primary interface and
     # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
-    #defaultMTU: 1450
+    #defaultMTU: 0
 
     # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
     # for the GRE tunnel type.
@@ -1504,7 +1504,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-ftckkg2dc8
+  name: antrea-config-b789kb895m
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1633,7 +1633,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-ftckkg2dc8
+          name: antrea-config-b789kb895m
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1932,7 +1932,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-ftckkg2dc8
+          name: antrea-config-b789kb895m
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1374,7 +1374,7 @@ data:
     # Default MTU to use for the host gateway interface and the network interface of each Pod.
     # If omitted, antrea-agent will discover the MTU of the Node's primary interface and
     # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
-    #defaultMTU: 1450
+    #defaultMTU: 0
 
     # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
     # for the GRE tunnel type.
@@ -1504,7 +1504,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-md64tc85t9
+  name: antrea-config-4f9kt42925
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1624,7 +1624,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-md64tc85t9
+          name: antrea-config-4f9kt42925
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1888,7 +1888,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-md64tc85t9
+          name: antrea-config-4f9kt42925
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -72,7 +72,7 @@ featureGates:
 # Default MTU to use for the host gateway interface and the network interface of each Pod.
 # If omitted, antrea-agent will discover the MTU of the Node's primary interface and
 # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
-#defaultMTU: 1450
+#defaultMTU: 0
 
 # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
 # for the GRE tunnel type.

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -70,9 +70,9 @@ type AgentConfig struct {
 	// - gre
 	// - stt
 	TunnelType string `yaml:"tunnelType,omitempty"`
-	// Default MTU to use for the host gateway interface and the network interface of each
-	// Pod. If omitted, antrea-agent will default this value to 1450 to accommodate for tunnel
-	// encapsulate overhead.
+	// Default MTU to use for the host gateway interface and the network interface of each Pod.
+	// If omitted, antrea-agent will discover the MTU of the Node's primary interface and
+	// also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
 	DefaultMTU int `yaml:"defaultMTU,omitempty"`
 	// Mount location of the /proc directory. The default is "/host", which is appropriate when
 	// antrea-agent is run as part of the Antrea DaemonSet (and the host's /proc directory is mounted


### PR DESCRIPTION
* Default value should not be 1450 in YAML manifest: if someone just
  uncomments this line, it will force the MTU to be set to 1450, as
  opposed to the default behavior which is auto-discovery.
* The corresponding comment in cmd/antrea-agent/config.go was incorrect.