### PR TITLE
Fix typo in build_tag workflow

### DIFF
--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -41,7 +41,7 @@ jobs:
         ref: refs/heads/main
         workflow: Build Antrea ARM images and push manifest
         token: ${{ secrets.ANTREA_BUILD_INFRA_WORKFLOW_DISPATCH_PAT }}
-        inputs: ${{ format('{{ "antrea-repository":"vmware-tanzu/antrea", "antrea-ref":"{0}", "docker-tag":"{1}" }}', github.ref, steps.get-version.outputs.version) }}
+        inputs: ${{ format('{{ "antrea-repository":"vmware-tanzu/antrea", "antrea-ref":"{0}", "docker-tag":"{1}" }}', github.ref, needs.get-version.outputs.version) }}
 
   build-windows:
     runs-on: [windows-2019]


### PR DESCRIPTION
When dispatching the build workflow to the
vmware-tanzu/antrea-build-infra repository (to build the multi-arch
Antrea docker image), the docker-tag parameter was wrong (empty string
instead of the Github tag).