### PR TITLE
Improve Antrea-native Policy CRD schema verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bin
 
 .idea/
 .vscode/
+vendor

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -119,7 +119,28 @@ spec:
               childGroups:
                 x-kubernetes-preserve-unknown-fields: true
               externalEntitySelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               ipBlock:
                 properties:
                   cidr:
@@ -135,9 +156,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -191,7 +254,28 @@ spec:
               childGroups:
                 x-kubernetes-preserve-unknown-fields: true
               externalEntitySelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               ipBlock:
                 properties:
                   cidr:
@@ -207,9 +291,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -289,9 +415,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -309,9 +477,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -341,9 +551,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -365,9 +617,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -384,9 +678,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -484,9 +820,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -504,9 +882,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -536,9 +956,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -560,9 +1022,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -579,9 +1083,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -661,9 +1207,51 @@ spec:
               appliedTo:
                 properties:
                   namespaceSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                   podSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                 type: object
               egressIP:
                 oneOf:
@@ -845,8 +1433,28 @@ spec:
                 items:
                   properties:
                     podSelector:
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
                       type: object
-                      x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
               egress:
@@ -862,8 +1470,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -885,7 +1513,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -893,9 +1542,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -915,8 +1606,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -925,7 +1636,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -933,9 +1665,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -1031,8 +1805,28 @@ spec:
                 items:
                   properties:
                     podSelector:
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
                       type: object
-                      x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
               egress:
@@ -1048,8 +1842,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -1071,7 +1885,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -1079,9 +1914,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -1101,8 +1978,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -1111,7 +2008,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -1119,9 +2037,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -139,7 +139,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               ipBlock:
                 properties:
@@ -176,7 +176,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               podSelector:
                 properties:
@@ -199,7 +199,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               serviceReference:
                 properties:
@@ -274,7 +274,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               ipBlock:
                 properties:
@@ -311,7 +311,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               podSelector:
                 properties:
@@ -334,7 +334,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               serviceReference:
                 properties:
@@ -435,7 +435,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                     podSelector:
                       properties:
@@ -458,7 +458,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -497,7 +497,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -520,7 +520,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -571,7 +571,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -594,7 +594,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -637,7 +637,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -660,7 +660,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -698,7 +698,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -721,7 +721,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -840,7 +840,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                     podSelector:
                       properties:
@@ -863,7 +863,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -902,7 +902,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -925,7 +925,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -976,7 +976,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -999,7 +999,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1042,7 +1042,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1065,7 +1065,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1103,7 +1103,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1126,7 +1126,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1227,7 +1227,7 @@ spec:
                           type: object
                         type: array
                       matchLabels:
-                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                     type: object
                   podSelector:
                     properties:
@@ -1250,7 +1250,7 @@ spec:
                           type: object
                         type: array
                       matchLabels:
-                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                     type: object
                 type: object
               egressIP:
@@ -1453,7 +1453,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -1490,7 +1490,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1533,7 +1533,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -1562,7 +1562,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1585,7 +1585,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1626,7 +1626,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1656,7 +1656,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -1685,7 +1685,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1708,7 +1708,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1825,7 +1825,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -1862,7 +1862,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1905,7 +1905,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -1934,7 +1934,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1957,7 +1957,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1998,7 +1998,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -2028,7 +2028,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -2057,7 +2057,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -2080,7 +2080,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -119,7 +119,28 @@ spec:
               childGroups:
                 x-kubernetes-preserve-unknown-fields: true
               externalEntitySelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               ipBlock:
                 properties:
                   cidr:
@@ -135,9 +156,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -191,7 +254,28 @@ spec:
               childGroups:
                 x-kubernetes-preserve-unknown-fields: true
               externalEntitySelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               ipBlock:
                 properties:
                   cidr:
@@ -207,9 +291,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -289,9 +415,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -309,9 +477,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -341,9 +551,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -365,9 +617,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -384,9 +678,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -484,9 +820,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -504,9 +882,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -536,9 +956,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -560,9 +1022,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -579,9 +1083,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -661,9 +1207,51 @@ spec:
               appliedTo:
                 properties:
                   namespaceSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                   podSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                 type: object
               egressIP:
                 oneOf:
@@ -845,8 +1433,28 @@ spec:
                 items:
                   properties:
                     podSelector:
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
                       type: object
-                      x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
               egress:
@@ -862,8 +1470,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -885,7 +1513,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -893,9 +1542,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -915,8 +1606,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -925,7 +1636,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -933,9 +1665,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -1031,8 +1805,28 @@ spec:
                 items:
                   properties:
                     podSelector:
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
                       type: object
-                      x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
               egress:
@@ -1048,8 +1842,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -1071,7 +1885,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -1079,9 +1914,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -1101,8 +1978,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -1111,7 +2008,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -1119,9 +2037,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -139,7 +139,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               ipBlock:
                 properties:
