### PR TITLE
Improve calculating symmetric difference

### DIFF
--- a/pkg/agent/nodeportlocal/k8s/npl_controller.go
+++ b/pkg/agent/nodeportlocal/k8s/npl_controller.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/nodeportlocal/portcache"
 	"github.com/vmware-tanzu/antrea/pkg/agent/nodeportlocal/rules"
+	utilsets "github.com/vmware-tanzu/antrea/pkg/util/sets"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -214,7 +215,7 @@ func (c *NPLController) enqueueSvcUpdate(oldObj, newObj interface{}) {
 		// Disjunctive union of Pods from both Service sets.
 		oldPodSet := sets.NewString(c.getPodsFromService(oldSvc)...)
 		newPodSet := sets.NewString(c.getPodsFromService(newSvc)...)
-		podKeys = oldPodSet.Difference(newPodSet).Union(newPodSet.Difference(oldPodSet))
+		podKeys = utilsets.SymmetricDifference(oldPodSet, newPodSet)
 	}
 
 	for podKey := range podKeys {

--- a/pkg/controller/networkpolicy/external_entity.go
+++ b/pkg/controller/networkpolicy/external_entity.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/apis/core/v1alpha2"
+	utilsets "github.com/vmware-tanzu/antrea/pkg/util/sets"
 )
 
 // addExternalEntity retrieves all AddressGroups and AppliedToGroups which match the ExternalEnitty's
