### PR TITLE
Add ability to specify a list of ipBlocks in crd/v1alpha2 ClusterGroup

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -126,6 +126,14 @@ spec:
                     format: cidr
                     type: string
                 type: object
+              ipBlocks:
+                items:
+                  properties:
+                    cidr:
+                      format: cidr
+                      type: string
+                  type: object
+                type: array
               namespaceSelector:
                 x-kubernetes-preserve-unknown-fields: true
               podSelector:
@@ -190,6 +198,14 @@ spec:
                     format: cidr
                     type: string
                 type: object
+              ipBlocks:
+                items:
+                  properties:
+                    cidr:
+                      format: cidr
+                      type: string
+                  type: object
+                type: array
               namespaceSelector:
                 x-kubernetes-preserve-unknown-fields: true
               podSelector:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -126,6 +126,14 @@ spec:
                     format: cidr
                     type: string
                 type: object
+              ipBlocks:
+                items:
+                  properties:
+                    cidr:
+                      format: cidr
+                      type: string
+                  type: object
+                type: array
               namespaceSelector:
                 x-kubernetes-preserve-unknown-fields: true
               podSelector:
@@ -190,6 +198,14 @@ spec:
                     format: cidr
                     type: string
                 type: object
+              ipBlocks:
+                items:
+                  properties:
+                    cidr:
+                      format: cidr
+                      type: string
+                  type: object
+                type: array
               namespaceSelector:
                 x-kubernetes-preserve-unknown-fields: true
               podSelector:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -126,6 +126,14 @@ spec:
                     format: cidr
                     type: string
                 type: object
+              ipBlocks:
+                items:
+                  properties:
+                    cidr:
+                      format: cidr
+                      type: string
+                  type: object
+                type: array
               namespaceSelector:
                 x-kubernetes-preserve-unknown-fields: true
               podSelector:
@@ -190,6 +198,14 @@ spec:
                     format: cidr
                     type: string
                 type: object
+              ipBlocks:
+                items:
+                  properties:
+                    cidr:
+                      format: cidr
+                      type: string
+                  type: object
+                type: array
               namespaceSelector:
                 x-kubernetes-preserve-unknown-fields: true
               podSelector:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -126,6 +126,14 @@ spec:
                     format: cidr
                     type: string
                 type: object
+              ipBlocks:
+                items:
+                  properties:
+                    cidr:
+                      format: cidr
+                      type: string
+                  type: object
+                type: array
               namespaceSelector:
                 x-kubernetes-preserve-unknown-fields: true
               podSelector:
@@ -190,6 +198,14 @@ spec:
                     format: cidr
                     type: string
                 type: object
+              ipBlocks:
+                items:
+                  properties:
+                    cidr:
+                      format: cidr
+                      type: string
+                  type: object
+                type: array
               namespaceSelector:
                 x-kubernetes-preserve-unknown-fields: true
               podSelector:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -126,6 +126,14 @@ spec:
                     format: cidr
                     type: string
                 type: object
+              ipBlocks:
+                items:
+                  properties:
+                    cidr:
+                      format: cidr
+                      type: string
+                  type: object
+                type: array
               namespaceSelector:
                 x-kubernetes-preserve-unknown-fields: true
               podSelector:
@@ -190,6 +198,14 @@ spec:
                     format: cidr
                     type: string
                 type: object
+              ipBlocks:
+                items:
+                  properties:
+                    cidr:
+                      format: cidr
+                      type: string
+                  type: object
+                type: array
               namespaceSelector:
                 x-kubernetes-preserve-unknown-fields: true
               podSelector:

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -725,6 +725,14 @@ spec:
                     cidr:
                       type: string
                       format: cidr
+                ipBlocks:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      cidr:
+                        type: string
+                        format: cidr
                 serviceReference:
                   type: object
                   properties:
@@ -1490,6 +1498,14 @@ spec:
                     cidr:
                       type: string
                       format: cidr
