### PR TITLE
Support any source or IP address source in live-traffic Traceflow

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1387,18 +1387,18 @@ spec:
                 type: object
               source:
                 properties:
+                  ip:
+                    oneOf:
+                    - format: ipv4
+                    - format: ipv6
+                    type: string
                   namespace:
                     type: string
                   pod:
                     type: string
-                required:
-                - pod
-                - namespace
                 type: object
               timeout:
                 type: integer
-            required:
-            - source
             type: object
           status:
             properties:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1387,18 +1387,18 @@ spec:
                 type: object
               source:
                 properties:
+                  ip:
+                    oneOf:
+                    - format: ipv4
+                    - format: ipv6
+                    type: string
                   namespace:
                     type: string
                   pod:
                     type: string
-                required:
-                - pod
-                - namespace
                 type: object
               timeout:
                 type: integer
-            required:
-            - source
             type: object
           status:
             properties:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1387,18 +1387,18 @@ spec:
                 type: object
               source:
                 properties:
+                  ip:
+                    oneOf:
+                    - format: ipv4
+                    - format: ipv6
+                    type: string
                   namespace:
                     type: string
                   pod:
                     type: string
-                required:
-                - pod
-                - namespace
                 type: object
               timeout:
                 type: integer
-            required:
-            - source
             type: object
           status:
             properties:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1387,18 +1387,18 @@ spec:
                 type: object
               source:
                 properties:
+                  ip:
+                    oneOf:
+                    - format: ipv4
+                    - format: ipv6
+                    type: string
                   namespace:
                     type: string
                   pod:
                     type: string
-                required:
-                - pod
-                - namespace
                 type: object
               timeout:
                 type: integer
-            required:
-            - source
             type: object
           status:
             properties:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1387,18 +1387,18 @@ spec:
                 type: object
               source:
                 properties:
+                  ip:
+                    oneOf:
+                    - format: ipv4
+                    - format: ipv6
+                    type: string
                   namespace:
                     type: string
                   pod:
                     type: string
-                required:
-                - pod
-                - namespace
                 type: object
               timeout:
                 type: integer
-            required:
-            - source
             type: object
           status:
             properties:

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -149,19 +149,19 @@ spec:
           properties:
             spec:
               type: object
-              required:
-                - source
               properties:
                 source:
                   type: object
-                  required:
-                    - pod
-                    - namespace
                   properties:
                     pod:
                       type: string
                     namespace:
                       type: string
