### PR TITLE
Increase verbosity level of logging OVS packet_in

### DIFF
--- a/pkg/ovs/openflow/ofctrl_bridge.go
+++ b/pkg/ovs/openflow/ofctrl_bridge.go
@@ -206,7 +206,7 @@ func (b *OFBridge) DumpTableStatus() []TableStatus {
 
 // PacketRcvd is a callback when a packetIn is received on ofctrl.OFSwitch.
 func (b *OFBridge) PacketRcvd(sw *ofctrl.OFSwitch, packet *ofctrl.PacketIn) {
-	klog.Infof("Received packet: %+v", packet)
+	klog.V(2).Infof("Received packet: %+v", packet)
 	reason := packet.Reason
 	ch, found := b.pktConsumers.Load(reason)
 	if found {


### PR DESCRIPTION
Logging every packet can generate great amount of logs for NetworkPolicy
logging and rejection. Change the verbosity level to V(2).