+                ipBlocks:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      cidr:
+                        type: string
+                        format: cidr
                 serviceReference:
                   type: object
                   properties:

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -132,9 +132,9 @@ function run_test {
   fi
   sleep 1
   if $coverage; then
-      go test -v -timeout=50m github.com/vmware-tanzu/antrea/test/e2e -provider=kind --logs-export-dir=$ANTREA_LOG_DIR --coverage --coverage-dir $ANTREA_COV_DIR
+      go test -v -timeout=55m github.com/vmware-tanzu/antrea/test/e2e -provider=kind --logs-export-dir=$ANTREA_LOG_DIR --coverage --coverage-dir $ANTREA_COV_DIR
   else
-      go test -v -timeout=45m github.com/vmware-tanzu/antrea/test/e2e -provider=kind --logs-export-dir=$ANTREA_LOG_DIR
+      go test -v -timeout=50m github.com/vmware-tanzu/antrea/test/e2e -provider=kind --logs-export-dir=$ANTREA_LOG_DIR
   fi
   $TESTBED_CMD destroy kind
 }

--- a/pkg/apis/crd/v1alpha2/types.go
+++ b/pkg/apis/crd/v1alpha2/types.go
@@ -119,8 +119,15 @@ type GroupSpec struct {
 	// IPBlock describes the IPAddresses/IPBlocks that is matched in to/from.
 	// IPBlock cannot be set as part of the AppliedTo field.
 	// Cannot be set with any other selector or ServiceReference.
+	// Cannot be set with IPBlocks.
 	// +optional
 	IPBlock *v1alpha1.IPBlock `json:"ipBlock,omitempty"`
+	// IPBlocks is a list of IPAddresses/IPBlocks that is matched in to/from.
+	// IPBlock cannot be set as part of the AppliedTo field.
+	// Cannot be set with any other selector or ServiceReference.
+	// Cannot be set with IPBlock.
+	// +optional
+	IPBlocks []v1alpha1.IPBlock `json:"ipBlocks,omitempty"`
 	// Select backend Pods of the referred Service.
 	// Cannot be set with any other selector or ipBlock.
 	// +optional

--- a/pkg/apis/crd/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/crd/v1alpha2/zz_generated.deepcopy.go
@@ -222,6 +222,11 @@ func (in *GroupSpec) DeepCopyInto(out *GroupSpec) {
 		*out = new(v1alpha1.IPBlock)
 		**out = **in
 	}
+	if in.IPBlocks != nil {
+		in, out := &in.IPBlocks, &out.IPBlocks
+		*out = make([]v1alpha1.IPBlock, len(*in))
+		copy(*out, *in)
+	}
 	if in.ServiceReference != nil {
 		in, out := &in.ServiceReference, &out.ServiceReference
 		*out = new(ServiceReference)

--- a/pkg/controller/networkpolicy/clustergroup_test.go
+++ b/pkg/controller/networkpolicy/clustergroup_test.go
@@ -96,9 +96,11 @@ func TestProcessClusterGroup(t *testing.T) {
 			expectedGroup: &antreatypes.Group{
 				UID:  "uidD",
 				Name: "cgD",
-				IPBlock: &controlplane.IPBlock{
-					CIDR:   *cidrIPNet,
-					Except: []controlplane.IPNet{},
+				IPBlocks: []controlplane.IPBlock{
+					{
+						CIDR:   *cidrIPNet,
+						Except: []controlplane.IPNet{},
+					},
 				},
 			},
 		},
@@ -214,9 +216,11 @@ func TestAddClusterGroup(t *testing.T) {
 			expectedGroup: &antreatypes.Group{
 				UID:  "uidD",
 				Name: "cgD",
-				IPBlock: &controlplane.IPBlock{
-					CIDR:   *cidrIPNet,
-					Except: []controlplane.IPNet{},
+				IPBlocks: []controlplane.IPBlock{
+					{
+						CIDR:   *cidrIPNet,
+						Except: []controlplane.IPNet{},
+					},
 				},
 			},
 		},
@@ -307,9 +311,11 @@ func TestUpdateClusterGroup(t *testing.T) {
 			expectedGroup: &antreatypes.Group{
 				UID:  "uidA",
 				Name: "cgA",
-				IPBlock: &controlplane.IPBlock{
-					CIDR:   *cidrIPNet,
-					Except: []controlplane.IPNet{},
+				IPBlocks: []controlplane.IPBlock{
+					{
+						CIDR:   *cidrIPNet,
+						Except: []controlplane.IPNet{},
+					},
 				},
 			},
 		},

--- a/pkg/controller/networkpolicy/clusternetworkpolicy.go
+++ b/pkg/controller/networkpolicy/clusternetworkpolicy.go
@@ -221,7 +221,7 @@ func (n *NetworkPolicyController) processClusterNetworkPolicy(cnp *crdv1alpha1.C
 
 // processRefCG processes the ClusterGroup reference present in the rule and returns the
 // NetworkPolicyPeer with the corresponding AddressGroup or IPBlock.
-func (n *NetworkPolicyController) processRefCG(g string) (string, *controlplane.IPBlock) {
+func (n *NetworkPolicyController) processRefCG(g string) (string, []controlplane.IPBlock) {
 	// Retrieve ClusterGroup for corresponding entry in the rule.
 	cg, err := n.cgLister.Get(g)
 	if err != nil {
@@ -240,8 +240,8 @@ func (n *NetworkPolicyController) processRefCG(g string) (string, *controlplane.
 		return "", nil
 	}
 	intGrp := ig.(*antreatypes.Group)
-	if intGrp.IPBlock != nil {
-		return "", intGrp.IPBlock
+	if len(intGrp.IPBlocks) > 0 {
+		return "", intGrp.IPBlocks
 	}
 	agKey := n.createAddressGroupForClusterGroupCRD(intGrp)
 	// Return if addressGroup was created or found.
@@ -267,8 +267,8 @@ func (n *NetworkPolicyController) processAppliedToGroupForCG(g string) string {
 		return ""
 	}
 	intGrp := ig.(*antreatypes.Group)
-	if intGrp.IPBlock != nil {
-		klog.V(2).Infof("ClusterGroup %s with IPBlock will not be processed as AppliedTo", g)
+	if len(intGrp.IPBlocks) > 0 {
+		klog.V(2).Infof("ClusterGroup %s with IPBlocks will not be processed as AppliedTo", g)
 		return ""
 	}
 	return n.createAppliedToGroupForClusterGroupCRD(intGrp)

--- a/pkg/controller/networkpolicy/clusternetworkpolicy_test.go
+++ b/pkg/controller/networkpolicy/clusternetworkpolicy_test.go
@@ -1280,7 +1280,7 @@ func TestProcessRefCG(t *testing.T) {
 		name        string
 		inputCG     string
 		expectedAG  string
-		expectedIPB *controlplane.IPBlock
+		expectedIPB []controlplane.IPBlock
 	}{
 		{
 			name:        "empty-cg-no-result",
@@ -1304,9 +1304,11 @@ func TestProcessRefCG(t *testing.T) {
 			name:       "cg-with-ipblock",
 			inputCG:    cgB.Name,
 			expectedAG: "",
-			expectedIPB: &controlplane.IPBlock{
-				CIDR:   *cidrIPNet,
-				Except: []controlplane.IPNet{},
+			expectedIPB: []controlplane.IPBlock{
+				{
+					CIDR:   *cidrIPNet,
+					Except: []controlplane.IPNet{},
+				},
 			},
 		},
 	}

--- a/pkg/controller/networkpolicy/crd_utils.go
+++ b/pkg/controller/networkpolicy/crd_utils.go
@@ -102,11 +102,11 @@ func (n *NetworkPolicyController) toAntreaPeerForCRD(peers []secv1alpha1.Network
 			}
 			ipBlocks = append(ipBlocks, *ipBlock)
 		} else if peer.Group != "" {
-			normalizedUID, ipBlock := n.processRefCG(peer.Group)
+			normalizedUID, groupIPBlocks := n.processRefCG(peer.Group)
 			if normalizedUID != "" {
 				addressGroups = append(addressGroups, normalizedUID)
-			} else if ipBlock != nil {
-				ipBlocks = append(ipBlocks, *ipBlock)
+			} else if len(groupIPBlocks) > 0 {
+				ipBlocks = append(ipBlocks, groupIPBlocks...)
 			}
 		} else {
 			normalizedUID := n.createAddressGroup(np.GetNamespace(), peer.PodSelector, peer.NamespaceSelector, peer.ExternalEntitySelector)

--- a/pkg/controller/types/group.go
+++ b/pkg/controller/types/group.go
@@ -108,7 +108,7 @@ type Group struct {
 	// Selector is nil if Group is defined with ipBlock, or if it has ServiceReference
 	// and has not been processed by the controller yet / Service cannot be found.
 	Selector *GroupSelector
-	IPBlock  *controlplane.IPBlock
+	IPBlocks []controlplane.IPBlock
 	// ServiceReference is reference to a v1.Service, which this Group keeps in sync
 	// and updates Selector based on the Service's selector.
 	ServiceReference *controlplane.ServiceReference

--- a/test/e2e/clustergroup_test.go
+++ b/test/e2e/clustergroup_test.go
@@ -66,6 +66,28 @@ func testInvalidCGIPBlockWithNSSelector(t *testing.T) {
 	}
 }
 
+func testInvalidCGIPBlockWithIPBlocks(t *testing.T) {
+	invalidErr := fmt.Errorf("clustergroup created with ipBlock and ipBlocks")
+	cgName := "ipb-ipbs"
+	cidr := "10.0.0.10/32"
+	cidr2 := "10.0.0.20/32"
+	ipb := &crdv1alpha1.IPBlock{CIDR: cidr}
+	ipbs := []crdv1alpha1.IPBlock{{CIDR: cidr2}}
+	cg := &crdv1alpha2.ClusterGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cgName,
+		},
+		Spec: crdv1alpha2.GroupSpec{
+			IPBlocks: ipbs,
+			IPBlock:  ipb,
+		},
+	}
+	if _, err := k8sUtils.CreateOrUpdateCG(cg); err == nil {
+		// Above creation of CG must fail as it is an invalid spec.
+		failOnError(invalidErr, t)
+	}
+}
+
 func testInvalidCGServiceRefWithPodSelector(t *testing.T) {
 	invalidErr := fmt.Errorf("clustergroup created with serviceReference and podSelector")
 	cgName := "svcref-pod-selector"
@@ -257,6 +279,7 @@ func TestClusterGroup(t *testing.T) {
 	t.Run("TestGroupClusterGroupValidate", func(t *testing.T) {
 		t.Run("Case=IPBlockWithPodSelectorDenied", func(t *testing.T) { testInvalidCGIPBlockWithPodSelector(t) })
 		t.Run("Case=IPBlockWithNamespaceSelectorDenied", func(t *testing.T) { testInvalidCGIPBlockWithNSSelector(t) })
+		t.Run("Case=IPBlockWithIPBlocksDenied", func(t *testing.T) { testInvalidCGIPBlockWithIPBlocks(t) })
 		t.Run("Case=ServiceRefWithPodSelectorDenied", func(t *testing.T) { testInvalidCGServiceRefWithPodSelector(t) })
 		t.Run("Case=ServiceRefWithNamespaceSelectorDenied", func(t *testing.T) { testInvalidCGServiceRefWithNSSelector(t) })
 		t.Run("Case=ServiceRefWithIPBlockDenied", func(t *testing.T) { testInvalidCGServiceRefWithIPBlock(t) })

--- a/test/e2e/utils/cgspecbuilder.go
+++ b/test/e2e/utils/cgspecbuilder.go
@@ -78,8 +78,8 @@ func (b *ClusterGroupSpecBuilder) SetNamespaceSelector(nsSelector map[string]str
 	return b
 }
 
-func (b *ClusterGroupSpecBuilder) SetIPBlock(ipb *crdv1alpha1.IPBlock) *ClusterGroupSpecBuilder {
-	b.Spec.IPBlock = ipb
+func (b *ClusterGroupSpecBuilder) SetIPBlocks(ipBlocks []crdv1alpha1.IPBlock) *ClusterGroupSpecBuilder {
+	b.Spec.IPBlocks = ipBlocks
 	return b
 }
 


### PR DESCRIPTION
This PR adds a new `ipBlocks` field for the ClusterGroup resource. It allows users to group a list of CIDRs in a ClusterGroup, instead of a single CIDR in the `ipBlock` field. For a single ClusterGroup, `ipBlock` and `ipBlocks` should not be set at the same time. Users can continue to create ClusterGroups with `ipBlock`. This field however will be deprecated in the next API upgrade for ClusterGroup. See #2008.