### PR TITLE
Add nested ClusterGroup support

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -68,6 +68,8 @@ spec:
         properties:
           spec:
             properties:
+              childGroups:
+                x-kubernetes-preserve-unknown-fields: true
               externalEntitySelector:
                 x-kubernetes-preserve-unknown-fields: true
               ipBlock:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -68,6 +68,8 @@ spec:
         properties:
           spec:
             properties:
+              childGroups:
+                x-kubernetes-preserve-unknown-fields: true
               externalEntitySelector:
                 x-kubernetes-preserve-unknown-fields: true
               ipBlock:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -68,6 +68,8 @@ spec:
         properties:
           spec:
             properties:
+              childGroups:
+                x-kubernetes-preserve-unknown-fields: true
               externalEntitySelector:
                 x-kubernetes-preserve-unknown-fields: true
               ipBlock:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -68,6 +68,8 @@ spec:
         properties:
           spec:
             properties:
+              childGroups:
+                x-kubernetes-preserve-unknown-fields: true
               externalEntitySelector:
                 x-kubernetes-preserve-unknown-fields: true
               ipBlock:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -68,6 +68,8 @@ spec:
         properties:
           spec:
             properties:
+              childGroups:
+                x-kubernetes-preserve-unknown-fields: true
               externalEntitySelector:
                 x-kubernetes-preserve-unknown-fields: true
               ipBlock:

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -715,6 +715,8 @@ spec:
             spec:
               type: object
               properties:
+                childGroups:
+                  x-kubernetes-preserve-unknown-fields: true
                 podSelector:
                   x-kubernetes-preserve-unknown-fields: true
                 namespaceSelector:

--- a/pkg/apis/core/v1alpha2/types.go
+++ b/pkg/apis/core/v1alpha2/types.go
@@ -85,6 +85,9 @@ type ServiceReference struct {
 	Namespace string `json:"namespace,omitempty"`
 }
 
+// ClusterGroupReference represent reference to a ClusterGroup.
+type ClusterGroupReference string
+
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -129,6 +132,11 @@ type GroupSpec struct {
 	// Cannot be set with any other selector except NamespaceSelector.
 	// +optional
 	ExternalEntitySelector *metav1.LabelSelector `json:"externalEntitySelector,omitempty"`
+	// Select other ClusterGroups by name. The ClusterGroups must already
+	// exist and must not contain ChildGroups themselves.
+	// Cannot be set with any selector/IPBlock/ServiceReference.
+	// +optional
+	ChildGroups []ClusterGroupReference `json:"childGroups,omitempty"`
 }
 
 type GroupConditionType string

