### PR TITLE
Specify antrea-agent as the default container for kubectl cmds

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2907,6 +2907,8 @@ spec:
       component: antrea-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: antrea-agent
       labels:
         app: antrea
         component: antrea-agent

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2907,6 +2907,8 @@ spec:
       component: antrea-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: antrea-agent
       labels:
         app: antrea
         component: antrea-agent

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2907,6 +2907,8 @@ spec:
       component: antrea-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: antrea-agent
       labels:
         app: antrea
         component: antrea-agent

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -2921,6 +2921,8 @@ spec:
       component: antrea-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: antrea-agent
       labels:
         app: antrea
         component: antrea-agent

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2912,6 +2912,8 @@ spec:
       component: antrea-agent
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: antrea-agent
       labels:
         app: antrea
         component: antrea-agent

--- a/build/yamls/base/agent.yml
+++ b/build/yamls/base/agent.yml
@@ -13,6 +13,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        # Starting with v1.21, Kubernetes supports default container annotation.
+        # Using "kubectl logs/exec/attach/cp" doesn't have to specify "-c antrea-agent" when troubleshooting.
+        kubectl.kubernetes.io/default-container: antrea-agent
       labels:
         component: antrea-agent
     spec:


### PR DESCRIPTION
Starting with v1.21, Kubernetes supports default container annotation. Using "kubectl logs/exec/attach/cp" doesn't have to specify "-c antrea-agent" when troubleshooting.