@@ -176,7 +176,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               podSelector:
                 properties:
@@ -199,7 +199,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               serviceReference:
                 properties:
@@ -274,7 +274,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               ipBlock:
                 properties:
@@ -311,7 +311,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               podSelector:
                 properties:
@@ -334,7 +334,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               serviceReference:
                 properties:
@@ -435,7 +435,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                     podSelector:
                       properties:
@@ -458,7 +458,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -497,7 +497,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -520,7 +520,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -571,7 +571,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -594,7 +594,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -637,7 +637,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -660,7 +660,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -698,7 +698,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -721,7 +721,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -840,7 +840,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                     podSelector:
                       properties:
@@ -863,7 +863,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -902,7 +902,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -925,7 +925,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -976,7 +976,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -999,7 +999,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1042,7 +1042,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1065,7 +1065,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1103,7 +1103,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1126,7 +1126,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1227,7 +1227,7 @@ spec:
                           type: object
                         type: array
                       matchLabels:
-                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                     type: object
                   podSelector:
                     properties:
@@ -1250,7 +1250,7 @@ spec:
                           type: object
                         type: array
                       matchLabels:
-                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                     type: object
                 type: object
               egressIP:
@@ -1453,7 +1453,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -1490,7 +1490,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1533,7 +1533,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -1562,7 +1562,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1585,7 +1585,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1626,7 +1626,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1656,7 +1656,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -1685,7 +1685,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1708,7 +1708,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1825,7 +1825,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -1862,7 +1862,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1905,7 +1905,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -1934,7 +1934,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1957,7 +1957,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1998,7 +1998,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -2028,7 +2028,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -2057,7 +2057,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -2080,7 +2080,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -119,7 +119,28 @@ spec:
               childGroups:
                 x-kubernetes-preserve-unknown-fields: true
               externalEntitySelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               ipBlock:
                 properties:
                   cidr:
@@ -135,9 +156,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -191,7 +254,28 @@ spec:
               childGroups:
                 x-kubernetes-preserve-unknown-fields: true
               externalEntitySelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               ipBlock:
                 properties:
                   cidr:
@@ -207,9 +291,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -289,9 +415,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -309,9 +477,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -341,9 +551,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -365,9 +617,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -384,9 +678,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -484,9 +820,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -504,9 +882,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -536,9 +956,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -560,9 +1022,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -579,9 +1083,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -661,9 +1207,51 @@ spec:
               appliedTo:
                 properties:
                   namespaceSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                   podSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                 type: object
               egressIP:
                 oneOf:
@@ -845,8 +1433,28 @@ spec:
                 items:
                   properties:
                     podSelector:
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
                       type: object
-                      x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
               egress:
@@ -862,8 +1470,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -885,7 +1513,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -893,9 +1542,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -915,8 +1606,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -925,7 +1636,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -933,9 +1665,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -1031,8 +1805,28 @@ spec:
                 items:
                   properties:
                     podSelector:
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
                       type: object
-                      x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
               egress:
@@ -1048,8 +1842,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -1071,7 +1885,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -1079,9 +1914,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -1101,8 +1978,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -1111,7 +2008,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -1119,9 +2037,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -139,7 +139,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               ipBlock:
                 properties:
@@ -176,7 +176,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               podSelector:
                 properties:
@@ -199,7 +199,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               serviceReference:
                 properties:
@@ -274,7 +274,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               ipBlock:
                 properties:
@@ -311,7 +311,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               podSelector:
                 properties:
@@ -334,7 +334,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               serviceReference:
                 properties:
@@ -435,7 +435,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                     podSelector:
                       properties:
@@ -458,7 +458,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -497,7 +497,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -520,7 +520,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -571,7 +571,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -594,7 +594,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -637,7 +637,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -660,7 +660,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -698,7 +698,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -721,7 +721,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -840,7 +840,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                     podSelector:
                       properties:
@@ -863,7 +863,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -902,7 +902,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -925,7 +925,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -976,7 +976,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -999,7 +999,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1042,7 +1042,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1065,7 +1065,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1103,7 +1103,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1126,7 +1126,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1227,7 +1227,7 @@ spec:
                           type: object
                         type: array
                       matchLabels:
-                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                     type: object
                   podSelector:
                     properties:
@@ -1250,7 +1250,7 @@ spec:
                           type: object
                         type: array
                       matchLabels:
-                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                     type: object
                 type: object
               egressIP:
@@ -1453,7 +1453,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -1490,7 +1490,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1533,7 +1533,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -1562,7 +1562,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1585,7 +1585,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1626,7 +1626,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1656,7 +1656,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -1685,7 +1685,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1708,7 +1708,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1825,7 +1825,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -1862,7 +1862,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1905,7 +1905,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -1934,7 +1934,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1957,7 +1957,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1998,7 +1998,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -2028,7 +2028,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -2057,7 +2057,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -2080,7 +2080,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -119,7 +119,28 @@ spec:
               childGroups:
                 x-kubernetes-preserve-unknown-fields: true
               externalEntitySelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               ipBlock:
                 properties:
                   cidr:
