### PR TITLE
Fix Antrea-native Policy with multiple AppliedTo

### DIFF
--- a/pkg/agent/controller/networkpolicy/cache.go
+++ b/pkg/agent/controller/networkpolicy/cache.go
@@ -223,22 +223,32 @@ func (c *ruleCache) getAppliedNetworkPolicies(pod, namespace string, npFilter *q
 	return policies
 }
 
-func (c *ruleCache) getRule(ruleID string) (*rule, bool) {
-	obj, exists, _ := c.rules.GetByKey(ruleID)
-	if !exists {
-		return nil, false
-	}
-	return obj.(*rule), true
-}
-
-func (c *ruleCache) getRulesByNetworkPolicy(uid string) []*rule {
+func (c *ruleCache) getEffectiveRulesByNetworkPolicy(uid string) []*rule {
 	objs, _ := c.rules.ByIndex(policyIndex, uid)
 	if len(objs) == 0 {
 		return nil
 	}
-	rules := make([]*rule, len(objs))
-	for i, obj := range objs {
-		rules[i] = obj.(*rule)
+	rules := make([]*rule, 0, len(objs))
+
+	// A rule is considered effective when any of its AppliedToGroups can be populated.
+	isEffective := func(r *rule) bool {
+		for _, g := range r.AppliedToGroups {
+			_, exists := c.appliedToSetByGroup[g]
+			if exists {
+				return true
+			}
+		}
+		return false
+	}
+
+	c.appliedToSetLock.RLock()
+	defer c.appliedToSetLock.RUnlock()
+
+	for _, obj := range objs {
+		rule := obj.(*rule)
+		if isEffective(rule) {
+			rules = append(rules, rule)
+		}
 	}
 	return rules
 }
@@ -524,13 +534,13 @@ func (c *ruleCache) PatchAppliedToGroup(patch *v1beta.AppliedToGroupPatch) error
 }
 
 // DeleteAppliedToGroup deletes a cached *v1beta.AppliedToGroup.
-// It should only happen when a group is no longer referenced by any rule, so
-// no need to mark dirty rules.
+// It may be called when a rule becomes ineffective, so it needs to mark dirty rules.
 func (c *ruleCache) DeleteAppliedToGroup(group *v1beta.AppliedToGroup) error {
 	c.appliedToSetLock.Lock()
 	defer c.appliedToSetLock.Unlock()
 
 	delete(c.appliedToSetByGroup, group.Name)
+	c.onAppliedToGroupUpdate(group.Name)
 	return nil
 }
 
@@ -700,26 +710,38 @@ func (c *ruleCache) deleteNetworkPolicyLocked(uid string) error {
 }
 
 // GetCompletedRule constructs a *CompletedRule for the provided ruleID.
-// If the rule is not found or not completed due to missing group data,
-// the return value will indicate it.
-func (c *ruleCache) GetCompletedRule(ruleID string) (completedRule *CompletedRule, exists bool, completed bool) {
+// If the rule is not effective or not realizable due to missing group data, the return value will indicate it.
+// A rule is considered effective when any of its AppliedToGroups can be populated.
+// A rule is considered realizable when it's effective and all of its AddressGroups can be populated.
+// When a rule is not effective, it should be removed from the datapath.
+// When a rule is effective but not realizable, the caller should wait for it being realizable before doing anything.
+// When a rule is effective and realizable, the caller should realize it.
+// This is because some AppliedToGroups in a rule might never be sent to this Node if one of the following is true:
+//   - The original policy has multiple AppliedToGroups and some AppliedToGroups' span does not include this Node.
+//   - The original policy is appliedTo-per-rule, and some of the rule's AppliedToGroups do not include this Node.
+//   - The original policy is appliedTo-per-rule, none of the rule's AppliedToGroups includes this Node, but some other rules' (in the same policy) AppliedToGroups include this Node.
+// In these cases, it is not guaranteed that all AppliedToGroups in the rule will eventually be present in the cache.
+// Only the AppliedToGroups whose span includes this Node will eventually be received.
+func (c *ruleCache) GetCompletedRule(ruleID string) (completedRule *CompletedRule, effective bool, realizable bool) {
 	obj, exists, _ := c.rules.GetByKey(ruleID)
 	if !exists {
 		return nil, false, false
 	}
 
 	r := obj.(*rule)
+
+	groupMembers, anyExists := c.unionAppliedToGroups(r.AppliedToGroups)
+	if !anyExists {
+		return nil, false, false
+	}
+
 	var fromAddresses, toAddresses v1beta.GroupMemberSet
+	var completed bool
 	if r.Direction == v1beta.DirectionIn {
 		fromAddresses, completed = c.unionAddressGroups(r.From.AddressGroups)
 	} else {
 		toAddresses, completed = c.unionAddressGroups(r.To.AddressGroups)
 	}
-	if !completed {
-		return nil, true, false
-	}
-
-	groupMembers, completed := c.unionAppliedToGroups(r.AppliedToGroups)
 	if !completed {
 		return nil, true, false
 	}
@@ -771,20 +793,21 @@ func (c *ruleCache) unionAddressGroups(groupNames []string) (v1beta.GroupMemberS
 }
 
 // unionAppliedToGroups gets the union of pods of the provided appliedTo groups.
-// If any group is not found, nil and false will be returned to indicate the
-// set is not complete yet.
+// If any group is found, the union and true will be returned. Otherwise an empty set and false will be returned.
 func (c *ruleCache) unionAppliedToGroups(groupNames []string) (v1beta.GroupMemberSet, bool) {
 	c.appliedToSetLock.RLock()
 	defer c.appliedToSetLock.RUnlock()
 
+	anyExists := false
 	set := v1beta.NewGroupMemberSet()
 	for _, groupName := range groupNames {
 		curSet, exists := c.appliedToSetByGroup[groupName]
 		if !exists {
 			klog.V(2).Infof("AppliedToGroup %v was not found", groupName)
-			return nil, false
+			continue
 		}
+		anyExists = true
 		set = set.Union(curSet)
 	}
-	return set, true
+	return set, anyExists
 }

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -476,9 +476,9 @@ func (c *Controller) syncRule(key string) error {
 		klog.V(4).Infof("Finished syncing rule %q. (%v)", key, time.Since(startTime))
 	}()
 
-	rule, exists, completed := c.ruleCache.GetCompletedRule(key)
-	if !exists {
-		klog.V(2).Infof("Rule %v had been deleted, removing its flows", key)
+	rule, effective, realizable := c.ruleCache.GetCompletedRule(key)
+	if !effective {
+		klog.V(2).Infof("Rule %v was not effective, removing its flows", key)
 		if err := c.reconciler.Forget(key); err != nil {
 			return err
 		}
@@ -489,10 +489,10 @@ func (c *Controller) syncRule(key string) error {
 		}
 		return nil
 	}
-	// If the rule is not complete, we can simply skip it as it will be marked as dirty
+	// If the rule is not realizable, we can simply skip it as it will be marked as dirty
 	// and queued again when we receive the missing group it missed.
-	if !completed {
-		klog.V(2).Infof("Rule %v was not complete, skipping", key)
+	if !realizable {
+		klog.V(2).Infof("Rule %v was not realizable, skipping", key)
 		return nil
 	}
 	if err := c.reconciler.Reconcile(rule); err != nil {
@@ -515,9 +515,13 @@ func (c *Controller) syncRules(keys []string) error {
 
 	var allRules []*CompletedRule
 	for _, key := range keys {
-		rule, exists, completed := c.ruleCache.GetCompletedRule(key)
-		if !exists || !completed {
-			klog.Errorf("Rule %s is not complete or does not exist in cache", key)
+		rule, effective, realizable := c.ruleCache.GetCompletedRule(key)
+		// It's normal that a rule is not effective on this Node but abnormal that it is not realizable after watchers
+		// complete full sync.
+		if !effective {
+			klog.Infof("Rule %s is not effective on this Node", key)
+		} else if !realizable {
+			klog.Errorf("Rule %s is effective but not realizable", key)
 		} else {
 			allRules = append(allRules, rule)
 		}

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -278,7 +278,7 @@ func TestAddMultipleGroupsRule(t *testing.T) {
 	desiredRule := &CompletedRule{
 		rule:          &rule{Direction: v1beta2.DirectionIn, Services: services},
 		FromAddresses: v1beta2.NewGroupMemberSet(newAddressGroupMember("1.1.1.1"), newAddressGroupMember("2.2.2.2"), newAddressGroupMember("3.3.3.3")),
-		ToAddresses:   v1beta2.NewGroupMemberSet(),
+		ToAddresses:   nil,
 		TargetMembers: v1beta2.NewGroupMemberSet(newAppliedToGroupMember("pod1", "ns1"), newAppliedToGroupMember("pod2", "ns2")),
 	}
 	stopCh := make(chan struct{})
@@ -307,37 +307,33 @@ func TestAddMultipleGroupsRule(t *testing.T) {
 	assert.Equal(t, 1, controller.GetAddressGroupNum())
 	assert.Equal(t, 1, controller.GetAppliedToGroupNum())
 
-	// addressGroup2 comes, no rule will be synced due to missing appliedToGroup2 data.
+	// addressGroup2 comes, policy1 will be synced with the TargetMembers populated from appliedToGroup1.
 	addressGroupWatcher.Add(newAddressGroup("addressGroup2", []v1beta2.GroupMember{*newAddressGroupMember("1.1.1.1"), *newAddressGroupMember("3.3.3.3")}))
 	select {
 	case ruleID := <-reconciler.updated:
-		t.Fatalf("Expected no update, got %v", ruleID)
+		actualRule, _ := reconciler.getLastRealized(ruleID)
+		assert.Equal(t, actualRule.Direction, desiredRule.Direction)
+		assert.ElementsMatch(t, actualRule.Services, desiredRule.Services)
+		assert.Equal(t, actualRule.FromAddresses, desiredRule.FromAddresses)
+		assert.Equal(t, actualRule.ToAddresses, desiredRule.ToAddresses)
+		assert.Equal(t, actualRule.TargetMembers, v1beta2.NewGroupMemberSet(newAppliedToGroupMember("pod1", "ns1")))
 	case <-time.After(time.Millisecond * 100):
+		t.Fatal("Expected one update, got none")
 	}
 	assert.Equal(t, 1, controller.GetNetworkPolicyNum())
 	assert.Equal(t, 2, controller.GetAddressGroupNum())
 	assert.Equal(t, 1, controller.GetAppliedToGroupNum())
 
-	// appliedToGroup2 comes, policy1 will be synced.
+	// appliedToGroup2 comes, policy1 will be synced with the TargetMembers populated from appliedToGroup1 and appliedToGroup2.
 	appliedToGroupWatcher.Add(newAppliedToGroup("appliedToGroup2", []v1beta2.GroupMember{*newAppliedToGroupMember("pod2", "ns2")}))
 	select {
 	case ruleID := <-reconciler.updated:
 		actualRule, _ := reconciler.getLastRealized(ruleID)
-		if actualRule.Direction != desiredRule.Direction {
-			t.Errorf("Expected Direction %v, got %v", actualRule.Direction, desiredRule.Direction)
-		}
-		if !assert.ElementsMatch(t, actualRule.Services, desiredRule.Services) {
-			t.Errorf("Expected Services %v, got %v", actualRule.Services, desiredRule.Services)
-		}
-		if !actualRule.FromAddresses.Equal(desiredRule.FromAddresses) {
-			t.Errorf("Expected FromAddresses %v, got %v", actualRule.FromAddresses, desiredRule.FromAddresses)
-		}
-		if !actualRule.ToAddresses.Equal(desiredRule.ToAddresses) {
-			t.Errorf("Expected ToAddresses %v, got %v", actualRule.ToAddresses, desiredRule.ToAddresses)
-		}
-		if !actualRule.TargetMembers.Equal(desiredRule.TargetMembers) {
-			t.Errorf("Expected Pods %v, got %v", actualRule.TargetMembers, desiredRule.TargetMembers)
-		}
+		assert.Equal(t, actualRule.Direction, desiredRule.Direction)
+		assert.ElementsMatch(t, actualRule.Services, desiredRule.Services)
+		assert.Equal(t, actualRule.FromAddresses, desiredRule.FromAddresses)
+		assert.Equal(t, actualRule.ToAddresses, desiredRule.ToAddresses)
+		assert.Equal(t, actualRule.TargetMembers, desiredRule.TargetMembers)
 	case <-time.After(time.Millisecond * 100):
 		t.Fatal("Expected one update, got none")
 	}

--- a/pkg/agent/controller/networkpolicy/status_controller.go
+++ b/pkg/agent/controller/networkpolicy/status_controller.go
@@ -164,7 +164,7 @@ func (c *StatusController) syncHandler(uid types.UID) error {
 	if policy == nil {
 		return nil
 	}
-	desiredRules := c.ruleCache.getRulesByNetworkPolicy(string(uid))
+	desiredRules := c.ruleCache.getEffectiveRulesByNetworkPolicy(string(uid))
 	// The policy must have been deleted, no further processing.
 	if len(desiredRules) == 0 {
 		return nil

--- a/pkg/agent/controller/networkpolicy/status_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/status_controller_test.go
@@ -106,7 +106,8 @@ func TestSyncStatusForNewPolicy(t *testing.T) {
 			go statusController.Run(stopCh)
 
 			ruleCache.AddNetworkPolicy(tt.policy)
-			rules := ruleCache.getRulesByNetworkPolicy(string(tt.policy.UID))
+			ruleCache.AddAppliedToGroup(newAppliedToGroup("appliedToGroup1", []v1beta2.GroupMember{*newAppliedToGroupMember("pod1", "ns1")}))
+			rules := ruleCache.getEffectiveRulesByNetworkPolicy(string(tt.policy.UID))
 			for i, rule := range rules {
 				// Only make specified number of rules realized.
 				if i >= tt.realizedRules {
@@ -127,10 +128,11 @@ func TestSyncStatusUpForUpdatedPolicy(t *testing.T) {
 	defer close(stopCh)
 	go statusController.Run(stopCh)
 
+	ruleCache.AddAppliedToGroup(newAppliedToGroup("appliedToGroup1", []v1beta2.GroupMember{*newAppliedToGroupMember("pod1", "ns1")}))
 	policy := newNetworkPolicy("policy1", "uid1", []string{"addressGroup1"}, []string{}, []string{"appliedToGroup1"}, nil)
 	policy.Generation = 1
 	ruleCache.AddNetworkPolicy(policy)
-	rule1 := ruleCache.getRulesByNetworkPolicy(string(policy.UID))[0]
+	rule1 := ruleCache.getEffectiveRulesByNetworkPolicy(string(policy.UID))[0]
 	statusController.SetRuleRealization(rule1.ID, policy.UID)
 
 	matchGeneration := func(generation int64) error {
@@ -150,7 +152,7 @@ func TestSyncStatusUpForUpdatedPolicy(t *testing.T) {
 	ruleCache.UpdateNetworkPolicy(policy)
 	assert.Error(t, matchGeneration(policy.Generation), "The generation should not be updated to %v but was updated", policy.Generation)
 
-	rules := ruleCache.getRulesByNetworkPolicy(string(policy.UID))
+	rules := ruleCache.getEffectiveRulesByNetworkPolicy(string(policy.UID))
 	for _, rule := range rules {
 		// Only call SetRuleRealization for new rule.
 		if rule.ID != rule1.ID {
@@ -185,7 +187,7 @@ func BenchmarkSyncHandler(b *testing.B) {
 		policy.Rules = append(policy.Rules, newPolicyRule(v1beta2.DirectionOut, nil, []string{fmt.Sprintf("addressGroup%d", i)}, nil))
 	}
 	ruleCache.AddNetworkPolicy(policy)
-	rules := ruleCache.getRulesByNetworkPolicy(string(policy.UID))
+	rules := ruleCache.getEffectiveRulesByNetworkPolicy(string(policy.UID))
 	for _, rule := range rules {
 		statusController.SetRuleRealization(rule.ID, policy.UID)
 	}

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -1920,6 +1920,72 @@ func testANPBasic(t *testing.T) {
 	executeTests(t, testCase)
 }
 
+// testANPMultipleAppliedTo tests traffic from X/B to Y/A on port 80 will be dropped, after applying Antrea
+// NetworkPolicy that applies to multiple AppliedTos, one of which doesn't select any Pod. It also ensures the Policy is
+// updated correctly when one of its AppliedToGroup starts and stops selecting Pods.
+func testANPMultipleAppliedTo(t *testing.T, singleRule bool) {
+	tempLabel := randName("temp-")
+	builder := &AntreaNetworkPolicySpecBuilder{}
+	builder = builder.SetName("y", "np-multiple-appliedto").SetPriority(1.0)
+	// Make it apply to an extra dummy AppliedTo to ensure it handles multiple AppliedToGroups correctly.
+	// See https://github.com/vmware-tanzu/antrea/issues/2083.
+	if singleRule {
+		builder.SetAppliedToGroup([]ANPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}, {PodSelector: map[string]string{tempLabel: ""}}})
+		builder.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "x"},
+			nil, nil, nil, crdv1alpha1.RuleActionDrop, "")
+	} else {
+		builder.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "x"},
+			nil, nil, []ANPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}}, crdv1alpha1.RuleActionDrop, "")
+		builder.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "x"},
+			nil, nil, []ANPAppliedToSpec{{PodSelector: map[string]string{tempLabel: ""}}}, crdv1alpha1.RuleActionDrop, "")
+	}
+
+	reachability := NewReachability(allPods, Connected)
+	reachability.Expect(Pod("x/b"), Pod("y/a"), Dropped)
+
+	_, err := k8sUtils.CreateOrUpdateANP(builder.Get())
+	failOnError(err, t)
+	time.Sleep(networkPolicyDelay)
+	k8sUtils.Validate(allPods, reachability, 80, v1.ProtocolTCP)
+	reachability.PrintSummary(true, true, true)
+	_, wrong, _ := reachability.Summary()
+	if wrong != 0 {
+		t.Errorf("failure -- %d wrong results", wrong)
+	}
+
+	t.Logf("Making the Policy apply to y/c by labeling it with the temporary label that matches the dummy AppliedTo")
+	podYC, _ := k8sUtils.GetPodByLabel("y", "c")
+	podYC.Labels[tempLabel] = ""
+	podYC, err = k8sUtils.clientset.CoreV1().Pods(podYC.Namespace).Update(context.TODO(), podYC, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	reachability = NewReachability(allPods, Connected)
+	reachability.Expect(Pod("x/b"), Pod("y/a"), Dropped)
+	reachability.Expect(Pod("x/b"), Pod("y/c"), Dropped)
+	time.Sleep(networkPolicyDelay)
+	k8sUtils.Validate(allPods, reachability, 80, v1.ProtocolTCP)
+	reachability.PrintSummary(true, true, true)
+	_, wrong, _ = reachability.Summary()
+	if wrong != 0 {
+		t.Errorf("failure -- %d wrong results", wrong)
+	}
+
+	t.Logf("Making the Policy not apply to y/c by removing the temporary label")
+	delete(podYC.Labels, tempLabel)
+	_, err = k8sUtils.clientset.CoreV1().Pods(podYC.Namespace).Update(context.TODO(), podYC, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	reachability = NewReachability(allPods, Connected)
+	reachability.Expect(Pod("x/b"), Pod("y/a"), Dropped)
+	time.Sleep(networkPolicyDelay)
+	k8sUtils.Validate(allPods, reachability, 80, v1.ProtocolTCP)
+	reachability.PrintSummary(true, true, true)
+	_, wrong, _ = reachability.Summary()
+	if wrong != 0 {
+		t.Errorf("failure -- %d wrong results", wrong)
+	}
+
+	failOnError(k8sUtils.DeleteANP(builder.Namespace, builder.Name), t)
+}
+
 // testAuditLoggingBasic tests that a audit log is generated when egress drop applied
 func testAuditLoggingBasic(t *testing.T, data *TestData) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
@@ -2542,6 +2608,8 @@ func TestAntreaPolicy(t *testing.T) {
 		t.Run("Case=ACNPRulePriority", func(t *testing.T) { testACNPRulePrioirty(t) })
 		t.Run("Case=ANPPortRange", func(t *testing.T) { testANPPortRange(t) })
 		t.Run("Case=ANPBasic", func(t *testing.T) { testANPBasic(t) })
+		t.Run("Case=testANPMultipleAppliedToSingleRule", func(t *testing.T) { testANPMultipleAppliedTo(t, true) })
+		t.Run("Case=testANPMultipleAppliedToMultipleRules", func(t *testing.T) { testANPMultipleAppliedTo(t, false) })
 		t.Run("Case=AppliedToPerRule", func(t *testing.T) { testAppliedToPerRule(t) })
 		t.Run("Case=ACNPClusterGroupEgressRulePodsAToCGWithNsZ", func(t *testing.T) { testACNPEgressRulePodsAToCGWithNsZ(t) })
 		t.Run("Case=ACNPClusterGroupUpdate", func(t *testing.T) { testACNPClusterGroupUpdate(t) })


### PR DESCRIPTION
A Policy rule may have multiple AppliedToGroups, not all of which select
some workloads on the Nodes that the Policy applies to. It's by design
that an AppliedToGroup won't be sent to a Node if it doesn't select any
workload on it, so agents shouldn't require all AppliedToGroups to be
received before it can realize a rule. What's more, it may happen that
none of its AppliedToGroups is sent to a Node when the rule itself is
being evaluated on the Node if it's sent to the Node because other rules
of its parent Policy apply to it.

This patch fixes the logic by making the controller install a rule when
any of its AppliedToGroups can be populated and all of its AddressGroups
can be populated, and uninstall it when none of its AppliedToGroups can
be populated.

Fixes #2083