+                    ip:
+                      type: string
+                      oneOf:
+                        - format: ipv4
+                        - format: ipv6
                 destination:
                   type: object
                   properties:

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -227,7 +227,7 @@ type Client interface {
 	SendTraceflowPacket(dataplaneTag uint8, packet *binding.Packet, inPort uint32, outPort int32) error
 
 	// InstallTraceflowFlows installs flows for a Traceflow request.
-	InstallTraceflowFlows(dataplaneTag uint8, liveTraffic, droppedOnly bool, packet *binding.Packet, srcOFPort uint32, timeoutSeconds uint16) error
+	InstallTraceflowFlows(dataplaneTag uint8, liveTraffic, droppedOnly, receiverOnly bool, packet *binding.Packet, ofPort uint32, timeoutSeconds uint16) error
 
 	// UninstallTraceflowFlows uninstalls flows for a Traceflow request.
 	UninstallTraceflowFlows(dataplaneTag uint8) error
@@ -860,10 +860,10 @@ func (c *client) SendTraceflowPacket(dataplaneTag uint8, packet *binding.Packet,
 	return c.bridge.SendPacketOut(packetOutObj)
 }
 
-func (c *client) InstallTraceflowFlows(dataplaneTag uint8, liveTraffic, droppedOnly bool, packet *binding.Packet, srcOFPort uint32, timeoutSeconds uint16) error {
+func (c *client) InstallTraceflowFlows(dataplaneTag uint8, liveTraffic, droppedOnly, receiverOnly bool, packet *binding.Packet, ofPort uint32, timeoutSeconds uint16) error {
 	cacheKey := fmt.Sprintf("%x", dataplaneTag)
 	flows := []binding.Flow{}
-	flows = append(flows, c.traceflowConnectionTrackFlows(dataplaneTag, packet, srcOFPort, timeoutSeconds, cookie.Default)...)
+	flows = append(flows, c.traceflowConnectionTrackFlows(dataplaneTag, receiverOnly, packet, ofPort, timeoutSeconds, cookie.Default)...)
 	flows = append(flows, c.traceflowL2ForwardOutputFlows(dataplaneTag, liveTraffic, droppedOnly, timeoutSeconds, cookie.Default)...)
 	flows = append(flows, c.traceflowNetworkPolicyFlows(dataplaneTag, timeoutSeconds, cookie.Default)...)
 	return c.addFlows(c.tfFlowCache, cacheKey, flows)

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -280,7 +280,7 @@ func Test_client_InstallTraceflowFlows(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			c := tt.prepareFunc(ctrl)
-			if err := c.InstallTraceflowFlows(tt.args.dataplaneTag, false, false, nil, 0, 300); (err != nil) != tt.wantErr {
+			if err := c.InstallTraceflowFlows(tt.args.dataplaneTag, false, false, false, nil, 0, 300); (err != nil) != tt.wantErr {
 				t.Errorf("InstallTraceflowFlows() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -447,17 +447,17 @@ func (mr *MockClientMockRecorder) InstallServiceGroup(arg0, arg1, arg2 interface
 }
 
 // InstallTraceflowFlows mocks base method
-func (m *MockClient) InstallTraceflowFlows(arg0 byte, arg1, arg2 bool, arg3 *openflow.Packet, arg4 uint32, arg5 uint16) error {
+func (m *MockClient) InstallTraceflowFlows(arg0 byte, arg1, arg2, arg3 bool, arg4 *openflow.Packet, arg5 uint32, arg6 uint16) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallTraceflowFlows", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "InstallTraceflowFlows", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallTraceflowFlows indicates an expected call of InstallTraceflowFlows
-func (mr *MockClientMockRecorder) InstallTraceflowFlows(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallTraceflowFlows(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallTraceflowFlows", reflect.TypeOf((*MockClient)(nil).InstallTraceflowFlows), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallTraceflowFlows", reflect.TypeOf((*MockClient)(nil).InstallTraceflowFlows), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // IsConnected mocks base method

--- a/pkg/apis/crd/v1alpha1/types.go
+++ b/pkg/apis/crd/v1alpha1/types.go
@@ -130,6 +130,9 @@ type Source struct {
 	Namespace string `json:"namespace,omitempty"`
 	// Pod is the source pod.
 	Pod string `json:"pod,omitempty"`
+	// IP is the source IPv4 or IPv6 address. IP as the source is supported
+	// only for live-traffic Traceflow.
+	IP string `json:"ip,omitempty"`
 }
 
 // Destination describes the destination spec of the traceflow.

--- a/pkg/controller/traceflow/controller.go
+++ b/pkg/controller/traceflow/controller.go
@@ -319,7 +319,11 @@ func (c *Controller) checkTraceflowStatus(tf *crdv1alpha1.Traceflow) error {
 				}
 			}
 		}
-		succeeded = sender && receiver
+		// When the Source Pod is specified, the Traceflow should receive
+		// results from both the sender and the receiver. When the Source
+		// Pod is not specified (in live-traffic Traceflow), only the
+		// receiver Node will report the results.
+		succeeded = (sender && receiver) || (receiver && tf.Spec.Source.Pod == "")
 	}
 	if succeeded {
 		c.deallocateTagForTF(tf)


### PR DESCRIPTION
For live-traffic Traffic, allow the source to be an IP address or not
specified (which means any source). In this case, the destination Pod
must be specified, and flows will be added on the destination Node that
match the Traceflow packet with the destination Pod's MAC in
l2ForwardingCalcTable. If a packet is dropped on the source Node or
before reaching l2ForwardingCalcTable on the destination Node, it will
not be captured.