### PR TITLE
Fix cleanup for the TestClusterGroup e2e test

### DIFF
--- a/test/e2e/clustergroup_test.go
+++ b/test/e2e/clustergroup_test.go
@@ -292,5 +292,6 @@ func TestClusterGroup(t *testing.T) {
 		t.Run("Case=ChildGroupExceedMaxNestedLevel", func(t *testing.T) { testInvalidCGMaxNestedLevel(t) })
 		cleanupChildCGForTest(t)
 	})
-	failOnError(k8sUtils.CleanCGs(), t)
+
+	k8sUtils.Cleanup(namespaces) // clean up all cluster-scope resources, including CGs
 }

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -749,16 +749,16 @@ func (k *KubernetesUtils) Bootstrap(namespaces, pods []string) (*map[string][]st
 func (k *KubernetesUtils) Cleanup(namespaces []string) {
 	// Cleanup any cluster-scoped resources.
 	if err := k.CleanACNPs(); err != nil {
-		log.Infof("Error when cleaning-up ACNPs: %v", err)
+		log.Errorf("Error when cleaning-up ACNPs: %v", err)
 	}
 	if err := k.CleanCGs(); err != nil {
-		log.Infof("Error when cleaning-up CGs: %v", err)
+		log.Errorf("Error when cleaning-up CGs: %v", err)
 	}
 
 	for _, ns := range namespaces {
 		log.Infof("Deleting test Namespace %s", ns)
 		if err := k.clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{}); err != nil {
-			log.Infof("Error when deleting Namespace '%s': %v", ns, err)
+			log.Errorf("Error when deleting Namespace '%s': %v", ns, err)
 		}
 	}
 }
@@ -962,19 +962,19 @@ func (k *KubernetesUtils) CleanLegacyACNPs() error {
 	return nil
 }
 
-func (k *KubernetesUtils) LegacyCleanup(namespaces []string) error {
+func (k *KubernetesUtils) LegacyCleanup(namespaces []string) {
 	// Cleanup any cluster-scoped resources.
 	if err := k.CleanLegacyACNPs(); err != nil {
-		return err
+		log.Errorf("Error when cleaning-up ACNPs: %v", err)
 	}
 	if err := k.CleanLegacyCGs(); err != nil {
-		return err
+		log.Errorf("Error when cleaning-up CGs: %v", err)
 	}
+
 	for _, ns := range namespaces {
 		log.Infof("Deleting test Namespace %s", ns)
 		if err := k.clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{}); err != nil {
-			return err
+			log.Errorf("Error when deleting Namespace '%s': %v", ns, err)
 		}
 	}
-	return nil
 }

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -746,22 +746,21 @@ func (k *KubernetesUtils) Bootstrap(namespaces, pods []string) (*map[string][]st
 	return &podIPs, nil
 }
 
-func (k *KubernetesUtils) Cleanup(namespaces []string) error {
+func (k *KubernetesUtils) Cleanup(namespaces []string) {
 	// Cleanup any cluster-scoped resources.
 	if err := k.CleanACNPs(); err != nil {
-		return err
+		log.Infof("Error when cleaning-up ACNPs: %v", err)
 	}
 	if err := k.CleanCGs(); err != nil {
-		return err
+		log.Infof("Error when cleaning-up CGs: %v", err)
 	}
 
 	for _, ns := range namespaces {
 		log.Infof("Deleting test Namespace %s", ns)
 		if err := k.clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{}); err != nil {
-			return err
+			log.Infof("Error when deleting Namespace '%s': %v", ns, err)
 		}
 	}
-	return nil
 }
 
 // CreateOrUpdateANP is a convenience function for updating/creating Antrea NetworkPolicies.

--- a/test/e2e/legacyclustergroup_test.go
+++ b/test/e2e/legacyclustergroup_test.go
@@ -270,5 +270,6 @@ func TestLegacyClusterGroup(t *testing.T) {
 		t.Run("Case=LegacyChildGroupExceedMaxNestedLevel", func(t *testing.T) { testLegacyInvalidCGMaxNestedLevel(t) })
 		cleanupLegacyChildCGForTest(t)
 	})
-	failOnError(k8sUtils.CleanLegacyCGs(), t)
+
+	k8sUtils.LegacyCleanup(namespaces) // clean up all cluster-scope resources, including CGs
 }


### PR DESCRIPTION
The test was not deleting the x, y and z Namespaces.
The implementation of the Cleanup function is also modified to avoid
early exit on error, so that all resources can get a chance to be
deleted. Instead, we log any error that may occur.