@@ -135,9 +156,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -191,7 +254,28 @@ spec:
               childGroups:
                 x-kubernetes-preserve-unknown-fields: true
               externalEntitySelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               ipBlock:
                 properties:
                   cidr:
@@ -207,9 +291,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -289,9 +415,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -309,9 +477,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -341,9 +551,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -365,9 +617,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -384,9 +678,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -484,9 +820,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -504,9 +882,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -536,9 +956,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -560,9 +1022,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -579,9 +1083,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -661,9 +1207,51 @@ spec:
               appliedTo:
                 properties:
                   namespaceSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                   podSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                 type: object
               egressIP:
                 oneOf:
@@ -845,8 +1433,28 @@ spec:
                 items:
                   properties:
                     podSelector:
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
                       type: object
-                      x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
               egress:
@@ -862,8 +1470,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -885,7 +1513,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -893,9 +1542,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -915,8 +1606,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -925,7 +1636,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -933,9 +1665,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -1031,8 +1805,28 @@ spec:
                 items:
                   properties:
                     podSelector:
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
                       type: object
-                      x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
               egress:
@@ -1048,8 +1842,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -1071,7 +1885,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -1079,9 +1914,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -1101,8 +1978,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -1111,7 +2008,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -1119,9 +2037,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -139,7 +139,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               ipBlock:
                 properties:
@@ -176,7 +176,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               podSelector:
                 properties:
@@ -199,7 +199,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               serviceReference:
                 properties:
@@ -274,7 +274,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               ipBlock:
                 properties:
@@ -311,7 +311,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               podSelector:
                 properties:
@@ -334,7 +334,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               serviceReference:
                 properties:
@@ -435,7 +435,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                     podSelector:
                       properties:
@@ -458,7 +458,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -497,7 +497,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -520,7 +520,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -571,7 +571,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -594,7 +594,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -637,7 +637,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -660,7 +660,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -698,7 +698,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -721,7 +721,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -840,7 +840,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                     podSelector:
                       properties:
@@ -863,7 +863,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -902,7 +902,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -925,7 +925,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -976,7 +976,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -999,7 +999,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1042,7 +1042,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1065,7 +1065,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1103,7 +1103,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1126,7 +1126,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1227,7 +1227,7 @@ spec:
                           type: object
                         type: array
                       matchLabels:
-                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                     type: object
                   podSelector:
                     properties:
@@ -1250,7 +1250,7 @@ spec:
                           type: object
                         type: array
                       matchLabels:
-                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                     type: object
                 type: object
               egressIP:
@@ -1453,7 +1453,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -1490,7 +1490,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1533,7 +1533,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -1562,7 +1562,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1585,7 +1585,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1626,7 +1626,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1656,7 +1656,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -1685,7 +1685,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1708,7 +1708,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1825,7 +1825,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -1862,7 +1862,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1905,7 +1905,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -1934,7 +1934,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1957,7 +1957,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1998,7 +1998,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -2028,7 +2028,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -2057,7 +2057,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -2080,7 +2080,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -119,7 +119,28 @@ spec:
               childGroups:
                 x-kubernetes-preserve-unknown-fields: true
               externalEntitySelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               ipBlock:
                 properties:
                   cidr:
@@ -135,9 +156,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -191,7 +254,28 @@ spec:
               childGroups:
                 x-kubernetes-preserve-unknown-fields: true
               externalEntitySelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               ipBlock:
                 properties:
                   cidr:
@@ -207,9 +291,51 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               podSelector:
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  matchLabels:
+                    type: object
+                type: object
               serviceReference:
                 properties:
                   name:
@@ -289,9 +415,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -309,9 +477,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -341,9 +551,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -365,9 +617,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -384,9 +678,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -484,9 +820,51 @@ spec:
                     group:
                       type: string
                     namespaceSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                     podSelector:
-                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
+                      type: object
                   type: object
                 type: array
               egress:
@@ -504,9 +882,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -536,9 +956,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -560,9 +1022,51 @@ spec:
                           group:
                             type: string
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     enableLogging:
@@ -579,9 +1083,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -661,9 +1207,51 @@ spec:
               appliedTo:
                 properties:
                   namespaceSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                   podSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        type: object
+                    type: object
                 type: object
               egressIP:
                 oneOf:
@@ -845,8 +1433,28 @@ spec:
                 items:
                   properties:
                     podSelector:
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
                       type: object
-                      x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
               egress:
@@ -862,8 +1470,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -885,7 +1513,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -893,9 +1542,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -915,8 +1606,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -925,7 +1636,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -933,9 +1665,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:
@@ -1031,8 +1805,28 @@ spec:
                 items:
                   properties:
                     podSelector:
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        matchLabels:
+                          type: object
                       type: object
