### PR TITLE
Improve Antrea-native Policy CRD schema verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bin
 
 .idea/
 .vscode/
+vendor

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -135,9 +135,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -207,9 +249,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -289,9 +373,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -309,9 +435,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -341,9 +509,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -365,9 +575,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -384,9 +636,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -484,9 +778,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -504,9 +840,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -536,9 +914,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -560,9 +980,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -579,9 +1041,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -661,9 +1165,51 @@ spec:
               appliedTo:
                 properties:
                   namespaceSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                   podSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                 type: object
               egressIP:
                 oneOf:
@@ -893,9 +1439,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -933,9 +1521,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -1079,9 +1709,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -1119,9 +1791,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -135,9 +135,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -207,9 +249,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -289,9 +373,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -309,9 +435,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -341,9 +509,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -365,9 +575,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -384,9 +636,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -484,9 +778,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -504,9 +840,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -536,9 +914,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -560,9 +980,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -579,9 +1041,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -661,9 +1165,51 @@ spec:
               appliedTo:
                 properties:
                   namespaceSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                   podSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                 type: object
               egressIP:
                 oneOf:
@@ -893,9 +1439,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -933,9 +1521,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -1079,9 +1709,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -1119,9 +1791,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -135,9 +135,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -207,9 +249,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -289,9 +373,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -309,9 +435,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -341,9 +509,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -365,9 +575,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -384,9 +636,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -484,9 +778,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -504,9 +840,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -536,9 +914,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -560,9 +980,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -579,9 +1041,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -661,9 +1165,51 @@ spec:
               appliedTo:
                 properties:
                   namespaceSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                   podSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                 type: object
               egressIP:
                 oneOf:
@@ -893,9 +1439,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -933,9 +1521,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -1079,9 +1709,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -1119,9 +1791,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -135,9 +135,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -207,9 +249,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -289,9 +373,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -309,9 +435,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -341,9 +509,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -365,9 +575,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -384,9 +636,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -484,9 +778,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -504,9 +840,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -536,9 +914,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -560,9 +980,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -579,9 +1041,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -661,9 +1165,51 @@ spec:
               appliedTo:
                 properties:
                   namespaceSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                   podSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                 type: object
               egressIP:
                 oneOf:
@@ -893,9 +1439,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -933,9 +1521,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -1079,9 +1709,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -1119,9 +1791,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -135,9 +135,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -207,9 +249,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -289,9 +373,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -309,9 +435,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -341,9 +509,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -365,9 +575,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -384,9 +636,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -484,9 +778,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -504,9 +840,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -536,9 +914,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -560,9 +980,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -579,9 +1041,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -661,9 +1165,51 @@ spec:
               appliedTo:
                 properties:
                   namespaceSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                   podSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                 type: object
               egressIP:
                 oneOf:
@@ -893,9 +1439,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -933,9 +1521,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -1079,9 +1709,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -1119,9 +1791,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -25,9 +25,51 @@ spec:
                 type: object
                 properties:
                   podSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                              type: string
+                            values:
+                              type: array
+                              items:
+                                type: string
+                      matchLabels:
+                        type: object
+                    type: object
                   namespaceSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                              type: string
+                            values:
+                              type: array
+                              items:
+                                type: string
+                      matchLabels:
+                        type: object
+                    type: object
               egressIP:
                 type: string
                 oneOf:
@@ -434,9 +476,51 @@ spec:
                     # Ensure that Spec.AppliedTo does not allow IPBlock field
                     properties:
                       podSelector:
-                        x-kubernetes-preserve-unknown-fields: true
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            type: object
+                        type: object
                       namespaceSelector:
-                        x-kubernetes-preserve-unknown-fields: true
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            type: object
+                        type: object
                       group:
                         type: string
                 ingress:
@@ -453,9 +537,51 @@ spec:
                           # Ensure that rule AppliedTo does not allow IPBlock field
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             group:
                               type: string
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
@@ -479,9 +605,51 @@ spec:
                           type: object
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             ipBlock:
                               type: object
                               properties:
