### PR TITLE
Fix and improve the docker image building process of Flow Aggregator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build flow-aggregator Docker image
-      run: make flow-aggregator-ubuntu
+      run: make flow-aggregator-image
+    - name: Check flow-aggregator Docker image
+      run: docker run projects.registry.vmware.com/antrea/flow-aggregator --version
     - name: Push flow-aggregator Docker image to registry
       if: ${{ github.repository == 'vmware-tanzu/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       env:

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -85,6 +85,6 @@ jobs:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         VERSION: ${{ needs.get-version.outputs.version }}
       run: |
-        make flow-aggregator-ubuntu
+        make flow-aggregator-image
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         docker push antrea/flow-aggregator:"${VERSION}"

--- a/Makefile
+++ b/Makefile
@@ -354,13 +354,13 @@ octant-antrea-ubuntu:
 	docker tag antrea/octant-antrea-ubuntu:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/octant-antrea-ubuntu
 	docker tag antrea/octant-antrea-ubuntu:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/octant-antrea-ubuntu:$(DOCKER_IMG_VERSION)
 
-.PHONY: flow-aggregator-ubuntu
-flow-aggregator-ubuntu:
+.PHONY: flow-aggregator-image
+flow-aggregator-image:
 	@echo "===> Building antrea/flow-aggregator Docker image <==="
 ifneq ($(NO_PULL),)
-	docker build -t antrea/flow-aggregator:$(DOCKER_IMG_VERSION) -f build/images/flow-aggregator/Dockerfile --build-arg OVS_VERSION=$(OVS_VERSION) .
+	docker build -t antrea/flow-aggregator:$(DOCKER_IMG_VERSION) -f build/images/flow-aggregator/Dockerfile .
 else
-	docker build --pull -t antrea/flow-aggregator:$(DOCKER_IMG_VERSION) -f build/images/flow-aggregator/Dockerfile --build-arg OVS_VERSION=$(OVS_VERSION) .
+	docker build --pull -t antrea/flow-aggregator:$(DOCKER_IMG_VERSION) -f build/images/flow-aggregator/Dockerfile .
 endif
 	docker tag antrea/flow-aggregator:$(DOCKER_IMG_VERSION) antrea/flow-aggregator
 	docker tag antrea/flow-aggregator:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/flow-aggregator
@@ -370,9 +370,9 @@ endif
 flow-aggregator-ubuntu-coverage:
 	@echo "===> Building antrea/flow-aggregator-coverage Docker image <==="
 ifneq ($(NO_PULL),)
-	docker build -t antrea/flow-aggregator-coverage:$(DOCKER_IMG_VERSION) -f build/images/flow-aggregator/Dockerfile.coverage --build-arg OVS_VERSION=$(OVS_VERSION) .
+	docker build -t antrea/flow-aggregator-coverage:$(DOCKER_IMG_VERSION) -f build/images/flow-aggregator/Dockerfile.coverage .
 else
-	docker build --pull -t antrea/flow-aggregator-coverage:$(DOCKER_IMG_VERSION) -f build/images/flow-aggregator/Dockerfile.coverage --build-arg OVS_VERSION=$(OVS_VERSION) .
+	docker build --pull -t antrea/flow-aggregator-coverage:$(DOCKER_IMG_VERSION) -f build/images/flow-aggregator/Dockerfile.coverage .
 endif
 	docker tag antrea/flow-aggregator-coverage:$(DOCKER_IMG_VERSION) antrea/flow-aggregator-coverage
 

--- a/build/images/flow-aggregator/Dockerfile
+++ b/build/images/flow-aggregator/Dockerfile
@@ -1,17 +1,19 @@
-ARG OVS_VERSION
 FROM golang:1.15 as flow-aggregator-build
 
 WORKDIR /antrea
 
 COPY . /antrea
 
-RUN make flow-aggregator
+# Make sure the flow-aggregator binary is statically linked.
+RUN CGO_ENABLED=0 make flow-aggregator
 
 FROM scratch
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The docker image for the flow aggregator"
 
-USER root
+ENV USER root
 
-COPY --from=flow-aggregator-build /antrea/bin/flow-aggregator /usr/local/bin/
+COPY --from=flow-aggregator-build /antrea/bin/flow-aggregator /
+
+ENTRYPOINT ["/flow-aggregator"]

--- a/build/images/flow-aggregator/Dockerfile.coverage
+++ b/build/images/flow-aggregator/Dockerfile.coverage
@@ -1,4 +1,3 @@
-ARG OVS_VERSION
 FROM golang:1.15 as flow-aggregator-build
 
 WORKDIR /antrea
@@ -7,7 +6,7 @@ COPY . /antrea
 
 RUN make flow-aggregator flow-aggregator-instr-binary
 
-FROM antrea/base-ubuntu:${OVS_VERSION}
+FROM ubuntu:20.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The docker image for the flow aggregator with code coverage measurement enabled for testing purposes."

--- a/build/yamls/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator.yml
@@ -202,13 +202,11 @@ spec:
         - --config
         - /etc/flow-aggregator/flow-aggregator.conf
         - --logtostderr=false
-        - --log_dir=/var/log/flowaggregator
+        - --log_dir=/var/log/antrea/flow-aggregator
         - --alsologtostderr
         - --log_file_max_size=100
         - --log_file_max_num=4
         - --v=0
-        command:
-        - flow-aggregator
         image: projects.registry.vmware.com/antrea/flow-aggregator:latest
         imagePullPolicy: IfNotPresent
         name: flow-aggregator
@@ -219,8 +217,14 @@ spec:
           name: flow-aggregator-config
           readOnly: true
           subPath: flow-aggregator.conf
+        - mountPath: /var/log/antrea/flow-aggregator
+          name: host-var-log-antrea-flow-aggregator
       serviceAccountName: flow-aggregator
       volumes:
       - configMap:
           name: flow-aggregator-configmap-hf78268hm6
         name: flow-aggregator-config
+      - hostPath:
+          path: /var/log/antrea/flow-aggregator
+          type: DirectoryOrCreate
+        name: host-var-log-antrea-flow-aggregator

--- a/build/yamls/flow-aggregator/base/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator/base/flow-aggregator.yml
@@ -125,13 +125,11 @@ spec:
         - --config
         - /etc/flow-aggregator/flow-aggregator.conf
         - --logtostderr=false
-        - --log_dir=/var/log/flowaggregator
+        - --log_dir=/var/log/antrea/flow-aggregator
         - --alsologtostderr
         - --log_file_max_size=100
         - --log_file_max_num=4
         - --v=0
-        command:
-          - flow-aggregator
         name: flow-aggregator
         image: flow-aggregator
         ports:
@@ -141,9 +139,14 @@ spec:
           name: flow-aggregator-config
           readOnly: true
           subPath: flow-aggregator.conf
+        - mountPath: /var/log/antrea/flow-aggregator
+          name: host-var-log-antrea-flow-aggregator
       serviceAccountName: flow-aggregator
       volumes:
       - name: flow-aggregator-config
         configMap:
           name: flow-aggregator-configmap
-        
+      - name: host-var-log-antrea-flow-aggregator
+        hostPath:
+          path: /var/log/antrea/flow-aggregator
+          type: DirectoryOrCreate

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -301,7 +301,7 @@ function deliver_antrea {
     if [[ "$COVERAGE" == true ]]; then
       VERSION="$CLUSTER" DOCKER_REGISTRY="${DOCKER_REGISTRY}" make flow-aggregator-ubuntu-coverage
     else
-      VERSION="$CLUSTER" DOCKER_REGISTRY="${DOCKER_REGISTRY}" make flow-aggregator-ubuntu
+      VERSION="$CLUSTER" DOCKER_REGISTRY="${DOCKER_REGISTRY}" make flow-aggregator-image
     fi
     cd ci/jenkins
 

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -289,7 +289,7 @@ function deliver_antrea {
         docker tag "${DOCKER_REGISTRY}/antrea/sonobuoy-systemd-logs:v0.3" "sonobuoy/systemd-logs:v0.3"
     fi
     DOCKER_REGISTRY=${DOCKER_REGISTRY} make
-    DOCKER_REGISTRY=${DOCKER_REGISTRY} make flow-aggregator-ubuntu
+    DOCKER_REGISTRY=${DOCKER_REGISTRY} make flow-aggregator-image
 
     echo "====== Delivering Antrea to all the Nodes ======"
     echo "=== Fill serviceCIDRv6 and serviceCIDR ==="

--- a/test/e2e/coverage/flow-aggregator-arg-file
+++ b/test/e2e/coverage/flow-aggregator-arg-file
@@ -1,7 +1,7 @@
 --config
 /etc/flow-aggregator/flow-aggregator.conf
 --logtostderr=false
---log_dir=/var/log/flowaggregator
+--log_dir=/var/log/antrea/flow-aggregator
 --alsologtostderr
 --log_file_max_size=100
 --log_file_max_num=4


### PR DESCRIPTION
Fix the error of Flow Aggregator image after PR #2004 changed the base image to scratch.
Change the image name target "flow-aggregator-ubuntu" to "flow-aggregtor-image" in Makefile since ubuntu is not relevant.
Change the base image of Flow Aggregator code coverage image to ubuntu:20.04.