### PR TITLE
Support Traceflow of live traffic

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1234,6 +1234,16 @@ spec:
       name: Destination-IP
       priority: 10
       type: string
+    - description: Trace live traffic.
+      jsonPath: .spec.liveTraffic
+      name: Live-Traffic
+      priority: 10
+      type: boolean
+    - description: Timeout in seconds.
+      jsonPath: .spec.timeout
+      name: Timeout
+      priority: 10
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -1244,15 +1254,6 @@ spec:
           spec:
             properties:
               destination:
-                oneOf:
-                - required:
-                  - pod
-                  - namespace
-                - required:
-                  - service
-                  - namespace
-                - required:
-                  - ip
                 properties:
                   ip:
                     pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
@@ -1264,6 +1265,8 @@ spec:
                   service:
                     type: string
                 type: object
+              liveTraffic:
+                type: boolean
               packet:
                 properties:
                   ipHeader:
@@ -1325,9 +1328,10 @@ spec:
                 - pod
                 - namespace
                 type: object
+              timeout:
+                type: integer
             required:
             - source
-            - destination
             type: object
           status:
             properties:
@@ -1428,15 +1432,6 @@ spec:
           spec:
             properties:
               destination:
-                oneOf:
-                - required:
-                  - pod
-                  - namespace
-                - required:
-                  - service
-                  - namespace
-                - required:
-                  - ip
                 properties:
                   ip:
                     pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
@@ -1511,7 +1506,6 @@ spec:
                 type: object
             required:
             - source
-            - destination
             type: object
           status:
             properties:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1234,6 +1234,16 @@ spec:
       name: Destination-IP
       priority: 10
       type: string
+    - description: Trace live traffic.
+      jsonPath: .spec.liveTraffic
+      name: Live-Traffic
+      priority: 10
+      type: boolean
+    - description: Timeout in seconds.
+      jsonPath: .spec.timeout
+      name: Timeout
+      priority: 10
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -1244,15 +1254,6 @@ spec:
           spec:
             properties:
               destination:
-                oneOf:
-                - required:
-                  - pod
-                  - namespace
-                - required:
-                  - service
-                  - namespace
-                - required:
-                  - ip
                 properties:
                   ip:
                     pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
@@ -1264,6 +1265,8 @@ spec:
                   service:
                     type: string
                 type: object
+              liveTraffic:
+                type: boolean
               packet:
                 properties:
                   ipHeader:
@@ -1325,9 +1328,10 @@ spec:
                 - pod
                 - namespace
                 type: object
+              timeout:
+                type: integer
             required:
             - source
-            - destination
             type: object
           status:
             properties:
@@ -1428,15 +1432,6 @@ spec:
           spec:
             properties:
               destination:
-                oneOf:
-                - required:
-                  - pod
-                  - namespace
-                - required:
-                  - service
-                  - namespace
-                - required:
-                  - ip
                 properties:
                   ip:
                     pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
@@ -1511,7 +1506,6 @@ spec:
                 type: object
             required:
             - source
-            - destination
             type: object
           status:
             properties:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1234,6 +1234,16 @@ spec:
       name: Destination-IP
       priority: 10
       type: string
+    - description: Trace live traffic.
+      jsonPath: .spec.liveTraffic
+      name: Live-Traffic
+      priority: 10
+      type: boolean
+    - description: Timeout in seconds.
+      jsonPath: .spec.timeout
+      name: Timeout
+      priority: 10
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -1244,15 +1254,6 @@ spec:
           spec:
             properties:
               destination:
-                oneOf:
-                - required:
-                  - pod
-                  - namespace
-                - required:
-                  - service
-                  - namespace
-                - required:
-                  - ip
                 properties:
                   ip:
                     pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
@@ -1264,6 +1265,8 @@ spec:
                   service:
                     type: string
                 type: object
+              liveTraffic:
+                type: boolean
               packet:
                 properties:
                   ipHeader:
@@ -1325,9 +1328,10 @@ spec:
                 - pod
                 - namespace
                 type: object
+              timeout:
+                type: integer
             required:
             - source
-            - destination
             type: object
           status:
             properties:
@@ -1428,15 +1432,6 @@ spec:
           spec:
             properties:
               destination:
-                oneOf:
-                - required:
-                  - pod
-                  - namespace
-                - required:
-                  - service
-                  - namespace
-                - required:
-                  - ip
                 properties:
                   ip:
                     pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
@@ -1511,7 +1506,6 @@ spec:
                 type: object
             required:
             - source
-            - destination
             type: object
           status:
             properties:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1234,6 +1234,16 @@ spec:
       name: Destination-IP
       priority: 10
       type: string
+    - description: Trace live traffic.
+      jsonPath: .spec.liveTraffic
+      name: Live-Traffic
+      priority: 10
+      type: boolean
+    - description: Timeout in seconds.
+      jsonPath: .spec.timeout
+      name: Timeout
+      priority: 10
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -1244,15 +1254,6 @@ spec:
           spec:
             properties:
               destination:
-                oneOf:
-                - required:
-                  - pod
-                  - namespace
-                - required:
-                  - service
-                  - namespace
-                - required:
-                  - ip
                 properties:
                   ip:
                     pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
@@ -1264,6 +1265,8 @@ spec:
                   service:
                     type: string
                 type: object
+              liveTraffic:
+                type: boolean
               packet:
                 properties:
                   ipHeader:
@@ -1325,9 +1328,10 @@ spec:
                 - pod
                 - namespace
                 type: object
+              timeout:
+                type: integer
             required:
             - source
-            - destination
             type: object
           status:
             properties:
@@ -1428,15 +1432,6 @@ spec:
           spec:
             properties:
               destination:
-                oneOf:
-                - required:
-                  - pod
-                  - namespace
-                - required:
-                  - service
-                  - namespace
-                - required:
-                  - ip
                 properties:
                   ip:
                     pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
@@ -1511,7 +1506,6 @@ spec:
                 type: object
             required:
             - source
-            - destination
             type: object
           status:
             properties:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1234,6 +1234,16 @@ spec:
       name: Destination-IP
       priority: 10
       type: string
+    - description: Trace live traffic.
+      jsonPath: .spec.liveTraffic
+      name: Live-Traffic
+      priority: 10
+      type: boolean
+    - description: Timeout in seconds.
+      jsonPath: .spec.timeout
+      name: Timeout
+      priority: 10
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -1244,15 +1254,6 @@ spec:
           spec:
             properties:
               destination:
-                oneOf:
-                - required:
-                  - pod
-                  - namespace
-                - required:
-                  - service
-                  - namespace
-                - required:
-                  - ip
                 properties:
                   ip:
                     pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
@@ -1264,6 +1265,8 @@ spec:
                   service:
                     type: string
                 type: object
+              liveTraffic:
+                type: boolean
               packet:
                 properties:
                   ipHeader:
@@ -1325,9 +1328,10 @@ spec:
                 - pod
                 - namespace
                 type: object
+              timeout:
+                type: integer
             required:
             - source
-            - destination
             type: object
           status:
             properties:
@@ -1428,15 +1432,6 @@ spec:
           spec:
             properties:
               destination:
-                oneOf:
-                - required:
-                  - pod
-                  - namespace
-                - required:
-                  - service
-                  - namespace
-                - required:
-                  - ip
                 properties:
                   ip:
                     pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
@@ -1511,7 +1506,6 @@ spec:
                 type: object
             required:
             - source
-            - destination
             type: object
           status:
             properties:

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -73,6 +73,16 @@ spec:
           name: Destination-IP
           type: string
           priority: 10
+        - jsonPath: .spec.liveTraffic
+          description: Trace live traffic.
+          name: Live-Traffic
+          type: boolean
+          priority: 10
+        - jsonPath: .spec.timeout
+          description: Timeout in seconds.
+          name: Timeout
+          type: integer
+          priority: 10
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
@@ -86,7 +96,6 @@ spec:
               type: object
               required:
                 - source
