### PR TITLE
[Windows] Small improvements to PowerShell installation scripts

### DIFF
--- a/hack/windows/Prepare-ServiceInterface.ps1
+++ b/hack/windows/Prepare-ServiceInterface.ps1
@@ -33,5 +33,5 @@ if ($StopKubeProxyOnCreation) {
   # Restart kube-proxy to ensure that the newly created interface can be used.
   # Kill kube-proxy and the process will be automatically restarted by the kube-proxy Pod.
   Write-Host "stopping running kube-proxy process if exists..."
-  taskkill /im rancher-wins-kube-proxy.exe /f
+  taskkill /fi "IMAGENAME eq rancher-wins-kube-proxy.exe" /f
 }

--- a/hack/windows/Reset-Node.ps1
+++ b/hack/windows/Reset-Node.ps1
@@ -4,9 +4,8 @@ Performs a best effort revert of changes made to this host by 'kubeadm join'
 #>
 Write-Host "Running kubeadm reset"
 kubeadm.exe reset -f
-rm -r -f C:\etc\kubernetes\pki
-rm -r -fo C:\etc\kubernetes\pki
-rm -r -fo C:\var\lib\kubelet
+rm -r -force C:\etc\kubernetes\pki
+rm -r -force C:\var\lib\kubelet
 
 mkdir -force C:\var\lib\kubelet\etc\kubernetes
 mkdir -force C:\etc\kubernetes\pki


### PR DESCRIPTION
 * Reset-Node.ps1: "rm -f" will fail because "-f" is ambiguous
 * Prepare-ServiceInterface.ps1: change taskkill command to print an INFO log
   instead of an ERROR log if the process does not exist, to avoid confusing
   users