### PR TITLE
[CI] Remove taint on Node from capv

### DIFF
--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -244,6 +244,11 @@ function setup_cluster() {
             exit 1
         fi
     fi
+
+    # Remove a taint on Node from capv: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
+    kubectl get node --no-headers=true --kubeconfig "${GIT_CHECKOUT_DIR}/jenkins/out/kubeconfig" | awk '{print $1}' | while read nodename; do
+        kubectl taint nodes $nodename node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule- || true
+    done
 }
 
 function copy_image {


### PR DESCRIPTION
There's a taint "node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule"
on Nodes created by capv. It blocks Antrea from deployment.

```
jenkins@vmc-bootstrap:~/workspace/antrea-e2e-for-pull-request$ kubectl describe node antrea-e2e-for-pull-request-2404-md-0-65b9865469-llzc9
Name:               antrea-e2e-for-pull-request-2404-md-0-65b9865469-llzc9
Roles:              <none>
Labels:             beta.kubernetes.io/arch=amd64
                    beta.kubernetes.io/os=linux
                    kubernetes.io/arch=amd64
                    kubernetes.io/hostname=antrea-e2e-for-pull-request-2404-md-0-65b9865469-llzc9
                    kubernetes.io/os=linux
Annotations:        kubeadm.alpha.kubernetes.io/cri-socket: /var/run/containerd/containerd.sock
                    node.alpha.kubernetes.io/ttl: 0
                    volumes.kubernetes.io/controller-managed-attach-detach: true
CreationTimestamp:  Tue, 20 Apr 2021 09:30:47 +0000
Taints:             node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
                    node.kubernetes.io/not-ready:NoSchedule
```