### PR TITLE
Use Ubuntu 20.04 image from Harbor registry for Jenkins CI

### DIFF
--- a/build/images/base/build.sh
+++ b/build/images/base/build.sh
@@ -83,7 +83,12 @@ OVS_VERSION=$(head -n 1 ../deps/ovs-version)
 CNI_BINARIES_VERSION=$(head -n 1 ../deps/cni-binaries-version)
 
 if $PULL; then
-    docker pull $PLATFORM_ARG ubuntu:20.04
+    if [[ ${DOCKER_REGISTRY} == "" ]]; then
+        docker pull $PLATFORM_ARG ubuntu:20.04
+    else
+        docker pull ${DOCKER_REGISTRY}/antrea/ubuntu:20.04
+        docker tag ${DOCKER_REGISTRY}/antrea/ubuntu:20.04 ubuntu:20.04
+    fi
     IMAGES_LIST=(
         "antrea/openvswitch:$OVS_VERSION"
         "antrea/cni-binaries:$CNI_BINARIES_VERSION"

--- a/build/images/ovs/build.sh
+++ b/build/images/ovs/build.sh
@@ -89,7 +89,12 @@ OVS_VERSION=$(head -n 1 ../deps/ovs-version)
 # See https://github.com/moby/moby/issues/34715.
 
 if $PULL; then
-    docker pull $PLATFORM_ARG ubuntu:20.04
+    if [[ ${DOCKER_REGISTRY} == "" ]]; then
+        docker pull $PLATFORM_ARG ubuntu:20.04
+    else
+        docker pull ${DOCKER_REGISTRY}/antrea/ubuntu:20.04
+        docker tag ${DOCKER_REGISTRY}/antrea/ubuntu:20.04 ubuntu:20.04
+    fi
     IMAGES_LIST=(
         "antrea/openvswitch-debs:$OVS_VERSION"
         "antrea/openvswitch:$OVS_VERSION"

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -185,7 +185,7 @@ function deliver_antrea_windows {
     docker images | grep '<none>' | awk '{print $3}' | xargs -r docker rmi || true
     chmod -R g-w build/images/ovs
     chmod -R g-w build/images/base
-    ./hack/build-antrea-ubuntu-all.sh --pull
+    DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-ubuntu-all.sh --pull
     if [[ "$TESTCASE" =~ "networkpolicy" ]]; then
         make windows-bin
     fi
@@ -284,7 +284,7 @@ function deliver_antrea {
     fi
     chmod -R g-w build/images/ovs
     chmod -R g-w build/images/base
-    ./hack/build-antrea-ubuntu-all.sh --pull
+    DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-ubuntu-all.sh --pull
     make flow-aggregator-image
 
     echo "====== Delivering Antrea to all the Nodes ======"

--- a/hack/build-antrea-ubuntu-all.sh
+++ b/hack/build-antrea-ubuntu-all.sh
@@ -93,13 +93,12 @@ CNI_BINARIES_VERSION=$(head -n 1 build/images/deps/cni-binaries-version)
 # image! This is a bit more inconvenient to maintain, but we rarely introduce
 # new base images in the build chain.
 if $PULL; then
-    # Always pull ubuntu:20.04 from DockerHub even if DOCKER_REGISTRY is set, as
-    # it is not an Antrea image and there should be no rate-limiting for
-    # Canonical images.
-    docker pull $PLATFORM_ARG ubuntu:20.04
     if [[ ${DOCKER_REGISTRY} == "" ]]; then
+        docker pull $PLATFORM_ARG ubuntu:20.04
         docker pull $PLATFORM_ARG golang:1.15
     else
+        docker pull ${DOCKER_REGISTRY}/antrea/ubuntu:20.04
+        docker tag ${DOCKER_REGISTRY}/antrea/ubuntu:20.04 ubuntu:20.04
         docker pull ${DOCKER_REGISTRY}/antrea/golang:1.15
         docker tag ${DOCKER_REGISTRY}/antrea/golang:1.15 golang:1.15
     fi


### PR DESCRIPTION
Contrary to what I was led to believe, there is indeed rate limiting for
official Ubuntu images on Dockerhub. So we use a copy from the Antrea
Harbor registry instead.