--- a/pkg/apis/core/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha2/zz_generated.deepcopy.go
@@ -232,6 +232,11 @@ func (in *GroupSpec) DeepCopyInto(out *GroupSpec) {
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ChildGroups != nil {
+		in, out := &in.ChildGroups, &out.ChildGroups
+		*out = make([]ClusterGroupReference, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/controller/networkpolicy/clustergroup.go
+++ b/pkg/controller/networkpolicy/clustergroup.go
@@ -385,7 +385,7 @@ func (n *NetworkPolicyController) GetAssociatedGroups(name, namespace string) ([
 }
 
 // getAssociatedGroupsByName retrieves the internal Group and all it's parent Group objects
-// (if any) by Group name. This function assumes that there's no loop in Group reference.
+// (if any) by Group name.
 func (n *NetworkPolicyController) getAssociatedGroupsByName(grpName string) []antreatypes.Group {
 	var groups []antreatypes.Group
 	groupObj, found, _ := n.internalGroupStore.Get(grpName)
@@ -400,7 +400,7 @@ func (n *NetworkPolicyController) getAssociatedGroupsByName(grpName string) []an
 	}
 	for _, p := range parentGroupObjs {
 		parentGrp := p.(*antreatypes.Group)
-		groups = append(groups, n.getAssociatedGroupsByName(parentGrp.Name)...)
+		groups = append(groups, *parentGrp)
 	}
 	return groups
 }

--- a/pkg/controller/networkpolicy/clustergroup.go
+++ b/pkg/controller/networkpolicy/clustergroup.go
@@ -16,6 +16,7 @@ package networkpolicy
 
 import (
 	"context"
+	"fmt"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,10 +50,19 @@ func (n *NetworkPolicyController) updateClusterGroup(oldObj, curObj interface{})
 	klog.V(2).Infof("Processing UPDATE event for ClusterGroup %s", cg.Name)
 	newGroup := n.processClusterGroup(cg)
 	oldGroup := n.processClusterGroup(og)
+	selectorUpdated := getNormalizedNameForSelector(newGroup.Selector) != getNormalizedNameForSelector(oldGroup.Selector)
 	ipBlockUpdated := newGroup.IPBlock != oldGroup.IPBlock
 	svcRefUpdated := newGroup.ServiceReference != oldGroup.ServiceReference
-	if getNormalizedNameForSelector(newGroup.Selector) == getNormalizedNameForSelector(oldGroup.Selector) && !ipBlockUpdated && !svcRefUpdated {
-		// No change in the selectors of the ClusterGroup. No need to enqueue for further sync.
+	oldChildGroups, newChildGroups := sets.String{}, sets.String{}
+	for _, c := range oldGroup.ChildGroups {
+		oldChildGroups.Insert(c)
+	}
+	for _, c := range newGroup.ChildGroups {
+		newChildGroups.Insert(c)
+	}
+	childGroupsUpdated := !oldChildGroups.Equal(newChildGroups)
+	if !selectorUpdated && !ipBlockUpdated && !svcRefUpdated && !childGroupsUpdated {
+		// No change in the contents of the ClusterGroup. No need to enqueue for further sync.
 		return
 	}
 	n.internalGroupStore.Update(newGroup)
@@ -88,6 +98,12 @@ func (n *NetworkPolicyController) processClusterGroup(cg *corev1a2.ClusterGroup)
 	internalGroup := antreatypes.Group{
 		Name: cg.Name,
 		UID:  cg.UID,
+	}
+	if len(cg.Spec.ChildGroups) > 0 {
+		for _, childCGName := range cg.Spec.ChildGroups {
+			internalGroup.ChildGroups = append(internalGroup.ChildGroups, string(childCGName))
+		}
+		return &internalGroup
 	}
 	if cg.Spec.IPBlock != nil {
 		ipb, _ := toAntreaIPBlockForCRD(cg.Spec.IPBlock)
@@ -175,17 +191,17 @@ func (n *NetworkPolicyController) syncInternalGroup(key string) error {
 	selectorUpdated := n.processServiceReference(grp)
 	if grp.Selector != nil {
 		n.groupingInterface.AddGroup(clusterGroupType, grp.Name, grp.Selector)
-	} else {
+	} else if len(grp.ChildGroups) == 0 {
 		n.groupingInterface.DeleteGroup(clusterGroupType, grp.Name)
 	}
-	// for ipBlock Groups, newMemberSet and grp.GroupMembers will both be empty.
 	if selectorUpdated {
-		// Update the internal Group object in the store with the Pods as GroupMembers.
+		// Update the internal Group object in the store with the new selector.
 		updatedGrp := &antreatypes.Group{
 			UID:              grp.UID,
 			Name:             grp.Name,
 			Selector:         grp.Selector,
 			ServiceReference: grp.ServiceReference,
+			ChildGroups:      grp.ChildGroups,
 		}
 		klog.V(2).Infof("Updating existing internal Group %s", key)
 		n.internalGroupStore.Update(updatedGrp)
@@ -197,7 +213,23 @@ func (n *NetworkPolicyController) syncInternalGroup(key string) error {
 		klog.Errorf("Failed to update ClusterGroup %s GroupMembersComputed condition to %s: %v", cg.Name, v1.ConditionTrue, err)
 		return err
 	}
+	n.triggerParentGroupSync(grp)
 	return n.triggerCNPUpdates(cg)
+}
+
+func (n *NetworkPolicyController) triggerParentGroupSync(grp *antreatypes.Group) {
+	// TODO: if the group nest level increases, this will no longer be a valid condition
+	//  to check whether a group can possibly have parents.
+	if len(grp.ChildGroups) == 0 {
+		parentGroupObjs, err := n.internalGroupStore.GetByIndex(store.ChildGroupIndex, grp.Name)
+		if err != nil {
+			klog.Errorf("Error retrieving parents of ClusterGroup %s: %v", grp.Name, err)
+		}
+		for _, p := range parentGroupObjs {
+			parentGrp := p.(*antreatypes.Group)
+			n.enqueueInternalGroup(parentGrp.Name)
+		}
+	}
 }
 
 // triggerCNPUpdates triggers processing of ClusterNetworkPolicies associated with the input ClusterGroup.
@@ -333,25 +365,48 @@ func (n *NetworkPolicyController) GetAssociatedGroups(name, namespace string) ([
 	if !exists {
 		return nil, nil
 	}
-	groupObjs := make([]antreatypes.Group, 0, len(clusterGroups))
+	var groupObjs []antreatypes.Group
 	for _, g := range clusterGroups {
-		group, found, _ := n.internalGroupStore.Get(g)
-		if found {
-			groupObjs = append(groupObjs, *group.(*antreatypes.Group))
+		groupObjs = append(groupObjs, n.getAssociatedGroupsByName(g)...)
+	}
+	// Remove duplicates in the groupObj slice.
+	groupKeys, j := make(map[string]bool), 0
+	for _, g := range groupObjs {
+		if _, exists := groupKeys[g.Name]; !exists {
+			groupKeys[g.Name] = true
+			groupObjs[j] = g
+			j++
 		}
 	}
-	return groupObjs, nil
+	return groupObjs[:j], nil
+}
+
+// getAssociatedGroupsByName retrieves the internal Group and all it's parent Group objects
+// (if any) by Group name. This function assumes that there's no loop in Group reference.
+func (n *NetworkPolicyController) getAssociatedGroupsByName(grpName string) []antreatypes.Group {
+	var groups []antreatypes.Group
+	groupObj, found, _ := n.internalGroupStore.Get(grpName)
+	if found {
+		grp := groupObj.(*antreatypes.Group)
+		groups = append(groups, *grp)
+		parentGroupObjs, err := n.internalGroupStore.GetByIndex(store.ChildGroupIndex, grp.Name)
+		if err != nil {
+			klog.Errorf("Error retrieving parents of ClusterGroup %s: %v", grp.Name, err)
+		}
+		for _, p := range parentGroupObjs {
+			parentGrp := p.(*antreatypes.Group)
+			groups = append(groups, n.getAssociatedGroupsByName(parentGrp.Name)...)
+		}
+	}
+	return groups
 }
 
 // GetGroupMembers returns the current members of a ClusterGroup.
 func (n *NetworkPolicyController) GetGroupMembers(cgName string) (controlplane.GroupMemberSet, error) {
-	pods, externalEntities := n.groupingInterface.GetEntities(clusterGroupType, cgName)
-	memberSet := controlplane.GroupMemberSet{}
-	for _, pod := range pods {
-		memberSet.Insert(podToGroupMember(pod, true))
+	groupObj, found, _ := n.internalGroupStore.Get(cgName)
+	if found {
+		group := groupObj.(*antreatypes.Group)
+		return n.getClusterGroupMemberSet(group), nil
 	}
-	for _, entity := range externalEntities {
-		memberSet.Insert(externalEntityToGroupMember(entity))
-	}
-	return memberSet, nil
+	return controlplane.GroupMemberSet{}, fmt.Errorf("no internal Group with name %s is found", cgName)
 }

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -1403,6 +1403,11 @@ func cidrStrToIPNet(cidr string) (*controlplane.IPNet, error) {
 	return ipNet, nil
 }
 
+// ipNetToCIDRStr returns the CIDR notation of a controlplane.IPNet.
+func ipNetToCIDRStr(ipNet controlplane.IPNet) string {
+	return net.IP(ipNet.IP).String() + "/" + strconv.Itoa(int(ipNet.PrefixLength))
+}
+
 // internalNetworkPolicyKeyFunc knows how to generate the key for an internal NetworkPolicy based on the object metadata
 // of the corresponding original NetworkPolicy resource (also referred to as the "source").
 // The key must be unique across K8s NetworkPolicies, Antrea NetworkPolicies, and Antrea ClusterNetworkPolicies.

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -60,6 +60,7 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/controller/networkpolicy/store"
 	antreatypes "github.com/vmware-tanzu/antrea/pkg/controller/types"
 	"github.com/vmware-tanzu/antrea/pkg/features"
+	"github.com/vmware-tanzu/antrea/pkg/k8s"
 	utilsets "github.com/vmware-tanzu/antrea/pkg/util/sets"
 )
 
@@ -1070,7 +1071,7 @@ func (n *NetworkPolicyController) syncAddressGroup(key string) error {
 		internalNP := internalNPObj.(*antreatypes.NetworkPolicy)
 		utilsets.Merge(addrGroupNodeNames, internalNP.SpanMeta.NodeNames)
 	}
-	memberSet := n.populateAddressGroupMemberSet(addressGroup)
+	memberSet := n.getAddressGroupMemberSet(addressGroup)
 	updatedAddressGroup := &antreatypes.AddressGroup{
 		Name:         addressGroup.Name,
 		UID:          addressGroup.UID,
@@ -1083,29 +1084,53 @@ func (n *NetworkPolicyController) syncAddressGroup(key string) error {
 	return nil
 }
 
-func (n *NetworkPolicyController) populateAddressGroupMemberSet(g *antreatypes.AddressGroup) controlplane.GroupMemberSet {
-	var pods []*v1.Pod
-	var externalEntities []*v1alpha2.ExternalEntity
+// getAddressGroupMemberSet knows how to construct a GroupMemberSet that contains
+// all the entities selected by an AddressGroup.
+func (n *NetworkPolicyController) getAddressGroupMemberSet(g *antreatypes.AddressGroup) controlplane.GroupMemberSet {
 	// Check if an internal Group object exists corresponding to this AddressGroup.
-	_, found, _ := n.internalGroupStore.Get(g.Name)
+	groupObj, found, _ := n.internalGroupStore.Get(g.Name)
 	if found {
 		// This AddressGroup is derived from a ClusterGroup.
-		pods, externalEntities = n.groupingInterface.GetEntities(clusterGroupType, g.Name)
-	} else {
-		pods, externalEntities = n.groupingInterface.GetEntities(addressGroupType, g.Name)
+		group := groupObj.(*antreatypes.Group)
+		return n.getClusterGroupMemberSet(group)
 	}
-	memberSet := controlplane.GroupMemberSet{}
+	return n.getMemberSetForGroupType(addressGroupType, g.Name)
+}
+
+// getClusterGroupMemberSet knows how to construct a GroupMemberSet that contains
+// all the entities selected by a ClusterGroup. For ClusterGroup that has childGroups,
+// the members are computed as the union of all its childGroup's members.
+// This function assumes that there's no loop in Group reference.
+func (n *NetworkPolicyController) getClusterGroupMemberSet(group *antreatypes.Group) controlplane.GroupMemberSet {
+	if len(group.ChildGroups) > 0 {
+		groupMemberSet := controlplane.GroupMemberSet{}
+		for _, childName := range group.ChildGroups {
+			childGroup, found, _ := n.internalGroupStore.Get(childName)
+			if found {
+				child := childGroup.(*antreatypes.Group)
+				groupMemberSet = groupMemberSet.Union(n.getClusterGroupMemberSet(child))
+			}
+		}
+		return groupMemberSet
+	}
+	return n.getMemberSetForGroupType(clusterGroupType, group.Name)
+}
+
+// getMemberSetForGroupType knows how to construct a GroupMemberSet for the given
+// groupType and group name.
+func (n *NetworkPolicyController) getMemberSetForGroupType(groupType grouping.GroupType, name string) controlplane.GroupMemberSet {
+	groupMemberSet := controlplane.GroupMemberSet{}
+	pods, externalEntities := n.groupingInterface.GetEntities(groupType, name)
 	for _, pod := range pods {
 		if len(pod.Status.PodIPs) == 0 {
-			// No need to insert Pod IPAddress when it is unset.
 			continue
 		}
-		memberSet.Insert(podToGroupMember(pod, true))
+		groupMemberSet.Insert(podToGroupMember(pod, true))
 	}
-	for _, entity := range externalEntities {
-		memberSet.Insert(externalEntityToGroupMember(entity))
+	for _, ee := range externalEntities {
+		groupMemberSet.Insert(externalEntityToGroupMember(ee))
 	}
-	return memberSet
+	return groupMemberSet
 }
 
 // podToGroupMember is util function to convert a Pod to a GroupMember type.
@@ -1243,15 +1268,51 @@ func (n *NetworkPolicyController) syncAppliedToGroup(key string) error {
 	return nil
 }
 
-// getAppliedToWorkloads returns a list of workloads like Pods and ExternalEntities matching an AppliedToGroup
+// getAppliedToWorkloads returns a list of workloads (Pods and ExternalEntities) selected by an AppliedToGroup
 // for standalone selectors or corresponding to a ClusterGroup.
 func (n *NetworkPolicyController) getAppliedToWorkloads(g *antreatypes.AppliedToGroup) ([]*v1.Pod, []*v1alpha2.ExternalEntity) {
 	// Check if an internal Group object exists corresponding to this AppliedToGroup.
-	_, found, _ := n.internalGroupStore.Get(g.Name)
+	group, found, _ := n.internalGroupStore.Get(g.Name)
 	if found {
-		return n.groupingInterface.GetEntities(clusterGroupType, g.Name)
+		// This AppliedToGroup is derived from a ClusterGroup.
+		grp := group.(*antreatypes.Group)
+		return n.getClusterGroupWorkloads(grp)
 	}
 	return n.groupingInterface.GetEntities(appliedToGroupType, g.Name)
+}
+
+// getClusterGroupWorkloads returns a list of workloads (Pods and ExternalEntities) selected by a ClusterGroup.
+// For ClusterGroup that has childGroups, the workloads are computed as the union of all its childGroup's workloads.
+// This function assumes that there's no loop in Group reference.
+func (n *NetworkPolicyController) getClusterGroupWorkloads(group *antreatypes.Group) ([]*v1.Pod, []*v1alpha2.ExternalEntity) {
+	podNameSet, eeNameSet := sets.String{}, sets.String{}
+	var pods []*v1.Pod
+	var ees []*v1alpha2.ExternalEntity
+	if len(group.ChildGroups) > 0 {
+		for _, childName := range group.ChildGroups {
+			childGroup, found, _ := n.internalGroupStore.Get(childName)
+			if found {
+				child := childGroup.(*antreatypes.Group)
+				childPods, childEEs := n.getClusterGroupWorkloads(child)
+				for _, pod := range childPods {
+					podString := k8s.NamespacedName(pod.Namespace, pod.Name)
+					if !podNameSet.Has(podString) {
+						podNameSet.Insert(podString)
+						pods = append(pods, pod)
+					}
+				}
+				for _, ee := range childEEs {
+					eeString := k8s.NamespacedName(ee.Namespace, ee.Name)
+					if !eeNameSet.Has(eeString) {
+						eeNameSet.Insert(eeString)
+						ees = append(ees, ee)
+					}
+				}
+			}
+		}
+		return pods, ees
+	}
+	return n.groupingInterface.GetEntities(clusterGroupType, group.Name)
 }
 
 // syncInternalNetworkPolicy retrieves all the AppliedToGroups associated with

--- a/pkg/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_test.go
@@ -2819,6 +2819,32 @@ func TestCIDRStrToIPNet(t *testing.T) {
 	}
 }
 
+func TestIPNetToCIDRStr(t *testing.T) {
+	ipNetV4, _ := cidrStrToIPNet("10.9.8.7/6")
+	ipNetV6, _ := cidrStrToIPNet("2002::1234:abcd:ffff:c0a8:101/64")
+	tests := []struct {
+		name string
+		inC  controlplane.IPNet
+		expC string
+	}{
+		{
+			name: "ipv4-address",
+			inC:  *ipNetV4,
+			expC: "10.9.8.7/6",
+		},
+		{
+			name: "ipv6-address",
+			inC:  *ipNetV6,
+			expC: "2002::1234:abcd:ffff:c0a8:101/64",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expC, ipNetToCIDRStr(tt.inC))
+		})
+	}
+}
+
 func TestIPStrToIPAddress(t *testing.T) {
 	ip1 := "10.0.1.10"
 	expIP1 := net.ParseIP(ip1)

--- a/pkg/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_test.go
@@ -92,7 +92,6 @@ func newController(objects ...runtime.Object) (*fake.Clientset, *networkPolicyCo
 	internalNetworkPolicyStore := store.NewNetworkPolicyStore()
 	internalGroupStore := store.NewGroupStore()
 	cgInformer := crdInformerFactory.Core().V1alpha2().ClusterGroups()
-	cgStore := crdInformerFactory.Core().V1alpha2().ClusterGroups().Informer().GetStore()
 	groupEntityIndex := grouping.NewGroupEntityIndex()
 	groupingController := grouping.NewGroupEntityController(groupEntityIndex,
 		informerFactory.Core().V1().Pods(),
@@ -126,7 +125,7 @@ func newController(objects ...runtime.Object) (*fake.Clientset, *networkPolicyCo
 		informerFactory.Networking().V1().NetworkPolicies().Informer().GetStore(),
 		crdInformerFactory.Security().V1alpha1().ClusterNetworkPolicies().Informer().GetStore(),
 		crdInformerFactory.Security().V1alpha1().Tiers().Informer().GetStore(),
-		cgStore,
+		crdInformerFactory.Core().V1alpha2().ClusterGroups().Informer().GetStore(),
 		appliedToGroupStore,
 		addressGroupStore,
 		internalNetworkPolicyStore,
@@ -2900,6 +2899,37 @@ func TestGetAppliedToWorkloads(t *testing.T) {
 			PodSelector: &selectorB,
 		},
 	}
+	selectorC := metav1.LabelSelector{MatchLabels: map[string]string{"foo3": "bar3"}}
+	cgC := v1alpha2.ClusterGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "cgC", UID: "uidC"},
+		Spec: v1alpha2.GroupSpec{
+			PodSelector: &selectorC,
+		},
+	}
+	cgD := v1alpha2.ClusterGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "cgD", UID: "uidD"},
+		Spec: v1alpha2.GroupSpec{
+			PodSelector: &selectorC,
+		},
+	}
+	nestedCG1 := v1alpha2.ClusterGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "nested-cg-A-B", UID: "uidE"},
+		Spec: v1alpha2.GroupSpec{
+			ChildGroups: []v1alpha2.ClusterGroupReference{"cgA", "cgB"},
+		},
+	}
+	nestedCG2 := v1alpha2.ClusterGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "nested-cg-A-C", UID: "uidF"},
+		Spec: v1alpha2.GroupSpec{
+			ChildGroups: []v1alpha2.ClusterGroupReference{"cgA", "cgC"},
+		},
+	}
+	nestedCG3 := v1alpha2.ClusterGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "nested-cg-A-C", UID: "uidG"},
+		Spec: v1alpha2.GroupSpec{
+			ChildGroups: []v1alpha2.ClusterGroupReference{"cgA", "cgC", "cgD"},
+		},
+	}
 	podA := getPod("podA", "nsA", "nodeA", "10.0.0.1", false)
 	podA.Labels = map[string]string{"foo1": "bar1"}
 	podB := getPod("podB", "nsA", "nodeB", "10.0.0.2", false)
@@ -2928,21 +2958,170 @@ func TestGetAppliedToWorkloads(t *testing.T) {
 			expPods: emptyPods,
 			expEEs:  emptyEEs,
 		},
+		{
+			name: "atg-for-nested-cg-one-child-empty",
+			inATG: &antreatypes.AppliedToGroup{
+				Name: nestedCG1.Name,
+				UID:  nestedCG1.UID,
+			},
+			expPods: []*corev1.Pod{podA},
+			expEEs:  emptyEEs,
+		},
+		{
+			name: "atg-for-nested-cg-both-children-match-pod",
+			inATG: &antreatypes.AppliedToGroup{
+				Name: nestedCG2.Name,
+				UID:  nestedCG2.UID,
+			},
+			expPods: []*corev1.Pod{podA, podB},
+			expEEs:  emptyEEs,
+		},
+		{
+			name: "atg-for-nested-cg-children-overlap-pod",
+			inATG: &antreatypes.AppliedToGroup{
+				Name: nestedCG3.Name,
+				UID:  nestedCG3.UID,
+			},
+			expPods: []*corev1.Pod{podA, podB},
+			expEEs:  emptyEEs,
+		},
 	}
 	_, c := newController()
 	c.groupingInterface.AddPod(podA)
 	c.groupingInterface.AddPod(podB)
-	c.cgStore.Add(&cgA)
-	c.cgStore.Add(&cgB)
-	c.addClusterGroup(&cgA)
-	c.syncInternalGroup(cgA.Name)
-	c.addClusterGroup(&cgB)
-	c.syncInternalGroup(cgB.Name)
+	clusterGroups := []v1alpha2.ClusterGroup{cgA, cgB, cgC, cgD, nestedCG1, nestedCG2}
+	for i, cg := range clusterGroups {
+		c.cgStore.Add(&clusterGroups[i])
+		c.addClusterGroup(&clusterGroups[i])
+		c.syncInternalGroup(cg.Name)
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actualPods, actualEEs := c.getAppliedToWorkloads(tt.inATG)
 			assert.Equal(t, tt.expEEs, actualEEs)
 			assert.Equal(t, tt.expPods, actualPods)
+		})
+	}
+}
+
+func TestGetAddressGroupMemberSet(t *testing.T) {
+	selectorA := metav1.LabelSelector{MatchLabels: map[string]string{"foo1": "bar1"}}
+	cgA := v1alpha2.ClusterGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "cgA", UID: "uidA"},
+		Spec: v1alpha2.GroupSpec{
+			PodSelector: &selectorA,
+		},
+	}
+	selectorB := metav1.LabelSelector{MatchLabels: map[string]string{"foo2": "bar2"}}
+	cgB := v1alpha2.ClusterGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "cgB", UID: "uidB"},
+		Spec: v1alpha2.GroupSpec{
+			PodSelector: &selectorB,
+		},
+	}
+	selectorC := metav1.LabelSelector{MatchLabels: map[string]string{"foo3": "bar3"}}
+	cgC := v1alpha2.ClusterGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "cgC", UID: "uidC"},
+		Spec: v1alpha2.GroupSpec{
+			PodSelector: &selectorC,
+		},
+	}
+	cgD := v1alpha2.ClusterGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "cgD", UID: "uidD"},
+		Spec: v1alpha2.GroupSpec{
+			PodSelector: &selectorC,
+		},
+	}
+	nestedCG1 := v1alpha2.ClusterGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "nested-cg-A-B", UID: "uidE"},
+		Spec: v1alpha2.GroupSpec{
+			ChildGroups: []v1alpha2.ClusterGroupReference{"cgA", "cgB"},
+		},
+	}
+	nestedCG2 := v1alpha2.ClusterGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "nested-cg-A-C", UID: "uidF"},
+		Spec: v1alpha2.GroupSpec{
+			ChildGroups: []v1alpha2.ClusterGroupReference{"cgA", "cgC"},
+		},
+	}
+	nestedCG3 := v1alpha2.ClusterGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "nested-cg-A-C", UID: "uidG"},
+		Spec: v1alpha2.GroupSpec{
+			ChildGroups: []v1alpha2.ClusterGroupReference{"cgA", "cgC", "cgD"},
+		},
+	}
+	podA := getPod("podA", "nsA", "nodeA", "10.0.0.1", false)
+	podA.Labels = map[string]string{"foo1": "bar1"}
+	podB := getPod("podB", "nsA", "nodeB", "10.0.0.2", false)
+	podB.Labels = map[string]string{"foo3": "bar3"}
+
+	podAMemberSet := controlplane.GroupMemberSet{}
+	podAMemberSet.Insert(podToGroupMember(podA, true))
+	podABMemberSet := controlplane.GroupMemberSet{}
+	podABMemberSet.Insert(podToGroupMember(podA, true))
+	podABMemberSet.Insert(podToGroupMember(podB, true))
+	tests := []struct {
+		name         string
+		inAddrGrp    *antreatypes.AddressGroup
+		expMemberSet controlplane.GroupMemberSet
+	}{
+		{
+			name: "addrgrp-for-cg",
+			inAddrGrp: &antreatypes.AddressGroup{
+				Name: cgA.Name,
+				UID:  cgA.UID,
+			},
+			expMemberSet: podAMemberSet,
+		},
+		{
+			name: "addrgrp-for-cg-no-pod-match",
+			inAddrGrp: &antreatypes.AddressGroup{
+				Name: cgB.Name,
+				UID:  cgB.UID,
+			},
+			expMemberSet: controlplane.GroupMemberSet{},
+		},
+		{
+			name: "addrgrp-for-nested-cg-one-child-empty",
+			inAddrGrp: &antreatypes.AddressGroup{
+				Name: nestedCG1.Name,
+				UID:  nestedCG1.UID,
+			},
+			expMemberSet: podAMemberSet,
+		},
+		{
+			name: "addrgrp-for-nested-cg-both-children-match-pod",
+			inAddrGrp: &antreatypes.AddressGroup{
+				Name: nestedCG2.Name,
+				UID:  nestedCG2.UID,
+			},
+			expMemberSet: podABMemberSet,
+		},
+		{
+			name: "addrgrp-for-nested-cg-children-overlap-pod",
+			inAddrGrp: &antreatypes.AddressGroup{
+				Name: nestedCG3.Name,
+				UID:  nestedCG3.UID,
+			},
+			expMemberSet: podABMemberSet,
+		},
+	}
+	_, c := newController()
+	c.groupingInterface.AddPod(podA)
+	c.groupingInterface.AddPod(podB)
+	clusterGroups := []v1alpha2.ClusterGroup{cgA, cgB, cgC, cgD, nestedCG1, nestedCG2}
+	for i, cg := range clusterGroups {
+		c.cgStore.Add(&clusterGroups[i])
+		c.addClusterGroup(&clusterGroups[i])
+		c.syncInternalGroup(cg.Name)
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualMemberSet := c.getAddressGroupMemberSet(tt.inAddrGrp)
+			extraItems := actualMemberSet.Difference(tt.expMemberSet)
+			missingItems := tt.expMemberSet.Difference(actualMemberSet)
+			assert.Equal(t, []*controlplane.GroupMember{}, extraItems.Items())
+			assert.Equal(t, []*controlplane.GroupMember{}, missingItems.Items())
 		})
 	}
 }