@@ -96,7 +97,7 @@ func (n *NetworkPolicyController) updateExternalEntity(oldObj, curObj interface{
 	} else if !labelsEqual {
 		// No need to enqueue common AppliedToGroups as they already have latest ExternalEntity
 		// information.
-		appliedToGroupKeys = oldAppliedToGroupKeySet.Difference(curAppliedToGroupKeySet).Union(curAppliedToGroupKeySet.Difference(oldAppliedToGroupKeySet))
+		appliedToGroupKeys = utilsets.SymmetricDifference(oldAppliedToGroupKeySet, curAppliedToGroupKeySet)
 	}
 	// AddressGroup keys must be enqueued only if the ExternalEntity's spec has changed or
 	// if ExternalEntity's label change causes it to match new Groups.
@@ -106,8 +107,8 @@ func (n *NetworkPolicyController) updateExternalEntity(oldObj, curObj interface{
 	} else if !labelsEqual {
 		// No need to enqueue common AddressGroups as they already have latest ExternalEntity
 		// information.
-		addressGroupKeys = oldAddressGroupKeySet.Difference(curAddressGroupKeySet).Union(curAddressGroupKeySet.Difference(oldAddressGroupKeySet))
-		groupKeys = oldGroupKeySet.Difference(curGroupKeySet).Union(curGroupKeySet.Difference(oldGroupKeySet))
+		addressGroupKeys = utilsets.SymmetricDifference(oldAddressGroupKeySet, curAddressGroupKeySet)
+		groupKeys = utilsets.SymmetricDifference(oldGroupKeySet, curGroupKeySet)
 	}
 	for group := range appliedToGroupKeys {
 		n.enqueueAppliedToGroup(group)

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -984,7 +984,7 @@ func (n *NetworkPolicyController) updatePod(oldObj, curObj interface{}) {
 	} else if !labelsEqual {
 		// No need to enqueue common AppliedToGroups as they already have latest Pod
 		// information.
-		appliedToGroupKeys = oldAppliedToGroupKeySet.Difference(curAppliedToGroupKeySet).Union(curAppliedToGroupKeySet.Difference(oldAppliedToGroupKeySet))
+		appliedToGroupKeys = utilsets.SymmetricDifference(oldAppliedToGroupKeySet, curAppliedToGroupKeySet)
 	}
 	// AddressGroup keys must be enqueued only if the Pod's IP has changed or
 	// if Pod's label change causes it to match new Groups. Same applies for ClusterGroups.
@@ -994,8 +994,8 @@ func (n *NetworkPolicyController) updatePod(oldObj, curObj interface{}) {
 	} else if !labelsEqual {
 		// No need to enqueue common AddressGroups as they already have latest Pod
 		// information.
-		addressGroupKeys = oldAddressGroupKeySet.Difference(curAddressGroupKeySet).Union(curAddressGroupKeySet.Difference(oldAddressGroupKeySet))
-		groupKeys = oldGroupKeySet.Difference(curGroupKeySet).Union(curGroupKeySet.Difference(oldGroupKeySet))
+		addressGroupKeys = utilsets.SymmetricDifference(oldAddressGroupKeySet, curAddressGroupKeySet)
+		groupKeys = utilsets.SymmetricDifference(oldGroupKeySet, curGroupKeySet)
 	}
 	for group := range appliedToGroupKeys {
 		n.enqueueAppliedToGroup(group)
@@ -1082,11 +1082,11 @@ func (n *NetworkPolicyController) updateNamespace(oldObj, curObj interface{}) {
 	oldGroupKeySet := n.filterInternalGroupsForNamespace(oldNamespace)
 	// No need to enqueue common AddressGroups as they already have latest
 	// Namespace information.
-	addressGroupKeys := oldAddressGroupKeySet.Difference(curAddressGroupKeySet).Union(curAddressGroupKeySet.Difference(oldAddressGroupKeySet))
+	addressGroupKeys := utilsets.SymmetricDifference(oldAddressGroupKeySet, curAddressGroupKeySet)
 	for group := range addressGroupKeys {
 		n.enqueueAddressGroup(group)
 	}
-	groupKeys := oldGroupKeySet.Difference(curGroupKeySet).Union(curGroupKeySet.Difference(oldGroupKeySet))
+	groupKeys := utilsets.SymmetricDifference(oldGroupKeySet, curGroupKeySet)
 	for group := range groupKeys {
 		n.enqueueInternalGroup(group)
 	}

--- a/pkg/util/sets/string.go
+++ b/pkg/util/sets/string.go
@@ -31,3 +31,26 @@ func Merge(dst, src sets.String) sets.String {
 	}
 	return dst
 }
+
+// SymmetricDifference returns the symmetric difference of two sets.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// SymmetricDifference(s1, s2) = {a3, a4, a5}
+//
+// It supersedes s1.Difference(s2).Union(s2.Difference(s1)) which is a little complicated and always builds several
+// unnecessary intermediate sets.
+func SymmetricDifference(s1, s2 sets.String) sets.String {
+	result := sets.NewString()
+	for key := range s1 {
+		if !s2.Has(key) {
+			result.Insert(key)
+		}
+	}
+	for key := range s2 {
+		if !s1.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
+}

--- a/pkg/util/sets/string_test.go
+++ b/pkg/util/sets/string_test.go
@@ -1,0 +1,104 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sets
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func getSets(start, end int) sets.String {
+	s := sets.NewString()
+	for i := start; i < end; i++ {
+		s.Insert(fmt.Sprintf("%v", i))
+	}
+	return s
+}
+
+func BenchmarkSymmetricDifference(b *testing.B) {
+	s1 := getSets(0, 2000)
+	s2 := getSets(1000, 3000)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		SymmetricDifference(s1, s2)
+	}
+}
+
+func TestMerge(t *testing.T) {
+	tests := []struct {
+		name string
+		src  sets.String
+		dst  sets.String
+		want sets.String
+	}{
+		{
+			name: "With common items",
+			src:  getSets(1, 10),
+			dst:  getSets(5, 15),
+			want: getSets(1, 15),
+		},
+		{
+			name: "Without common items",
+			src:  getSets(1, 10),
+			dst:  getSets(10, 15),
+			want: getSets(1, 15),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Merge(tt.dst, tt.src)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want, tt.dst)
+		})
+	}
+}
+
+func TestSymmetricDifference(t *testing.T) {
+	tests := []struct {
+		name string
+		s1   sets.String
+		s2   sets.String
+		want sets.String
+	}{
+		{
+			name: "Equivalent sets",
+			s1:   getSets(1, 4),
+			s2:   getSets(1, 4),
+			want: sets.NewString(),
+		},
+		{
+			name: "With common items",
+			s1:   getSets(1, 4),
+			s2:   getSets(3, 6),
+			want: sets.NewString("1", "2", "4", "5"),
+		},
+		{
+			name: "Without common items",
+			s1:   getSets(1, 4),
+			s2:   getSets(4, 8),
+			want: getSets(1, 8),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SymmetricDifference(tt.s1, tt.s2)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Calculating symmetric difference is common in the code, while
s1.Difference(s2).Union(s2.Difference(s1)) is a little complicated,
error-prone, and always builds several unnecessary intermediate sets.
This patch adds an util function SymmetricDifference to improve it. The
benchmark impact is as below when calculating symmetric difference of
two sets each of which contains 2000 items:

```
name                    old time/op    new time/op    delta
SymmetricDifference-48    1.50ms ± 1%    0.87ms ± 3%  -42.10%  (p=0.008 n=5+5)

name                    old alloc/op   new alloc/op   delta
SymmetricDifference-48     342kB ± 0%     171kB ± 0%  -49.99%  (p=0.008 n=5+5)

name                    old allocs/op  new allocs/op  delta
SymmetricDifference-48       132 ± 0%        61 ± 0%  -53.79%  (p=0.029 n=4+4)
```