### PR TITLE
Add script for semi-automatic bug fix backporting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,14 @@ cases to our [automated test suite](ci/README.md) to guarantee enough
 coverage. A PR that makes significant code changes without contributing new test
 cases will be flagged by reviewers and will not be accepted.
 
+### Cherry-picks to release branches
+
+If your PR fixes a critical bug, it may need to be backported to older release
+branches which are still maintained. If this is the case, one of the Antrea
+maintainers will let you know once your PR is approved. Please refer to the
+documentation on [cherry-picks](docs/contributors/cherry-picks.md) for more
+information.
+
 ### Inclusive Naming
 
 For symbol names and documentation, do not introduce new usage of harmful

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,21 +5,23 @@ Thank you for taking the time out to contribute to project Antrea!
 This guide will walk you through the process of making your first commit and how
 to effectively get it merged upstream.
 
-- [Developer Guide](#developer-guide)
-  - [Getting Started](#getting-started)
-    - [CLA](#cla)
-    - [Accounts Setup](#accounts-setup)
-  - [Contribute](#contribute)
-    - [GitHub Workflow](#github-workflow)
-    - [Getting reviewers](#getting-reviewers)
-    - [Inclusive Naming](#inclusive-naming)
-    - [Building and testing your change](#building-and-testing-your-change)
-    - [CI testing](#ci-testing)
-    - [Reverting a commit](#reverting-a-commit)
-  - [Issue and PR Management](#issue-and-pr-management)
-    - [Filing An Issue](#filing-an-issue)
-    - [Issue Triage](#issue-triage)
-    - [Issue and PR Kinds](#issue-and-pr-kinds)
+<!-- toc -->
+- [Getting Started](#getting-started)
+  - [CLA](#cla)
+  - [Accounts Setup](#accounts-setup)
+- [Contribute](#contribute)
+  - [GitHub Workflow](#github-workflow)
+  - [Getting reviewers](#getting-reviewers)
+  - [Cherry-picks to release branches](#cherry-picks-to-release-branches)
+  - [Inclusive Naming](#inclusive-naming)
+  - [Building and testing your change](#building-and-testing-your-change)
+  - [CI testing](#ci-testing)
+  - [Reverting a commit](#reverting-a-commit)
+- [Issue and PR Management](#issue-and-pr-management)
+  - [Filing An Issue](#filing-an-issue)
+  - [Issue Triage](#issue-triage)
+  - [Issue and PR Kinds](#issue-and-pr-kinds)
+<!-- /toc -->
 
 ## Getting Started
 

--- a/docs/contributors/cherry-picks.md
+++ b/docs/contributors/cherry-picks.md
@@ -1,0 +1,64 @@
+# Cherry-picks to release branches
+
+Some Pull Requests (PRs) which fix bugs in the main branch of Antrea can be
+identified as good candidates for backporting to currently maintained release
+branches (using a Git [cherry-pick](https://git-scm.com/docs/git-cherry-pick)),
+so that they can be included in subsequent patch releases. If you have authored
+such a PR (thank you!!!), one of the Antrea maintainers may comment on your PR
+to ask for your assistance with that process. This document provides the steps
+you can use to cherry-pick your change to one or more release branches, with the
+help of the [cherry-pick script][cherry-pick-script].
+
+For information about which changes are good candidates for cherry-picking,
+please refer to our [versioning
+policy](../versioning.md#minor-releases-and-patch-releases).
+
+## Prerequisites
+
+* A PR which was approved and merged into the main branch.
+* The PR was identified as a good candidate for backporting by an Antrea
+  maintainer: they will leave a comment on Github for the PR and provide a list
+  of release branches to which the patch should be backported (example:
+  [`release-1.0`](https://github.com/vmware-tanzu/antrea/tree/release-1.0)).
+* Have the [Github CLI](https://cli.github.com/) installed (version >= 1.3) and
+  make sure you authenticate yourself by running `gh auth`.
+* Your own fork of the Antrea repository, and a clone of this fork with two
+  remotes: the `origin` remote tracking your fork and the `upstream` remote
+  tracking the upstream Antrea repository. If you followed our recommended
+  [Github Workflow], this should already be the case.
+
+## Cherry-pick your changes
+
+* Set the GITHUB_USER environment variable.
+* _Optional_ If your remote names do not match our recommended [Github
+  Workflow], you must set the `UPSTREAM_REMOTE` and `FORK_REMOTE` environment
+  variables.
+* Run the [cherry-pick script][cherry-pick-script]
+
+  This example applies a main branch PR #2134 to the remote branch
+  `upstream/release-1.0`:
+
+  ```shell
+  hack/cherry-pick-pull.sh upstream/release-1.0 2134
+  ```
+
+  If the cherry-picked PR does not apply cleanly against an old release branch,
+  the script will let you resolve conflicts manually. This is one of the reasons
+  why we ask contributors to backport their own bug fixes, as thei participation
+  is critical in case of such a conflict.
+
+The script will create a PR on Github for you, which will automatically be
+labelled with `kind/cherry-pick`. This PR will go through the normal testing
+process, although it should be very quickly given that the original PR was
+already approved and merged into the main branch. The PR should also go through
+normal CI testing. In some cases, a few CI tests may fail because we do not have
+dedicated CI infrastructure for past Antrea releases. If this happens, the PR
+will be merged despite the presence of CI test failures.
+
+You will need to run the cherry pick script separately for each release branch
+you need to cherry-pick to. Typically, cherry-picks should be applied to all
+[maintained](../versioning.md#release-cycle) release branches for which the fix
+is applicable.
+
+[cherry-pick-script]: ../../hack/cherry-pick-pull.sh
+[Github Workflow]: ../../CONTRIBUTING.md#github-workflow

--- a/docs/contributors/cherry-picks.md
+++ b/docs/contributors/cherry-picks.md
@@ -44,14 +44,14 @@ policy](../versioning.md#minor-releases-and-patch-releases).
 
   If the cherry-picked PR does not apply cleanly against an old release branch,
   the script will let you resolve conflicts manually. This is one of the reasons
-  why we ask contributors to backport their own bug fixes, as thei participation
-  is critical in case of such a conflict.
+  why we ask contributors to backport their own bug fixes, as their
+  participation is critical in case of such a conflict.
 
 The script will create a PR on Github for you, which will automatically be
 labelled with `kind/cherry-pick`. This PR will go through the normal testing
-process, although it should be very quickly given that the original PR was
-already approved and merged into the main branch. The PR should also go through
-normal CI testing. In some cases, a few CI tests may fail because we do not have
+process, although it should be very quick given that the original PR was already
+approved and merged into the main branch. The PR should also go through normal
+CI testing. In some cases, a few CI tests may fail because we do not have
 dedicated CI infrastructure for past Antrea releases. If this happens, the PR
 will be merged despite the presence of CI test failures.
 

--- a/docs/contributors/github-labels.md
+++ b/docs/contributors/github-labels.md
@@ -79,6 +79,7 @@ The labels in this list originated within Kubernetes at
 | area/transit/routing               | Issues or PRs related to routing and forwarding | Any |
 | kind/api-change                    | Categorizes issue or PR as related to adding, removing, or otherwise changing an API. | Any |
 | kind/bug                           | Categorizes issue or PR as related to a bug.              | Any                |
+| kind/cherry-pick                   | Categorizes issue or PR as related to the cherry-pick of a bug fix from the main branch to a release branch | Any |
 | kind/cleanup                       | Categorizes issue or PR as related to cleaning up code, process, or technical debt | Any |
 | kind/deprecation                   | Categorizes issue or PR as related to feature marked for deprecation | Any |
 | kind/design                        | Categorizes issue or PR as related to design | Any |

--- a/hack/.notableofcontents
+++ b/hack/.notableofcontents
@@ -3,6 +3,7 @@ docs/api.md
 docs/antrea-agent-simulator.md
 docs/assets/README.md
 docs/assets/logo/README.md
+docs/contributors/cherry-picks.md
 docs/contributors/code-generation.md
 docs/contributors/eks-terraform.md
 docs/contributors/github-labels.md

--- a/hack/cherry-pick-pull.sh
+++ b/hack/cherry-pick-pull.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 Antrea Authors.
+# Copyright 2015 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This files is a copy of
+# https://github.com/kubernetes/kubernetes/blob/6c3654db1b30020150ec3ff51926454be9675519/hack/cherry_pick_pull.sh
+# with some changes: remove REGENERATE_DOCS, add 'kind/cherry-pick' label when
+# creating PR
+
+# Usage Instructions: https://github.com/vmware-tanzu/antrea/blob/main/docs/contributors/cherry-picks.md
+
+# Checkout a PR from GitHub. (Yes, this is sitting in a Git tree. How
+# meta.) Assumes you care about pulls from remote "upstream" and
+# checks them out to a branch named:
+#  automated-cherry-pick-of-<pr>-<target branch>-<timestamp>
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+declare -r REPO_ROOT
+cd "${REPO_ROOT}"
+
+STARTINGBRANCH=$(git symbolic-ref --short HEAD)
+declare -r STARTINGBRANCH
+declare -r REBASEMAGIC="${REPO_ROOT}/.git/rebase-apply"
+DRY_RUN=${DRY_RUN:-""}
+UPSTREAM_REMOTE=${UPSTREAM_REMOTE:-upstream}
+FORK_REMOTE=${FORK_REMOTE:-origin}
+MAIN_REPO_ORG=${MAIN_REPO_ORG:-$(git remote get-url "$UPSTREAM_REMOTE" | awk '{gsub(/http[s]:\/\/|git@/,"")}1' | awk -F'[@:./]' 'NR==1{print $3}')}
+MAIN_REPO_NAME=${MAIN_REPO_NAME:-$(git remote get-url "$UPSTREAM_REMOTE" | awk '{gsub(/http[s]:\/\/|git@/,"")}1' | awk -F'[@:./]' 'NR==1{print $4}')}
+
+if [[ -z ${GITHUB_USER:-} ]]; then
+  echo "Please export GITHUB_USER=<your-user> (or GH organization, if that's where your fork lives)"
+  exit 1
+fi
+
+if ! command -v gh > /dev/null; then
+  echo "Can't find 'gh' tool in PATH, please install from https://github.com/cli/cli"
+  exit 1
+fi
+
+if [[ "$#" -lt 2 ]]; then
+  echo "${0} <remote branch> <pr-number>...: cherry pick one or more <pr> onto <remote branch> and leave instructions for proposing pull request"
+  echo
+  echo "  Checks out <remote branch> and handles the cherry-pick of <pr> (possibly multiple) for you."
+  echo "  Examples:"
+  echo "    $0 upstream/release-3.14 12345        # Cherry-picks PR 12345 onto upstream/release-3.14 and proposes that as a PR."
+  echo "    $0 upstream/release-3.14 12345 56789  # Cherry-picks PR 12345, then 56789 and proposes the combination as a single PR."
+  echo
+  echo "  Set the DRY_RUN environment var to skip git push and creating PR."
+  echo "  This is useful for creating patches to a release branch without making a PR."
+  echo "  When DRY_RUN is set the script will leave you in a branch containing the commits you cherry-picked."
+  echo
+  echo "  Set UPSTREAM_REMOTE (default: upstream) and FORK_REMOTE (default: origin)"
+  echo "  to override the default remote names to what you have locally."
+  echo
+  echo "  For merge process info, see https://github.com/vmware-tanzu/antrea/blob/main/docs/contributors/cherry-picks.md"
+  exit 2
+fi
+
+# Checks if you are logged in. Will error/bail if you are not.
+gh auth status
+
+if git_status=$(git status --porcelain --untracked=no 2>/dev/null) && [[ -n "${git_status}" ]]; then
+  echo "!!! Dirty tree. Clean up and try again."
+  exit 1
+fi
+
+if [[ -e "${REBASEMAGIC}" ]]; then
+  echo "!!! 'git rebase' or 'git am' in progress. Clean up and try again."
+  exit 1
+fi
+
+declare -r BRANCH="$1"
+shift 1
+declare -r PULLS=( "$@" )
+
+function join { local IFS="$1"; shift; echo "$*"; }
+PULLDASH=$(join - "${PULLS[@]/#/#}") # Generates something like "#12345-#56789"
+declare -r PULLDASH
+PULLSUBJ=$(join " " "${PULLS[@]/#/#}") # Generates something like "#12345 #56789"
+declare -r PULLSUBJ
+
+echo "+++ Updating remotes..."
+git remote update "${UPSTREAM_REMOTE}" "${FORK_REMOTE}"
+
+if ! git log -n1 --format=%H "${BRANCH}" >/dev/null 2>&1; then
+  echo "!!! '${BRANCH}' not found. The second argument should be something like ${UPSTREAM_REMOTE}/release-0.21."
+  echo "    (In particular, it needs to be a valid, existing remote branch that I can 'git checkout'.)"
+  exit 1
+fi
+
+NEWBRANCHREQ="automated-cherry-pick-of-${PULLDASH}" # "Required" portion for tools.
+declare -r NEWBRANCHREQ
+NEWBRANCH="$(echo "${NEWBRANCHREQ}-${BRANCH}" | sed 's/\//-/g')"
+declare -r NEWBRANCH
+NEWBRANCHUNIQ="${NEWBRANCH}-$(date +%s)"
+declare -r NEWBRANCHUNIQ
+echo "+++ Creating local branch ${NEWBRANCHUNIQ}"
+
+cleanbranch=""
+gitamcleanup=false
+function return_to_kansas {
+  if [[ "${gitamcleanup}" == "true" ]]; then
+    echo
+    echo "+++ Aborting in-progress git am."
+    git am --abort >/dev/null 2>&1 || true
+  fi
+
+  # return to the starting branch and delete the PR text file
+  if [[ -z "${DRY_RUN}" ]]; then
+    echo
+    echo "+++ Returning you to the ${STARTINGBRANCH} branch and cleaning up."
+    git checkout -f "${STARTINGBRANCH}" >/dev/null 2>&1 || true
+    if [[ -n "${cleanbranch}" ]]; then
+      git branch -D "${cleanbranch}" >/dev/null 2>&1 || true
+    fi
+  fi
+}
+trap return_to_kansas EXIT
+
+SUBJECTS=()
+function make-a-pr() {
+  local rel
+  rel="$(basename "${BRANCH}")"
+  echo
+  echo "+++ Creating a pull request on GitHub at ${GITHUB_USER}:${NEWBRANCH}"
+
+  local numandtitle
+  numandtitle=$(printf '%s\n' "${SUBJECTS[@]}")
+  prtext=$(cat <<EOF
+Cherry pick of ${PULLSUBJ} on ${rel}.
+
+${numandtitle}
+
+For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
+EOF
+)
+
+  gh pr create --label="kind/cherry-pick" --title="Automated cherry pick of ${numandtitle}" --body="${prtext}" --head "${GITHUB_USER}:${NEWBRANCH}" --base "${rel}" --repo="${MAIN_REPO_ORG}/${MAIN_REPO_NAME}"
+}
+
+git checkout -b "${NEWBRANCHUNIQ}" "${BRANCH}"
+cleanbranch="${NEWBRANCHUNIQ}"
+
+gitamcleanup=true
+for pull in "${PULLS[@]}"; do
+  echo "+++ Downloading patch to /tmp/${pull}.patch (in case you need to do this again)"
+
+  curl -o "/tmp/${pull}.patch" -sSL "https://github.com/${MAIN_REPO_ORG}/${MAIN_REPO_NAME}/pull/${pull}.patch"
+  echo
+  echo "+++ About to attempt cherry pick of PR. To reattempt:"
+  echo "  $ git am -3 /tmp/${pull}.patch"
+  echo
+  git am -3 "/tmp/${pull}.patch" || {
+    conflicts=false
+    while unmerged=$(git status --porcelain | grep ^U) && [[ -n ${unmerged} ]] \
+      || [[ -e "${REBASEMAGIC}" ]]; do
+      conflicts=true # <-- We should have detected conflicts once
+      echo
+      echo "+++ Conflicts detected:"
+      echo
+      (git status --porcelain | grep ^U) || echo "!!! None. Did you git am --continue?"
+      echo
+      echo "+++ Please resolve the conflicts in another window (and remember to 'git add / git am --continue')"
+      read -p "+++ Proceed (anything but 'y' aborts the cherry-pick)? [y/n] " -r
+      echo
+      if ! [[ "${REPLY}" =~ ^[yY]$ ]]; then
+        echo "Aborting." >&2
+        exit 1
+      fi
+    done
+
+    if [[ "${conflicts}" != "true" ]]; then
+      echo "!!! git am failed, likely because of an in-progress 'git am' or 'git rebase'"
+      exit 1
+    fi
+  }
+
+  # set the subject
+  subject=$(grep -m 1 "^Subject" "/tmp/${pull}.patch" | sed -e 's/Subject: \[PATCH//g' | sed 's/.*] //')
+  SUBJECTS+=("#${pull}: ${subject}")
+
+  # remove the patch file from /tmp
+  rm -f "/tmp/${pull}.patch"
+done
+gitamcleanup=false
+
+if [[ -n "${DRY_RUN}" ]]; then
+  echo "!!! Skipping git push and PR creation because you set DRY_RUN."
+  echo "To return to the branch you were in when you invoked this script:"
+  echo
+  echo "  git checkout ${STARTINGBRANCH}"
+  echo
+  echo "To delete this branch:"
+  echo
+  echo "  git branch -D ${NEWBRANCHUNIQ}"
+  exit 0
+fi
+
+if git remote -v | grep ^"${FORK_REMOTE}" | grep "${MAIN_REPO_ORG}/${MAIN_REPO_NAME}.git"; then
+  echo "!!! You have ${FORK_REMOTE} configured as your ${MAIN_REPO_ORG}/${MAIN_REPO_NAME}.git"
+  echo "This isn't normal. Leaving you with push instructions:"
+  echo
+  echo "+++ First manually push the branch this script created:"
+  echo
+  echo "  git push REMOTE ${NEWBRANCHUNIQ}:${NEWBRANCH}"
+  echo
+  echo "where REMOTE is your personal fork (maybe ${UPSTREAM_REMOTE}? Consider swapping those.)."
+  echo "OR consider setting UPSTREAM_REMOTE and FORK_REMOTE to different values."
+  echo
+  make-a-pr
+  cleanbranch=""
+  exit 0
+fi
+
+echo
+echo "+++ I'm about to do the following to push to GitHub (and I'm assuming ${FORK_REMOTE} is your personal fork):"
+echo
+echo "  git push ${FORK_REMOTE} ${NEWBRANCHUNIQ}:${NEWBRANCH}"
+echo
+read -p "+++ Proceed (anything but 'y' aborts the cherry-pick)? [y/n] " -r
+if ! [[ "${REPLY}" =~ ^[yY]$ ]]; then
+  echo "Aborting." >&2
+  exit 1
+fi
+
+git push "${FORK_REMOTE}" -f "${NEWBRANCHUNIQ}:${NEWBRANCH}"
+make-a-pr

--- a/hack/update-toc.sh
+++ b/hack/update-toc.sh
@@ -46,3 +46,4 @@ cd "${ROOT}"
 
 # Update tables of contents if necessary.
 find docs -name '*.md' | grep -Fxvf hack/.notableofcontents | xargs mdtoc --inplace
+mdtoc --inplace CONTRIBUTING.md

--- a/hack/verify-toc.sh
+++ b/hack/verify-toc.sh
@@ -47,3 +47,4 @@ cd "${ROOT}"
 echo "Checking table of contents are up to date..."
 # Verify tables of contents are up-to-date
 find docs -name '*.md' | grep -Fxvf hack/.notableofcontents | xargs mdtoc --inplace --dryrun
+mdtoc --inplace --dryrun CONTRIBUTING.md


### PR DESCRIPTION
Just like the Kubernetes project, I think we should start asking
contributors to backport their critical bug fixes themselves when
required. The main benefit is that contributors are in a better position
to resolve possible merge conflicts than whoever is responsible for the
patch release. If the contributor cannot take care of it, a maintainer
can still step up and handle that task.

To simplify this process, we provide a script which will take care of
cherry-picking the change to the correct release branch, and will
automatically open a PR on Github, with the 'kind/cherry-pick'
label. The script is basically a copy of the one provided for
Kubernetes.

We also add documentation to guide contributors through the
cherry-picking process.

Fixes #1532