### PR TITLE
Fix incorrect docker build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ docker-test-integration: .coverage
 ifneq ($(NO_PULL),)
 	docker build -t antrea/test -f build/images/test/Dockerfile --build-arg OVS_VERSION=$(OVS_VERSION) .
 else
-	docker build --pull -t antrea/test -f build/images/test/Dockerfile -build-arg OVS_VERSION=$(OVS_VERSION) .
+	docker build --pull -t antrea/test -f build/images/test/Dockerfile --build-arg OVS_VERSION=$(OVS_VERSION) .
 endif
 	@docker run --privileged --rm \
 		-e "GOCACHE=/tmp/gocache" \


### PR DESCRIPTION
`make docker-test-integration` was broken if NO_PULL was false.

```
# make docker-test-integration
mkdir -p /root/antrea/.coverage
===> Building Antrea Integration Test Docker image <===
docker build --pull -t antrea/test -f build/images/test/Dockerfile -build-arg OVS_VERSION=2.14.0 .
unknown shorthand flag: 'b' in -build-arg
See 'docker build --help'.
Makefile:151: recipe for target 'docker-test-integration' failed
make: *** [docker-test-integration] Error 125
```