### PR TITLE
Fix Network Policy logging on Windows Nodes

### DIFF
--- a/pkg/agent/controller/networkpolicy/packetin.go
+++ b/pkg/agent/controller/networkpolicy/packetin.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/contiv/libOpenflow/openflow13"
 	"github.com/contiv/libOpenflow/protocol"
@@ -31,11 +32,12 @@ import (
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
 	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
 	"github.com/vmware-tanzu/antrea/pkg/util/ip"
+	"github.com/vmware-tanzu/antrea/pkg/util/logdir"
 )
 
 const (
-	logDir      string = "/var/log/antrea/networkpolicy/"
-	logfileName string = "np.log"
+	logfileSubdir string = "networkpolicy"
+	logfileName   string = "np.log"
 
 	IPv4HdrLen uint16 = 20
 	IPv6HdrLen uint16 = 40
@@ -71,14 +73,13 @@ type logInfo struct {
 // initLogger is called while newing Antrea network policy agent controller.
 // Customize AntreaPolicyLogger specifically for Antrea Policies audit logging.
 func initLogger() error {
-	// logging file should be /var/log/antrea/networkpolicy/np.log
+	logDir := filepath.Join(logdir.GetLogDir(), logfileSubdir)
 	if _, err := os.Stat(logDir); os.IsNotExist(err) {
 		os.Mkdir(logDir, 0755)
 	}
-	file, err := os.OpenFile(logDir+logfileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	file, err := os.OpenFile(filepath.Join(logDir, logfileName), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
-		klog.Errorf("Failed to initialize logger to audit Antrea Policies %v", err)
-		return err
+		return fmt.Errorf("failed to initialize logger to audit Antrea Policies %v", err)
 	}
 
 	AntreaPolicyLogger = log.New(file, "", log.Ldate|log.Lmicroseconds)

--- a/pkg/agent/controller/networkpolicy/packetin.go
+++ b/pkg/agent/controller/networkpolicy/packetin.go
@@ -74,24 +74,21 @@ type logInfo struct {
 // Customize AntreaPolicyLogger specifically for Antrea Policies audit logging.
 func initLogger() error {
 	logDir := filepath.Join(logdir.GetLogDir(), logfileSubdir)
+	logFile := filepath.Join(logDir, logfileName)
 	if _, err := os.Stat(logDir); os.IsNotExist(err) {
 		os.Mkdir(logDir, 0755)
 	}
-	file, err := os.OpenFile(filepath.Join(logDir, logfileName), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
-	if err != nil {
-		return fmt.Errorf("failed to initialize logger to audit Antrea Policies %v", err)
-	}
 
-	AntreaPolicyLogger = log.New(file, "", log.Ldate|log.Lmicroseconds)
-	// Use lumberjack log file rotation
-	AntreaPolicyLogger.SetOutput(&lumberjack.Logger{
-		Filename:   logDir + logfileName,
+	// Use lumberjack log file rot
+	logOutput := &lumberjack.Logger{
+		Filename:   logFile,
 		MaxSize:    500,  // allow max 500 megabytes for one log file
 		MaxBackups: 3,    // allow max 3 old log file backups
 		MaxAge:     28,   // allow max 28 days maintenance of old log files
 		Compress:   true, // compress the old log files for backup
-	})
-	klog.V(2).Info("Initialized Antrea-native Policy Logger for audit logging")
+	}
+	AntreaPolicyLogger = log.New(logOutput, "", log.Ldate|log.Lmicroseconds)
+	klog.V(2).Infof("Initialized Antrea-native Policy Logger for audit logging with log file '%s'", logFile)
 	return nil
 }
 

--- a/pkg/support/dump.go
+++ b/pkg/support/dump.go
@@ -1,8 +1,21 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package support
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -19,9 +32,8 @@ import (
 	controllerquerier "github.com/vmware-tanzu/antrea/pkg/controller/querier"
 	"github.com/vmware-tanzu/antrea/pkg/ovs/ovsctl"
 	"github.com/vmware-tanzu/antrea/pkg/querier"
+	"github.com/vmware-tanzu/antrea/pkg/util/logdir"
 )
-
-const antreaLinuxWellKnownLogDir = "/var/log/antrea"
 
 // AgentDumper is the interface for dumping runtime information of the agent. Its
 // functions should only work in an agent Pod or a Windows Node which has an agent
@@ -151,15 +163,7 @@ func (d *controllerDumper) DumpNetworkPolicyResources(basedir string) error {
 }
 
 func (d *controllerDumper) DumpLog(basedir string) error {
-	logDirFlag := flag.CommandLine.Lookup("log_dir")
-	var logDir string
-	if logDirFlag == nil {
-		logDir = antreaLinuxWellKnownLogDir
-	} else if len(logDirFlag.Value.String()) == 0 {
-		logDir = logDirFlag.DefValue
-	} else {
-		logDir = logDirFlag.Value.String()
-	}
+	logDir := logdir.GetLogDir()
 	return fileCopy(d.fs, path.Join(basedir, "logs", "controller"), logDir, "antrea-controller")
 }
 

--- a/pkg/support/dump_others.go
+++ b/pkg/support/dump_others.go
@@ -17,25 +17,17 @@
 package support
 
 import (
-	"flag"
 	"fmt"
 	"path"
 	"path/filepath"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util/iptables"
+	"github.com/vmware-tanzu/antrea/pkg/util/logdir"
 )
 
 func (d *agentDumper) DumpLog(basedir string) error {
-	logDirFlag := flag.CommandLine.Lookup("log_dir")
-	var logDir string
-	if logDirFlag == nil {
-		logDir = antreaLinuxWellKnownLogDir
-	} else if len(logDirFlag.Value.String()) == 0 {
-		logDir = logDirFlag.DefValue
-	} else {
-		logDir = logDirFlag.Value.String()
-	}
+	logDir := logdir.GetLogDir()
 	if err := fileCopy(d.fs, path.Join(basedir, "logs", "agent"), logDir, "antrea-agent"); err != nil {
 		return err
 	}

--- a/pkg/support/dump_windows.go
+++ b/pkg/support/dump_windows.go
@@ -17,30 +17,22 @@
 package support
 
 import (
-	"flag"
 	"fmt"
 	"path"
 	"path/filepath"
+
+	"github.com/vmware-tanzu/antrea/pkg/util/logdir"
 )
 
 const (
-	antreaWindowsWellKnownLogDir = `C:\k\antrea\logs`
-	antreaWindowsOVSLogDir       = `C:\openvswitch\var\log\openvswitch`
-	antreaWindowsKubeletLogDir   = `C:\var\log\kubelet`
+	antreaWindowsOVSLogDir     = `C:\openvswitch\var\log\openvswitch`
+	antreaWindowsKubeletLogDir = `C:\var\log\kubelet`
 )
 
 // Todo: Logs for OVS and kubelet are collected from the fixed path currently, more enhancements are needed to support
 // collecting them from a configurable path in the future.
 func (d *agentDumper) DumpLog(basedir string) error {
-	logDirFlag := flag.CommandLine.Lookup("log_dir")
-	var logDir string
-	if logDirFlag == nil {
-		logDir = antreaWindowsWellKnownLogDir
-	} else if len(logDirFlag.Value.String()) == 0 {
-		logDir = logDirFlag.DefValue
-	} else {
-		logDir = logDirFlag.Value.String()
-	}
+	logDir := logdir.GetLogDir()
 	if err := fileCopy(d.fs, path.Join(basedir, "logs", "agent"), logDir, "rancher-wins-antrea-agent"); err != nil {
 		return err
 	}

--- a/pkg/util/logdir/logdir.go
+++ b/pkg/util/logdir/logdir.go
@@ -1,0 +1,35 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logdir
+
+import (
+	"flag"
+)
+
+// GetLogDir returns the path to the directory where Antrea logs are written.
+// It will look for the value of the log_dir command-line flag, or default to a
+// well-known OS-dependent location.
+func GetLogDir() string {
+	logDirFlag := flag.CommandLine.Lookup("log_dir")
+	var logDir string
+	if logDirFlag == nil {
+		logDir = antreaWellKnownLogDir
+	} else if len(logDirFlag.Value.String()) == 0 {
+		logDir = logDirFlag.DefValue
+	} else {
+		logDir = logDirFlag.Value.String()
+	}
+	return logDir
+}

--- a/pkg/util/logdir/logdir.go
+++ b/pkg/util/logdir/logdir.go
@@ -16,6 +16,7 @@ package logdir
 
 import (
 	"flag"
+	"os"
 )
 
 // GetLogDir returns the path to the directory where Antrea logs are written.
@@ -27,7 +28,8 @@ func GetLogDir() string {
 	if logDirFlag == nil {
 		logDir = antreaWellKnownLogDir
 	} else if len(logDirFlag.Value.String()) == 0 {
-		logDir = logDirFlag.DefValue
+		// default log directory used by klog
+		logDir = os.TempDir()
 	} else {
 		logDir = logDirFlag.Value.String()
 	}

--- a/pkg/util/logdir/logdir_others.go
+++ b/pkg/util/logdir/logdir_others.go
@@ -16,4 +16,4 @@
 
 package logdir
 
-const antreaWellKnownLogDir = "/var/logs/antrea"
+const antreaWellKnownLogDir = "/var/log/antrea"

--- a/pkg/util/logdir/logdir_others.go
+++ b/pkg/util/logdir/logdir_others.go
@@ -1,0 +1,19 @@
+// +build !windows
+
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logdir
+
+const antreaWellKnownLogDir = "/var/logs/antrea"

--- a/pkg/util/logdir/logdir_windows.go
+++ b/pkg/util/logdir/logdir_windows.go
@@ -1,0 +1,19 @@
+// +build windows
+
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logdir
+
+const antreaWellKnownLogDir = `C:\k\antrea\logs`


### PR DESCRIPTION
On Windows Nodes the path should be /k/antrea/logs/networkpolicy/np.log
and not /var/log/antrea/networkpolicy/np.log, as decided by the log_dir
flag.

We unify the approach for support bundle and Network Policy logging.

Fixes #2050