-                      x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
               egress:
@@ -1048,8 +1842,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -1071,7 +1885,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -1079,9 +1914,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                   required:
@@ -1101,8 +1978,28 @@ spec:
                       items:
                         properties:
                           podSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
                             type: object
-                            x-kubernetes-preserve-unknown-fields: true
                         type: object
                       type: array
                     enableLogging:
@@ -1111,7 +2008,28 @@ spec:
                       items:
                         properties:
                           externalEntitySelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           ipBlock:
                             properties:
                               cidr:
@@ -1119,9 +2037,51 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                           podSelector:
-                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                type: object
+                            type: object
                         type: object
                       type: array
                     name:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -139,7 +139,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               ipBlock:
                 properties:
@@ -176,7 +176,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               podSelector:
                 properties:
@@ -199,7 +199,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               serviceReference:
                 properties:
@@ -274,7 +274,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               ipBlock:
                 properties:
@@ -311,7 +311,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               podSelector:
                 properties:
@@ -334,7 +334,7 @@ spec:
                       type: object
                     type: array
                   matchLabels:
-                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               serviceReference:
                 properties:
@@ -435,7 +435,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                     podSelector:
                       properties:
@@ -458,7 +458,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -497,7 +497,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -520,7 +520,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -571,7 +571,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -594,7 +594,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -637,7 +637,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -660,7 +660,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -698,7 +698,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -721,7 +721,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -840,7 +840,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                     podSelector:
                       properties:
@@ -863,7 +863,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -902,7 +902,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -925,7 +925,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -976,7 +976,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -999,7 +999,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1042,7 +1042,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1065,7 +1065,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1103,7 +1103,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1126,7 +1126,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1227,7 +1227,7 @@ spec:
                           type: object
                         type: array
                       matchLabels:
-                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                     type: object
                   podSelector:
                     properties:
@@ -1250,7 +1250,7 @@ spec:
                           type: object
                         type: array
                       matchLabels:
-                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                     type: object
                 type: object
               egressIP:
@@ -1453,7 +1453,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -1490,7 +1490,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1533,7 +1533,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -1562,7 +1562,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1585,7 +1585,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1626,7 +1626,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1656,7 +1656,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -1685,7 +1685,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1708,7 +1708,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1825,7 +1825,7 @@ spec:
                             type: object
                           type: array
                         matchLabels:
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
                 type: array
@@ -1862,7 +1862,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1905,7 +1905,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -1934,7 +1934,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1957,7 +1957,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -1998,7 +1998,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array
@@ -2028,7 +2028,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           ipBlock:
                             properties:
@@ -2057,7 +2057,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -2080,7 +2080,7 @@ spec:
                                   type: object
                                 type: array
                               matchLabels:
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                         type: object
                       type: array

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -25,6 +25,7 @@ spec:
                 type: object
                 properties:
                   podSelector:
+                    type: object
                     properties:
                       matchExpressions:
                         type: array
@@ -45,9 +46,9 @@ spec:
                               items:
                                 type: string
                       matchLabels:
-                        type: object
-                    type: object
+                        x-kubernetes-preserve-unknown-fields: true
                   namespaceSelector:
+                    type: object
                     properties:
                       matchExpressions:
                         type: array
@@ -68,8 +69,7 @@ spec:
                               items:
                                 type: string
                       matchLabels:
-                        type: object
-                    type: object
+                        x-kubernetes-preserve-unknown-fields: true
               egressIP:
                 type: string
                 oneOf:
@@ -476,6 +476,7 @@ spec:
                     # Ensure that Spec.AppliedTo does not allow IPBlock field
                     properties:
                       podSelector:
+                        type: object
                         properties:
                           matchExpressions:
                             type: array
@@ -496,9 +497,9 @@ spec:
                                   items:
                                     type: string
                           matchLabels:
-                            type: object
-                        type: object
+                            x-kubernetes-preserve-unknown-fields: true
                       namespaceSelector:
+                        type: object
                         properties:
                           matchExpressions:
                             type: array
@@ -519,8 +520,7 @@ spec:
                                   items:
                                     type: string
                           matchLabels:
-                            type: object
-                        type: object
+                            x-kubernetes-preserve-unknown-fields: true
                       group:
                         type: string
                 ingress:
@@ -537,6 +537,7 @@ spec:
                           # Ensure that rule AppliedTo does not allow IPBlock field
                           properties:
                             podSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -557,9 +558,9 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             namespaceSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -580,8 +581,7 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             group:
                               type: string
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
@@ -605,6 +605,7 @@ spec:
                           type: object
                           properties:
                             podSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -625,9 +626,9 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             namespaceSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -648,8 +649,7 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             ipBlock:
                               type: object
                               properties:
