### PR TITLE
Ensure Jenkins CI jobs use up-to-date base Docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,6 @@ UNAME_S := $(shell uname -s)
 USERID  := $(shell id -u)
 GRPID   := $(shell id -g)
 
-# If NO_PULL is set, base Docker images will not be pulled.
-# If DOCKER_REGISTRY is set, we always set NO_PULL.
-ifneq ($(DOCKER_REGISTRY),)
-	NO_PULL := 1
-endif
-
 .PHONY: bin
 bin:
 	@mkdir -p $(BINDIR)

--- a/build/images/base/build.sh
+++ b/build/images/base/build.sh
@@ -93,6 +93,7 @@ if $PULL; then
         if [[ ${DOCKER_REGISTRY} == "" ]]; then
             docker pull $PLATFORM_ARG "${image}" || true
         else
+            rc=0
             docker pull "${DOCKER_REGISTRY}/${image}" || rc=$?
             if [[ $rc -eq 0 ]]; then
                 docker tag "${DOCKER_REGISTRY}/${image}" "${image}"

--- a/build/images/ovs/build.sh
+++ b/build/images/ovs/build.sh
@@ -98,6 +98,7 @@ if $PULL; then
         if [[ ${DOCKER_REGISTRY} == "" ]]; then
             docker pull $PLATFORM_ARG "${image}" || true
         else
+            rc=0
             docker pull "${DOCKER_REGISTRY}/${image}" || rc=$?
             if [[ $rc -eq 0 ]]; then
                 docker tag "${DOCKER_REGISTRY}/${image}" "${image}"

--- a/build/images/ovs/build.sh
+++ b/build/images/ovs/build.sh
@@ -90,8 +90,20 @@ OVS_VERSION=$(head -n 1 ../deps/ovs-version)
 
 if $PULL; then
     docker pull $PLATFORM_ARG ubuntu:20.04
-    docker pull $PLATFORM_ARG antrea/openvswitch-debs:$OVS_VERSION || true
-    docker pull $PLATFORM_ARG antrea/openvswitch:$OVS_VERSION || true
+    IMAGES_LIST=(
+        "antrea/openvswitch-debs:$OVS_VERSION"
+        "antrea/openvswitch:$OVS_VERSION"
+    )
+    for image in "${IMAGES_LIST[@]}"; do
+        if [[ ${DOCKER_REGISTRY} == "" ]]; then
+            docker pull $PLATFORM_ARG "${image}" || true
+        else
+            docker pull "${DOCKER_REGISTRY}/${image}" || rc=$?
+            if [[ $rc -eq 0 ]]; then
+                docker tag "${DOCKER_REGISTRY}/${image}" "${image}"
+            fi
+        fi
+    done
 fi
 
 docker build $PLATFORM_ARG --target ovs-debs \

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -166,7 +166,7 @@
           wrappers:
           - timeout:
               fail: true
-              timeout: 10
+              timeout: 20
               type: absolute
           - credentials-binding:
               - text:
@@ -208,7 +208,7 @@
           wrappers:
           - timeout:
               fail: true
-              timeout: 10
+              timeout: 20
               type: absolute
           - credentials-binding:
               - text:

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -183,6 +183,8 @@ function deliver_antrea_windows {
     make clean
     docker images | grep 'antrea-ubuntu' | awk '{print $3}' | xargs -r docker rmi -f || true
     docker images | grep '<none>' | awk '{print $3}' | xargs -r docker rmi || true
+    chmod -R g-w build/images/ovs
+    chmod -R g-w build/images/base
     ./hack/build-antrea-ubuntu-all.sh --pull
     if [[ "$TESTCASE" =~ "networkpolicy" ]]; then
         make windows-bin
@@ -280,6 +282,8 @@ function deliver_antrea {
         docker pull "${DOCKER_REGISTRY}/antrea/sonobuoy-systemd-logs:v0.3"
         docker tag "${DOCKER_REGISTRY}/antrea/sonobuoy-systemd-logs:v0.3" "sonobuoy/systemd-logs:v0.3"
     fi
+    chmod -R g-w build/images/ovs
+    chmod -R g-w build/images/base
     ./hack/build-antrea-ubuntu-all.sh --pull
     make flow-aggregator-image
 

--- a/hack/build-antrea-ubuntu-all.sh
+++ b/hack/build-antrea-ubuntu-all.sh
@@ -93,11 +93,32 @@ CNI_BINARIES_VERSION=$(head -n 1 build/images/deps/cni-binaries-version)
 # image! This is a bit more inconvenient to maintain, but we rarely introduce
 # new base images in the build chain.
 if $PULL; then
+    # Always pull ubuntu:20.04 from DockerHub even if DOCKER_REGISTRY is set, as
+    # it is not an Antrea image and there should be no rate-limiting for
+    # Canonical images.
     docker pull $PLATFORM_ARG ubuntu:20.04
-    docker pull $PLATFORM_ARG antrea/openvswitch-debs:$OVS_VERSION || true
-    docker pull $PLATFORM_ARG antrea/openvswitch:$OVS_VERSION || true
-    docker pull $PLATFORM_ARG antrea/cni-binaries:$CNI_BINARIES_VERSION || true
-    docker pull $PLATFORM_ARG antrea/base-ubuntu:$OVS_VERSION || true
+    if [[ ${DOCKER_REGISTRY} == "" ]]; then
+        docker pull $PLATFORM_ARG golang:1.15
+    else
+        docker pull ${DOCKER_REGISTRY}/antrea/golang:1.15
+        docker tag ${DOCKER_REGISTRY}/antrea/golang:1.15 golang:1.15
+    fi
+    IMAGES_LIST=(
+        "antrea/openvswitch-debs:$OVS_VERSION"
+        "antrea/openvswitch:$OVS_VERSION"
+        "antrea/cni-binaries:$CNI_BINARIES_VERSION"
+        "antrea/base-ubuntu:$OVS_VERSION"
+    )
+    for image in "${IMAGES_LIST[@]}"; do
+        if [[ ${DOCKER_REGISTRY} == "" ]]; then
+            docker pull $PLATFORM_ARG "${image}" || true
+        else
+            docker pull "${DOCKER_REGISTRY}/${image}" || rc=$?
+            if [[ $rc -eq 0 ]]; then
+                docker tag "${DOCKER_REGISTRY}/${image}" "${image}"
+            fi
+        fi
+    done
 fi
 
 cd build/images/ovs

--- a/hack/build-antrea-ubuntu-all.sh
+++ b/hack/build-antrea-ubuntu-all.sh
@@ -113,6 +113,7 @@ if $PULL; then
         if [[ ${DOCKER_REGISTRY} == "" ]]; then
             docker pull $PLATFORM_ARG "${image}" || true
         else
+            rc=0
             docker pull "${DOCKER_REGISTRY}/${image}" || rc=$?
             if [[ $rc -eq 0 ]]; then
                 docker tag "${DOCKER_REGISTRY}/${image}" "${image}"


### PR DESCRIPTION
In https://github.com/vmware-tanzu/antrea/pull/1951 we ensured that the
Github workflows would use up-to-date base Docker images by building all
images in every run and leveraging Docker caching to reduce build
times. With this new change, we do the same thing for Jenkins jobs.

See #1540