@@ -508,9 +676,51 @@ spec:
                           # Ensure that rule AppliedTo does not allow IPBlock field
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             group:
                               type: string
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
@@ -534,9 +744,51 @@ spec:
                           type: object
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             ipBlock:
                               type: object
                               properties:
@@ -667,9 +919,51 @@ spec:
                           type: object
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             externalEntitySelector:
                               x-kubernetes-preserve-unknown-fields: true
                             ipBlock:
@@ -719,9 +1013,51 @@ spec:
                           type: object
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             externalEntitySelector:
                               x-kubernetes-preserve-unknown-fields: true
                             ipBlock:
@@ -831,9 +1167,51 @@ spec:
                 childGroups:
                   x-kubernetes-preserve-unknown-fields: true
                 podSelector:
-                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    matchExpressions:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                            type: string
+                          values:
+                            type: array
+                            items:
+                              type: string
+                    matchLabels:
+                      type: object
+                  type: object
                 namespaceSelector:
-                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    matchExpressions:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                            type: string
+                          values:
+                            type: array
+                            items:
+                              type: string
+                    matchLabels:
+                      type: object
+                  type: object
                 externalEntitySelector:
                   x-kubernetes-preserve-unknown-fields: true
                 ipBlock:
@@ -1205,9 +1583,51 @@ spec:
                     # Ensure that Spec.AppliedTo does not allow IPBlock field
                     properties:
                       podSelector:
-                        x-kubernetes-preserve-unknown-fields: true
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            type: object
+                        type: object
                       namespaceSelector:
-                        x-kubernetes-preserve-unknown-fields: true
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            type: object
+                        type: object
                       group:
                         type: string
                 ingress:
@@ -1224,9 +1644,51 @@ spec:
                           # Ensure that rule AppliedTo does not allow IPBlock field
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             group:
                               type: string
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
@@ -1250,9 +1712,51 @@ spec:
                           type: object
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             ipBlock:
                               type: object
                               properties:
@@ -1279,9 +1783,51 @@ spec:
                           # Ensure that rule AppliedTo does not allow IPBlock field
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             group:
                               type: string
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
@@ -1305,9 +1851,51 @@ spec:
                           type: object
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             ipBlock:
                               type: object
                               properties:
@@ -1439,9 +2027,51 @@ spec:
                           type: object
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             externalEntitySelector:
                               x-kubernetes-preserve-unknown-fields: true
                             ipBlock:
@@ -1491,9 +2121,51 @@ spec:
                           type: object
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             externalEntitySelector:
                               x-kubernetes-preserve-unknown-fields: true
                             ipBlock:
@@ -1605,9 +2277,51 @@ spec:
                 childGroups:
                   x-kubernetes-preserve-unknown-fields: true
                 podSelector:
-                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    matchExpressions:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                            type: string
+                          values:
+                            type: array
+                            items:
+                              type: string
+                    matchLabels:
+                      type: object
+                  type: object
                 namespaceSelector:
-                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    matchExpressions:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                            type: string
+                          values:
+                            type: array
+                            items:
+                              type: string
+                    matchLabels:
+                      type: object
+                  type: object
                 externalEntitySelector:
                   x-kubernetes-preserve-unknown-fields: true
                 ipBlock:


### PR DESCRIPTION

The incorrect input of labelSelector fields that have known schema should be rejected:

`cat acnp_demo.yaml`
```yaml
apiVersion: crd.antrea.io/v1alpha1
kind: ClusterNetworkPolicy
metadata:
  name: blacklist
spec:
    priority: 5
    tier: securityops
    appliedTo:
      - namespaceSelector:
          matchLables:
            env: dummy
    ingress:
      - action: Drop
```

`kubectl create -f acnp_demo.yaml`
error: error validating "acnp_demo.yaml": error validating data: ValidationError(ClusterNetworkPolicy.spec.appliedTo[0].namespaceSelector): unknown field "matchLables" in io.antrea.crd.v1alpha1.ClusterNetworkPolicy.spec.appliedTo.namespaceSelector; if you choose to ignore these errors, turn validation off with --validate=false

all of namespaceSelector/podSelector parameters verification in CRD schema will be improved.

Fix #2090