@@ -676,6 +676,7 @@ spec:
                           # Ensure that rule AppliedTo does not allow IPBlock field
                           properties:
                             podSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -696,9 +697,9 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             namespaceSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -719,8 +720,7 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             group:
                               type: string
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
@@ -744,6 +744,7 @@ spec:
                           type: object
                           properties:
                             podSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -764,9 +765,9 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             namespaceSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -787,8 +788,7 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             ipBlock:
                               type: object
                               properties:
@@ -901,7 +901,7 @@ spec:
                                   items:
                                     type: string
                           matchLabels:
-                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                 ingress:
                   type: array
                   items:
@@ -937,7 +937,7 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
                       action:
                         type: string
@@ -959,6 +959,7 @@ spec:
                           type: object
                           properties:
                             podSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -979,9 +980,9 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             namespaceSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -1002,9 +1003,9 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             externalEntitySelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -1025,8 +1026,7 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             ipBlock:
                               type: object
                               properties:
@@ -1072,7 +1072,7 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
                       action:
                         type: string
@@ -1094,6 +1094,7 @@ spec:
                           type: object
                           properties:
                             podSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -1114,9 +1115,9 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             namespaceSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -1137,9 +1138,9 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             externalEntitySelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -1160,8 +1161,7 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             ipBlock:
                               type: object
                               properties:
@@ -1269,6 +1269,7 @@ spec:
                 childGroups:
                   x-kubernetes-preserve-unknown-fields: true
                 podSelector:
+                  type: object
                   properties:
                     matchExpressions:
                       type: array
@@ -1289,9 +1290,9 @@ spec:
                             items:
                               type: string
                     matchLabels:
-                      type: object
-                  type: object
+                      x-kubernetes-preserve-unknown-fields: true
                 namespaceSelector:
+                  type: object
                   properties:
                     matchExpressions:
                       type: array
@@ -1312,9 +1313,9 @@ spec:
                             items:
                               type: string
                     matchLabels:
-                      type: object
-                  type: object
+                      x-kubernetes-preserve-unknown-fields: true
                 externalEntitySelector:
+                  type: object
                   properties:
                     matchExpressions:
                       type: array
@@ -1335,8 +1336,7 @@ spec:
                             items:
                               type: string
                     matchLabels:
-                      type: object
-                  type: object
+                      x-kubernetes-preserve-unknown-fields: true
                 ipBlock:
                   type: object
                   properties:
@@ -1706,6 +1706,7 @@ spec:
                     # Ensure that Spec.AppliedTo does not allow IPBlock field
                     properties:
                       podSelector:
+                        type: object
                         properties:
                           matchExpressions:
                             type: array
@@ -1726,9 +1727,9 @@ spec:
                                   items:
                                     type: string
                           matchLabels:
-                            type: object
-                        type: object
+                            x-kubernetes-preserve-unknown-fields: true
                       namespaceSelector:
+                        type: object
                         properties:
                           matchExpressions:
                             type: array
@@ -1749,8 +1750,7 @@ spec:
                                   items:
                                     type: string
                           matchLabels:
-                            type: object
-                        type: object
+                            x-kubernetes-preserve-unknown-fields: true
                       group:
                         type: string
                 ingress:
@@ -1767,6 +1767,7 @@ spec:
                           # Ensure that rule AppliedTo does not allow IPBlock field
                           properties:
                             podSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -1787,9 +1788,9 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             namespaceSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -1810,8 +1811,7 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             group:
                               type: string
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
@@ -1835,6 +1835,7 @@ spec:
                           type: object
                           properties:
                             podSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -1855,9 +1856,9 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             namespaceSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -1878,8 +1879,7 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             ipBlock:
                               type: object
                               properties:
@@ -1906,6 +1906,7 @@ spec:
                           # Ensure that rule AppliedTo does not allow IPBlock field
                           properties:
                             podSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -1926,9 +1927,9 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             namespaceSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -1949,8 +1950,7 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             group:
                               type: string
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
@@ -1974,6 +1974,7 @@ spec:
                           type: object
                           properties:
                             podSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -1994,9 +1995,9 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             namespaceSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -2017,8 +2018,7 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             ipBlock:
                               type: object
                               properties:
@@ -2132,7 +2132,7 @@ spec:
                                   items:
                                     type: string
                           matchLabels:
-                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                 ingress:
                   type: array
                   items:
@@ -2147,6 +2147,7 @@ spec:
                           # Ensure that rule AppliedTo does not allow NamespaceSelector/IPBlock field
                           properties:
                             podSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -2167,8 +2168,7 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
                       action:
                         type: string
@@ -2190,6 +2190,7 @@ spec:
                           type: object
                           properties:
                             podSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -2210,9 +2211,9 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             namespaceSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -2233,9 +2234,9 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             externalEntitySelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -2256,8 +2257,7 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             ipBlock:
                               type: object
                               properties:
@@ -2303,7 +2303,7 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
                       action:
                         type: string