--- a/pkg/controller/networkpolicy/store/group.go
+++ b/pkg/controller/networkpolicy/store/group.go
@@ -27,7 +27,8 @@ import (
 )
 
 const (
-	ServiceIndex = "service"
+	ServiceIndex    = "service"
+	ChildGroupIndex = "childGroup"
 )
 
 // GroupKeyFunc knows how to get the key of an Group.
@@ -56,6 +57,13 @@ func NewGroupStore() storage.Interface {
 				return []string{}, nil
 			}
 			return []string{k8s.NamespacedName(g.ServiceReference.Namespace, g.ServiceReference.Name)}, nil
+		},
+		ChildGroupIndex: func(obj interface{}) ([]string, error) {
+			g, ok := obj.(*antreatypes.Group)
+			if !ok {
+				return []string{}, nil
+			}
+			return g.ChildGroups, nil
 		},
 	}
 	// genEventFunc is set to nil, thus watchers of this store will not be created.

--- a/pkg/controller/types/group.go
+++ b/pkg/controller/types/group.go
@@ -112,6 +112,6 @@ type Group struct {
 	// ServiceReference is reference to a v1.Service, which this Group keeps in sync
 	// and updates Selector based on the Service's selector.
 	ServiceReference *controlplane.ServiceReference
-	// ChildGroups is the list of Group names that is belongs to this Group.
+	// ChildGroups is the list of Group names that belongs to this Group.
 	ChildGroups []string
 }

