### PR TITLE
[Windows] Fix timeout value for EnableHostInterface

### DIFF
--- a/pkg/agent/util/net_windows.go
+++ b/pkg/agent/util/net_windows.go
@@ -39,8 +39,8 @@ const (
 	LocalHNSNetwork      = "antrea-hnsnetwork"
 	OVSExtensionID       = "583CC151-73EC-4A6A-8B47-578297AD7623"
 	namedPipePrefix      = `\\.\pipe\`
-	commandMaxRetry      = 5
-	commandRetryInternal = time.Second
+	commandRetryTimeout  = 5 * time.Second
+	commandRetryInterval = time.Second
 )
 
 func GetNSPath(containerNetNS string) (string, error) {
@@ -62,7 +62,7 @@ func EnableHostInterface(ifaceName string) error {
 	// Enable-NetAdapter is not a blocking operation based on our testing.
 	// It returns immediately no matter whether the interface has been enabled or not.
 	// So we need to check the interface status to ensure it is up before returning.
-	if err := wait.PollImmediate(commandRetryInternal, commandMaxRetry, func() (done bool, err error) {
+	if err := wait.PollImmediate(commandRetryInterval, commandRetryTimeout, func() (done bool, err error) {
 		if err := InvokePSCommand(cmd); err != nil {
 			klog.Errorf("Failed to run command %s: %v", cmd, err)
 			return false, nil


### PR DESCRIPTION
The second parameter to wait.PollImmediate (the timeout) is a
time.Duration value. When using 5 as the parameter value, it is
interpreted as 5ns, and not 5s. This means that EnableHostInterface
basically never does any retry.