### PR TITLE
Increase Jenkins job timeout from 100m to 120m

### DIFF
--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -279,7 +279,7 @@
                 variable: CODECOV_TOKEN
           - timeout:
               fail: true
-              timeout: 100
+              timeout: 120
               type: absolute
           - credentials-binding:
             - text:


### PR DESCRIPTION
The e2e tests job is timeout quite frequently after 100m. The go test
timeout does not need to change: based on what I can see the tests
themselves take at most 20m to run.