### PR TITLE
Do not override global testData in e2e tests

### DIFF
--- a/test/e2e/nodeportlocal_test.go
+++ b/test/e2e/nodeportlocal_test.go
@@ -157,8 +157,7 @@ func validatePortInRange(t *testing.T, nplAnnotations []k8s.NPLAnnotation, start
 
 func TestNPLAddPod(t *testing.T) {
 	skipIfNotIPv4Cluster(t)
-	var err error
-	testData, err = setupTest(t)
+	testData, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)
 	}


### PR DESCRIPTION
Otherwise a setup failure would panic and terminate all tests.

For instance: https://jenkins.antrea-ci.rocks/job/antrea-e2e-for-pull-request/2181/console