### PR TITLE
Reject unsupported postional arguments for antctl

### DIFF
--- a/pkg/antctl/raw/proxy/command.go
+++ b/pkg/antctl/raw/proxy/command.go
@@ -132,6 +132,7 @@ func init() {
 		Long:    "Run a reverse proxy to access Antrea API (Controller or Agent). Command only supports remote mode. HTTPS connections between the proxy and the Antrea API will not be secure (no certificate verification).",
 		Example: proxyCommandExample,
 		RunE:    runE,
+		Args:    cobra.NoArgs,
 	}
 
 	// Options are the same as for "kubectl proxy"

--- a/pkg/antctl/raw/traceflow/command.go
+++ b/pkg/antctl/raw/traceflow/command.go
@@ -83,6 +83,7 @@ func init() {
   $antctl traceflow -S busybox0 -D busybox1 -f tcp,tcp_dst=80
 `,
 		RunE: runE,
+		Args: cobra.NoArgs,
 	}
 
 	Command.Flags().StringVarP(&option.source, "source", "S", "", "source of the Traceflow: Namespace/Pod or Pod")


### PR DESCRIPTION
For traceflow and proxy, antctl will fail and log error when the user
enters extra postional arguments.

Before:
```
# antctl traceflow -S coredns-7f89b7bc75-4xzxg -D coredns-7f89b7bc75-cczbd udp,udp_dst=53,udp_src=1000
name: default-coredns-7f89b7bc75-4xzxg-to-default-coredns-7f89b7bc75-cczbd-xzfgd55x
phase: Running
source: default/coredns-7f89b7bc75-4xzxg
destination: default/coredns-7f89b7bc75-cczbd
...
```

After:
```
# antctl traceflow -S coredns-7f89b7bc75-4xzxg -D coredns-7f89b7bc75-cczbd udp,udp_dst=53,udp_src=1000
Error: adding extra postional arguments
```

Fixes #1915