--- a/pkg/controller/types/group.go
+++ b/pkg/controller/types/group.go
@@ -112,4 +112,6 @@ type Group struct {
 	// ServiceReference is reference to a v1.Service, which this Group keeps in sync
 	// and updates Selector based on the Service's selector.
 	ServiceReference *controlplane.ServiceReference
+	// ChildGroups is the list of Group names that is belongs to this Group.
+	ChildGroups []string
 }

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -343,7 +343,7 @@ func teardownTest(tb testing.TB, data *TestData) {
 
 func deletePodWrapper(tb testing.TB, data *TestData, name string) {
 	tb.Logf("Deleting Pod '%s'", name)
-	if err := data.deletePod(name); err != nil {
+	if err := data.deletePod(testNamespace, name); err != nil {
 		tb.Logf("Error when deleting Pod: %v", err)
 	}
 }

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -951,12 +951,12 @@ func (data *TestData) createServerPodWithLabels(name, ns string, portNum int32, 
 }
 
 // deletePod deletes a Pod in the test namespace.
-func (data *TestData) deletePod(name string) error {
+func (data *TestData) deletePod(namespace, name string) error {
 	var gracePeriodSeconds int64 = 5
 	deleteOptions := metav1.DeleteOptions{
 		GracePeriodSeconds: &gracePeriodSeconds,
 	}
-	if err := data.clientset.CoreV1().Pods(testNamespace).Delete(context.TODO(), name, deleteOptions); err != nil {
+	if err := data.clientset.CoreV1().Pods(namespace).Delete(context.TODO(), name, deleteOptions); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
 		}
@@ -967,7 +967,7 @@ func (data *TestData) deletePod(name string) error {
 // Deletes a Pod in the test namespace then waits us to timeout for the Pod not to be visible to the
 // client any more.
 func (data *TestData) deletePodAndWait(timeout time.Duration, name string) error {
-	if err := data.deletePod(name); err != nil {
+	if err := data.deletePod(testNamespace, name); err != nil {
 		return err
 	}
 

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -794,12 +794,15 @@ func createAndWaitForPod(t *testing.T, data *TestData, createFunc func(name stri
 	return name, podIP, cleanupFunc
 }
 
-func createAndWaitForPodWithLabels(t *testing.T, data *TestData, createFunc func(name, ns string, portNum int32, labels map[string]string) error, name, ns string, portNum int32, labels map[string]string) (string, *PodIPs, func()) {
+func createAndWaitForPodWithLabels(t *testing.T, data *TestData, createFunc func(name, ns string, portNum int32, labels map[string]string) error, name, ns string, portNum int32, labels map[string]string) (string, *PodIPs, func() error) {
 	if err := createFunc(name, ns, portNum, labels); err != nil {
 		t.Fatalf("Error when creating busybox test Pod: %v", err)
 	}
-	cleanupFunc := func() {
-		deletePodWrapper(t, data, name)
+	cleanupFunc := func() error {
+		if err := data.deletePod(ns, name); err != nil {
+			return fmt.Errorf("error when deleting Pod: %v", err)
+		}
+		return nil
 	}
 	podIP, err := data.podWaitForIPs(defaultTimeout, name, ns)
 	if err != nil {

--- a/test/e2e/nodeportlocal_test.go
+++ b/test/e2e/nodeportlocal_test.go
@@ -211,7 +211,7 @@ func NPLTestMultiplePods(t *testing.T) {
 		validatePortInRange(t, nplAnnotations, defaultStartPort, defaultEndPort)
 		checkTrafficForNPL(testData, r, nplAnnotations, clientName)
 
-		testData.deletePod(testPodName)
+		testData.deletePod(testNamespace, testPodName)
 		checkNPLRulesForPod(t, testData, r, nplAnnotations, antreaPod, testPodIP, false)
 	}
 }
@@ -274,7 +274,7 @@ func NPLTestPodAddMultiPort(t *testing.T) {
 	validatePortInRange(t, nplAnnotations, defaultStartPort, defaultEndPort)
 	checkTrafficForNPL(testData, r, nplAnnotations, clientName)
 
-	testData.deletePod(testPodName)
+	testData.deletePod(testNamespace, testPodName)
 	checkNPLRulesForPod(t, testData, r, nplAnnotations, antreaPod, testPodIP, false)
 }
 

--- a/test/e2e/utils/cgspecbuilder.go
+++ b/test/e2e/utils/cgspecbuilder.go
@@ -81,3 +81,12 @@ func (b *ClusterGroupSpecBuilder) SetServiceReference(svcNS, svcName string) *Cl
 	b.Spec.ServiceReference = svcRef
 	return b
 }
+
+func (b *ClusterGroupSpecBuilder) SetChildGroups(cgs []string) *ClusterGroupSpecBuilder {
+	var childGroups []corev1a2.ClusterGroupReference
+	for _, c := range cgs {
+		childGroups = append(childGroups, corev1a2.ClusterGroupReference(c))
+	}
+	b.Spec.ChildGroups = childGroups
+	return b
+}


### PR DESCRIPTION
This PR adds a new `childGroups` field for ClusterGroups, which allows a ClusterGroup to select other ClusterGroups by name. The effective members of the 'parent' CG will be the union of its `childGroups`' members. Restrictions do apply:
1. `childGroups` cannot be used concurrently with selectors/ipBlock/serviceReference. A ClusterGroup can either select other CGs, or select workloads/ipBlock/Services, but not both. 
2. Currently only one level of 'nested-ness' is supported: If a ClusterGroup has `childGroups`, it cannot be selected as a `childGroup` by other CGs.
3. ClusterGroup must exist before another ClusterGroup can select it by name as its `childGroup`. A ClusterGroup cannot be deleted if it is referred by other ClusterGroup as `childGroup`.