### PR TITLE
Add agnhost for E2E test

### DIFF
--- a/hack/netpol/pkg/utils/k8s_util.go
+++ b/hack/netpol/pkg/utils/k8s_util.go
@@ -104,7 +104,7 @@ func (k *Kubernetes) Probe(ns1, pod1, ns2, pod2 string, port int) (bool, error) 
 		"/bin/sh",
 		"-c",
 		// 3 tries, timeout is 1 second
-		fmt.Sprintf("for i in $(seq 1 3); do ncat -vz -w 1 %s %d && exit 0 || true; done; exit 1", toIP, port),
+		fmt.Sprintf("for i in $(seq 1 3); do /agnhost connect %s:%d --timeout=1s --protocol=tcp && exit 0 || true; done; exit 1", toIP, port),
 	}
 	// HACK: inferring container name as c80, c81, etc, for simplicity.
 	containerName := fmt.Sprintf("c%v", port)
@@ -205,9 +205,9 @@ func (k *Kubernetes) CreateOrUpdateDeployment(ns, deploymentName string, replica
 		return v1.Container{
 			Name:            fmt.Sprintf("c%d", port),
 			ImagePullPolicy: v1.PullIfNotPresent,
-			Image:           "antrea/netpol-test:latest",
+			Image:           "k8s.gcr.io/e2e-test-images/agnhost:2.29",
 			// "-k" for persistent server
-			Command:         []string{"ncat", "-lk", "-p", fmt.Sprintf("%d", port)},
+			Command:         []string{"/agnhost", "serve-hostname", "--tcp", "--http=false", "--port", fmt.Sprintf("%d", port)},
 			SecurityContext: &v1.SecurityContext{},
 			Ports: []v1.ContainerPort{
 				{

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -937,8 +937,8 @@ func (data *TestData) createServerPod(name string, portName string, portNum int3
 
 // createCustomPod creates a Pod in given Namespace with custom labels.
 func (data *TestData) createServerPodWithLabels(name, ns string, portNum int32, labels map[string]string) error {
-	cmd := []string{"ncat", "-lk", "-p", fmt.Sprintf("%d", portNum)}
-	image := "antrea/netpol-test:latest"
+	cmd := []string{"/agnhost", "serve-hostname", "--tcp", "--http=false", "--port", fmt.Sprintf("%d", portNum)}
+	image := "k8s.gcr.io/e2e-test-images/agnhost:2.29"
 	env := corev1.EnvVar{Name: fmt.Sprintf("SERVE_PORT_%d", portNum), Value: "foo"}
 	port := corev1.ContainerPort{ContainerPort: portNum}
 	containerName := fmt.Sprintf("c%v", portNum)

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -81,7 +81,7 @@ func (k *KubernetesUtils) GetPodsByLabel(ns string, key string, val string) ([]v
 }
 
 // Probe execs into a Pod and checks its connectivity to another Pod.  Of course it assumes
-// that the target Pod is serving on the input port, and also that ncat is installed.
+// that the target Pod is serving on the input port, and also that agnhost is installed.
 func (k *KubernetesUtils) Probe(ns1, pod1, ns2, pod2 string, port int32, protocol v1.Protocol) (PodConnectivityMark, error) {
 	fromPods, err := k.GetPodsByLabel(ns1, "pod", pod1)
 	if err != nil {
@@ -112,9 +112,11 @@ func (k *KubernetesUtils) Probe(ns1, pod1, ns2, pod2 string, port int32, protoco
 	}
 	switch protocol {
 	case v1.ProtocolTCP:
-		cmd = append(cmd, fmt.Sprintf("for i in $(seq 1 3); do ncat -vz -w 1 %s %d && exit 0 || true; done; exit 1", toIP, port))
+		cmd = append(cmd, fmt.Sprintf("for i in $(seq 1 3); do /agnhost connect %s:%d --timeout=1s --protocol=tcp && exit 0 || true; done; exit 1", toIP, port))
 	case v1.ProtocolUDP:
-		cmd = append(cmd, fmt.Sprintf("for i in $(seq 1 3); do ncat -uvz -w 1 %s %d && exit 0 || true; done; exit 1", toIP, port))
+		cmd = append(cmd, fmt.Sprintf("for i in $(seq 1 3); do /agnhost connect %s:%d --timeout=1s --protocol=udp && exit 0 || true; done; exit 1", toIP, port))
+	case v1.ProtocolSCTP:
+		cmd = append(cmd, fmt.Sprintf("for i in $(seq 1 3); do /agnhost connect %s:%d --timeout=1s --protocol=sctp && exit 0 || true; done; exit 1", toIP, port))
 	}
 	// HACK: inferring container name as c80, c81, etc, for simplicity.
 	containerName := fmt.Sprintf("c%v", port)
@@ -124,12 +126,11 @@ func (k *KubernetesUtils) Probe(ns1, pod1, ns2, pod2 string, port int32, protoco
 		// log this error as trace since may be an expected failure
 		log.Tracef("%s/%s -> %s/%s: error when running command: err - %v /// stdout - %s /// stderr - %s", ns1, pod1, ns2, pod2, err, stdout, stderr)
 		// do not return an error
-		if protocol == v1.ProtocolTCP && strings.Contains(stderr, TCPRejectProbeReturn) || protocol == v1.ProtocolUDP && strings.Contains(stderr, UDPRejectProbeReturn) {
-			return Rejected, nil
-		} else if strings.Contains(stderr, DropProbeReturn) {
+		if strings.Contains(stderr, "TIMEOUT") {
 			return Dropped, nil
+		} else {
+			return Rejected, nil
 		}
-		return Error, nil
 	}
 	return Connected, nil
 }
@@ -163,23 +164,33 @@ func (k *KubernetesUtils) CreateOrUpdateDeployment(ns, deploymentName string, re
 	log.Infof("Creating/updating Deployment '%s/%s'", ns, deploymentName)
 	makeContainerSpec := func(port int32, protocol v1.Protocol) v1.Container {
 		var command []string
+		var env []v1.EnvVar
 		switch protocol {
 		case v1.ProtocolTCP:
-			command = []string{"ncat", "-lk", "-p", fmt.Sprintf("%d", port)}
+			command = []string{"/agnhost", "serve-hostname", "--tcp", "--http=false", "--port", fmt.Sprintf("%d", port)}
 		case v1.ProtocolUDP:
-			command = []string{"socat", "-", fmt.Sprintf("udp-listen:%d,fork", port)}
+			command = []string{"/agnhost", "serve-hostname", "--udp", "--http=false", "--port", fmt.Sprintf("%d", port)}
+		case v1.ProtocolSCTP:
+			env = append(env, v1.EnvVar{
+				Name:  fmt.Sprintf("SERVE_SCTP_PORT_%d", port),
+				Value: "foo",
+			})
+			command = []string{"/agnhost", "porter"}
+		default:
+			log.Errorf("invalid protocol %v", protocol)
 		}
 		return v1.Container{
 			Name:            fmt.Sprintf("c%d", port),
 			ImagePullPolicy: v1.PullIfNotPresent,
-			Image:           "antrea/netpol-test:latest",
-			// "-k" for persistent server
+			Image:           "k8s.gcr.io/e2e-test-images/agnhost:2.29",
+			Env:             env,
 			Command:         command,
 			SecurityContext: &v1.SecurityContext{},
 			Ports: []v1.ContainerPort{
 				{
 					ContainerPort: port,
 					Name:          fmt.Sprintf("serve-%d", port),
+					Protocol:      protocol,
 				},
 			},
 		}
@@ -205,6 +216,7 @@ func (k *KubernetesUtils) CreateOrUpdateDeployment(ns, deploymentName string, re
 						makeContainerSpec(80, v1.ProtocolTCP),
 						makeContainerSpec(81, v1.ProtocolTCP),
 						makeContainerSpec(5000, v1.ProtocolUDP),
+						makeContainerSpec(6000, v1.ProtocolSCTP),
 						makeContainerSpec(8080, v1.ProtocolTCP),
 						makeContainerSpec(8081, v1.ProtocolTCP),
 						makeContainerSpec(8082, v1.ProtocolTCP),
@@ -569,13 +581,14 @@ func (k *KubernetesUtils) waitForPodInNamespace(ns string, pod string) (*string,
 
 func (k *KubernetesUtils) waitForHTTPServers(allPods []Pod) error {
 	const maxTries = 10
-	log.Infof("waiting for HTTP servers (ports 80, 81, 5000 and 8080:8085) to become ready")
+	log.Infof("waiting for HTTP servers (ports 80, 81, 5000, 6000 and 8080:8085) to become ready")
 	var wrong int
 	for i := 0; i < maxTries; i++ {
 		reachability := NewReachability(allPods, Connected)
 		k.Validate(allPods, reachability, 80, v1.ProtocolTCP)
 		k.Validate(allPods, reachability, 81, v1.ProtocolTCP)
 		k.Validate(allPods, reachability, 5000, v1.ProtocolUDP)
+		k.Validate(allPods, reachability, 6000, v1.ProtocolSCTP)
 		for j := 8080; j < 8086; j++ {
 			k.Validate(allPods, reachability, int32(j), v1.ProtocolTCP)
 		}

--- a/test/e2e/reachability.go
+++ b/test/e2e/reachability.go
@@ -62,10 +62,6 @@ const (
 	Error     PodConnectivityMark = "Err"
 	Dropped   PodConnectivityMark = "Drp"
 	Rejected  PodConnectivityMark = "Rej"
-
-	TCPRejectProbeReturn string = "Connection refused."
-	UDPRejectProbeReturn string = "Host is unreachable."
-	DropProbeReturn      string = "Operation timed out."
 )
 
 type Connectivity struct {


### PR DESCRIPTION
This PR fixes #1967. 
1. Change to use agnhost to test connectivity between Pods in E2E test.
2. Add UDP, SCTP test case in E2E test (Since OVS userspace conntrack doesn't support SCTP, SCTP cases will be skipped)