-                - destination
               properties:
                 source:
                   type: object
@@ -110,10 +119,6 @@ spec:
                     ip:
                       type: string
                       pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
-                  oneOf:
-                    - required: ["pod", "namespace"]
-                    - required: ["service", "namespace"]
-                    - required: ["ip"]
                 packet:
                   type: object
                   properties:
@@ -165,6 +170,10 @@ spec:
                               type: integer
                             flags:
                               type: integer
+                liveTraffic:
+                  type: boolean
+                timeout:
+                  type: integer
             status:
               type: object
               properties:
@@ -854,7 +863,6 @@ spec:
               type: object
               required:
                 - source
-                - destination
               properties:
                 source:
                   type: object
@@ -878,10 +886,6 @@ spec:
                     ip:
                       type: string
                       pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
-                  oneOf:
-                    - required: ["pod", "namespace"]
-                    - required: ["service", "namespace"]
-                    - required: ["ip"]
                 packet:
                   type: object
                   properties:

--- a/pkg/agent/controller/traceflow/traceflow_controller.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/contiv/libOpenflow/protocol"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -43,12 +44,10 @@ import (
 	crdinformers "github.com/vmware-tanzu/antrea/pkg/client/informers/externalversions/crd/v1alpha1"
 	crdlisters "github.com/vmware-tanzu/antrea/pkg/client/listers/crd/v1alpha1"
 	"github.com/vmware-tanzu/antrea/pkg/features"
+	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
 	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsconfig"
 	"github.com/vmware-tanzu/antrea/pkg/querier"
 )