@@ -2325,6 +2325,7 @@ spec:
                           type: object
                           properties:
                             podSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -2345,9 +2346,9 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             namespaceSelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -2368,9 +2369,9 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             externalEntitySelector:
+                              type: object
                               properties:
                                 matchExpressions:
                                   type: array
@@ -2391,8 +2392,7 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  type: object
-                              type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                             ipBlock:
                               type: object
                               properties:
@@ -2502,6 +2502,7 @@ spec:
                 childGroups:
                   x-kubernetes-preserve-unknown-fields: true
                 podSelector:
+                  type: object
                   properties:
                     matchExpressions:
                       type: array
@@ -2522,9 +2523,9 @@ spec:
                             items:
                               type: string
                     matchLabels:
-                      type: object
-                  type: object
+                      x-kubernetes-preserve-unknown-fields: true
                 namespaceSelector:
+                  type: object
                   properties:
                     matchExpressions:
                       type: array
@@ -2545,9 +2546,9 @@ spec:
                             items:
                               type: string
                     matchLabels:
-                      type: object
-                  type: object
+                      x-kubernetes-preserve-unknown-fields: true
                 externalEntitySelector:
+                  type: object
                   properties:
                     matchExpressions:
                       type: array
@@ -2568,8 +2569,7 @@ spec:
                             items:
                               type: string
                     matchLabels:
-                      type: object
-                  type: object
+                      x-kubernetes-preserve-unknown-fields: true
                 ipBlock:
                   type: object
                   properties:

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -25,9 +25,51 @@ spec:
                 type: object
                 properties:
                   podSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                              type: string
+                            values:
+                              type: array
+                              items:
+                                type: string
+                      matchLabels:
+                        type: object
+                    type: object
                   namespaceSelector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      matchExpressions:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                              type: string
+                            values:
+                              type: array
+                              items:
+                                type: string
+                      matchLabels:
+                        type: object
+                    type: object
               egressIP:
                 type: string
                 oneOf:
@@ -434,9 +476,51 @@ spec:
                     # Ensure that Spec.AppliedTo does not allow IPBlock field
                     properties:
                       podSelector:
-                        x-kubernetes-preserve-unknown-fields: true
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            type: object
+                        type: object
                       namespaceSelector:
-                        x-kubernetes-preserve-unknown-fields: true
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            type: object
+                        type: object
                       group:
                         type: string
                 ingress:
@@ -453,9 +537,51 @@ spec:
                           # Ensure that rule AppliedTo does not allow IPBlock field
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             group:
                               type: string
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
@@ -479,9 +605,51 @@ spec:
                           type: object
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             ipBlock:
                               type: object
                               properties:
@@ -508,9 +676,51 @@ spec:
                           # Ensure that rule AppliedTo does not allow IPBlock field
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             group:
                               type: string
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
@@ -534,9 +744,51 @@ spec:
                           type: object
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             ipBlock:
                               type: object
                               properties:
@@ -629,7 +881,27 @@ spec:
                     properties:
                       podSelector:
                         type: object
-                        x-kubernetes-preserve-unknown-fields: true
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            type: object
                 ingress:
                   type: array
                   items:
@@ -645,7 +917,27 @@ spec:
                           properties:
                             podSelector:
                               type: object
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
                       action:
                         type: string
@@ -667,11 +959,74 @@ spec:
                           type: object
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             externalEntitySelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             ipBlock:
                               type: object
                               properties:
@@ -697,7 +1052,27 @@ spec:
                           properties:
                             podSelector:
                               type: object
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
                       action:
                         type: string
@@ -719,11 +1094,74 @@ spec:
                           type: object
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             externalEntitySelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             ipBlock:
                               type: object
                               properties:
@@ -831,11 +1269,74 @@ spec:
                 childGroups:
                   x-kubernetes-preserve-unknown-fields: true
                 podSelector:
-                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    matchExpressions:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                            type: string
+                          values:
+                            type: array
+                            items:
+                              type: string
+                    matchLabels:
+                      type: object
+                  type: object
                 namespaceSelector:
-                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    matchExpressions:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                            type: string
+                          values:
+                            type: array
+                            items:
+                              type: string
+                    matchLabels:
+                      type: object
+                  type: object
                 externalEntitySelector:
-                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    matchExpressions:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                            type: string
+                          values:
+                            type: array
+                            items:
+                              type: string
+                    matchLabels:
+                      type: object
+                  type: object
                 ipBlock:
                   type: object
                   properties:
@@ -1205,9 +1706,51 @@ spec:
                     # Ensure that Spec.AppliedTo does not allow IPBlock field
                     properties:
                       podSelector:
-                        x-kubernetes-preserve-unknown-fields: true
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            type: object
+                        type: object
                       namespaceSelector:
-                        x-kubernetes-preserve-unknown-fields: true
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            type: object
+                        type: object
                       group:
                         type: string
                 ingress:
