### PR TITLE
Fix Docker build when main branch is updated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         repo: vmware-tanzu/antrea-build-infra
         ref: refs/heads/main
         workflow: Build Antrea ARM images and push manifest
-        token: ${{ secrets.WORKFLOW_DISPATCH_PAT }}
+        token: ${{ secrets.ANTREA_BUILD_INFRA_WORKFLOW_DISPATCH_PAT }}
         inputs: ${{ format('{{ "antrea-repository":"vmware-tanzu/antrea", "antrea-ref":"{0}", "docker-tag":"{1}" }}', github.ref, 'latest') }}
 
   build-scale:

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -40,7 +40,7 @@ jobs:
         repo: vmware-tanzu/antrea-build-infra
         ref: refs/heads/main
         workflow: Build Antrea ARM images and push manifest
-        token: ${{ secrets.WORKFLOW_DISPATCH_PAT }}
+        token: ${{ secrets.ANTREA_BUILD_INFRA_WORKFLOW_DISPATCH_PAT }}
         inputs: ${{ format('{{ "antrea-repository":"vmware-tanzu/antrea", "antrea-ref":"{0}", "docker-tag":"{1}" }}', github.ref, steps.get-version.outputs.version) }}
 
   build-windows:

--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -1,6 +1,7 @@
 ARG OVS_VERSION=2.14.0
-ARG CNI_BINARIES_VERSION
 FROM ubuntu:20.04 as cni-binaries
+
+ARG CNI_BINARIES_VERSION
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget ca-certificates

--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -1,4 +1,5 @@
 ARG OVS_VERSION=2.14.0
+ARG CNI_BINARIES_VERSION
 FROM ubuntu:20.04 as cni-binaries
 
 RUN apt-get update && \
@@ -17,7 +18,7 @@ RUN set -eux; \
          *) pluginsArch=''; echo >&2; echo >&2 "unsupported architecture '$dpkgArch'"; echo >&2 ; exit 1 ;; \
     esac; \
     mkdir -p /opt/cni/bin; \
-    wget -q -O - https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${pluginsArch}-v0.8.7.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
+    wget -q -O - https://github.com/containernetworking/plugins/releases/download/$CNI_BINARIES_VERSION/cni-plugins-linux-${pluginsArch}-$CNI_BINARIES_VERSION.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
 
 
 FROM antrea/openvswitch:${OVS_VERSION}

--- a/build/images/base/build.sh
+++ b/build/images/base/build.sh
@@ -80,6 +80,8 @@ if [ "$PLATFORM" != "" ]; then
     PLATFORM_ARG="--platform $PLATFORM"
 fi
 
+CNI_BINARIES_VERSION=v0.8.7
+
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 pushd $THIS_DIR > /dev/null
@@ -92,18 +94,20 @@ if $PULL; then
 fi
 
 docker build $PLATFORM_ARG --target cni-binaries \
-       --cache-from antrea/cni-binaries \
-       -t antrea/cni-binaries \
+       --cache-from antrea/cni-binaries:$CNI_BINARIES_VERSION \
+       -t antrea/cni-binaries:$CNI_BINARIES_VERSION \
+       --build-arg CNI_BINARIES_VERSION=$CNI_BINARIES_VERSION \
        --build-arg OVS_VERSION=$OVS_VERSION .
 
 docker build $PLATFORM_ARG \
-       --cache-from antrea/cni-binaries \
+       --cache-from antrea/cni-binaries:$CNI_BINARIES_VERSION \
        --cache-from antrea/base-ubuntu:$OVS_VERSION \
        -t antrea/base-ubuntu:$OVS_VERSION \
+       --build-arg CNI_BINARIES_VERSION=$CNI_BINARIES_VERSION \
        --build-arg OVS_VERSION=$OVS_VERSION .
 
 if $PUSH; then
-    docker push antrea/cni-binaries:$OVS_VERSION
+    docker push antrea/cni-binaries:$CNI_BINARIES_VERSION
     docker push antrea/base-ubuntu:$OVS_VERSION
 fi
 

--- a/ci/run-k8s-e2e-tests.sh
+++ b/ci/run-k8s-e2e-tests.sh
@@ -50,7 +50,7 @@ using the sonobuoy tool.
         --e2e-focus TestRegex                                     Run only tests matching a specific regex, this is useful to run a single tests for example.
         --e2e-skip TestRegex                                      Skip some tests matching a specific regex.
         --kubeconfig Kubeconfig                                   Explicit path to Kubeconfig file. You may also set the KUBECONFIG environment variable.
-        --kube-conformance-image ConformacneImage                 Container image override for the kube conformance image. Overrides --kube-conformance-image-version.
+        --kube-conformance-image ConformanceImage                 Container image override for the kube conformance image. Overrides --kube-conformance-image-version.
         --kube-conformance-image-version ConformanceImageVersion  Use specific version of the Conformance tests container image. Default is $KUBE_CONFORMANCE_IMAGE_VERSION.
         --log-mode                                                Use the flag to set either 'report', 'detail', or 'dump' level data for sonobouy results.
         --image-pull-policy                                       The ImagePullPolicy Sonobuoy should use for the aggregators and workers. (default Always)


### PR DESCRIPTION
The build/images/base/build.sh script was incorrectly using the
OVS_VERSION env variable as the tag for the intermediate cni-binaries
image. Instead, we should be using the version of the CNI binaries
packaged in the Docker image.

This is currently causing the CI build on the main branch to fail,
preventing the antrea/antrea-ubuntu:latest Docker image to be updated
automatically.