-
-type icmpType uint8
-type icmpCode uint8
 
 const (
 	controllerName = "AntreaAgentTraceflowController"
@@ -62,11 +61,23 @@ const (
 	// Seconds delay before injecting packet into OVS. The time of different nodes may not be completely
 	// synchronized, which requires a delay before inject packet.
 	injectPacketDelay = 5
+
 	// ICMP Echo Request type and code.
-	icmpEchoRequestType   icmpType = 8
-	icmpv6EchoRequestType icmpType = 128
-	icmpEchoRequestCode   icmpCode = 0
+	icmpEchoRequestType   uint8 = 8
+	icmpv6EchoRequestType uint8 = 128
+	icmpEchoRequestCode   uint8 = 0
+
+	defaultTTL uint8 = 64
 )
+
+type traceflowState struct {
+	name        string
+	tag         uint8
+	liveTraffic bool
+	isSender    bool
+	// Agent received the first Traceflow packet from OVS.
+	receivedPacket bool
+}
 
 // Controller is responsible for setting up Openflow entries and injecting traceflow packet into
 // the switch for traceflow request.
@@ -87,9 +98,9 @@ type Controller struct {
 	serviceCIDR            *net.IPNet // K8s Service ClusterIP CIDR
 	queue                  workqueue.RateLimitingInterface
 	runningTraceflowsMutex sync.RWMutex
-	runningTraceflows      map[uint8]string // tag->traceflowName if tf.Status.Phase is Running.
-	injectedTagsMutex      sync.RWMutex
-	injectedTags           map[uint8]string // tag->traceflowName if this Node is sender.
+	// runningTraceflows is a map for storing the running Traceflow state
+	// with dataplane tag to be the key.
+	runningTraceflows map[uint8]*traceflowState
 }
 
 // NewTraceflowController instantiates a new Controller object which will process Traceflow
@@ -120,8 +131,8 @@ func NewTraceflowController(
 		nodeConfig:            nodeConfig,
 		serviceCIDR:           serviceCIDR,
 		queue:                 workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "traceflow"),
-		runningTraceflows:     make(map[uint8]string),
-		injectedTags:          make(map[uint8]string)}
+		runningTraceflows:     make(map[uint8]*traceflowState),
+	}
 
 	// Add handlers for Traceflow events.
 	traceflowInformer.Informer().AddEventHandlerWithResyncPeriod(
@@ -184,7 +195,7 @@ func (c *Controller) updateTraceflow(_, curObj interface{}) {
 func (c *Controller) deleteTraceflow(old interface{}) {
 	tf := old.(*crdv1alpha1.Traceflow)
 	klog.Infof("Processing Traceflow %s DELETE event", tf.Name)
-	c.deallocateTag(tf)
+	c.enqueueTraceflow(tf)
 }
 
 // worker is a long-running function that will continually call the processTraceflowItem function
@@ -239,15 +250,19 @@ func (c *Controller) syncTraceflow(traceflowName string) error {
 
 	tf, err := c.traceflowLister.Get(traceflowName)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			c.cleanupTraceflow(traceflowName)
+			return nil
+		}
 		return err
 	}
+
 	switch tf.Status.Phase {
 	case crdv1alpha1.Running:
 		if tf.Status.DataplaneTag != 0 {
 			start := false
 			c.runningTraceflowsMutex.Lock()
 			if _, ok := c.runningTraceflows[tf.Status.DataplaneTag]; !ok {
-				c.runningTraceflows[tf.Status.DataplaneTag] = tf.Name
 				start = true
 			}
 			c.runningTraceflowsMutex.Unlock()
@@ -258,7 +273,7 @@ func (c *Controller) syncTraceflow(traceflowName string) error {
 			klog.Warningf("Invalid data plane tag %d for Traceflow %s", tf.Status.DataplaneTag, tf.Name)
 		}
 	default:
-		c.deallocateTag(tf)
+		c.cleanupTraceflow(traceflowName)
 	}
 	return err
 }
@@ -269,28 +284,64 @@ func (c *Controller) startTraceflow(tf *crdv1alpha1.Traceflow) error {
 	err := c.validateTraceflow(tf)
 	defer func() {
 		if err != nil {
+			c.cleanupTraceflow(tf.Name)
 			c.errorTraceflowCRD(tf, fmt.Sprintf("Node: %s, error: %+v", c.nodeConfig.Name, err))
 		}
 	}()
 	if err != nil {
 		return err
 	}
-	// Deploy flow entries for traceflow
-	klog.V(2).Infof("Deploy flow entries for Traceflow %s", tf.Name)
-	err = c.ofClient.InstallTraceflowFlows(tf.Status.DataplaneTag)
+
+	// TODO: let controller compute the source Node, and the source Node can just return an error,
+	//  if fails to find the Pod.
+	podInterfaces := c.interfaceStore.GetContainerInterfacesByPod(tf.Spec.Source.Pod, tf.Spec.Source.Namespace)
+	liveTraffic := tf.Spec.LiveTraffic
+	isSender := len(podInterfaces) > 0
+
+	var packet, matchPacket *binding.Packet
+	var srcOFPort uint32
+	if isSender {
+		packet, err = c.preparePacket(tf, podInterfaces[0])
+		if err != nil {
+			return err
+		}
+		srcOFPort = uint32(podInterfaces[0].OFPort)
+		// On the source Node, trace the first packet of the first
+		// connection that matches the Traceflow spec.
+		if liveTraffic {
+			matchPacket = packet
+		}
+		klog.V(2).Infof("Traceflow packet %v", *packet)
+	}
+
+	// Store Traceflow to cache.
+	c.runningTraceflowsMutex.Lock()
+	tfState := traceflowState{name: tf.Name, tag: tf.Status.DataplaneTag, liveTraffic: tf.Spec.LiveTraffic, isSender: isSender}
+	c.runningTraceflows[tfState.tag] = &tfState
+	c.runningTraceflowsMutex.Unlock()
+
+	// Install flow entries for traceflow.
+	klog.V(2).Infof("Installing flow entries for Traceflow %s", tf.Name)
+	timeout := tf.Spec.Timeout
+	if timeout == 0 {
+		timeout = crdv1alpha1.DefaultTraceflowTimeout
+	}
+	err = c.ofClient.InstallTraceflowFlows(tfState.tag, liveTraffic, matchPacket, srcOFPort, timeout)
 	if err != nil {
 		return err
 	}
 
-	// TODO: let controller compute the source Node, and the source Node can just return an error,
-	//  if fails to find the Pod.
-	// Inject packet if this Node is sender.
-	podInterfaces := c.interfaceStore.GetContainerInterfacesByPod(tf.Spec.Source.Pod, tf.Spec.Source.Namespace)
-	// Skip inject packet if Pod not found in current Node.
-	if len(podInterfaces) == 0 {
-		return nil
+	// Skip packet injection if the source Pod is not found on the local Node.
+	if !liveTraffic && isSender {
+		if packet.DestinationMAC == nil {
+			// If the destination is Service/IP or the packet will
+			// be sent to remote Node, wait a small period for other
+			// Nodes.
+			time.Sleep(time.Duration(injectPacketDelay) * time.Second)
+		}
+		klog.V(2).Infof("Injecting packet for Traceflow %s", tf.Name)
+		err = c.ofClient.SendTraceflowPacket(tfState.tag, packet, srcOFPort, -1)
 	}
-	err = c.injectPacket(tf)
 	return err
 }
 
@@ -312,144 +363,171 @@ func (c *Controller) validateTraceflow(tf *crdv1alpha1.Traceflow) error {
 	return nil
 }
 
-func (c *Controller) injectPacket(tf *crdv1alpha1.Traceflow) error {
-	podInterfaces := c.interfaceStore.GetContainerInterfacesByPod(tf.Spec.Source.Pod, tf.Spec.Source.Namespace)
-	// Update Traceflow phase to Running.
-	klog.V(2).Infof("Injecting packet for Traceflow %s", tf.Name)
-	c.injectedTagsMutex.Lock()
-	c.injectedTags[tf.Status.DataplaneTag] = tf.Name
-	c.injectedTagsMutex.Unlock()
-
-	var srcTCPPort, dstTCPPort, srcUDPPort, dstUDPPort, idICMP, sequenceICMP uint16
-	var flagsTCP uint8
-
-	// Calculate destination MAC/IP.
-	isIPv6 := tf.Spec.Packet.IPv6Header != nil
-	srcIP := ""
-	dstMAC := ""
-	dstIP := tf.Spec.Destination.IP
-	if isIPv6 {
-		srcIP = podInterfaces[0].GetIPv6Addr().String()
-	} else {
-		srcIP = podInterfaces[0].GetIPv4Addr().String()
-	}
-	if err := validateIPVersion(srcIP, isIPv6); err != nil {
-		return err
+func (c *Controller) preparePacket(tf *crdv1alpha1.Traceflow, intf *interfacestore.InterfaceConfig) (*binding.Packet, error) {
+	liveTraffic := tf.Spec.LiveTraffic
+	isICMP := false
+	packet := new(binding.Packet)
+	packet.IsIPv6 = tf.Spec.Packet.IPv6Header != nil
+	if !liveTraffic {
+		if packet.IsIPv6 {
+			packet.SourceIP = intf.GetIPv6Addr()
+			if packet.SourceIP == nil {
+				return nil, errors.New("source Pod does not have an IPv6 address")
+			}
+		} else {
+			packet.SourceIP = intf.GetIPv4Addr()
+			if packet.SourceIP == nil {
+				return nil, errors.New("source Pod does not have an IPv4 address")
+			}
+		}
+		packet.SourceMAC = intf.MAC
 	}
 
-	if dstIP != "" {
-		dstPodInterface, hasInterface := c.interfaceStore.GetInterfaceByIP(dstIP)
-		if hasInterface {
-			dstMAC = dstPodInterface.MAC.String()
+	if tf.Spec.Destination.IP != "" {
+		packet.DestinationIP = net.ParseIP(tf.Spec.Destination.IP)
+		if packet.DestinationIP == nil {
+			return nil, errors.New("invalid destination IP address")
+		}
+		if !packet.IsIPv6 {
+			packet.DestinationIP = packet.DestinationIP.To4()
+			if packet.DestinationIP == nil {
+				return nil, errors.New("destination IP should be an IPv4 address")
+			}
+		} else if packet.DestinationIP.To4() != nil {
+			return nil, errors.New("destination IP should be an IPv6 address")
+		}
+		if !liveTraffic {
+			dstPodInterface, hasInterface := c.interfaceStore.GetInterfaceByIP(tf.Spec.Destination.IP)
+			if hasInterface {
+				packet.DestinationMAC = dstPodInterface.MAC
+			}
 		}
 	} else if tf.Spec.Destination.Pod != "" {
 		dstPodInterfaces := c.interfaceStore.GetContainerInterfacesByPod(tf.Spec.Destination.Pod, tf.Spec.Destination.Namespace)
 		if len(dstPodInterfaces) > 0 {
-			dstMAC = dstPodInterfaces[0].MAC.String()
-			if isIPv6 {
-				dstIP = dstPodInterfaces[0].GetIPv6Addr().String()
+			if packet.IsIPv6 {
+				packet.DestinationIP = dstPodInterfaces[0].GetIPv6Addr()
 			} else {
-				dstIP = dstPodInterfaces[0].GetIPv4Addr().String()
+				packet.DestinationIP = dstPodInterfaces[0].GetIPv4Addr()
+			}
+			if !liveTraffic {
+				packet.DestinationMAC = dstPodInterfaces[0].MAC
 			}
 		} else {
 			dstPod, err := c.kubeClient.CoreV1().Pods(tf.Spec.Destination.Namespace).Get(context.TODO(), tf.Spec.Destination.Pod, metav1.GetOptions{})
 			if err != nil {
-				return err
+				return nil, fmt.Errorf("failed to get the destination Pod: %v", err)
 			}
-			// dstMAC is "" here, will be set to Gateway MAC in ofClient.SendTraceflowPacket
+			// DestinationMAC is nil here, will be set to gateway
+			// MAC in ofClient.SendTraceflowPacket()
 			podIPs := make([]net.IP, len(dstPod.Status.PodIPs))
 			for i, ip := range dstPod.Status.PodIPs {
 				podIPs[i] = net.ParseIP(ip.IP)
 			}
-			if isIPv6 {
-				ipv6, _ := util.GetIPWithFamily(podIPs, util.FamilyIPv6)
-				dstIP = ipv6.String()
+			if packet.IsIPv6 {
+				packet.DestinationIP, _ = util.GetIPWithFamily(podIPs, util.FamilyIPv6)
 			} else {
-				dstIP = util.GetIPv4Addr(podIPs).String()
+				packet.DestinationIP = util.GetIPv4Addr(podIPs)
+			}
+		}
+		if packet.DestinationIP == nil {
+			if packet.IsIPv6 {
+				return nil, errors.New("destination Pod does not have an IPv6 address")
+			} else {
+				return nil, errors.New("destination Pod does not have an IPv4 address")
 			}
 		}
 	} else if tf.Spec.Destination.Service != "" {
 		dstSvc, err := c.serviceLister.Services(tf.Spec.Destination.Namespace).Get(tf.Spec.Destination.Service)
 		if err != nil {
-			return err
+			return nil, fmt.Errorf("failed to get the destination Service: %v", err)
 		}
-		dstIP = dstSvc.Spec.ClusterIP
-		flagsTCP = 2
-	}
-	if err := validateIPVersion(dstIP, isIPv6); err != nil {
-		return err
+		if dstSvc.Spec.ClusterIP == "" {
+			return nil, errors.New("destination Service does not have a ClusterIP")
+		}
+		packet.DestinationIP = net.ParseIP(dstSvc.Spec.ClusterIP)
+		if !packet.IsIPv6 {
+			packet.DestinationIP = packet.DestinationIP.To4()
+			if packet.DestinationIP == nil {
+				return nil, errors.New("destination Service does not have an IPv4 ClusterIP")
+			}
+		} else if packet.DestinationIP.To4() != nil {
+			return nil, errors.New("destination Service does not have an IPv6 ClusterIP")
+		}
+
+		if !liveTraffic {
+			// Set the SYN flag. In encap mode, the SYN flag is only required for
+			// Service traffic, but probably we should always set it.
+			packet.TCPFlags = 2
+		}
+	} else if !liveTraffic {
+		return nil, errors.New("destination is not specified")
 	}
 
-	if dstMAC == "" {
-		// If the destination is Service/IP or the packet will be sent to remote Node, wait a small period for other Nodes.
-		time.Sleep(time.Duration(injectPacketDelay) * time.Second)
-	}
-
-	var ipProtocol uint8
-	var ttl uint8
-	var ipFlags uint16
-	if isIPv6 {
-		if tf.Spec.Packet.IPv6Header.NextHeader == nil {
-			ipProtocol = protocol.Type_IPv6ICMP
-		} else {
-			ipProtocol = uint8(*tf.Spec.Packet.IPv6Header.NextHeader)
+	if tf.Spec.Packet.IPv6Header != nil {
+		// IP Protocol 0 (IPv6 Hop-by-Hop Option) is not supported by
+		// Traceflow. If NextHeader is not provided, protocol ICMPv6
+		// will be used as the default.
+		if tf.Spec.Packet.IPv6Header.NextHeader != nil {
+			packet.IPProto = uint8(*tf.Spec.Packet.IPv6Header.NextHeader)
 		}
-		ttl = uint8(tf.Spec.Packet.IPv6Header.HopLimit)
-		ipFlags = 0
+		if !liveTraffic {
+			packet.TTL = uint8(tf.Spec.Packet.IPv6Header.HopLimit)
+			packet.IPFlags = 0
+		}
 	} else {
-		ipProtocol = uint8(tf.Spec.Packet.IPHeader.Protocol)
-		// Protocol is 0 (IPv6 Hop-by-Hop Option) if not set in CRD, which is not supported by Traceflow
-		// Use Protocol=1 (ICMP) as default.
-		if ipProtocol == 0 {
-			ipProtocol = protocol.Type_ICMP
+		packet.IPProto = uint8(tf.Spec.Packet.IPHeader.Protocol)
+		if !liveTraffic {
+			packet.TTL = uint8(tf.Spec.Packet.IPHeader.TTL)
+			packet.IPFlags = uint16(tf.Spec.Packet.IPHeader.Flags)
 		}
-		ttl = uint8(tf.Spec.Packet.IPHeader.TTL)
-		ipFlags = uint16(tf.Spec.Packet.IPHeader.Flags)
+	}
+	if !liveTraffic && packet.TTL == 0 {
+		packet.TTL = defaultTTL
 	}
 
+	// TCP > UDP > ICMP > other IP protocol.
 	if tf.Spec.Packet.TransportHeader.TCP != nil {
-		srcTCPPort = uint16(tf.Spec.Packet.TransportHeader.TCP.SrcPort)
-		dstTCPPort = uint16(tf.Spec.Packet.TransportHeader.TCP.DstPort)
+		packet.IPProto = protocol.Type_TCP
+		packet.SourcePort = uint16(tf.Spec.Packet.TransportHeader.TCP.SrcPort)
+		packet.DestinationPort = uint16(tf.Spec.Packet.TransportHeader.TCP.DstPort)
 		if tf.Spec.Packet.TransportHeader.TCP.Flags != 0 {
-			flagsTCP = uint8(tf.Spec.Packet.TransportHeader.TCP.Flags)
+			packet.TCPFlags = uint8(tf.Spec.Packet.TransportHeader.TCP.Flags)
+		}
+	} else if tf.Spec.Packet.TransportHeader.UDP != nil {
+		packet.IPProto = protocol.Type_UDP
+		packet.SourcePort = uint16(tf.Spec.Packet.TransportHeader.UDP.SrcPort)
+		packet.DestinationPort = uint16(tf.Spec.Packet.TransportHeader.UDP.DstPort)
+	} else if tf.Spec.Packet.TransportHeader.ICMP != nil {
+		isICMP = true
+		if !liveTraffic {
+			packet.ICMPEchoID = uint16(tf.Spec.Packet.TransportHeader.ICMP.ID)
+			packet.ICMPEchoSeq = uint16(tf.Spec.Packet.TransportHeader.ICMP.Sequence)
 		}
 	}
-	if tf.Spec.Packet.TransportHeader.UDP != nil {
-		srcUDPPort = uint16(tf.Spec.Packet.TransportHeader.UDP.SrcPort)
-		dstUDPPort = uint16(tf.Spec.Packet.TransportHeader.UDP.DstPort)
+
+	if packet.IPProto == 0 || packet.IPProto == protocol.Type_ICMP || packet.IPProto == protocol.Type_IPv6ICMP {
+		// IPProto defaults to ICMP.
+		isICMP = true
 	}
-	if tf.Spec.Packet.TransportHeader.ICMP != nil {
-		idICMP = uint16(tf.Spec.Packet.TransportHeader.ICMP.ID)
-		sequenceICMP = uint16(tf.Spec.Packet.TransportHeader.ICMP.Sequence)
+	if isICMP {
+		if packet.IsIPv6 {
+			packet.IPProto = protocol.Type_IPv6ICMP
+			if !liveTraffic {
+				packet.ICMPType = icmpv6EchoRequestType
+			}
+		} else {
+			packet.IPProto = protocol.Type_ICMP
+			if !liveTraffic {
+				packet.ICMPType = icmpEchoRequestType
+			}
+		}
+		if !liveTraffic {
+			packet.ICMPCode = icmpEchoRequestCode
+		}
 	}
 
-	var packetOutIcmpEchoRequestType icmpType
-	if isIPv6 {
-		packetOutIcmpEchoRequestType = icmpv6EchoRequestType
-	} else {
-		packetOutIcmpEchoRequestType = icmpEchoRequestType
-	}
-
-	return c.ofClient.SendTraceflowPacket(
-		tf.Status.DataplaneTag,
-		podInterfaces[0].MAC.String(),
-		dstMAC,
-		srcIP,
-		dstIP,
-		ipProtocol,
-		ttl,
-		ipFlags,
-		srcTCPPort,
-		dstTCPPort,
-		flagsTCP,
-		srcUDPPort,
-		dstUDPPort,
-		uint8(packetOutIcmpEchoRequestType),
-		uint8(icmpEchoRequestCode),
-		idICMP,
-		sequenceICMP,
-		uint32(podInterfaces[0].OFPort),
-		-1)
+	return packet, nil
 }
 
 func (c *Controller) errorTraceflowCRD(tf *crdv1alpha1.Traceflow, reason string) (*crdv1alpha1.Traceflow, error) {
@@ -463,68 +541,29 @@ func (c *Controller) errorTraceflowCRD(tf *crdv1alpha1.Traceflow, reason string)
 	return c.traceflowClient.CrdV1alpha1().Traceflows().Patch(context.TODO(), tf.Name, types.MergePatchType, payloads, metav1.PatchOptions{}, "status")
 }
 
-// Deallocate tag from cache.
-func (c *Controller) deallocateTag(tf *crdv1alpha1.Traceflow) {
-	dataplaneTag := uint8(0)
+// Delete Traceflow from cache.
+func (c *Controller) deleteTraceflowState(tfName string) *traceflowState {
 	c.runningTraceflowsMutex.Lock()
+	defer c.runningTraceflowsMutex.Unlock()
 	// Controller could have deallocated the tag and cleared the DataplaneTag
 	// field in the Traceflow Status, so try looking up the tag from the
 	// cache by Traceflow name.
-	for tag, existingTraceflowName := range c.runningTraceflows {
-		if tf.Name == existingTraceflowName {
+	for tag, tfState := range c.runningTraceflows {
+		if tfName == tfState.name {
 			delete(c.runningTraceflows, tag)
-			dataplaneTag = tag
-			break
-		}
-	}
-	c.runningTraceflowsMutex.Unlock()
-	if dataplaneTag == 0 {
-		return
-	}
-	c.injectedTagsMutex.Lock()
-	if existingTraceflowName, ok := c.injectedTags[dataplaneTag]; ok {
-		if tf.Name == existingTraceflowName {
-			delete(c.injectedTags, dataplaneTag)
-		} else {
-			klog.Warningf("runningTraceflows cache mismatch tag: %d name: %s existingName: %s",
-				dataplaneTag, tf.Name, existingTraceflowName)
-		}
-	}
-	c.injectedTagsMutex.Unlock()
-}
-
-func (c *Controller) isSender(tag uint8) bool {
-	c.injectedTagsMutex.RLock()
-	defer c.injectedTagsMutex.RUnlock()
-	if _, ok := c.injectedTags[tag]; ok {
-		return true
-	}
-	return false
-}
-
-// getTraceflowCRD gets traceflow CRD by data plane tag.
-func (c *Controller) GetRunningTraceflowCRD(tag uint8) (*crdv1alpha1.Traceflow, error) {
-	c.runningTraceflowsMutex.RLock()
-	defer c.runningTraceflowsMutex.RUnlock()
-	if traceflowName, ok := c.runningTraceflows[tag]; ok {
-		return c.traceflowLister.Get(traceflowName)
-	}
-	return nil, errors.New(fmt.Sprintf("traceflow with the data plane tag %d doesn't exist", tag))
-}
-
-func validateIPVersion(ip string, isIPv6 bool) error {
-	parsedIP := net.ParseIP(ip)
-	if parsedIP == nil {
-		return errors.New(fmt.Sprintf("invalid ip string %s", ip))
-	}
-	if isIPv6 {
-		if parsedIP.To4() != nil {
-			return errors.New(fmt.Sprintf("expect IPv6, but got IPv4 %s", ip))
-		}
-	} else {
-		if parsedIP.To4() == nil {
-			return errors.New(fmt.Sprintf("expect IPv4, but got IPv6 %s", ip))
+			return tfState
 		}
 	}
 	return nil
+}
+
+// Delete Traceflow state and OVS flows.
+func (c *Controller) cleanupTraceflow(tfName string) {
+	tfState := c.deleteTraceflowState(tfName)
+	if tfState != nil {
+		err := c.ofClient.UninstallTraceflowFlows(tfState.tag)
+		if err != nil {
+			klog.Errorf("Failed to uninstall Traceflow %s flows: %v", tfName, err)
+		}
+	}
 }

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -448,17 +448,17 @@ func (mr *MockClientMockRecorder) InstallServiceGroup(arg0, arg1, arg2 interface
 }
 
 // InstallTraceflowFlows mocks base method
-func (m *MockClient) InstallTraceflowFlows(arg0 byte) error {
+func (m *MockClient) InstallTraceflowFlows(arg0 byte, arg1 bool, arg2 *openflow.Packet, arg3 uint32, arg4 uint16) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallTraceflowFlows", arg0)
+	ret := m.ctrl.Call(m, "InstallTraceflowFlows", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallTraceflowFlows indicates an expected call of InstallTraceflowFlows
-func (mr *MockClientMockRecorder) InstallTraceflowFlows(arg0 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallTraceflowFlows(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallTraceflowFlows", reflect.TypeOf((*MockClient)(nil).InstallTraceflowFlows), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallTraceflowFlows", reflect.TypeOf((*MockClient)(nil).InstallTraceflowFlows), arg0, arg1, arg2, arg3, arg4)
 }
 
 // IsConnected mocks base method
@@ -584,17 +584,17 @@ func (mr *MockClientMockRecorder) SendTCPPacketOut(arg0, arg1, arg2, arg3, arg4,
 }
 
 // SendTraceflowPacket mocks base method
-func (m *MockClient) SendTraceflowPacket(arg0 byte, arg1, arg2, arg3, arg4 string, arg5, arg6 byte, arg7, arg8, arg9 uint16, arg10 byte, arg11, arg12 uint16, arg13, arg14 byte, arg15, arg16 uint16, arg17 uint32, arg18 int32) error {
+func (m *MockClient) SendTraceflowPacket(arg0 byte, arg1 *openflow.Packet, arg2 uint32, arg3 int32) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendTraceflowPacket", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18)
+	ret := m.ctrl.Call(m, "SendTraceflowPacket", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SendTraceflowPacket indicates an expected call of SendTraceflowPacket
-func (mr *MockClientMockRecorder) SendTraceflowPacket(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) SendTraceflowPacket(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTraceflowPacket", reflect.TypeOf((*MockClient)(nil).SendTraceflowPacket), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTraceflowPacket", reflect.TypeOf((*MockClient)(nil).SendTraceflowPacket), arg0, arg1, arg2, arg3)
 }
 
 // StartPacketInHandler mocks base method
@@ -748,6 +748,20 @@ func (m *MockClient) UninstallServiceGroup(arg0 openflow.GroupIDType) error {
 func (mr *MockClientMockRecorder) UninstallServiceGroup(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninstallServiceGroup", reflect.TypeOf((*MockClient)(nil).UninstallServiceGroup), arg0)
+}
+
+// UninstallTraceflowFlows mocks base method
+func (m *MockClient) UninstallTraceflowFlows(arg0 byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UninstallTraceflowFlows", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UninstallTraceflowFlows indicates an expected call of UninstallTraceflowFlows
+func (mr *MockClientMockRecorder) UninstallTraceflowFlows(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninstallTraceflowFlows", reflect.TypeOf((*MockClient)(nil).UninstallTraceflowFlows), arg0)
 }
 
 // MockOFEntryOperations is a mock of OFEntryOperations interface

--- a/pkg/antctl/raw/traceflow/command.go
+++ b/pkg/antctl/raw/traceflow/command.go
@@ -39,6 +39,8 @@ import (
 	clientset "github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned"
 )
 
+const defaultTimeout time.Duration = time.Second * 10
+
 var (
 	Command *cobra.Command
 	option  = &struct {
@@ -46,7 +48,9 @@ var (
 		destination string
 		outputType  string
 		flow        string
-		waiting     bool
+		liveTraffic bool
+		nowait      bool
+		timeout     time.Duration
 	}{}
 )
 
@@ -79,8 +83,10 @@ func init() {
   $antctl traceflow -S busybox0 -D svc0 -f tcp,tcp_dst=80,tcp_flags=2
   Start a Traceflow from busybox0 in Namespace ns0 to busybox1 in Namespace ns1, output type is json
   $antctl traceflow -S ns0/busybox0 -D ns1/busybox1 -o json
-  Start a Traceflow from busybox0 to busybox1, with TCP header and 80 as destination port
+  Start a Traceflow from busybox0 to busybox1, with a TCP packet to destination port 80
   $antctl traceflow -S busybox0 -D busybox1 -f tcp,tcp_dst=80
+  Start a Traceflow for live TCP traffic from busybox0 to TCP port 80, with 1 minute timeout
+  $antctl traceflow -S busybox0 -f tcp,tcp_dst=80 --live-traffic -t 1m
 `,
 		RunE: runE,
 	}
@@ -88,13 +94,28 @@ func init() {
 	Command.Flags().StringVarP(&option.source, "source", "S", "", "source of the Traceflow: Namespace/Pod or Pod")
 	Command.Flags().StringVarP(&option.destination, "destination", "D", "", "destination of the Traceflow: Namespace/Pod, Pod, Namespace/Service, Service or IP")
 	Command.Flags().StringVarP(&option.outputType, "output", "o", "yaml", "output type: yaml (default), json")
-	Command.Flags().BoolVarP(&option.waiting, "wait", "", true, "if false, command returns without retrieving results")
 	Command.Flags().StringVarP(&option.flow, "flow", "f", "", "specify the flow (packet headers) of the Traceflow packet, including tcp_src, tcp_dst, tcp_flags, udp_src, udp_dst, ipv6")
+	Command.Flags().BoolVarP(&option.liveTraffic, "live-traffic", "L", false, "if set, the Traceflow will trace the first packet of the matched live traffic flow")
+	Command.Flags().BoolVarP(&option.nowait, "nowait", "", false, "if set, command returns without retrieving results")
 }
 
 func runE(cmd *cobra.Command, _ []string) error {
-	if len(option.source) == 0 || len(option.destination) == 0 {
-		fmt.Println("Please provide source and destination.")
+	option.timeout, _ = cmd.Flags().GetDuration("timeout")
+	if option.timeout > time.Hour*12 {
+		fmt.Println("Timeout cannot be longer than 12 hours")
+		return nil
+	}
+	if option.timeout == 0 {
+		option.timeout = defaultTimeout
+	}
+
+	if len(option.source) == 0 {
+		fmt.Println("Please provide source")
+		return nil
+	}
+
+	if !option.liveTraffic && len(option.destination) == 0 {
+		fmt.Println("Please provide destination")
 		return nil
 	}
 
@@ -127,19 +148,19 @@ func runE(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("error when creating Traceflow, is Traceflow feature gate enabled? %w", err)
 	}
 	defer func() {
-		if option.waiting {
+		if !option.nowait {
 			if err = client.CrdV1alpha1().Traceflows().Delete(context.TODO(), tf.Name, metav1.DeleteOptions{}); err != nil {
 				klog.Errorf("error when deleting Traceflow: %+v", err)
 			}
 		}
 	}()
 
-	if !option.waiting {
+	if option.nowait {
 		return nil
 	}
 
 	var res *v1alpha1.Traceflow
-	err = wait.Poll(1*time.Second, 15*time.Second, func() (bool, error) {
+	err = wait.Poll(1*time.Second, option.timeout, func() (bool, error) {
 		res, err = client.CrdV1alpha1().Traceflows().Get(context.TODO(), tf.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -180,33 +201,37 @@ func newTraceflow(client kubernetes.Interface) (*v1alpha1.Traceflow, error) {
 	}
 
 	var dst v1alpha1.Destination
-	dstIP := net.ParseIP(option.destination)
-	if dstIP != nil {
-		dst.IP = dstIP.String()
-		name = getTFName(fmt.Sprintf("%s-%s-to-%s", src.Namespace, src.Pod, dst.IP))
+	if option.destination != "" {
+		dstIP := net.ParseIP(option.destination)
+		if dstIP != nil {
+			dst.IP = dstIP.String()
+			name = getTFName(fmt.Sprintf("%s-%s-to-%s", src.Namespace, src.Pod, dst.IP))
+		} else {
+			var isPod bool
+			var dest string
+			var err error
+			split = strings.Split(option.destination, "/")
+			if len(split) == 1 {
+				dst.Namespace = "default"
+				dest = split[0]
+			} else if len(split) == 2 && len(split[0]) != 0 && len(split[1]) != 0 {
+				dst.Namespace = split[0]
+				dest = split[1]
+			} else {
+				return nil, fmt.Errorf("destination should be in the format of Namespace/Pod, Pod, Namespace/Service or Service")
+			}
+			if isPod, err = dstIsPod(client, dst.Namespace, dest); err != nil {
+				return nil, fmt.Errorf("failed to check if destination is Pod or Service: %w", err)
+			}
+			if isPod {
+				dst.Pod = dest
+			} else {
+				dst.Service = dest
+			}
+			name = getTFName(fmt.Sprintf("%s-%s-to-%s-%s", src.Namespace, src.Pod, dst.Namespace, dest))
+		}
 	} else {
-		var isPod bool
-		var dest string
-		var err error
-		split = strings.Split(option.destination, "/")
-		if len(split) == 1 {
-			dst.Namespace = "default"
-			dest = split[0]
-		} else if len(split) == 2 && len(split[0]) != 0 && len(split[1]) != 0 {
-			dst.Namespace = split[0]
-			dest = split[1]
-		} else {
-			return nil, fmt.Errorf("destination should be in the format of Namespace/Pod, Pod, Namespace/Service or Service")
-		}
-		if isPod, err = dstIsPod(client, dst.Namespace, dest); err != nil {
-			return nil, fmt.Errorf("failed to check if destination is Pod or Service: %w", err)
-		}
-		if isPod {
-			dst.Pod = dest
-		} else {
-			dst.Service = dest
-		}
-		name = getTFName(fmt.Sprintf("%s-%s-to-%s-%s", src.Namespace, src.Pod, dst.Namespace, dest))
+		name = getTFName(fmt.Sprintf("%s-%s-to-any", src.Namespace, src.Pod))
 	}
 
 	pkt, err := parseFlow()
@@ -222,9 +247,10 @@ func newTraceflow(client kubernetes.Interface) (*v1alpha1.Traceflow, error) {
 			Source:      src,
 			Destination: dst,
 			Packet:      *pkt,
+			Timeout:     uint16(option.timeout.Seconds()),
+			LiveTraffic: option.liveTraffic,
 		},
 	}
-
 	return tf, nil
 }
 
@@ -248,12 +274,12 @@ func parseFlow() (*v1alpha1.Packet, error) {
 		return nil, fmt.Errorf("error when parsing the flow: %w", err)
 	}
 
-	pkt := new(v1alpha1.Packet)
+	var pkt v1alpha1.Packet
+
 	_, isIPv6 := fields["ipv6"]
 	if isIPv6 {
 		pkt.IPv6Header = new(v1alpha1.IPv6Header)
 	}
-
 	for k, v := range protocols {
 		if _, ok := fields[k]; ok {
 			if isIPv6 {
@@ -293,7 +319,7 @@ func parseFlow() (*v1alpha1.Packet, error) {
 		pkt.TransportHeader.UDP.DstPort = int32(r)
 	}
 
-	return pkt, nil
+	return &pkt, nil
 }
 
 func getPortFields(cleanFlow string) (map[string]int, error) {
@@ -322,15 +348,14 @@ func output(tf *v1alpha1.Traceflow) error {
 		Name:        tf.Name,
 		Phase:       tf.Status.Phase,
 		Source:      fmt.Sprintf("%s/%s", tf.Spec.Source.Namespace, tf.Spec.Source.Pod),
-		Destination: tf.Spec.Destination.IP,
 		NodeResults: tf.Status.Results,
 	}
-	if len(tf.Spec.Destination.IP) == 0 {
-		if len(tf.Spec.Destination.Service) != 0 {
-			r.Destination = fmt.Sprintf("%s/%s", tf.Spec.Destination.Namespace, tf.Spec.Destination.Service)
-		} else {
-			r.Destination = fmt.Sprintf("%s/%s", tf.Spec.Destination.Namespace, tf.Spec.Destination.Pod)
-		}
+	if len(tf.Spec.Destination.IP) > 0 {
+		r.Destination = tf.Spec.Destination.IP
+	} else if len(tf.Spec.Destination.Pod) != 0 {
+		r.Destination = fmt.Sprintf("%s/%s", tf.Spec.Destination.Namespace, tf.Spec.Destination.Pod)
+	} else if len(tf.Spec.Destination.Service) != 0 {
+		r.Destination = fmt.Sprintf("%s/%s", tf.Spec.Destination.Namespace, tf.Spec.Destination.Service)
 	}
 	if option.outputType == "json" {
 		if err := jsonOutput(&r); err != nil {
@@ -369,7 +394,7 @@ func jsonOutput(r *Response) error {
 }
 
 func getTFName(prefix string) string {
-	if !option.waiting {
+	if option.nowait {
 		return prefix
 	}
 	return fmt.Sprintf("%s-%s", prefix, rand.String(8))

--- a/pkg/antctl/raw/traceflow/command_test.go
+++ b/pkg/antctl/raw/traceflow/command_test.go
@@ -98,6 +98,7 @@ func TestParseFlow(t *testing.T) {
 						IPHeader: v1alpha1.IPHeader{
 							Protocol: 1,
 						},
+						TransportHeader: v1alpha1.TransportHeader{},
 					},
 				},
 			},

--- a/pkg/apis/crd/v1alpha1/types.go
+++ b/pkg/apis/crd/v1alpha1/types.go
@@ -92,6 +92,9 @@ const (
 	EtherTypeIPv6 uint16 = 0x86DD
 )
 
+// Default timeout in seconds.
+const DefaultTraceflowTimeout uint16 = 20
+
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -108,6 +111,13 @@ type TraceflowSpec struct {
 	Source      Source      `json:"source,omitempty"`
 	Destination Destination `json:"destination,omitempty"`
 	Packet      Packet      `json:"packet,omitempty"`
+	// LiveTraffic indicates the Traceflow is to trace the live traffic
+	// rather than an injected packet, when set to true. The first packet of
+	// the first connection that matches the packet spec will be traced.
+	LiveTraffic bool `json:"liveTraffic,omitempty"`
+	// Timeout specifies the timeout of the Traceflow in seconds. Defaults
+	// to 20 seconds if not set.
+	Timeout uint16 `json:"timeout,omitempty"`
 }
 
 // Source describes the source spec of the traceflow.

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -78,6 +78,9 @@ const (
 	DeleteMessage
 )
 
+// IPDSCPToSRange stores the DSCP bits in ToS field of IP header.
+var IPDSCPToSRange = Range{2, 7}
+
 // Bridge defines operations on an openflow bridge.
 type Bridge interface {
 	CreateTable(id, next TableIDType, missAction MissActionType) Table
@@ -172,6 +175,7 @@ type Action interface {
 	LoadARPOperation(value uint16) FlowBuilder
 	LoadRegRange(regID int, value uint32, to Range) FlowBuilder
 	LoadPktMarkRange(value uint32, to Range) FlowBuilder
+	LoadIPDSCP(value uint8) FlowBuilder
 	LoadRange(name string, addr uint64, to Range) FlowBuilder
 	Move(from, to string) FlowBuilder
 	MoveRange(fromName, toName string, from, to Range) FlowBuilder
@@ -205,6 +209,7 @@ type Action interface {
 type FlowBuilder interface {
 	MatchPriority(uint16) FlowBuilder
 	MatchProtocol(name Protocol) FlowBuilder
+	MatchIPProtocolValue(isIPv6 bool, protoValue uint8) FlowBuilder
 	MatchReg(regID int, data uint32) FlowBuilder
 	MatchXXReg(regID int, data []byte) FlowBuilder
 	MatchRegRange(regID int, data uint32, rng Range) FlowBuilder
@@ -220,7 +225,7 @@ type FlowBuilder interface {
 	MatchARPSpa(ip net.IP) FlowBuilder
 	MatchARPTpa(ip net.IP) FlowBuilder
 	MatchARPOp(op uint16) FlowBuilder
-	MatchIPDscp(dscp uint8) FlowBuilder
+	MatchIPDSCP(dscp uint8) FlowBuilder
 	MatchCTStateNew(isSet bool) FlowBuilder
 	MatchCTStateRel(isSet bool) FlowBuilder
 	MatchCTStateRpl(isSet bool) FlowBuilder
@@ -234,6 +239,7 @@ type FlowBuilder interface {
 	MatchPktMark(value uint32, mask *uint32) FlowBuilder
 	MatchConjID(value uint32) FlowBuilder
 	MatchDstPort(port uint16, portMask *uint16) FlowBuilder
+	MatchSrcPort(port uint16, portMask *uint16) FlowBuilder
 	MatchICMPv6Type(icmp6Type byte) FlowBuilder
 	MatchICMPv6Code(icmp6Code byte) FlowBuilder
 	MatchTunnelDst(dstIP net.IP) FlowBuilder
@@ -320,6 +326,7 @@ type PacketOutBuilder interface {
 	SetSrcIP(ip net.IP) PacketOutBuilder
 	SetDstIP(ip net.IP) PacketOutBuilder
 	SetIPProtocol(protocol Protocol) PacketOutBuilder
+	SetIPProtocolValue(isIPv6 bool, protoValue uint8) PacketOutBuilder
 	SetTTL(ttl uint8) PacketOutBuilder
 	SetIPFlags(flags uint16) PacketOutBuilder
 	SetTCPSrcPort(port uint16) PacketOutBuilder
@@ -355,4 +362,22 @@ type IPRange struct {
 type PortRange struct {
 	StartPort uint16
 	EndPort   uint16
+}
+
+type Packet struct {
+	IsIPv6          bool
+	DestinationMAC  net.HardwareAddr
+	SourceMAC       net.HardwareAddr
+	DestinationIP   net.IP
+	SourceIP        net.IP
+	IPProto         uint8
+	IPFlags         uint16
+	TTL             uint8
+	DestinationPort uint16
+	SourcePort      uint16
+	TCPFlags        uint8
+	ICMPType        uint8
+	ICMPCode        uint8
+	ICMPEchoID      uint16
+	ICMPEchoSeq     uint16
 }

--- a/pkg/ovs/openflow/ofctrl_action.go
+++ b/pkg/ovs/openflow/ofctrl_action.go
@@ -244,6 +244,11 @@ func (a *ofFlowAction) LoadPktMarkRange(value uint32, rng Range) FlowBuilder {
 	return a.LoadRange(NxmFieldPktMark, uint64(value), rng)
 }
 
+// LoadIPDSCP is an action to load data to IP DSCP bits.
+func (a *ofFlowAction) LoadIPDSCP(value uint8) FlowBuilder {
+	return a.LoadRange(NxmFieldIPToS, uint64(value), IPDSCPToSRange)
+}
+
 // Move is an action to copy all data from "fromField" to "toField". Fields with name "fromField" and "fromField" should
 // have the same data length, otherwise there will be error when realizing the flow on OFSwitch.
 func (a *ofFlowAction) Move(fromField, toField string) FlowBuilder {

--- a/pkg/ovs/openflow/ofctrl_builder.go
+++ b/pkg/ovs/openflow/ofctrl_builder.go
@@ -416,10 +416,10 @@ func (b *ofFlowBuilder) MatchARPOp(op uint16) FlowBuilder {
 	return b
 }
 
-// MatchIPDscp adds match condition for matching DSCP field in the IP header. Note, OVS use TOS to present DSCP, and
+// MatchIPDSCP adds match condition for matching DSCP field in the IP header. Note, OVS use TOS to present DSCP, and
 // the field name is shown as "nw_tos" with OVS command line, and the value is calculated by shifting the given value
 // left 2 bits.
-func (b *ofFlowBuilder) MatchIPDscp(dscp uint8) FlowBuilder {
+func (b *ofFlowBuilder) MatchIPDSCP(dscp uint8) FlowBuilder {
 	b.matchers = append(b.matchers, fmt.Sprintf("nw_tos=%d", dscp<<2))
 	b.Match.IpDscp = dscp
 	return b
@@ -475,12 +475,36 @@ func (b *ofFlowBuilder) MatchProtocol(protocol Protocol) FlowBuilder {
 	return b
 }
 
+// MatchProtocol adds match condition for IP protocol with the intetger value.
+func (b *ofFlowBuilder) MatchIPProtocolValue(isIPv6 bool, protoValue uint8) FlowBuilder {
+	if isIPv6 {
+		b.Match.Ethertype = 0x86dd
+	} else {
+		b.Match.Ethertype = 0x0800
+	}
+	b.Match.IpProto = protoValue
+	return b
+}
+
 // MatchDstPort adds match condition for matching destination port in transport layer. OVS will match the port exactly
 // if portMask is nil.
 func (b *ofFlowBuilder) MatchDstPort(port uint16, portMask *uint16) FlowBuilder {
 	b.Match.DstPort = port
 	b.Match.DstPortMask = portMask
 	matchStr := fmt.Sprintf("tp_dst=0x%x", port)
+	if portMask != nil {
+		matchStr = fmt.Sprintf("%s/0x%x", matchStr, portMask)
+	}
+	b.matchers = append(b.matchers, matchStr)
+	return b
+}
+
+// MatchSrcPort adds match condition for matching source port in transport layer. OVS will match the port exactly
+// if portMask is nil.
+func (b *ofFlowBuilder) MatchSrcPort(port uint16, portMask *uint16) FlowBuilder {
+	b.Match.SrcPort = port
+	b.Match.SrcPortMask = portMask
+	matchStr := fmt.Sprintf("tp_src=0x%x", port)
 	if portMask != nil {
 		matchStr = fmt.Sprintf("%s/0x%x", matchStr, portMask)
 	}

--- a/pkg/ovs/openflow/ofctrl_packetout.go
+++ b/pkg/ovs/openflow/ofctrl_packetout.go
@@ -109,6 +109,23 @@ func (b *ofPacketOutBuilder) SetIPProtocol(proto Protocol) PacketOutBuilder {
 	return b
 }
 
+// ofPacketOutBuilder sets IP protocol in the packet's IP header with the
+// intetger protocol value.
+func (b *ofPacketOutBuilder) SetIPProtocolValue(isIPv6 bool, protoValue uint8) PacketOutBuilder {
+	if isIPv6 {
+		if b.pktOut.IPv6Header == nil {
+			b.pktOut.IPv6Header = new(protocol.IPv6)
+		}
+		b.pktOut.IPv6Header.NextHeader = protoValue
+	} else {
+		if b.pktOut.IPHeader == nil {
+			b.pktOut.IPHeader = new(protocol.IPv4)
+		}
+		b.pktOut.IPHeader.Protocol = protoValue
+	}
+	return b
+}
+
 // SetTTL sets TTL in the packet's IP header.
 func (b *ofPacketOutBuilder) SetTTL(ttl uint8) PacketOutBuilder {
 	if b.pktOut.IPv6Header == nil {

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -693,6 +693,20 @@ func (mr *MockActionMockRecorder) LoadARPOperation(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadARPOperation", reflect.TypeOf((*MockAction)(nil).LoadARPOperation), arg0)
 }
 
+// LoadIPDSCP mocks base method
+func (m *MockAction) LoadIPDSCP(arg0 byte) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadIPDSCP", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// LoadIPDSCP indicates an expected call of LoadIPDSCP
+func (mr *MockActionMockRecorder) LoadIPDSCP(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadIPDSCP", reflect.TypeOf((*MockAction)(nil).LoadIPDSCP), arg0)
+}
+
 // LoadPktMarkRange mocks base method
 func (m *MockAction) LoadPktMarkRange(arg0 uint32, arg1 openflow.Range) openflow.FlowBuilder {
 	m.ctrl.T.Helper()
@@ -1607,18 +1621,32 @@ func (mr *MockFlowBuilderMockRecorder) MatchICMPv6Type(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchICMPv6Type", reflect.TypeOf((*MockFlowBuilder)(nil).MatchICMPv6Type), arg0)
 }
 
-// MatchIPDscp mocks base method
-func (m *MockFlowBuilder) MatchIPDscp(arg0 byte) openflow.FlowBuilder {
+// MatchIPDSCP mocks base method
+func (m *MockFlowBuilder) MatchIPDSCP(arg0 byte) openflow.FlowBuilder {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MatchIPDscp", arg0)
+	ret := m.ctrl.Call(m, "MatchIPDSCP", arg0)
 	ret0, _ := ret[0].(openflow.FlowBuilder)
 	return ret0
 }
 
-// MatchIPDscp indicates an expected call of MatchIPDscp
-func (mr *MockFlowBuilderMockRecorder) MatchIPDscp(arg0 interface{}) *gomock.Call {
+// MatchIPDSCP indicates an expected call of MatchIPDSCP
+func (mr *MockFlowBuilderMockRecorder) MatchIPDSCP(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchIPDscp", reflect.TypeOf((*MockFlowBuilder)(nil).MatchIPDscp), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchIPDSCP", reflect.TypeOf((*MockFlowBuilder)(nil).MatchIPDSCP), arg0)
+}
+
+// MatchIPProtocolValue mocks base method
+func (m *MockFlowBuilder) MatchIPProtocolValue(arg0 bool, arg1 byte) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MatchIPProtocolValue", arg0, arg1)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// MatchIPProtocolValue indicates an expected call of MatchIPProtocolValue
+func (mr *MockFlowBuilderMockRecorder) MatchIPProtocolValue(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchIPProtocolValue", reflect.TypeOf((*MockFlowBuilder)(nil).MatchIPProtocolValue), arg0, arg1)
 }
 
 // MatchInPort mocks base method
@@ -1745,6 +1773,20 @@ func (m *MockFlowBuilder) MatchSrcMAC(arg0 net.HardwareAddr) openflow.FlowBuilde
 func (mr *MockFlowBuilderMockRecorder) MatchSrcMAC(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchSrcMAC", reflect.TypeOf((*MockFlowBuilder)(nil).MatchSrcMAC), arg0)
+}
+
+// MatchSrcPort mocks base method
+func (m *MockFlowBuilder) MatchSrcPort(arg0 uint16, arg1 *uint16) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MatchSrcPort", arg0, arg1)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// MatchSrcPort indicates an expected call of MatchSrcPort
+func (mr *MockFlowBuilderMockRecorder) MatchSrcPort(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchSrcPort", reflect.TypeOf((*MockFlowBuilder)(nil).MatchSrcPort), arg0, arg1)
 }
 
 // MatchTunMetadata mocks base method

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -67,7 +67,7 @@ var (
 	peerGW           = net.ParseIP("192.168.2.1")
 	vMAC, _          = net.ParseMAC("aa:bb:cc:dd:ee:ff")
 
-	ipDscp = uint8(10)
+	ipDSCP = uint8(10)
 )
 
 func newOFBridge(brName string) binding.Bridge {
@@ -974,7 +974,7 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 			Cookie(getCookieID()).
 			MatchProtocol(binding.ProtocolIP).
 			MatchSrcIP(podIP).
-			MatchIPDscp(ipDscp).
+			MatchIPDSCP(ipDSCP).
 			Action().GotoTable(table.GetNext()).
 			Done(),
 		table.BuildFlow(priorityNormal+20).MatchProtocol(binding.ProtocolTCP).Cookie(getCookieID()).MatchDstPort(uint16(8080), nil).
@@ -1015,7 +1015,7 @@ func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 		&ExpectFlow{"priority=200,dl_dst=aa:aa:aa:aa:aa:13", fmt.Sprintf("load:0x3->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],%s", gotoTableAction)},
 		&ExpectFlow{"priority=200,ip,reg0=0x10000/0x10000", "output:NXM_NX_REG1[]"},
 		&ExpectFlow{"priority=200,ip,nw_dst=172.16.0.0/16", "output:1"},
-		&ExpectFlow{fmt.Sprintf("priority=200,ip,nw_src=192.168.1.3,nw_tos=%d", ipDscp<<2), gotoTableAction},
+		&ExpectFlow{fmt.Sprintf("priority=200,ip,nw_src=192.168.1.3,nw_tos=%d", ipDSCP<<2), gotoTableAction},
 		&ExpectFlow{"priority=220,tcp,tp_dst=8080", "conjunction(1001,3/3)"},
 		&ExpectFlow{"priority=220,ip,nw_src=192.168.1.3", "conjunction(1001,1/3)"},
 		&ExpectFlow{"priority=220,ip,nw_dst=192.168.3.0/24", "conjunction(1001,2/3)"},


### PR DESCRIPTION
Add support of tracing live traffic. Rather than injecting a Traceflow
packet, a live traffic Traceflow will trace the real traffic between
Pods - the first packet of the first connection that matches the
Traceflow spec will be traced.
antctl traceflow command is extended to support live traffic Traceflow.
This commit also makes a few others changes to Traceflow: change
Destination (live traffic Traceflow does not require Traceflow
Destination to be provided), Packet, and Packet IPHeader in Traceflow
Spec to optional fields; add a Timeout parameter to Traceflow Spec and
antctl traceflow command to specify the timeout time of a Traceflow;
delete OVS flows added for the Traceflow after agent receives the first
captured packet of the Traceflow; support all IP protocols.