@@ -1224,9 +1767,51 @@ spec:
                           # Ensure that rule AppliedTo does not allow IPBlock field
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             group:
                               type: string
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
@@ -1250,9 +1835,51 @@ spec:
                           type: object
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             ipBlock:
                               type: object
                               properties:
@@ -1279,9 +1906,51 @@ spec:
                           # Ensure that rule AppliedTo does not allow IPBlock field
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             group:
                               type: string
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
@@ -1305,9 +1974,51 @@ spec:
                           type: object
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             ipBlock:
                               type: object
                               properties:
@@ -1401,7 +2112,27 @@ spec:
                     properties:
                       podSelector:
                         type: object
-                        x-kubernetes-preserve-unknown-fields: true
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            type: object
                 ingress:
                   type: array
                   items:
@@ -1416,8 +2147,28 @@ spec:
                           # Ensure that rule AppliedTo does not allow NamespaceSelector/IPBlock field
                           properties:
                             podSelector:
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
                               type: object
-                              x-kubernetes-preserve-unknown-fields: true
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
                       action:
                         type: string
@@ -1439,11 +2190,74 @@ spec:
                           type: object
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             externalEntitySelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             ipBlock:
                               type: object
                               properties:
@@ -1469,7 +2283,27 @@ spec:
                           properties:
                             podSelector:
                               type: object
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
                       # Ensure that Action field allows only ALLOW, DROP and REJECT values
                       action:
                         type: string
@@ -1491,11 +2325,74 @@ spec:
                           type: object
                           properties:
                             podSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             namespaceSelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             externalEntitySelector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                              type: object
                             ipBlock:
                               type: object
                               properties:
@@ -1605,11 +2502,74 @@ spec:
                 childGroups:
                   x-kubernetes-preserve-unknown-fields: true
                 podSelector:
-                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    matchExpressions:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                            type: string
+                          values:
+                            type: array
+                            items:
+                              type: string
+                    matchLabels:
+                      type: object
+                  type: object
                 namespaceSelector:
-                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    matchExpressions:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                            type: string
+                          values:
+                            type: array
+                            items:
+                              type: string
+                    matchLabels:
+                      type: object
+                  type: object
                 externalEntitySelector:
-                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    matchExpressions:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                            type: string
+                          values:
+                            type: array
+                            items:
+                              type: string
+                    matchLabels:
+                      type: object
+                  type: object
                 ipBlock:
                   type: object
                   properties:

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -664,6 +664,36 @@ func testInvalidTierANPRefDelete(t *testing.T) {
 	failOnError(k8sUtils.DeleteTier(tr.Name), t)
 }
 
