### PR TITLE
CreateOrUpdateDeployment should use deployment to update

### DIFF
--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -207,7 +207,7 @@ func (k *KubernetesUtils) CreateOrUpdateDeployment(ns, deploymentName string, re
 	}
 
 	log.Debugf("Unable to create deployment %s in ns %s, let's try update instead", deployment.Name, ns)
-	d, err = k.clientset.AppsV1().Deployments(ns).Update(context.TODO(), d, metav1.UpdateOptions{})
+	d, err = k.clientset.AppsV1().Deployments(ns).Update(context.TODO(), deployment, metav1.UpdateOptions{})
 	if err != nil {
 		log.Debugf("Unable to update deployment %s in ns %s: %s", deployment.Name, ns, err)
 	}


### PR DESCRIPTION
In CreateOrUpdateDeployment, the function will return when Create succeeds,
and call Update when create fails. But Create will return an empty deployment
object d, if we use d, Update will return error that resource name is empty.