### PR TITLE
[CI] Clone Kubernetes using `git` instead of `go get`

### DIFF
--- a/ci/jenkins/mellanox/common/common_functions.sh
+++ b/ci/jenkins/mellanox/common/common_functions.sh
@@ -79,9 +79,9 @@ k8s_build(){
     fi
     rm -rf $GOPATH/src/k8s.io/kubernetes
 
-    go get -d k8s.io/kubernetes
+    git clone https://github.com/kubernetes/kubernetes.git $WORKSPACE/src/k8s.io/kubernetes
 
-    pushd $GOPATH/src/k8s.io/kubernetes
+    pushd $WORKSPACE/src/k8s.io/kubernetes
     git checkout ${KUBERNETES_VERSION}
     git log -p -1 > $ARTIFACTS/kubernetes.txt
 


### PR DESCRIPTION
In hw-offload CI `go get` started to fail on recent Kubernetes version
because of a bug in go mods. This patch uses git to directly clone the
Kubernetes project source.