### PR TITLE
Add OVS_VERSION to hw-offload CI docker build

### DIFF
--- a/ci/jenkins/mellanox/scripts/start_ci.sh
+++ b/ci/jenkins/mellanox/scripts/start_ci.sh
@@ -78,11 +78,11 @@ EOF
         cp -rf "$antrea_scm_dir" $WORKSPACE/antrea-cni
         pushd $WORKSPACE/antrea-cni
         
-        sudo docker build -t antrea/antrea-ubuntu:latest -f build/images/Dockerfile.build.ubuntu .
+        sudo docker build -t antrea/antrea-ubuntu:latest -f build/images/Dockerfile.build.ubuntu --build-arg OVS_VERSION=$(head -n 1 build/images/deps/ovs-version) .
         let status=status+$?
         popd
     else
-        build_github_project "antrea-cni" "sudo docker build -t antrea/antrea-ubuntu:latest -f build/images/Dockerfile.build.ubuntu ."
+        build_github_project "antrea-cni" "sudo docker build -t antrea/antrea-ubuntu:latest -f build/images/Dockerfile.build.ubuntu --build-arg OVS_VERSION=$(head -n 1 build/images/deps/ovs-version) ."
         let status=status+$?
     fi
 


### PR DESCRIPTION
Following #1985, the `docker build` command needs to be provided with
the OVS_VERSION variable. Since hw-offload CI uses the `docker build`
command directly instead of `make build`, it started to fail. This
patch fixes this by adding the variable to the `docker build` command.