### PR TITLE
Change flow-aggregator base images to reduce image size

### DIFF
--- a/build/images/flow-aggregator/Dockerfile
+++ b/build/images/flow-aggregator/Dockerfile
@@ -7,7 +7,7 @@ COPY . /antrea
 
 RUN make flow-aggregator
 
-FROM antrea/base-ubuntu:${OVS_VERSION}
+FROM scratch
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The docker image for the flow aggregator"


### PR DESCRIPTION
Flow aggregator only needs the Golang binary and doesn't have dependencies on OVS. Changing the base image to reduce image size.

Closes https://github.com/vmware-tanzu/antrea/issues/1986.