### PR TITLE
Fix OVS "flow" replay for groups

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -281,6 +281,12 @@ func persistRoundNum(num uint64, bridgeClient ovsconfig.OVSBridgeClient, interva
 // agent restarts (with the agent crashing before step 4 can be completed). With the sequence
 // described above, We guarantee that at most two rounds of flows exist in the switch at any given
 // time.
+// Note that at the moment we assume that all OpenFlow groups are deleted every time there is an
+// Antrea Agent restart. This allows us to add the necessary groups without having to worry about
+// the operation failing because a (stale) group with the same ID already exists in OVS. This
+// assumption is currently guaranteed by the ofnet implementation:
+// https://github.com/wenyingd/ofnet/blob/14a78b27ef8762e45a0cfc858c4d07a4572a99d5/ofctrl/fgraphSwitch.go#L57-L62
+// All previous groups have been deleted by the time the call to i.ofClient.Initialize returns.
 func (i *Initializer) initOpenFlowPipeline() error {
 	roundInfo := getRoundInfo(i.ovsBridgeClient)
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -427,7 +427,7 @@ func (i *Initializer) FlowRestoreComplete() error {
 	if err != nil {
 		if err == wait.ErrWaitTimeout {
 			// This could happen if the method is triggered by OVS disconnection event, in which OVS doesn't restart.
-			klog.Info("flow-restore-wait was not true, skip cleaning up it")
+			klog.Info("flow-restore-wait was not true, skip cleaning it up")
 			return nil
 		}
 		return err

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -753,8 +753,10 @@ func (c *client) ReplayFlows() {
 		return true
 	}
 
-	c.groupCache.Range(func(id, gEntry interface{}) bool {
-		if err := gEntry.(binding.Group).Add(); err != nil {
+	c.groupCache.Range(func(id, value interface{}) bool {
+		group := value.(binding.Group)
+		group.Reset()
+		if err := group.Add(); err != nil {
 			klog.Errorf("Error when replaying cached group %d: %v", id, err)
 		}
 		return true

--- a/pkg/ovs/openflow/ofctrl_bridge.go
+++ b/pkg/ovs/openflow/ofctrl_bridge.go
@@ -150,7 +150,7 @@ type OFBridge struct {
 
 func (b *OFBridge) CreateGroup(id GroupIDType) Group {
 	ofctrlGroup, err := b.ofSwitch.NewGroup(uint32(id), ofctrl.GroupSelect)
-	if err != nil {
+	if err != nil { // group already exists
 		ofctrlGroup = b.ofSwitch.GetGroup(uint32(id))
 	}
 	g := &ofGroup{bridge: b, ofctrl: ofctrlGroup}

--- a/pkg/ovs/openflow/ofctrl_group.go
+++ b/pkg/ovs/openflow/ofctrl_group.go
@@ -26,8 +26,17 @@ type ofGroup struct {
 	bridge *OFBridge
 }
 
+// Reset creates a new ofctrl.Group object for the updated ofSwitch. The
+// ofSwitch keeps a list of all Group objects, so this operation is
+// needed. Reset() should be called before replaying the Group to OVS.
 func (g *ofGroup) Reset() {
-	g.ofctrl.Switch = g.bridge.ofSwitch
+	// An error ("group already exists") is not possible here since the same
+	// group was created successfully before. If something is wrong and
+	// there is an error, g.ofctrl will be set to nil and the Agent will
+	// crash later.
+	newGroup, _ := g.bridge.ofSwitch.NewGroup(g.ofctrl.ID, g.ofctrl.GroupType)
+	newGroup.Buckets = g.ofctrl.Buckets
+	g.ofctrl = newGroup
 }
 
 func (g *ofGroup) Add() error {

--- a/pkg/ovs/openflow/ofctrl_group.go
+++ b/pkg/ovs/openflow/ofctrl_group.go
@@ -30,10 +30,11 @@ type ofGroup struct {
 // ofSwitch keeps a list of all Group objects, so this operation is
 // needed. Reset() should be called before replaying the Group to OVS.
 func (g *ofGroup) Reset() {
-	// An error ("group already exists") is not possible here since the same
-	// group was created successfully before. If something is wrong and
-	// there is an error, g.ofctrl will be set to nil and the Agent will
-	// crash later.
+	// An error ("group already exists") is not possible here since we are
+	// using a new instance of ofSwitch and re-creating a group which was
+	// created successfully before. There will be no duplicate group IDs. If
+	// something is wrong and there is an error, g.ofctrl will be set to nil
+	// and the Agent will crash later.
 	newGroup, _ := g.bridge.ofSwitch.NewGroup(g.ofctrl.ID, g.ofctrl.GroupType)
 	newGroup.Buckets = g.ofctrl.Buckets
 	g.ofctrl = newGroup


### PR DESCRIPTION
The Group objects were not reset correctly when attempting to replay
them, leading to confusing error log messages and invalid datapath
state. We fix the implementation of Reset() for groups and we ensure
that the method is called during replay.

We also update the TestOVSFlowReplay e2e test to make sure it is more
comprehensive: instead of just checking Pod-to-Pod connectivity after a
replay, we ensure that the number of OVS flows / groups is the same
before and after a restart / replay. We confirmed that the updated test
fails when the patch is not applied.

Fixes #2127