### PR TITLE
update brew install commands

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -33,8 +33,8 @@ virtualbox`.
 
 You can install all the dependencies with [brew](https://brew.sh/):
 
-* `brew cask install virtualbox`
-* `brew cask install vagrant`
+* `brew install --cask virtualbox`
+* `brew install --cask vagrant`
 * `brew install ansible`
 
 If an action is required on your part, `brew` will let you know in its log


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524