### PR TITLE
Do not populate HostNetwork Pods into AppliedToGroups

### DIFF
--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -1211,8 +1211,9 @@ func (n *NetworkPolicyController) syncAppliedToGroup(key string) error {
 	appliedToGroup := appliedToGroupObj.(*antreatypes.AppliedToGroup)
 	pods, externalEntities := n.getAppliedToWorkloads(appliedToGroup)
 	for _, pod := range pods {
-		if pod.Spec.NodeName == "" {
+		if pod.Spec.NodeName == "" || pod.Spec.HostNetwork == true {
 			// No need to process Pod when it's not scheduled.
+			// HostNetwork Pods will not be applied to by policies.
 			continue
 		}
 		scheduledPodNum++

--- a/pkg/controller/networkpolicy/networkpolicy_controller_perf_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_perf_test.go
@@ -360,8 +360,11 @@ func newPod(namespace, name string, labels map[string]string) *corev1.Pod {
 	podIP := getRandomIP()
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, UID: types.UID(uuid.New().String()), Labels: labels},
-		Spec:       corev1.PodSpec{NodeName: getRandomNodeName()},
-		Status:     corev1.PodStatus{PodIP: podIP, PodIPs: []corev1.PodIP{{IP: podIP}}},
+		Spec: corev1.PodSpec{
+			NodeName:    getRandomNodeName(),
+			HostNetwork: false,
+		},
+		Status: corev1.PodStatus{PodIP: podIP, PodIPs: []corev1.PodIP{{IP: podIP}}},
 	}
 	return pod
 }

--- a/pkg/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_test.go
@@ -1193,6 +1193,44 @@ func TestAddPod(t *testing.T) {
 			groupMatch:           false,
 		},
 		{
+			name: "match-all-selectors-host-network",
+			addedPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "podA",
+					Namespace: "nsA",
+					Labels: map[string]string{
+						"role":     "app",
+						"group":    "appliedTo",
+						"inGroup":  "inAddress",
+						"outGroup": "outAddress",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "container-1",
+					}},
+					NodeName:    "nodeA",
+					HostNetwork: true,
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+					PodIP: "1.2.3.4",
+					PodIPs: []corev1.PodIP{
+						{IP: "1.2.3.4"},
+					},
+				},
+			},
+			appGroupMatch:        false,
+			inAddressGroupMatch:  true,
+			outAddressGroupMatch: true,
+			groupMatch:           false,
+		},
+		{
 			name: "match-spec-podselector-no-podip",
 			addedPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Fixes #2086. HostNetwork Pods should not be part of AppliedToGroups as they are not in the Pod network.