### PR TITLE
Update Multus cookbook

### DIFF
--- a/docs/cookbooks/multus/README.md
+++ b/docs/cookbooks/multus/README.md
@@ -1,7 +1,7 @@
 # Using Antrea with Multus
 
 This guide will describe how to use Project Antrea with
-[Multus](https://github.com/intel/multus-cni), in order to attach multiple
+[Multus](https://github.com/k8snetworkplumbingwg/multus-cni), in order to attach multiple
 network interfaces to Pods. In this scenario, Antrea is used for the default
 network, i.e. it is the CNI plugin which provisions the "primary" network
 interface ("eth0") for each Pod. For the sake of this guide, we will use the
@@ -93,7 +93,7 @@ version](https://github.com/vmware-tanzu/antrea/releases).
 ### Step 2: Deploy Multus as a DaemonSet
 
 ```bash
-git clone https://github.com/intel/multus-cni.git && cd multus-cni
+git clone https://github.com/k8snetworkplumbingwg/multus-cni && cd multus-cni
 cat ./images/multus-daemonset.yml | kubectl apply -f -
 ```
 

--- a/docs/cookbooks/multus/test/Vagrantfile
+++ b/docs/cookbooks/multus/test/Vagrantfile
@@ -2,7 +2,10 @@ VAGRANTFILE_API_VERSION = "2"
 
 NUM_WORKERS = 2
 
+MODE = "v4"
 K8S_POD_NETWORK_CIDR = "10.10.0.0/16"
+K8S_SERVICE_NETWORK_CIDR = "10.96.0.0/12"
+K8S_NODE_CP_GW_IP = "10.10.0.1"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/bionic64"
@@ -19,7 +22,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   groups = {
-    "control-plane" => ["k8s-node-control-plane"],
+    "controlplane" => ["k8s-node-control-plane"],
     "workers" => ["k8s-node-worker-[1:#{NUM_WORKERS}]"],
   }
 
@@ -38,7 +41,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         node_ip: node_ip,
         node_name: "k8s-node-control-plane",
         k8s_pod_network_cidr: K8S_POD_NETWORK_CIDR,
+        k8s_service_network_cidr: K8S_SERVICE_NETWORK_CIDR,
         k8s_api_server_ip: node_ip,
+        k8s_ip_family: MODE,
+        k8s_antrea_gw_ip: K8S_NODE_CP_GW_IP,
       }
     end
   end


### PR DESCRIPTION
- The Ansible playbooks have changed, requiring some changes to the
  Vagrantfile used to provision a testbed
- Update links to multus-cni to point to the new repo