### PR TITLE
Improve the annotations of some structs in pkg/api

### DIFF
--- a/pkg/apis/controlplane/types.go
+++ b/pkg/apis/controlplane/types.go
@@ -24,6 +24,7 @@ import (
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AppliedToGroup is the message format of antrea/pkg/controller/types.AppliedToGroup in an API response.
 type AppliedToGroup struct {
 	metav1.TypeMeta
@@ -79,6 +80,7 @@ type GroupMember struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // ClusterGroupMembers is a list of GroupMember objects that are currently selected by a ClusterGroup.
 type ClusterGroupMembers struct {
 	metav1.TypeMeta
@@ -87,6 +89,7 @@ type ClusterGroupMembers struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AppliedToGroupPatch describes the incremental update of an AppliedToGroup.
 type AppliedToGroupPatch struct {
 	metav1.TypeMeta
@@ -96,6 +99,7 @@ type AppliedToGroupPatch struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AppliedToGroupList is a list of AppliedToGroup objects.
 type AppliedToGroupList struct {
 	metav1.TypeMeta
@@ -104,6 +108,7 @@ type AppliedToGroupList struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AddressGroup is the message format of antrea/pkg/controller/types.AddressGroup in an API response.
 type AddressGroup struct {
 	metav1.TypeMeta
@@ -122,6 +127,7 @@ type IPNet struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AddressGroupPatch describes the incremental update of an AddressGroup.
 type AddressGroupPatch struct {
 	metav1.TypeMeta
@@ -131,6 +137,7 @@ type AddressGroupPatch struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AddressGroupList is a list of AddressGroup objects.
 type AddressGroupList struct {
 	metav1.TypeMeta
@@ -158,6 +165,7 @@ type NetworkPolicyReference struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // NetworkPolicy is the message format of antrea/pkg/controller/types.NetworkPolicy in an API response.
 type NetworkPolicy struct {
 	metav1.TypeMeta
@@ -264,6 +272,7 @@ type IPBlock struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // NetworkPolicyList is a list of NetworkPolicy objects.
 type NetworkPolicyList struct {
 	metav1.TypeMeta
@@ -272,6 +281,7 @@ type NetworkPolicyList struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // NodeStatsSummary contains stats produced on a Node. It's used by the antrea-agents to report stats to the antrea-controller.
 type NodeStatsSummary struct {
 	metav1.TypeMeta
@@ -296,6 +306,7 @@ type NetworkPolicyStats struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // NetworkPolicyStatus is the status of a NetworkPolicy.
 type NetworkPolicyStatus struct {
 	metav1.TypeMeta
@@ -322,6 +333,7 @@ type GroupReference struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // GroupAssociation is a list of GroupReferences for responses to groupassociation queries.
 type GroupAssociation struct {
 	metav1.TypeMeta
@@ -332,6 +344,7 @@ type GroupAssociation struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 type EgressGroup struct {
 	metav1.TypeMeta
 	metav1.ObjectMeta
@@ -340,6 +353,7 @@ type EgressGroup struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // EgressGroupPatch describes the incremental update of an EgressGroup.
 type EgressGroupPatch struct {
 	metav1.TypeMeta
@@ -349,6 +363,7 @@ type EgressGroupPatch struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // EgressGroupList is a list of EgressGroup objects.
 type EgressGroupList struct {
 	metav1.TypeMeta

--- a/pkg/apis/controlplane/v1beta1/generated.proto
+++ b/pkg/apis/controlplane/v1beta1/generated.proto
@@ -27,10 +27,6 @@ import "k8s.io/apimachinery/pkg/util/intstr/generated.proto";
 // Package-wide variables from generator "generated".
 option go_package = "v1beta1";
 
-// +genclient
-// +genclient:nonNamespaced
-// +genclient:onlyVerbs=list,get,watch
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // AddressGroup is the message format of antrea/pkg/controller/types.AddressGroup in an API response.
 message AddressGroup {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
@@ -40,7 +36,6 @@ message AddressGroup {
   repeated GroupMember groupMembers = 3;
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // AddressGroupList is a list of AddressGroup objects.
 message AddressGroupList {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
@@ -48,7 +43,6 @@ message AddressGroupList {
   repeated AddressGroup items = 2;
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // AddressGroupPatch describes the incremental update of an AddressGroup.
 message AddressGroupPatch {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
@@ -62,10 +56,6 @@ message AddressGroupPatch {
   repeated GroupMember removedGroupMembers = 5;
 }
 
-// +genclient
-// +genclient:nonNamespaced
-// +genclient:onlyVerbs=list,get,watch
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // AppliedToGroup is the message format of antrea/pkg/controller/types.AppliedToGroup in an API response.
 message AppliedToGroup {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
@@ -77,7 +67,6 @@ message AppliedToGroup {
   repeated GroupMember groupMembers = 3;
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // AppliedToGroupList is a list of AppliedToGroup objects.
 message AppliedToGroupList {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
@@ -85,7 +74,6 @@ message AppliedToGroupList {
   repeated AppliedToGroup items = 2;
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // AppliedToGroupPatch describes the incremental update of an AppliedToGroup.
 message AppliedToGroupPatch {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
@@ -173,9 +161,6 @@ message NamedPort {
   optional string protocol = 3;
 }
 
-// +genclient
-// +genclient:onlyVerbs=list,get,watch
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // NetworkPolicy is the message format of antrea/pkg/controller/types.NetworkPolicy in an API response.
 message NetworkPolicy {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
@@ -198,7 +183,6 @@ message NetworkPolicy {
   optional NetworkPolicyReference sourceRef = 6;
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // NetworkPolicyList is a list of NetworkPolicy objects.
 message NetworkPolicyList {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;

--- a/pkg/apis/controlplane/v1beta1/types.go
+++ b/pkg/apis/controlplane/v1beta1/types.go
@@ -27,6 +27,7 @@ import (
 // +genclient:nonNamespaced
 // +genclient:onlyVerbs=list,get,watch
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AppliedToGroup is the message format of antrea/pkg/controller/types.AppliedToGroup in an API response.
 type AppliedToGroup struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -95,6 +96,7 @@ type GroupMember struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AppliedToGroupPatch describes the incremental update of an AppliedToGroup.
 type AppliedToGroupPatch struct {
 	metav1.TypeMeta     `json:",inline"`
@@ -106,6 +108,7 @@ type AppliedToGroupPatch struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AppliedToGroupList is a list of AppliedToGroup objects.
 type AppliedToGroupList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -117,6 +120,7 @@ type AppliedToGroupList struct {
 // +genclient:nonNamespaced
 // +genclient:onlyVerbs=list,get,watch
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AddressGroup is the message format of antrea/pkg/controller/types.AddressGroup in an API response.
 type AddressGroup struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -135,6 +139,7 @@ type IPNet struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AddressGroupPatch describes the incremental update of an AddressGroup.
 type AddressGroupPatch struct {
 	metav1.TypeMeta     `json:",inline"`
@@ -146,6 +151,7 @@ type AddressGroupPatch struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AddressGroupList is a list of AddressGroup objects.
 type AddressGroupList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -175,6 +181,7 @@ type NetworkPolicyReference struct {
 // +genclient
 // +genclient:onlyVerbs=list,get,watch
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // NetworkPolicy is the message format of antrea/pkg/controller/types.NetworkPolicy in an API response.
 type NetworkPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -268,6 +275,7 @@ type IPBlock struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // NetworkPolicyList is a list of NetworkPolicy objects.
 type NetworkPolicyList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/controlplane/v1beta2/generated.proto
+++ b/pkg/apis/controlplane/v1beta2/generated.proto
@@ -27,10 +27,6 @@ import "k8s.io/apimachinery/pkg/util/intstr/generated.proto";
 // Package-wide variables from generator "generated".
 option go_package = "v1beta2";
 
-// +genclient
-// +genclient:nonNamespaced
-// +genclient:onlyVerbs=list,get,watch
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // AddressGroup is the message format of antrea/pkg/controller/types.AddressGroup in an API response.
 message AddressGroup {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
@@ -38,7 +34,6 @@ message AddressGroup {
   repeated GroupMember groupMembers = 2;
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // AddressGroupList is a list of AddressGroup objects.
 message AddressGroupList {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
@@ -46,7 +41,6 @@ message AddressGroupList {
   repeated AddressGroup items = 2;
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // AddressGroupPatch describes the incremental update of an AddressGroup.
 message AddressGroupPatch {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
@@ -56,10 +50,6 @@ message AddressGroupPatch {
   repeated GroupMember removedGroupMembers = 3;
 }
 
-// +genclient
-// +genclient:nonNamespaced
-// +genclient:onlyVerbs=list,get,watch
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // AppliedToGroup is the message format of antrea/pkg/controller/types.AppliedToGroup in an API response.
 message AppliedToGroup {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
@@ -68,7 +58,6 @@ message AppliedToGroup {
   repeated GroupMember groupMembers = 2;
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // AppliedToGroupList is a list of AppliedToGroup objects.
 message AppliedToGroupList {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
@@ -76,7 +65,6 @@ message AppliedToGroupList {
   repeated AppliedToGroup items = 2;
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // AppliedToGroupPatch describes the incremental update of an AppliedToGroup.
 message AppliedToGroupPatch {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
@@ -86,10 +74,6 @@ message AppliedToGroupPatch {
   repeated GroupMember removedGroupMembers = 3;
 }
 
-// +genclient
-// +genclient:nonNamespaced
-// +genclient:onlyVerbs=get
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // ClusterGroupMembers is a list of GroupMember objects that are currently selected by a ClusterGroup.
 message ClusterGroupMembers {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
@@ -97,10 +81,6 @@ message ClusterGroupMembers {
   repeated GroupMember effectiveMembers = 2;
 }
 
-// +genclient
-// +genclient:nonNamespaced
-// +genclient:onlyVerbs=list,get,watch
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 message EgressGroup {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
@@ -108,7 +88,6 @@ message EgressGroup {
   repeated GroupMember groupMembers = 2;
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // EgressGroupList is a list of EgressGroup objects.
 message EgressGroupList {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
@@ -116,7 +95,6 @@ message EgressGroupList {
   repeated EgressGroup items = 2;
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // EgressGroupPatch describes the incremental update of an EgressGroup.
 message EgressGroupPatch {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta objectMeta = 1;
@@ -135,9 +113,6 @@ message ExternalEntityReference {
   optional string namespace = 2;
 }
 
-// +genclient
-// +genclient:onlyVerbs=get
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // GroupAssociation is the message format in an API response for groupassociation queries.
 message GroupAssociation {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
@@ -204,10 +179,6 @@ message NamedPort {
   optional string protocol = 3;
 }
 
-// +genclient
-// +genclient:nonNamespaced
-// +genclient:onlyVerbs=list,get,watch
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // NetworkPolicy is the message format of antrea/pkg/controller/types.NetworkPolicy in an API response.
 message NetworkPolicy {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
@@ -231,7 +202,6 @@ message NetworkPolicy {
   optional NetworkPolicyReference sourceRef = 6;
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // NetworkPolicyList is a list of NetworkPolicy objects.
 message NetworkPolicyList {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
@@ -322,7 +292,6 @@ message NetworkPolicyStats {
   repeated github.com.vmware_tanzu.antrea.pkg.apis.stats.v1alpha1.RuleTrafficStats ruleTrafficStats = 3;
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // NetworkPolicyStatus is the status of a NetworkPolicy.
 message NetworkPolicyStatus {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;

--- a/pkg/apis/controlplane/v1beta2/types.go
+++ b/pkg/apis/controlplane/v1beta2/types.go
@@ -27,6 +27,7 @@ import (
 // +genclient:nonNamespaced
 // +genclient:onlyVerbs=list,get,watch
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AppliedToGroup is the message format of antrea/pkg/controller/types.AppliedToGroup in an API response.
 type AppliedToGroup struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -85,6 +86,7 @@ type GroupMember struct {
 // +genclient:nonNamespaced
 // +genclient:onlyVerbs=get
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // ClusterGroupMembers is a list of GroupMember objects that are currently selected by a ClusterGroup.
 type ClusterGroupMembers struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -93,6 +95,7 @@ type ClusterGroupMembers struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AppliedToGroupPatch describes the incremental update of an AppliedToGroup.
 type AppliedToGroupPatch struct {
 	metav1.TypeMeta     `json:",inline"`
@@ -102,6 +105,7 @@ type AppliedToGroupPatch struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AppliedToGroupList is a list of AppliedToGroup objects.
 type AppliedToGroupList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -113,6 +117,7 @@ type AppliedToGroupList struct {
 // +genclient:nonNamespaced
 // +genclient:onlyVerbs=list,get,watch
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AddressGroup is the message format of antrea/pkg/controller/types.AddressGroup in an API response.
 type AddressGroup struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -130,6 +135,7 @@ type IPNet struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AddressGroupPatch describes the incremental update of an AddressGroup.
 type AddressGroupPatch struct {
 	metav1.TypeMeta     `json:",inline"`
@@ -139,6 +145,7 @@ type AddressGroupPatch struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AddressGroupList is a list of AddressGroup objects.
 type AddressGroupList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -169,6 +176,7 @@ type NetworkPolicyReference struct {
 // +genclient:nonNamespaced
 // +genclient:onlyVerbs=list,get,watch
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // NetworkPolicy is the message format of antrea/pkg/controller/types.NetworkPolicy in an API response.
 type NetworkPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -274,6 +282,7 @@ type IPBlock struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // NetworkPolicyList is a list of NetworkPolicy objects.
 type NetworkPolicyList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -310,6 +319,7 @@ type NetworkPolicyStats struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // NetworkPolicyStatus is the status of a NetworkPolicy.
 type NetworkPolicyStatus struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -338,6 +348,7 @@ type GroupReference struct {
 // +genclient
 // +genclient:onlyVerbs=get
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // GroupAssociation is the message format in an API response for groupassociation queries.
 type GroupAssociation struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -351,6 +362,7 @@ type GroupAssociation struct {
 // +genclient:nonNamespaced
 // +genclient:onlyVerbs=list,get,watch
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 type EgressGroup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
@@ -359,6 +371,7 @@ type EgressGroup struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // EgressGroupPatch describes the incremental update of an EgressGroup.
 type EgressGroupPatch struct {
 	metav1.TypeMeta
@@ -368,6 +381,7 @@ type EgressGroupPatch struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // EgressGroupList is a list of EgressGroup objects.
 type EgressGroupList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/crd/v1alpha1/types.go
+++ b/pkg/apis/crd/v1alpha1/types.go
@@ -99,6 +99,7 @@ const DefaultTraceflowTimeout uint16 = 20
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 type Traceflow struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -264,6 +265,7 @@ type Observation struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 type TraceflowList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/apis/crd/v1beta1/types.go
+++ b/pkg/apis/crd/v1beta1/types.go
@@ -22,6 +22,7 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 type AntreaAgentInfo struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -61,6 +62,7 @@ type AgentCondition struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 type AntreaAgentInfoList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -71,6 +73,7 @@ type AntreaAgentInfoList struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 type AntreaControllerInfo struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -92,6 +95,7 @@ type NetworkPolicyControllerInfo struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 type AntreaControllerInfoList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/apis/system/v1beta1/types.go
+++ b/pkg/apis/system/v1beta1/types.go
@@ -28,6 +28,7 @@ const (
 // +genclient:nonNamespaced
 // +genclient:onlyVerbs=get,create,delete
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 type SupportBundle struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Fixed some annotations that violated the golang struct annotation specification.