### PR TITLE
Add more time for Jenkins antrea e2e test

### DIFF
--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -279,7 +279,7 @@
                 variable: CODECOV_TOKEN
           - timeout:
               fail: true
-              timeout: 80
+              timeout: 100
               type: absolute
           - credentials-binding:
             - text:


### PR DESCRIPTION
When AntreaPolicy is enabled by default, antrea-e2e-for-pull-request in Jenkins need more time to avoid timeout.
For example: https://jenkins.antrea-ci.rocks/job/antrea-e2e-for-pull-request/2329/