### PR TITLE
[CI] Retry docker pulling if failure when testing Antrea upgrade

### DIFF
--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -105,7 +105,10 @@ fi
 
 COMMON_IMAGES_LIST=("gcr.io/kubernetes-e2e-test-images/agnhost:2.8" "projects.registry.vmware.com/library/busybox" "projects.registry.vmware.com/antrea/nginx" "projects.registry.vmware.com/antrea/perftool" "projects.registry.vmware.com/antrea/ipfix-collector:v0.4.7")
 for image in "${COMMON_IMAGES_LIST[@]}"; do
-    docker pull $image
+    for i in `seq 3`; do
+        docker pull $image && break
+        sleep 1
+    done
 done
 if $coverage; then
     manifest_args="$manifest_args --coverage"

--- a/ci/kind/test-upgrade-antrea.sh
+++ b/ci/kind/test-upgrade-antrea.sh
@@ -124,7 +124,10 @@ DOCKER_IMAGES=("busybox" "projects.registry.vmware.com/antrea/antrea-ubuntu:$FRO
 
 for img in "${DOCKER_IMAGES[@]}"; do
     echo "Pulling $img"
-    docker pull $img > /dev/null
+    for i in `seq 3`; do
+        docker pull $img > /dev/null && break
+        sleep 1
+    done
 done
 
 DOCKER_IMAGES+=("projects.registry.vmware.com/antrea/antrea-ubuntu:latest")


### PR DESCRIPTION
Sometimes antrea upgrade check fails when docker pulling antrea-ubuntu image because of "Error response from daemon: missing or empty Content-Length header". It happens occasionally and retry should help.

https://github.com/vmware-tanzu/antrea/runs/2305288919?check_suite_focus=true
https://github.com/vmware-tanzu/antrea/runs/2305321865?check_suite_focus=true
