### PR TITLE
Move mutable configmaps out of deployment manifest

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1186,6 +1186,12 @@ rules:
   - get
   - update
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
   - apiregistration.k8s.io
   resourceNames:
   - v1alpha1.stats.antrea.tanzu.vmware.com
@@ -1309,22 +1315,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: antrea-controller
-  namespace: kube-system
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app: antrea
-  name: antrea-ca
-  namespace: kube-system
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app: antrea
-  name: antrea-cluster-identity
   namespace: kube-system
 ---
 apiVersion: v1

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1186,6 +1186,12 @@ rules:
   - get
   - update
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
   - apiregistration.k8s.io
   resourceNames:
   - v1alpha1.stats.antrea.tanzu.vmware.com
@@ -1309,22 +1315,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: antrea-controller
-  namespace: kube-system
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app: antrea
-  name: antrea-ca
-  namespace: kube-system
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app: antrea
-  name: antrea-cluster-identity
   namespace: kube-system
 ---
 apiVersion: v1

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1186,6 +1186,12 @@ rules:
   - get
   - update
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
   - apiregistration.k8s.io
   resourceNames:
   - v1alpha1.stats.antrea.tanzu.vmware.com
@@ -1309,22 +1315,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: antrea-controller
-  namespace: kube-system
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app: antrea
-  name: antrea-ca
-  namespace: kube-system
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app: antrea
-  name: antrea-cluster-identity
   namespace: kube-system
 ---
 apiVersion: v1

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1186,6 +1186,12 @@ rules:
   - get
   - update
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
   - apiregistration.k8s.io
   resourceNames:
   - v1alpha1.stats.antrea.tanzu.vmware.com
@@ -1309,22 +1315,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: antrea-controller
-  namespace: kube-system
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app: antrea
-  name: antrea-ca
-  namespace: kube-system
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app: antrea
-  name: antrea-cluster-identity
   namespace: kube-system
 ---
 apiVersion: v1

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1186,6 +1186,12 @@ rules:
   - get
   - update
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
   - apiregistration.k8s.io
   resourceNames:
   - v1alpha1.stats.antrea.tanzu.vmware.com
@@ -1309,22 +1315,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: antrea-controller
-  namespace: kube-system
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app: antrea
-  name: antrea-ca
-  namespace: kube-system
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app: antrea
-  name: antrea-cluster-identity
   namespace: kube-system
 ---
 apiVersion: v1

--- a/build/yamls/base/controller-rbac.yml
+++ b/build/yamls/base/controller-rbac.yml
@@ -84,6 +84,12 @@ rules:
       - get
       - update
   - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
       - apiregistration.k8s.io
     resources:
       - apiservices

--- a/build/yamls/base/controller.yml
+++ b/build/yamls/base/controller.yml
@@ -11,16 +11,6 @@ spec:
   selector:
     component: antrea-controller
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: antrea-ca
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: antrea-cluster-identity
----
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:

--- a/build/yamls/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator.yml
@@ -32,6 +32,12 @@ rules:
   - update
 - apiGroups:
   - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
+  - ""
   resourceNames:
   - flow-aggregator-client-tls
   resources:
@@ -116,14 +122,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: flow-aggregator
-  namespace: flow-aggregator
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app: flow-aggregator
-  name: flow-aggregator-ca
   namespace: flow-aggregator
 ---
 apiVersion: v1

--- a/build/yamls/flow-aggregator/base/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator/base/flow-aggregator.yml
@@ -5,12 +5,6 @@ metadata:
   name: flow-aggregator
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: flow-aggregator-ca
-  namespace: flow-aggregator
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: flow-aggregator
@@ -26,6 +20,9 @@ rules:
     resources: ["configmaps"]
     resourceNames: ["flow-aggregator-ca"]
     verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
   - apiGroups: [""]
     resources: ["secrets"]
     resourceNames: ["flow-aggregator-client-tls"]


### PR DESCRIPTION
Moving "antrea-ca" and "antrea-cluster-identity" out of deployment manifest.
Instead creating them in the code.

Fixes #1945