### PR TITLE
Add agent API and antctl command to dump OVS groups

### DIFF
--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -237,7 +237,7 @@ Starting from version 0.6.0, Antrea Agent supports dumping Antrea OVS flows. The
 `antctl` `get ovsflows` (or `get of`) command can dump all OVS flows, flows
 added for a specified Pod, or flows added for Service load-balancing of a
 specified Service, or flows added to realize a specified NetworkPolicy, or flows
-in a specified OVS flow table.
+in the specified OVS flow tables, or all or the specified OVS groups.
 
 ```bash
 antctl get ovsflows
@@ -246,7 +246,8 @@ antctl get ovsflows -S SERVICE -n NAMESPACE
 antctl get ovsflows -N NETWORKPOLICY -n NAMESPACE
 antctl get ovsflows -T TABLE_A,TABLE_B
 antctl get ovsflows -T TABLE_A,TABLE_B_NUM
-antctl get ovsflows -T TABLE_A_NUM,TABLE_B_NUM
+antctl get ovsflows -G all
+antctl get ovsflows -G GROUP_ID1,GROUP_ID2
 ```
 
 OVS flow tables can be specified using table names, or the table numbers.

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -299,6 +299,10 @@ var CommandList = &commandList{
   $ antctl get ovsflows -N np1 -n ns1
   Dump OVS flows of a flow Table
   $ antctl get ovsflows -T IngressRule
+  Dump OVS groups
+  $ antctl get ovsflows -G 10,20
+  Dump all OVS groups
+  $ antctl get ovsflows -G all
 
   Antrea OVS Flow Tables:` + generateFlowTableHelpMsg(),
 			agentEndpoint: &endpoint{
@@ -329,6 +333,11 @@ var CommandList = &commandList{
 							name:      "table",
 							usage:     "Comma separated Antrea OVS flow table names or numbers",
 							shorthand: "T",
+						},
+						{
+							name:      "groups",
+							usage:     "Comma separated OVS group IDs. Use 'all' to dump all groups",
+							shorthand: "G",
 						},
 					},
 					outputType: multiple,

--- a/pkg/ovs/ovsctl/interface.go
+++ b/pkg/ovs/ovsctl/interface.go
@@ -40,9 +40,9 @@ type OVSCtlClient interface {
 	// DumpTableFlows returns all flows in the table.
 	DumpTableFlows(table uint8) ([]string, error)
 	// DumpGroup returns the OpenFlow group if it exists on the bridge.
-	DumpGroup(groupID int) (string, error)
+	DumpGroup(groupID uint32) (string, error)
 	// DumpGroups returns OpenFlow groups of the bridge.
-	DumpGroups(args ...string) ([][]string, error)
+	DumpGroups() ([]string, error)
 	// DumpPortsDesc returns OpenFlow ports descriptions of the bridge.
 	DumpPortsDesc() ([][]string, error)
 	// RunOfctlCmd executes "ovs-ofctl" command and returns the outputs.

--- a/pkg/ovs/ovsctl/testing/mock_ovsctl.go
+++ b/pkg/ovs/ovsctl/testing/mock_ovsctl.go
@@ -68,7 +68,7 @@ func (mr *MockOVSCtlClientMockRecorder) DumpFlows(arg0 ...interface{}) *gomock.C
 }
 
 // DumpGroup mocks base method
-func (m *MockOVSCtlClient) DumpGroup(arg0 int) (string, error) {
+func (m *MockOVSCtlClient) DumpGroup(arg0 uint32) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DumpGroup", arg0)
 	ret0, _ := ret[0].(string)
@@ -83,22 +83,18 @@ func (mr *MockOVSCtlClientMockRecorder) DumpGroup(arg0 interface{}) *gomock.Call
 }
 
 // DumpGroups mocks base method
-func (m *MockOVSCtlClient) DumpGroups(arg0 ...string) ([][]string, error) {
+func (m *MockOVSCtlClient) DumpGroups() ([]string, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{}
-	for _, a := range arg0 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DumpGroups", varargs...)
-	ret0, _ := ret[0].([][]string)
+	ret := m.ctrl.Call(m, "DumpGroups")
+	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DumpGroups indicates an expected call of DumpGroups
-func (mr *MockOVSCtlClientMockRecorder) DumpGroups(arg0 ...interface{}) *gomock.Call {
+func (mr *MockOVSCtlClientMockRecorder) DumpGroups() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DumpGroups", reflect.TypeOf((*MockOVSCtlClient)(nil).DumpGroups), arg0...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DumpGroups", reflect.TypeOf((*MockOVSCtlClient)(nil).DumpGroups))
 }
 
 // DumpMatchedFlow mocks base method

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -290,7 +290,7 @@ func TestOFctrlGroup(t *testing.T) {
 			}
 			// Check if the group could be added.
 			require.Nil(t, group.Add())
-			groups, err := ovsCtlClient.DumpGroups()
+			groups, err := OfCtlDumpGroups(ovsCtlClient)
 			require.Nil(t, err)
 			require.Len(t, groups, 1)
 			dumpedGroup := groups[0]
@@ -312,7 +312,7 @@ func TestOFctrlGroup(t *testing.T) {
 			}
 			// Check if the group could be deleted.
 			require.Nil(t, group.Delete())
-			groups, err = ovsCtlClient.DumpGroups()
+			groups, err = OfCtlDumpGroups(ovsCtlClient)
 			require.Nil(t, err)
 			require.Len(t, groups, 0)
 		})

--- a/test/integration/ovs/openflow_test_utils.go
+++ b/test/integration/ovs/openflow_test_utils.go
@@ -71,7 +71,7 @@ func CheckFlowExists(t *testing.T, ovsCtlClient ovsctl.OVSCtlClient, tableID uin
 
 func CheckGroupExists(t *testing.T, ovsCtlClient ovsctl.OVSCtlClient, groupID binding.GroupIDType, groupType string, buckets []string, expectExists bool) {
 	// dump groups
-	groupList, err := ovsCtlClient.DumpGroups()
+	groupList, err := OfCtlDumpGroups(ovsCtlClient)
 	if err != nil {
 		t.Errorf("Error dumping flows: Err %v", err)
 	}
@@ -139,4 +139,18 @@ func OfctlDumpTableFlows(ovsCtlClient ovsctl.OVSCtlClient, table uint8) ([]strin
 func OfctlDeleteFlows(ovsCtlClient ovsctl.OVSCtlClient) error {
 	_, err := ovsCtlClient.RunOfctlCmd("del-flows")
 	return err
+}
+
+func OfCtlDumpGroups(ovsCtlClient ovsctl.OVSCtlClient) ([][]string, error) {
+	rawGroupItems, err := ovsCtlClient.DumpGroups()
+	if err != nil {
+		return nil, err
+	}
+
+	var groupList [][]string
+	for _, item := range rawGroupItems {
+		elems := strings.Split(item, ",bucket=")
+		groupList = append(groupList, elems)
+	}
+	return groupList, nil
 }


### PR DESCRIPTION
# antctl get of -G 1,10,2
FLOW
group_id=1,type=select,bucket=bucket_id:0,weight:100,actions=load:0xac640003->NXM_NX_REG3[],load:0x35->NXM_NX_REG4[0..15],load:0x2->NXM_NX_REG4[16..18],load:0x1->NXM_NX_REG0[19],resubmit(,42),bucket=bucket_id:1,weight:100,actions=load:0xac640002->NXM_NX_REG3[],load:0x35->NXM_NX_REG4[0..15],load:0x2->NXM_NX_REG4[16..18],load:0x1->NXM_NX_REG0[19],resubmit(,42)
group_id=2,type=select,bucket=bucket_id:0,weight:100,actions=load:0xac640003->NXM_NX_REG3[],load:0x23c1->NXM_NX_REG4[0..15],load:0x2->NXM_NX_REG4[16..18],load:0x1->NXM_NX_REG0[19],resubmit(,42),bucket=bucket_id:1,weight:100,actions=load:0xac640002->NXM_NX_REG3[],load:0x23c1->NXM_NX_REG4[0..15],load:0x2->NXM_NX_REG4[16..18],load:0x1->NXM_NX_REG0[19],resubmit(,42)