### PR TITLE
Add nodeSelector for FlowAggregator and ELK Pods

### DIFF
--- a/build/yamls/elk-flow-collector/elk-flow-collector.yml
+++ b/build/yamls/elk-flow-collector/elk-flow-collector.yml
@@ -114,6 +114,9 @@ spec:
           volumeMounts:
             - name: es-data
               mountPath: /data
+      nodeSelector:
+        kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
       volumes:
         - name: es-data
           persistentVolumeClaim:
@@ -171,6 +174,9 @@ spec:
           ports:
             - containerPort: 5601
               name: http
+      nodeSelector:
+        kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
 ---
 apiVersion: v1
 kind: Service
@@ -220,6 +226,9 @@ spec:
           ports:
             - containerPort: 4739
               protocol: UDP
+      nodeSelector:
+        kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
       volumes:
         - name: logstash-definition-volume
           configMap:

--- a/build/yamls/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator.yml
@@ -217,6 +217,9 @@ spec:
           subPath: flow-aggregator.conf
         - mountPath: /var/log/antrea/flow-aggregator
           name: host-var-log-antrea-flow-aggregator
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       serviceAccountName: flow-aggregator
       volumes:
       - configMap:

--- a/build/yamls/flow-aggregator/base/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator/base/flow-aggregator.yml
@@ -138,6 +138,9 @@ spec:
           subPath: flow-aggregator.conf
         - mountPath: /var/log/antrea/flow-aggregator
           name: host-var-log-antrea-flow-aggregator
+      nodeSelector:
+        kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
       serviceAccountName: flow-aggregator
       volumes:
       - name: flow-aggregator-config


### PR DESCRIPTION
When using the FlowAggregator or the ELK reference stack on a cluster
with ARM and Windows Nodes, Pods should be scheduled on Linux AMD64
Nodes.

For the FlowAggregator, we may consider providing a multi-arch Docker
manifest with support for ARM achitectures, like we do for the the
Antrea image.