### PR TITLE
Fix the bug in Flow Exporter that cause intermittent errors in e2e tests

### DIFF
--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -109,8 +109,8 @@ func TestFlowAggregator(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)
 	}
-	defer teardownFlowAggregator(t, data)
 	defer teardownTest(t, data)
+	defer teardownFlowAggregator(t, data)
 
 	podAIP, podBIP, podCIP, svcB, svcC, err := createPerftestPods(data)
 	if err != nil {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -681,7 +681,8 @@ func (data *TestData) waitForAntreaDaemonSetPods(timeout time.Duration) error {
 		return true, nil
 	})
 	if err == wait.ErrWaitTimeout {
-		return fmt.Errorf("antrea-agent DaemonSet not ready within %v", defaultTimeout)
+		_, stdout, _, _ := provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s describe pod", antreaNamespace))
+		return fmt.Errorf("antrea-agent DaemonSet not ready within %v; kubectl describe pod output: %v", defaultTimeout, stdout)
 	} else if err != nil {
 		return err
 	}


### PR DESCRIPTION
The bug is because IPFIX exporting process interface in Flow Exporter is assigned with typecasted nil (typecasted to corresponding structure `ipfixExportingProcess`). This code was modified in PR #1714 . Therefore, the code comparing with `nil` breaks in exporting process initialization code of Flow Exporter. 
This PR fixes the bug along with another issue in fetching certificates that exacerbates this bug when the Flow Exporter cannot connect to the Flow Aggregator.

Fixes #1956 