### PR TITLE
Add IPv4/v6 dual stack support in Flow aggregator

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -52,7 +52,6 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/signals"
 	"github.com/vmware-tanzu/antrea/pkg/util/cipher"
 	"github.com/vmware-tanzu/antrea/pkg/version"
-	k8sproxy "github.com/vmware-tanzu/antrea/third_party/proxy"
 )
 
 // informerDefaultResync is the default resync period if a handler doesn't specify one.
@@ -339,10 +338,6 @@ func run(o *Options) error {
 		v4Enabled := config.IsIPv4Enabled(nodeConfig, networkConfig.TrafficEncapMode)
 		v6Enabled := config.IsIPv6Enabled(nodeConfig, networkConfig.TrafficEncapMode)
 
-		var proxyProvider k8sproxy.Provider
-		if proxier != nil {
-			proxyProvider = proxier.GetProxyProvider()
-		}
 		flowRecords := flowrecords.NewFlowRecords()
 		connStore := connections.NewConnectionStore(
 			connections.InitializeConnTrackDumper(nodeConfig, serviceCIDRNet, serviceCIDRNetv6, ovsDatapathType, features.DefaultFeatureGate.Enabled(features.AntreaProxy)),
@@ -350,7 +345,7 @@ func run(o *Options) error {
 			ifaceStore,
 			v4Enabled,
 			v6Enabled,
-			proxyProvider,
+			proxier,
 			networkPolicyController,
 			o.pollInterval)
 		go connStore.Run(stopCh)

--- a/pkg/agent/flowexporter/connections/connections.go
+++ b/pkg/agent/flowexporter/connections/connections.go
@@ -28,8 +28,8 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/interfacestore"
 	"github.com/vmware-tanzu/antrea/pkg/agent/metrics"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
+	"github.com/vmware-tanzu/antrea/pkg/agent/proxy"
 	"github.com/vmware-tanzu/antrea/pkg/querier"
-	"github.com/vmware-tanzu/antrea/third_party/proxy"
 )
 
 var serviceProtocolMap = map[uint8]corev1.Protocol{
@@ -58,7 +58,7 @@ type connectionStore struct {
 	ifaceStore           interfacestore.InterfaceStore
 	v4Enabled            bool
 	v6Enabled            bool
-	antreaProxier        proxy.Provider
+	antreaProxier        proxy.Proxier
 	networkPolicyQuerier querier.AgentNetworkPolicyInfoQuerier
 	pollInterval         time.Duration
 	mutex                sync.Mutex
@@ -70,7 +70,7 @@ func NewConnectionStore(
 	ifaceStore interfacestore.InterfaceStore,
 	v4Enabled bool,
 	v6Enabled bool,
-	proxier proxy.Provider,
+	proxier proxy.Proxier,
 	npQuerier querier.AgentNetworkPolicyInfoQuerier,
 	pollInterval time.Duration,
 ) *connectionStore {

--- a/pkg/agent/flowexporter/connections/connections_test.go
+++ b/pkg/agent/flowexporter/connections/connections_test.go
@@ -37,10 +37,10 @@ import (
 	interfacestoretest "github.com/vmware-tanzu/antrea/pkg/agent/interfacestore/testing"
 	"github.com/vmware-tanzu/antrea/pkg/agent/metrics"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
+	proxytest "github.com/vmware-tanzu/antrea/pkg/agent/proxy/testing"
 	cpv1beta "github.com/vmware-tanzu/antrea/pkg/apis/controlplane/v1beta2"
 	queriertest "github.com/vmware-tanzu/antrea/pkg/querier/testing"
 	k8sproxy "github.com/vmware-tanzu/antrea/third_party/proxy"
-	k8proxytest "github.com/vmware-tanzu/antrea/third_party/proxy/testing"
 )
 
 var (
@@ -164,7 +164,7 @@ func TestConnectionStore_addAndUpdateConn(t *testing.T) {
 	// Mock interface store with one of the couple of IPs correspond to Pods
 	mockIfaceStore := interfacestoretest.NewMockInterfaceStore(ctrl)
 	mockConnDumper := connectionstest.NewMockConnTrackDumper(ctrl)
-	mockProxier := k8proxytest.NewMockProvider(ctrl)
+	mockProxier := proxytest.NewMockProxier(ctrl)
 	npQuerier := queriertest.NewMockAgentNetworkPolicyInfoQuerier(ctrl)
 	connStore := NewConnectionStore(mockConnDumper, flowrecords.NewFlowRecords(), mockIfaceStore, true, false, mockProxier, npQuerier, testPollInterval)
 

--- a/pkg/agent/proxy/testing/mock_proxy.go
+++ b/pkg/agent/proxy/testing/mock_proxy.go
@@ -63,6 +63,21 @@ func (mr *MockProxierMockRecorder) GetProxyProvider() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProxyProvider", reflect.TypeOf((*MockProxier)(nil).GetProxyProvider))
 }
 
+// GetServiceByIP mocks base method
+func (m *MockProxier) GetServiceByIP(arg0 string) (proxy.ServicePortName, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetServiceByIP", arg0)
+	ret0, _ := ret[0].(proxy.ServicePortName)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetServiceByIP indicates an expected call of GetServiceByIP
+func (mr *MockProxierMockRecorder) GetServiceByIP(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceByIP", reflect.TypeOf((*MockProxier)(nil).GetServiceByIP), arg0)
+}
+
 // GetServiceFlowKeys mocks base method
 func (m *MockProxier) GetServiceFlowKeys(arg0, arg1 string) ([]string, []openflow.GroupIDType, bool) {
 	m.ctrl.T.Helper()

--- a/third_party/proxy/meta_proxier.go
+++ b/third_party/proxy/meta_proxier.go
@@ -159,15 +159,6 @@ func (proxier *metaProxier) OnEndpointsSynced() {
 	proxier.ipv6Proxier.OnEndpointsSynced()
 }
 
-func (proxier *metaProxier) GetServiceByIP(serviceStr string) (ServicePortName, bool) {
-	if utilnet.IsIPv6String(serviceStr) {
-		return proxier.ipv6Proxier.GetServiceByIP(serviceStr)
-	} else {
-		return proxier.ipv4Proxier.GetServiceByIP(serviceStr)
-	}
-
-}
-
 func (proxier *metaProxier) Run(stopCh <-chan struct{}) {
 	go proxier.ipv4Proxier.Run(stopCh)
 	proxier.ipv6Proxier.Run(stopCh)

--- a/third_party/proxy/testing/mock_proxy.go
+++ b/third_party/proxy/testing/mock_proxy.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Antrea Authors
+// Copyright 2021 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ package testing
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	proxy "github.com/vmware-tanzu/antrea/third_party/proxy"
 	v1 "k8s.io/api/core/v1"
 	reflect "reflect"
 )
@@ -47,21 +46,6 @@ func NewMockProvider(ctrl *gomock.Controller) *MockProvider {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 	return m.recorder
-}
-
-// GetServiceByIP mocks base method
-func (m *MockProvider) GetServiceByIP(arg0 string) (proxy.ServicePortName, bool) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetServiceByIP", arg0)
-	ret0, _ := ret[0].(proxy.ServicePortName)
-	ret1, _ := ret[1].(bool)
-	return ret0, ret1
-}
-
-// GetServiceByIP indicates an expected call of GetServiceByIP
-func (mr *MockProviderMockRecorder) GetServiceByIP(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceByIP", reflect.TypeOf((*MockProvider)(nil).GetServiceByIP), arg0)
 }
 
 // OnEndpointsAdd mocks base method

--- a/third_party/proxy/types.go
+++ b/third_party/proxy/types.go
@@ -32,7 +32,7 @@ Modifies:
 - Replace import "k8s.io/kubernetes/pkg/proxy/config" with "github.com/vmware-tanzu/antrea/third_party/proxy/config"
 - Remove config.EndpointSliceHandler, config.NodeHandler from Provider interface type
 - Remove NodeHandler, EndpointSliceHandler, Sync() from Provider interface
-- Add Run(), GetServiceByIP() to Provider interface
+- Add Run() to Provider interface
 */
 
 package proxy
@@ -57,7 +57,6 @@ type Provider interface {
 	// It does not return.
 	SyncLoop()
 	Run(stopCh <-chan struct{})
-	GetServiceByIP(serviceStr string) (ServicePortName, bool)
 }
 
 // ServicePortName carries a namespace + name + portname.  This is the unique


### PR DESCRIPTION
After investigation, we found that the e2e test failure in dual stack cluster of flow aggregator is because we couldn't retrieve the service info from antrea-agent-proxier for IPv6 service address in jenkins dual stack cluster. 

In this commit, we fixed a bug in GetServiceByIP() function of dual-stack proxy. 
Also, we improved the e2e test of flow aggregator: for dual stack clusters, we will test services for both IPv4 and IPv6 clusterIP.