### PR TITLE
Fix syncHandler issue in status_controller

### DIFF
--- a/pkg/controller/networkpolicy/status_controller.go
+++ b/pkg/controller/networkpolicy/status_controller.go
@@ -269,10 +269,15 @@ func (c *StatusController) syncHandler(key string) error {
 	// It means the NetworkPolicy hasn't been processed once. Set it to Pending to differentiate from NetworkPolicies
 	// that spans 0 Node.
 	if internalNP.SpanMeta.NodeNames == nil {
-		return c.npControlInterface.UpdateAntreaNetworkPolicyStatus(internalNP.SourceRef.Namespace, internalNP.SourceRef.Name, &crdv1alpha1.NetworkPolicyStatus{
+		status := &crdv1alpha1.NetworkPolicyStatus{
 			Phase:              crdv1alpha1.NetworkPolicyPending,
 			ObservedGeneration: internalNP.Generation,
-		})
+		}
+		if internalNP.SourceRef.Type == controlplane.AntreaNetworkPolicy {
+			return c.npControlInterface.UpdateAntreaNetworkPolicyStatus(internalNP.SourceRef.Namespace, internalNP.SourceRef.Name, status)
+		} else {
+			return c.npControlInterface.UpdateAntreaClusterNetworkPolicyStatus(internalNP.SourceRef.Name, status)
+		}
 	}
 	desiredNodes := len(internalNP.SpanMeta.NodeNames)
 	currentNodes := 0


### PR DESCRIPTION
Fix the issue when the status_controller tries to update NetworkPolicyStatus to Pending, it always assumes the policy is Antrea NetworkPolicy instead of Antrea ClusterNetworkPolicy. This will result in failures in status updates which are visible at lowest klog verbose level.