### PR TITLE
Use correct output format for CNI Add in networkPolicyOnly mode

### DIFF
--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -108,39 +108,40 @@ const (
 	ipamEndStr = `
     }`
 
-	chainCNINetworkConfigTemplate = `{
-"cniVersion":"{{.CNIVersion}}",
-"name":"azure",
-"prevResult":
-  {
-    "cniVersion":"{{.CNIVersion}}",
-    "interfaces":
-     [
-       {"name":"eth0"},
-       {"name":"eth0"}
-     ],
-    "ips":
-     [
-       {
-         "version":"4",
-         "address":"{{.Subnet}}",
-         "gateway":"{{.Gateway}}"}
-     ],
-    "routes":
-     [
-       {
-         "dst":"{{ (index .Routes 0) }}",
-         "gw":"{{.Gateway}}"
-       }
-     ],
-     "dns":
+	chainCNIPrevResultTemplate = `{
+  "cniVersion":"{{.CNIVersion}}",
+  "interfaces":
+   [
+     {"name":"eth0"},
+     {"name":"eth0"}
+   ],
+  "ips":
+   [
      {
-       "nameservers":
-        [
-          "{{.DNS}}"
-        ]
+       "version":"4",
+       "address":"{{.Subnet}}",
+       "gateway":"{{.Gateway}}"}
+   ],
+  "routes":
+   [
+     {
+       "dst":"{{ (index .Routes 0) }}",
+       "gw":"{{.Gateway}}"
      }
-  } 
+   ],
+   "dns":
+   {
+     "nameservers":
+      [
+        "{{.DNS}}"
+      ]
+   }
+}`
+
+	chainCNIConfStr = `{
+"cniVersion":"%s",
+"name":"azure",
+"prevResult":%s
 }`
 )
 
@@ -797,12 +798,12 @@ func TestCNIServerChaining(t *testing.T) {
 		}
 
 		// create request
-		confParser := template.Must(template.New("").Parse(chainCNINetworkConfigTemplate))
-		conf := bytes.NewBuffer(nil)
-		if err := confParser.Execute(conf, tc); err != nil {
+		prevResultParser := template.Must(template.New("").Parse(chainCNIPrevResultTemplate))
+		prevResult := bytes.NewBuffer(nil)
+		if err := prevResultParser.Execute(prevResult, tc); err != nil {
 			t.Errorf("parse template failed: %v", err)
 		}
-		tc.networkConfig = conf.String()
+		tc.networkConfig = fmt.Sprintf(chainCNIConfStr, tc.CNIVersion, prevResult.String())
 		cniReq := tc.createCmdArgs(netNS, "")
 
 		// test cmdAdd
@@ -826,7 +827,8 @@ func TestCNIServerChaining(t *testing.T) {
 		mock.InOrder(orderedCalls...)
 		cniResp, err := server.CmdAdd(ctx, cniReq)
 		testRequire.Nil(err)
-		testRequire.Equal(tc.networkConfig, string(cniResp.CniResult))
+		// in chaining mode, we do not modify the result
+		testRequire.JSONEq(prevResult.String(), string(cniResp.CniResult))
 
 		// test cmdDel
 		containterHostRt := &net.IPNet{IP: podIP, Mask: net.CIDRMask(32, 32)}


### PR DESCRIPTION
As per the CNI specification for the Add command:
> If the plugin was supplied a prevResult as part of its input
configuration, it MUST handle prevResult by either passing it through,
or modifying it appropriately.

In networkPolicyOnly mode, CNI chaining is used. Antrea receives a
prevResult from the container runtime and must output it in case of
success. We do not make any changes to the result, but we may convert it
to a different CNI version format (the default one for Antrea).

Previously, Antrea would output the entire input configuration (which
does include prevResult), which would cause containerd to return an
error.

The integration test was incorrect and had to be fixed.

Fixes #2002