+// testInvalidACNPPodSelectorNsSelectorMatchExpressions testes creating a ClusterNetworkPolicy with invalid LabelSelector(MatchExpressions)
+func testInvalidACNPPodSelectorNsSelectorMatchExpressions(t *testing.T) {
+	invalidLSErr := fmt.Errorf("create Antrea NetworkPolicy with namespaceSelector but matchExpressions invalid")
+
+	allowAction := crdv1alpha1.RuleActionAllow
+	selectorA := metav1.LabelSelector{MatchLabels: map[string]string{"env": "dummy"}}
+	nsSelectA := metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "env", Operator: "xxx", Values: []string{"xxxx"}}}}
+
+	var acnp = &crdv1alpha1.ClusterNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace, Name: "cnptest", Labels: map[string]string{"antrea-e2e": "cnp1"}},
+		Spec: crdv1alpha1.ClusterNetworkPolicySpec{
+			AppliedTo: []crdv1alpha1.NetworkPolicyPeer{
+				{PodSelector: &selectorA},
+				{NamespaceSelector: &nsSelectA},
+			},
+			Priority: 10,
+			Ingress: []crdv1alpha1.Rule{
+				{
+					Action: &allowAction,
+				},
+			},
+		},
+	}
+
+	if _, err := k8sUtils.CreateOrUpdateACNP(acnp); err == nil {
+		failOnError(invalidLSErr, t)
+	}
+}
+
 // testACNPAllowXBtoA tests traffic from X/B to pods with label A, after applying the default deny
 // k8s NetworkPolicies in all namespaces and ACNP to allow X/B to A.
 func testACNPAllowXBtoA(t *testing.T) {
@@ -2560,6 +2590,7 @@ func TestAntreaPolicy(t *testing.T) {
 		t.Run("Case=ANPTierDoesNotExistDenied", func(t *testing.T) { testInvalidANPTierDoesNotExist(t) })
 		t.Run("Case=ANPPortRangePortUnsetDenied", func(t *testing.T) { testInvalidANPPortRangePortUnset(t) })
 		t.Run("Case=ANPPortRangePortEndPortSmallDenied", func(t *testing.T) { testInvalidANPPortRangeEndPortSmall(t) })
+		t.Run("Case=ACNPInvalidPodSelectorNsSelectorMatchExpressions", func(t *testing.T) { testInvalidACNPPodSelectorNsSelectorMatchExpressions(t) })
 	})
 
 	t.Run("TestGroupValidateTiers", func(t *testing.T) {
@@ -2994,80 +3025,4 @@ func TestAntreaClusterNetworkPolicyStats(t *testing.T) {
 		failOnError(err, t)
 	}
 	k8sUtils.Cleanup(namespaces)
-}
-
-func testInvalidACNPPodSelectorNsSelectorMatchExpressions(t *testing.T) {
-	invalidLSErr := fmt.Errorf("invalid Antrea NetworkPolicy with namespaceSelector but matchExpressions invalid")
-
-	allowAction := crdv1alpha1.RuleActionAllow
-	selectorA := metav1.LabelSelector{MatchLabels: map[string]string{"env": "dummy"}}
-	nsSelectA := metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "env", Operator: "xxx", Values: []string{"xxxx"}}}}
-
-	var acnp = &crdv1alpha1.ClusterNetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testNamespace, Name: "cnptest", Labels: map[string]string{"antrea-e2e": "cnp1"}},
-		Spec: crdv1alpha1.ClusterNetworkPolicySpec{
-			AppliedTo: []crdv1alpha1.NetworkPolicyPeer{
-				{PodSelector: &selectorA},
-				{NamespaceSelector: &nsSelectA},
-			},
-			Priority: 10,
-			Ingress: []crdv1alpha1.Rule{
-				{
-					Action: &allowAction,
-				},
-			},
-		},
-	}
-
-	if _, err := k8sUtils.CreateOrUpdateACNP(acnp); err == nil {
-		failOnError(invalidLSErr, t)
-	}
-}
-
-func testInvalidCGPPodSelectorNsSelectorMatchExpressions(t *testing.T) {
-	invalidLSErr := fmt.Errorf("invalid clustergroup with namespaceSelector but matchExpressions invalid")
-
-	nsSelectA := metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "env", Operator: "xxx", Values: []string{"xxxx"}}}}
-
-	cgName := "cg-test"
-	cg := &crdv1alpha2.ClusterGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: cgName,
-		},
-		Spec: crdv1alpha2.GroupSpec{
-			NamespaceSelector: &nsSelectA,
-		},
-	}
-	if _, err := k8sUtils.CreateOrUpdateCG(cg); err == nil {
-		// Above creation of CG must fail as it is an invalid spec.
-		failOnError(invalidLSErr, t)
-	}
-}
-
-func TestInvalidLabelSelectorInResource(t *testing.T) {
-	data, err := setupTest(t)
-	if err != nil {
-		t.Fatalf("Error when setting up test: %v", err)
-	}
-	defer teardownTest(t, data)
-	initK8s := func() {
-		skipIfAntreaPolicyDisabled(t, data)
-		var err error
-		// k8sUtils is a global var
-		k8sUtils, err = NewKubernetesUtils(data)
-		failOnError(err, t)
-	}
-	if k8sUtils == nil {
-		initK8s()
-	}
-
-	t.Run("TestGroupInvalidLabelSelectorInResource", func(t *testing.T) {
-		t.Run("Case=InvalidACNPPodSelectorNsSelectorMatchExpressions", func(t *testing.T) {
-			testInvalidACNPPodSelectorNsSelectorMatchExpressions(t)
-		})
-		t.Run("CASE=InvalidCGPPodSelectorNsSelectorMatchExpressions", func(t *testing.T) {
-			testInvalidCGPPodSelectorNsSelectorMatchExpressions(t)
-		})
-	})
 }


### PR DESCRIPTION
Add namespaceSelector/podSelector validations in all CRD schema.

The incorrect input of labelSelector fields that have known schema should be rejected;

In the following example, we want to create ClusterNetworkPolicy resource:

spec.appliedTo.namespaceSelector must be matchLabels or matchExpressions, 
actually in the existing version the spelling mistake ‘matchLables’ can not be checked out.
Save the CustomResourceDefinition to resourcedefinition.yaml:

`cat acnp_demo.yaml`
```yaml
apiVersion: crd.antrea.io/v1alpha1
kind: ClusterNetworkPolicy
metadata:
  name: blacklist
spec:
    priority: 5
    tier: securityops
    appliedTo:
      - namespaceSelector:
          matchLables:
            env: dummy
    ingress:
      - action: Drop
```

We created it succeeded without any error.

After fixed the issue, we will get the following error message as expected:

`kubectl create -f acnp_demo.yaml`
error: error validating "acnp_demo.yaml": error validating data: ValidationError(ClusterNetworkPolicy.spec.appliedTo[0].namespaceSelector): unknown field "matchLables" in io.antrea.crd.v1alpha1.ClusterNetworkPolicy.spec.appliedTo.namespaceSelector; if you choose to ignore these errors, turn validation off with --validate=false

In addition, all of namespaceSelector/podSelector parameters verification in CRD schema will be improved.

Fix #2090