### PR TITLE
Fix NetworkPolicy logging for IPv6 connections

### DIFF
--- a/pkg/agent/controller/networkpolicy/packetin.go
+++ b/pkg/agent/controller/networkpolicy/packetin.go
@@ -30,8 +30,8 @@ import (
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
-	opsv1alpha1 "github.com/vmware-tanzu/antrea/pkg/apis/ops/v1alpha1"
 	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
+	"github.com/vmware-tanzu/antrea/pkg/util/ip"
 )
 
 const (
@@ -232,7 +232,9 @@ func getPacketInfo(pktIn *ofctrl.PacketIn, ob *logInfo) error {
 	default:
 		return errors.New("unsupported packet-in: should be a valid IPv4 or IPv6 packet")
 	}
-	ob.protocolStr = opsv1alpha1.ProtocolsToString[int32(prot)]
+
+	ob.protocolStr = ip.IPProtocolNumberToString(prot, "UnknownProtocol")
+
 	return nil
 }
 

--- a/pkg/ovs/openflow/ofctrl_action.go
+++ b/pkg/ovs/openflow/ofctrl_action.go
@@ -418,13 +418,13 @@ func (a *ofLearnAction) MatchLearnedUDPv6DstPort() LearnAction {
 	return a.MatchTransportDst(ProtocolUDPv6)
 }
 
-// MatchLearnedSTCPDstPort specifies that the sctp_dst field in the learned flow
+// MatchLearnedSCTPDstPort specifies that the sctp_dst field in the learned flow
 // must match the sctp_dst of the packet currently being processed.
 func (a *ofLearnAction) MatchLearnedSCTPDstPort() LearnAction {
 	return a.MatchTransportDst(ProtocolSCTP)
 }
 
-// MatchLearnedSTCPv6DstPort specifies that the sctp_dst field in the learned flow
+// MatchLearnedSCTPv6DstPort specifies that the sctp_dst field in the learned flow
 // must match the sctp_dst of the packet currently being processed.
 func (a *ofLearnAction) MatchLearnedSCTPv6DstPort() LearnAction {
 	return a.MatchTransportDst(ProtocolSCTPv6)

--- a/pkg/util/ip/ip.go
+++ b/pkg/util/ip/ip.go
@@ -142,3 +142,30 @@ func IPNetToNetIPNet(ipNet *v1beta2.IPNet) *net.IPNet {
 	maskedIP := ip.Mask(mask)
 	return &net.IPNet{IP: maskedIP, Mask: mask}
 }
+
+const (
+	ICMPProtocol   = 1
+	TCPProtocol    = 6
+	UDPProtocol    = 17
+	ICMPv6Protocol = 58
+	SCTPProtocol   = 132
+)
+
+// IPProtocolNumberToString returns the string name of the IP protocol with number protocolNum. If
+// the number does not match a "known" protocol, we return the defaultValue string.
+func IPProtocolNumberToString(protocolNum uint8, defaultValue string) string {
+	switch protocolNum {
+	case ICMPProtocol:
+		return "ICMP"
+	case TCPProtocol:
+		return "TCP"
+	case UDPProtocol:
+		return "UDP"
+	case ICMPv6Protocol:
+		return "IPv6-ICMP"
+	case SCTPProtocol:
+		return "SCTP"
+	default:
+		return defaultValue
+	}
+}

--- a/pkg/util/ip/ip_test.go
+++ b/pkg/util/ip/ip_test.go
@@ -156,3 +156,9 @@ func TestIPNetToNetIPNet(t *testing.T) {
 		})
 	}
 }
+
+func TestIPProtocolNumberToString(t *testing.T) {
+	const defaultValue = "UnknownProtocol"
+	assert.Equal(t, "IPv6-ICMP", IPProtocolNumberToString(ICMPv6Protocol, defaultValue))
+	assert.Equal(t, defaultValue, IPProtocolNumberToString(44, defaultValue))
+}


### PR DESCRIPTION
The code in charge of parsing the PacketIn messages was only handling
IPv4 packets and not filling-in any information for IPv6 packets,
leading to logs with empty fields.

Fixes #1989

I ran the test successfully in an IPv6 cluster creating with Vagrant VMs:
```
=== RUN   TestAntreaPolicy/TestGroupAuditLogging
=== RUN   TestAntreaPolicy/TestGroupAuditLogging/Case=AuditLoggingBasic
I0324 16:58:27.096931   80575 entry.go:314] Creating/updating ClusterNetworkPolicy test-log-acnp-deny
I0324 16:58:40.655439   80575 entry.go:314] Deleting AntreaClusterNetworkPolicies test-log-acnp-deny
I0324 16:58:40.664245   80575 entry.go:314] Deleting test Namespace x
I0324 16:58:40.667629   80575 entry.go:314] Deleting test Namespace y
I0324 16:58:40.670239   80575 entry.go:314] Deleting test Namespace z
=== CONT  TestAntreaPolicy
    fixtures.go:338: Deleting 'antrea-test' K8s Namespace
--- PASS: TestAntreaPolicy (85.75s)
    --- PASS: TestAntreaPolicy/TestGroupAuditLogging (13.56s)
        --- PASS: TestAntreaPolicy/TestGroupAuditLogging/Case=AuditLoggingBasic (13.56s)
=== RUN   TestAntreaPolicyStatus
    fixtures.go:140: Creating 'antrea-test' K8s Namespace
    fixtures.go:103: Applying Antrea YAML
    fixtures.go:107: Waiting for all Antrea DaemonSet Pods
    fixtures.go:111: Checking CoreDNS deployment
    fixtures.go:345: Deleting Pod 'server-1vo3xb5yy'
    fixtures.go:345: Deleting Pod 'server-0krb06ddg'
    fixtures.go:338: Deleting 'antrea-test' K8s Namespace
--- PASS: TestAntreaPolicyStatus (21.07s)
PASS
```