### PR TITLE
Improve conformance test scripts

### DIFF
--- a/ci/run-k8s-e2e-tests.sh
+++ b/ci/run-k8s-e2e-tests.sh
@@ -14,7 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eo pipefail
+# ERR trap is inherited by shell functions
+set -E
+
+# Possible exit codes are 0 (all tests pass), 1 (all tests were run, but at least one failed) and 2
+# (internal error when running tests, not a test failure).
+trap 'exit 2' ERR
 
 function echoerr {
     >&2 echo "$@"
@@ -42,7 +47,8 @@ _usage="Usage: $0 [--e2e-conformance] [--e2e-network-policy] [--e2e-focus <TestR
                   [--kubeconfig <Kubeconfig>] [--kube-conformance-image-version <ConformanceImageVersion>]
                   [--log-mode <SonobuoyResultLogLevel>]
 Run the K8s e2e community tests (Conformance & Network Policy) which are relevant to Project Antrea,
-using the sonobuoy tool.
+using the sonobuoy tool. Possible exit codes are 0 (all tests pass), 1 (all tests were run, but at
+least one failed) and 2 (internal error when running tests, not a test failure).
         --e2e-conformance                                         Run Conformance tests.
         --e2e-whole-conformance                                   Run whole Conformance tests.
         --e2e-network-policy                                      Run Network Policy tests.
@@ -226,4 +232,7 @@ fi
 echoerr "Deleting sonobuoy resources"
 $SONOBUOY delete --wait $KUBECONFIG_OPTION
 
-exit $errors
+if [[ $errors -ne 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -224,14 +224,14 @@ function run_conformance() {
     skip_regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]|NodePort"
     ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-conformance --e2e-network-policy --e2e-skip ${skip_regex} \
        --kube-conformance-image-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
-       --log-mode ${MODE} > ${GIT_CHECKOUT_DIR}/eks-test.log
+       --log-mode ${MODE} > ${GIT_CHECKOUT_DIR}/eks-test.log || TEST_FAILURE=true
 
-    if grep -Fxq "Failed tests:" ${GIT_CHECKOUT_DIR}/eks-test.log
-    then
-        echo "Failed cases exist."
-        TEST_FAILURE=true
-    else
+    if [[ "$TEST_FAILURE" == false ]]; then
         echo "All tests passed."
+        echo "=== SUCCESS !!! ==="
+    else
+        echo "Failed cases exist."
+        echo "=== FAILURE !!! ==="
     fi
 
     echo "=== Cleanup Antrea Installation ==="
@@ -239,12 +239,6 @@ function run_conformance() {
     do
         kubectl delete -f ${antrea_yml} --ignore-not-found=true || true
     done
-
-    if [[ "$TEST_FAILURE" == false ]]; then
-        echo "=== SUCCESS !!! ==="
-    else
-        echo "=== FAILURE !!! ==="
-    fi
 }
 
 function cleanup_cluster() {

--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -30,7 +30,7 @@ RUN_SETUP_ONLY=false
 RUN_CLEANUP_ONLY=false
 KUBECONFIG_PATH="$HOME/jenkins/out/eks"
 MODE="report"
-TEST_FAILURE=false
+TEST_SCRIPT_RC=0
 KUBE_CONFORMANCE_IMAGE_VERSION=v1.18.5
 
 _usage="Usage: $0 [--cluster-name <EKSClusterNameToUse>] [--kubeconfig <KubeconfigSavePath>] [--k8s-version <ClusterVersion>]\
@@ -224,13 +224,16 @@ function run_conformance() {
     skip_regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]|NodePort"
     ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-conformance --e2e-network-policy --e2e-skip ${skip_regex} \
        --kube-conformance-image-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
-       --log-mode ${MODE} > ${GIT_CHECKOUT_DIR}/eks-test.log || TEST_FAILURE=true
+       --log-mode ${MODE} > ${GIT_CHECKOUT_DIR}/eks-test.log || TEST_SCRIPT_RC=$?
 
-    if [[ "$TEST_FAILURE" == false ]]; then
+    if [[ $TEST_SCRIPT_RC -eq 0 ]]; then
         echo "All tests passed."
         echo "=== SUCCESS !!! ==="
+    elif [[ $TEST_SCRIPT_RC -eq 1 ]]; then
+        echo "Failed test cases exist."
+        echo "=== FAILURE !!! ==="
     else
-        echo "Failed cases exist."
+        echo "Unexpected error when running tests."
         echo "=== FAILURE !!! ==="
     fi
 
@@ -275,6 +278,6 @@ if [[ "$RUN_ALL" == true || "$RUN_CLEANUP_ONLY" == true ]]; then
     cleanup_cluster
 fi
 
-if [[ "$RUN_CLEANUP_ONLY" == false &&  "$TEST_FAILURE" == true ]]; then
+if [[ "$RUN_CLEANUP_ONLY" == false && $TEST_SCRIPT_RC -ne 0 ]]; then
     exit 1
 fi

--- a/ci/test-conformance-gke.sh
+++ b/ci/test-conformance-gke.sh
@@ -263,16 +263,17 @@ function run_conformance() {
 
     ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-conformance --e2e-network-policy \
       --kube-conformance-image-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
-      --log-mode ${MODE} > ${GIT_CHECKOUT_DIR}/gke-test.log
+      --log-mode ${MODE} > ${GIT_CHECKOUT_DIR}/gke-test.log || TEST_FAILURE=true
+
+    if [[ "$TEST_FAILURE" == false ]]; then
+        echo "All tests passed."
+        echo "=== SUCCESS !!! ==="
+    else
+        echo "Failed cases exist."
+        echo "=== FAILURE !!! ==="
+    fi
 
     ${GCLOUD_PATH} compute firewall-rules delete allow-nodeport
-    if grep -Fxq "Failed tests:" ${GIT_CHECKOUT_DIR}/gke-test.log
-    then
-        echo "Failed cases exist."
-        TEST_FAILURE=true
-    else
-        echo "All tests passed."
-    fi
 
     if [[ -z ${GIT_CHECKOUT_DIR+x} ]]; then
         GIT_CHECKOUT_DIR=..
@@ -282,11 +283,6 @@ function run_conformance() {
     do
         kubectl delete -f ${antrea_yml} --ignore-not-found=true || true
     done
-
-    if [[ "$TEST_FAILURE" == false ]]; then
-        echo "=== SUCCESS !!! ==="
-    fi
-    echo "=== FAILURE !!! ==="
 }
 
 function cleanup_cluster() {


### PR DESCRIPTION
* exit with a non-zero code in ci/run-k8s-e2e-tests.sh in case of a test
  failure
* exit with a zon-zero code in ci/test-conformance-aks.sh in case of a
  test failure (the TEST_FAILURE variable was never set to true!)