### PR TITLE
Trigger Docker multi-arch build on pushes and releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,14 +33,24 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build Antrea Docker image
       run: make
-    - name: Push Antrea Docker image to registry
+    - name: Push Antrea amd64 Docker image to registry
       if: ${{ github.repository == 'vmware-tanzu/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       run: |
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        docker push antrea/antrea-ubuntu:latest
+        docker tag antrea/antrea-ubuntu:latest antrea/antrea-ubuntu-amd64:latest
+        docker push antrea/antrea-ubuntu-amd64:latest
+    - name: Trigger Antrea arm builds and multi-arch manifest update
+      if: ${{ github.repository == 'vmware-tanzu/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      uses: benc-uk/workflow-dispatch@v1
+      with:
+        repo: vmware-tanzu/antrea-build-infra
+        ref: refs/heads/main
+        workflow: Build Antrea ARM images and push manifest
+        token: ${{ secrets.WORKFLOW_DISPATCH_PAT }}
+        inputs: ${{ format('{{ "antrea-repository":"vmware-tanzu/antrea", "antrea-ref":"{0}", "docker-tag":"{1}" }}', github.ref, 'latest') }}
 
   build-scale:
     needs: check-changes

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -6,60 +6,85 @@ on:
       - v*
 
 jobs:
+  get-version:
+    runs-on: [ubuntu-latest]
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+    steps:
+    - name: Extract version from Github ref
+      id: get-version
+      env:
+        TAG: ${{ github.ref }}
+      run: |
+        version=${TAG:10}
+        echo "::set-output name=version::$version"
+
   build:
     runs-on: [ubuntu-latest]
+    needs: get-version
     steps:
     - uses: actions/checkout@v2
-    - name: Build Antrea Docker image and push to registry
+    - name: Build Antrea amd64 Docker image and push to registry
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        TAG: ${{ github.ref }}
+        VERSION: ${{ needs.get-version.outputs.version }}
       run: |
-        VERSION="${TAG:10}" make
+        make
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        docker push antrea/antrea-ubuntu:"${TAG:10}"
+        docker tag antrea/antrea-ubuntu:"${VERSION}" antrea/antrea-ubuntu-amd64:"${VERSION}"
+        docker push antrea/antrea-ubuntu-amd64:"${VERSION}"
+    - name: Trigger Antrea arm builds and multi-arch manifest update
+      uses: benc-uk/workflow-dispatch@v1
+      with:
+        repo: vmware-tanzu/antrea-build-infra
+        ref: refs/heads/main
+        workflow: Build Antrea ARM images and push manifest
+        token: ${{ secrets.WORKFLOW_DISPATCH_PAT }}
+        inputs: ${{ format('{{ "antrea-repository":"vmware-tanzu/antrea", "antrea-ref":"{0}", "docker-tag":"{1}" }}', github.ref, steps.get-version.outputs.version) }}
 
   build-windows:
     runs-on: [windows-2019]
+    needs: get-version
     steps:
     - uses: actions/checkout@v2
     - name: Build Antrea Windows Docker image and push to registry
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        TAG: ${{ github.ref }}
+        VERSION: ${{ needs.get-version.outputs.version }}
       run: |
-        export VERSION="${TAG:10}"
         make build-windows
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        docker push antrea/antrea-windows:"${TAG:10}"
+        docker push antrea/antrea-windows:"${VERSION}"
       shell: bash
 
   build-octant-antrea-ubuntu:
     runs-on: [ubuntu-latest]
+    needs: get-version
     steps:
-      - uses: actions/checkout@v2
-      - name: Build octant-antrea-ubuntu Docker image and push to registry
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          TAG: ${{ github.ref }}
-        run: |
-          VERSION="${TAG:10}" make octant-antrea-ubuntu
-          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          docker push antrea/octant-antrea-ubuntu:"${TAG:10}"
+    - uses: actions/checkout@v2
+    - name: Build octant-antrea-ubuntu Docker image and push to registry
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        VERSION: ${{ needs.get-version.outputs.version }}
+      run: |
+        make octant-antrea-ubuntu
+        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        docker push antrea/octant-antrea-ubuntu:"${VERSION}"
 
   build-flow-aggregator:
     runs-on: [ubuntu-latest]
+    needs: get-version
     steps:
     - uses: actions/checkout@v2
     - name: Build flow-aggregator Docker image and push to registry
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        TAG: ${{ github.ref }}
+        VERSION: ${{ needs.get-version.outputs.version }}
       run: |
-        VERSION="${TAG:10}" make flow-aggregator-ubuntu
+        make flow-aggregator-ubuntu
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        docker push antrea/flow-aggregator:"${TAG:10}"
+        docker push antrea/flow-aggregator:"${VERSION}"


### PR DESCRIPTION
When the main branch is updated, or a new relese tag is creted, we build
and push the amd64 Antrea Docker image (renamed from
antrea/antrea-ubuntu to antrea/antrea-ubuntu-amd64), then trigger a
workflow in the private vmware-tanzu/antrea-build-infra repository which
will build the Antrea ARM images (antrea/antrea-ubuntu-arm and
antrea/antrea-ubuntu-arm64) as well as the multi-arch manifest list
(antrea/antrea-ubuntu).

As a reminder, vmware-tanzu/antrea-build-infra is private (maintainer
access only) because of security issues when using self-hosted runners
(in our case, arm64 machines) in a public repo. When / if these security
issues are addressed by Github, we will merge
vmware-tanzu/antrea-build-infra into vmware-tanzu/antrea.

See #450