### PR TITLE
Change Mellanox CI logs URL to point to the HTML logs directly

### DIFF
--- a/ci/jenkins/mellanox/jobs/00-functions.yaml
+++ b/ci/jenkins/mellanox/jobs/00-functions.yaml
@@ -75,11 +75,11 @@
           <html>
           <head>
              <meta http-equiv="refresh"
-             content="0; url=http://13.74.249.42:8080/job/${target_job_name}/${target_job_id}/consoleFull">
+             content="0; url=http://13.74.249.42/${target_job_name}/${target_job_id}">
           </head>
           <body>
              <p>The page has moved to:
-             <a href="http://13.74.249.42:8080/job/${target_job_name}/${target_job_id}/consoleFull">this page</a></p>
+             <a href="http://13.74.249.42/${target_job_name}/${target_job_id}">this page</a></p>
           </body>
           </html>
           EOF

--- a/ci/jenkins/mellanox/jobs/antrea_trigger_ci.yaml
+++ b/ci/jenkins/mellanox/jobs/antrea_trigger_ci.yaml
@@ -65,6 +65,13 @@
         failure: true
         content-type: html
         body: Failed ANTREA_HW_OFFLOAD_CI_EXECUTER
+    - trigger-parameterized-builds:
+      - project:
+          - Console-fetcher
+        predefined-parameters: |
+            TARGET_BUILD_NAME=$JOB_NAME
+            TARGET_BUILD_NUMBER=$BUILD_ID
+        condition: "ALWAYS"
     wrappers:
       - timeout:
           timeout: 120
@@ -127,6 +134,13 @@
               build-steps:
                   - construct-downstream-fail-email
                   - post-full-console
+    - trigger-parameterized-builds:
+      - project:
+          - Console-fetcher
+        predefined-parameters: |
+            TARGET_BUILD_NAME=$JOB_NAME
+            TARGET_BUILD_NUMBER=$BUILD_ID
+        condition: "ALWAYS"
     scm:
     - git:
         branches: ["${sha1}"]

--- a/ci/jenkins/mellanox/jobs/console-text-fetcher.yaml
+++ b/ci/jenkins/mellanox/jobs/console-text-fetcher.yaml
@@ -1,0 +1,63 @@
+- project:
+    name: Post-builders
+    jobs:
+        - 'Console-fetcher':
+            disabled: false
+            node: {}
+
+- job-template:
+    name: 'Console-fetcher'
+    node: '{node}'
+    disabled: '{disabled}'
+    parameters:
+      - string:
+          name: TARGET_BUILD_NAME
+      - string:
+          name: TARGET_BUILD_NUMBER
+    builders:
+      - inject:
+          properties-content: |
+            LOGDIR=$WORKSPACE/ci-artifacts/logs
+            NFS_LOGS=$WORKSPACE/../CI_LOGS
+            MAX_LOG_DAYS=60
+            EXT_SERVER=13.74.249.42
+            LOGSERVER={}@$EXT_SERVER
+      - fetch-text-console
+      - upload-console-logs
+    properties:
+      - build-discarder:
+          days-to-keep: 60
+          num-to-keep: 100
+          artifact-days-to-keep: 60
+          artifact-num-to-keep: 100
+    publishers:
+      - email-ext:
+          recipients: {}
+          subject: Console fetcher Failed
+          failure: true
+          always: false
+          content-type: text
+          body: "Failed "
+
+- builder:
+    name: fetch-text-console
+    builders:
+         - shell: |
+             #!/bin/bash -ex
+             sleep 30
+             pushd $WORKSPACE
+             rm -rf $TARGET_BUILD_NAME/$TARGET_BUILD_NUMBER/consoleText
+             mkdir -p $TARGET_BUILD_NAME/
+             mkdir -p $TARGET_BUILD_NAME/$TARGET_BUILD_NUMBER/           
+             wget http://dev-l-vrt-019-4:8080/job/$TARGET_BUILD_NAME/$TARGET_BUILD_NUMBER/consoleText -P $WORKSPACE/$TARGET_BUILD_NAME/$TARGET_BUILD_NUMBER/
+             popd
+
+- builder:
+    name: upload-console-logs
+    builders:
+         - shell: |
+             #!/bin/bash -ex
+             UPLOAD_LOGPATH=$TARGET_BUILD_NAME/$TARGET_BUILD_NUMBER/
+             target=/var/www/html/$UPLOAD_LOGPATH
+             scp $WORKSPACE/$UPLOAD_LOGPATH/* $LOGSERVER:$target 2>&1 | tee > /dev/null
+


### PR DESCRIPTION
Previously the CI used to point to the Jenkins job console as its
context URL, and the end of that, there was a link to an HTML server
that contained the logs. As a part of logs improvement, a change to
directly point to the HTML server with the console being uploaded to
it was adopted. This was done for ease of accessing the logs, and
to avoid slow uploading times of uploading the logs from the internal
Jenkins to the Public Jenkins.