### PR TITLE
Do not construct intermediate sets when calculating union of multiple sets

### DIFF
--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -59,6 +59,7 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/controller/networkpolicy/store"
 	antreatypes "github.com/vmware-tanzu/antrea/pkg/controller/types"
 	"github.com/vmware-tanzu/antrea/pkg/features"
+	utilsets "github.com/vmware-tanzu/antrea/pkg/util/sets"
 )
 
 const (
@@ -1416,7 +1417,7 @@ func (n *NetworkPolicyController) syncAddressGroup(key string) error {
 	addrGroupNodeNames := sets.String{}
 	for _, internalNPObj := range nps {
 		internalNP := internalNPObj.(*antreatypes.NetworkPolicy)
-		addrGroupNodeNames = addrGroupNodeNames.Union(internalNP.SpanMeta.NodeNames)
+		utilsets.Merge(addrGroupNodeNames, internalNP.SpanMeta.NodeNames)
 	}
 	memberSet := n.populateAddressGroupMemberSet(addressGroup)
 	updatedAddressGroup := &antreatypes.AddressGroup{
@@ -1697,7 +1698,7 @@ func (n *NetworkPolicyController) syncInternalNetworkPolicy(key string) error {
 			continue
 		}
 		appGroup := appGroupObj.(*antreatypes.AppliedToGroup)
-		nodeNames = nodeNames.Union(appGroup.SpanMeta.NodeNames)
+		utilsets.Merge(nodeNames, appGroup.SpanMeta.NodeNames)
 	}
 	updatedNetworkPolicy := &antreatypes.NetworkPolicy{
 		UID:             internalNP.UID,

--- a/pkg/controller/networkpolicy/status_controller_test.go
+++ b/pkg/controller/networkpolicy/status_controller_test.go
@@ -88,7 +88,7 @@ func newTestStatusController(initialObjects ...runtime.Object) (*StatusControlle
 	return statusController, antreaClientset, antreaInformerFactory, networkPolicyStore, networkPolicyControl
 }
 
-func newNetworkPolicy(name string, generation int64, nodes []string, ref *controlplane.NetworkPolicyReference) *types.NetworkPolicy {
+func newInternalNetworkPolicy(name string, generation int64, nodes []string, ref *controlplane.NetworkPolicyReference) *types.NetworkPolicy {
 	return &types.NetworkPolicy{
 		SpanMeta:   types.SpanMeta{NodeNames: sets.NewString(nodes...)},
 		Generation: generation,
@@ -156,8 +156,8 @@ func TestCreateAntreaNetworkPolicy(t *testing.T) {
 		{
 			name: "no realization status",
 			networkPolicy: []*types.NetworkPolicy{
-				newNetworkPolicy("anp1", 1, []string{"node1", "node2"}, newAntreaNetworkPolicyReference("ns1", "anp1")),
-				newNetworkPolicy("cnp1", 1, []string{"node1", "node2"}, newAntreaClusterNetworkPolicyReference("cnp1")),
+				newInternalNetworkPolicy("anp1", 1, []string{"node1", "node2"}, newAntreaNetworkPolicyReference("ns1", "anp1")),
+				newInternalNetworkPolicy("cnp1", 1, []string{"node1", "node2"}, newAntreaClusterNetworkPolicyReference("cnp1")),
 			},
 			expectedANPStatus: &secv1alpha1.NetworkPolicyStatus{
 				Phase:                secv1alpha1.NetworkPolicyRealizing,
@@ -175,8 +175,8 @@ func TestCreateAntreaNetworkPolicy(t *testing.T) {
 		{
 			name: "partially realized",
 			networkPolicy: []*types.NetworkPolicy{
-				newNetworkPolicy("anp1", 2, []string{"node1", "node2"}, newAntreaNetworkPolicyReference("ns1", "anp1")),
-				newNetworkPolicy("cnp1", 3, []string{"node1", "node2"}, newAntreaClusterNetworkPolicyReference("cnp1")),
+				newInternalNetworkPolicy("anp1", 2, []string{"node1", "node2"}, newAntreaNetworkPolicyReference("ns1", "anp1")),
+				newInternalNetworkPolicy("cnp1", 3, []string{"node1", "node2"}, newAntreaClusterNetworkPolicyReference("cnp1")),
 			},
 			collectedNetworkPolicyStatus: []*controlplane.NetworkPolicyStatus{
 				newNetworkPolicyStatus("anp1", "node1", 1),
@@ -200,8 +200,8 @@ func TestCreateAntreaNetworkPolicy(t *testing.T) {
 		{
 			name: "entirely realized",
 			networkPolicy: []*types.NetworkPolicy{
-				newNetworkPolicy("anp1", 3, []string{"node1", "node2"}, newAntreaNetworkPolicyReference("ns1", "anp1")),
-				newNetworkPolicy("cnp1", 4, []string{"node1", "node2"}, newAntreaClusterNetworkPolicyReference("cnp1")),
+				newInternalNetworkPolicy("anp1", 3, []string{"node1", "node2"}, newAntreaNetworkPolicyReference("ns1", "anp1")),
+				newInternalNetworkPolicy("cnp1", 4, []string{"node1", "node2"}, newAntreaClusterNetworkPolicyReference("cnp1")),
 			},
 			collectedNetworkPolicyStatus: []*controlplane.NetworkPolicyStatus{
 				newNetworkPolicyStatus("anp1", "node1", 3),
@@ -251,8 +251,8 @@ func TestCreateAntreaNetworkPolicy(t *testing.T) {
 }
 
 func TestUpdateAntreaNetworkPolicy(t *testing.T) {
-	anp1 := newNetworkPolicy("anp1", 1, []string{"node1", "node2"}, newAntreaNetworkPolicyReference("ns1", "anp1"))
-	cnp1 := newNetworkPolicy("cnp1", 2, []string{"node3", "node4", "node5"}, newAntreaClusterNetworkPolicyReference("cnp1"))
+	anp1 := newInternalNetworkPolicy("anp1", 1, []string{"node1", "node2"}, newAntreaNetworkPolicyReference("ns1", "anp1"))
+	cnp1 := newInternalNetworkPolicy("cnp1", 2, []string{"node3", "node4", "node5"}, newAntreaClusterNetworkPolicyReference("cnp1"))
 	statusController, _, antreaInformerFactory, networkPolicyStore, networkPolicyControl := newTestStatusController(toAntreaNetworkPolicy(anp1), toAntreaNetworkPolicy(cnp1))
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -281,8 +281,8 @@ func TestUpdateAntreaNetworkPolicy(t *testing.T) {
 		DesiredNodesRealized: 3,
 	}, networkPolicyControl.getAntreaClusterNetworkPolicyStatus())
 
-	anp1Updated := newNetworkPolicy("anp1", 2, []string{"node1", "node2", "node3"}, newAntreaNetworkPolicyReference("ns1", "anp1"))
-	cnp1Updated := newNetworkPolicy("cnp1", 3, []string{"node4", "node5"}, newAntreaClusterNetworkPolicyReference("cnp1"))
+	anp1Updated := newInternalNetworkPolicy("anp1", 2, []string{"node1", "node2", "node3"}, newAntreaNetworkPolicyReference("ns1", "anp1"))
+	cnp1Updated := newInternalNetworkPolicy("cnp1", 3, []string{"node4", "node5"}, newAntreaClusterNetworkPolicyReference("cnp1"))
 	networkPolicyStore.Update(anp1Updated)
 	networkPolicyStore.Update(cnp1Updated)
 	// TODO: Use a determinate mechanism.
@@ -302,7 +302,7 @@ func TestUpdateAntreaNetworkPolicy(t *testing.T) {
 }
 
 func TestDeleteAntreaNetworkPolicy(t *testing.T) {
-	initialNetworkPolicy := newNetworkPolicy("anp1", 1, []string{"node1", "node2"}, newAntreaNetworkPolicyReference("ns1", "anp1"))
+	initialNetworkPolicy := newInternalNetworkPolicy("anp1", 1, []string{"node1", "node2"}, newAntreaNetworkPolicyReference("ns1", "anp1"))
 	initialANP := toAntreaNetworkPolicy(initialNetworkPolicy)
 	statusController, _, antreaInformerFactory, networkPolicyStore, _ := newTestStatusController(initialANP)
 	stopCh := make(chan struct{})
@@ -334,7 +334,7 @@ func BenchmarkSyncHandler(b *testing.B) {
 	for i := 0; i < nodeNum; i++ {
 		nodes = append(nodes, fmt.Sprintf("node%d", i))
 	}
-	networkPolicy := newNetworkPolicy("anp1", 1, nodes, newAntreaNetworkPolicyReference("ns1", "anp1"))
+	networkPolicy := newInternalNetworkPolicy("anp1", 1, nodes, newAntreaNetworkPolicyReference("ns1", "anp1"))
 	statusController, _, _, networkPolicyStore, _ := newTestStatusController()
 
 	networkPolicyStore.Create(networkPolicy)

--- a/pkg/util/sets/string.go
+++ b/pkg/util/sets/string.go
@@ -1,0 +1,33 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sets
+
+import "k8s.io/apimachinery/pkg/util/sets"
+
+// Merge merges the src sets into dst and returns dst.
+// This assumes that dst is non-nil.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// Merge(s1, s2) = {a1, a2, a3, a4, a5}
+// s1 = {a1, a2, a3, a4, a5}
+//
+// It supersedes s1.Union(s2) when constructing a new set is not the intention.
+func Merge(dst, src sets.String) sets.String {
+	for item := range src {
+		dst.Insert(item)
+	}
+	return dst
+}


### PR DESCRIPTION
An AddressGroup can be shared by multiple NetworkPolicies and its span
is the union of the NetworkPolicies'. The syncAddressGroup method uses
"Union" method to calculate the union set. However, the method always
create a new sets and copies the original items when traversing each
set. This performs badly when the number of the NetworkPolicies increase
and the span is big.

This patch optimizes it by using a "Merge" function to avoid above cost.
The benchmark impact is as below when there are 1000 NetworkPolicies
sharing the AddressGroup and the span is 1000 Nodes:

```
name                 old time/op    new time/op    delta
SyncAddressGroup-48     417µs ± 4%     326µs ± 4%  -21.91%  (p=0.008 n=5+5)

name                 old alloc/op   new alloc/op   delta
SyncAddressGroup-48    98.9kB ± 0%    51.1kB ± 1%  -48.27%  (p=0.008 n=5+5)

name                 old allocs/op  new allocs/op  delta
SyncAddressGroup-48     1.05k ± 0%     0.05k ± 8%  -94.78%  (p=0.008 n=5+5)
```