### PR TITLE
Add flowType field for Flow Exporter

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -353,6 +353,7 @@ func run(o *Options) error {
 	if features.DefaultFeatureGate.Enabled(features.FlowExporter) {
 		v4Enabled := config.IsIPv4Enabled(nodeConfig, networkConfig.TrafficEncapMode)
 		v6Enabled := config.IsIPv6Enabled(nodeConfig, networkConfig.TrafficEncapMode)
+		isNetworkPolicyOnly := networkConfig.TrafficEncapMode.IsNetworkPolicyOnly()
 
 		flowRecords := flowrecords.NewFlowRecords()
 		connStore := connections.NewConnectionStore(
@@ -376,7 +377,9 @@ func run(o *Options) error {
 			o.config.EnableTLSToFlowAggregator,
 			v4Enabled,
 			v6Enabled,
-			k8sClient)
+			k8sClient,
+			nodeRouteController,
+			isNetworkPolicyOnly)
 		if err != nil {
 			return fmt.Errorf("error when creating IPFIX flow exporter: %v", err)
 		}

--- a/pkg/agent/controller/noderoute/node_route_controller_test.go
+++ b/pkg/agent/controller/noderoute/node_route_controller_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
@@ -35,11 +36,13 @@ import (
 )
 
 var (
-	gatewayMAC, _  = net.ParseMAC("00:00:00:00:00:01")
-	_, podCIDR, _  = net.ParseCIDR("1.1.1.0/24")
-	podCIDRGateway = ip.NextIP(podCIDR.IP)
-	nodeIP1        = net.ParseIP("10.10.10.10")
-	nodeIP2        = net.ParseIP("10.10.10.11")
+	gatewayMAC, _   = net.ParseMAC("00:00:00:00:00:01")
+	_, podCIDR, _   = net.ParseCIDR("1.1.1.0/24")
+	_, podCIDR2, _  = net.ParseCIDR("1.1.2.0/24")
+	podCIDRGateway  = ip.NextIP(podCIDR.IP)
+	podCIDR2Gateway = ip.NextIP(podCIDR2.IP)
+	nodeIP1         = net.ParseIP("10.10.10.10")
+	nodeIP2         = net.ParseIP("10.10.10.11")
 )
 
 type fakeController struct {
@@ -157,4 +160,71 @@ func TestControllerWithDuplicatePodCIDR(t *testing.T) {
 		t.Errorf("Test didn't finish in time")
 	case <-finishCh:
 	}
+}
+
+func TestIPInPodSubnets(t *testing.T) {
+	c, closeFn := newController(t)
+	defer closeFn()
+	defer c.queue.ShutDown()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	c.informerFactory.Start(stopCh)
+	// Must wait for cache sync, otherwise resource creation events will be missing if the resources are created
+	// in-between list and watch call of an informer. This is because fake clientset doesn't support watching with
+	// resourceVersion. A watcher of fake clientset only gets events that happen after the watcher is created.
+	c.informerFactory.WaitForCacheSync(stopCh)
+	c.Controller.nodeConfig.PodIPv4CIDR = podCIDR
+
+	node1 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+		},
+		Spec: corev1.NodeSpec{
+			PodCIDR:  podCIDR.String(),
+			PodCIDRs: []string{podCIDR.String()},
+		},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{
+					Type:    corev1.NodeInternalIP,
+					Address: nodeIP1.String(),
+				},
+			},
+		},
+	}
+	node2 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node2",
+		},
+		Spec: corev1.NodeSpec{
+			PodCIDR:  podCIDR2.String(),
+			PodCIDRs: []string{podCIDR2.String()},
+		},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{
+					Type:    corev1.NodeInternalIP,
+					Address: nodeIP2.String(),
+				},
+			},
+		},
+	}
+
+	c.clientset.CoreV1().Nodes().Create(context.TODO(), node1, metav1.CreateOptions{})
+	// The 2nd argument is Any() because the argument is unpredictable when it uses pointer as the key of map.
+	// The argument type is map[*net.IPNet]net.IP.
+	c.ofClient.EXPECT().InstallNodeFlows("node1", gomock.Any(), nodeIP1, uint32(0)).Times(1)
+	c.routeClient.EXPECT().AddRoutes(podCIDR, "node1", nodeIP1, podCIDRGateway).Times(1)
+	c.processNextWorkItem()
+
+	c.clientset.CoreV1().Nodes().Create(context.TODO(), node2, metav1.CreateOptions{})
+	c.ofClient.EXPECT().InstallNodeFlows("node2", gomock.Any(), nodeIP2, uint32(0)).Times(1)
+	c.routeClient.EXPECT().AddRoutes(podCIDR2, "node2", nodeIP2, podCIDR2Gateway).Times(1)
+	c.processNextWorkItem()
+
+	assert.Equal(t, true, c.Controller.IPInPodSubnets(net.ParseIP("1.1.1.1")))
+	assert.Equal(t, true, c.Controller.IPInPodSubnets(net.ParseIP("1.1.2.1")))
+	assert.Equal(t, false, c.Controller.IPInPodSubnets(net.ParseIP("10.10.10.10")))
+	assert.Equal(t, false, c.Controller.IPInPodSubnets(net.ParseIP("8.8.8.8")))
 }

--- a/pkg/util/ip/ip.go
+++ b/pkg/util/ip/ip.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	v4BitLen = 8 * net.IPv4len
-	v6BitLen = 8 * net.IPv6len
+	V4BitLen = 8 * net.IPv4len
+	V6BitLen = 8 * net.IPv6len
 )
 
 // This function takes in one allow CIDR and multiple except CIDRs and gives diff CIDRs
@@ -71,9 +71,9 @@ func diffFromCIDR(allowCIDR, exceptCIDR *net.IPNet) []*net.IPNet {
 	exceptStartIP := exceptCIDR.IP.Mask(exceptCIDR.Mask)
 	var bits int
 	if allowStartIP.To4() != nil {
-		bits = v4BitLen
+		bits = V4BitLen
 	} else {
-		bits = v6BitLen
+		bits = V6BitLen
 	}
 
 	// New CIDRs should not contain the IPs in exceptCIDR. Manipulating the bits in start IP of


### PR DESCRIPTION
Fixes #1925 
In this PR, we implemented the logic of flowType value assignment.
We distinguished Pod-To-Pod flows and Pod-To-External flows using the podCIDRs of all nodes in the k8s cluster.