### PR TITLE
[Website] Set up vanity import path for Antrea

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -173,6 +173,7 @@ collections:
   - contributors
   - features
   - presentations
+  - golang
 versioning: true
 latest: v1.0.1
 versions:
@@ -217,6 +218,7 @@ include:
   - CONTRIBUTING.md
   - README.md
   - CODE_OF_CONDUCT.md
+  - _redirects
 # Exclude these files from your production _site
 exclude:
   - Gemfile

--- a/site/_redirects
+++ b/site/_redirects
@@ -1,0 +1,4 @@
+# TODO: this could be auto-generated based on the different repositories in antrea-io
+# See https://github.com/knative/website/tree/main/tools/redir-gen
+
+/antrea/* go-get=1 /golang/antrea.html 200

--- a/site/golang/antrea.html
+++ b/site/golang/antrea.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="antrea.io/antrea git https://github.com/vmware-tanzu/antrea">
+    <meta name="go-source" content="antrea.io/antrea     https://github.com/vmware-tanzu/antrea https://github.com/vmware-tanzu/antrea/tree/main{/dir} https://github.com/vmware-tanzu/antrea/blob/main{/dir}/{file}#L{line}">
+</head></html>


### PR DESCRIPTION
The import path for the Antrea Go module will now be "antrea.io/antrea".
We leverage Netlify's redirect support (this is inspired by the Knative
project) to serve the necessary HTML content. It will be super easy to
add new Go modules in the future.

For now "antrea.io/antrea" points to "github.com/vmware-tanzu/antrea".
After we transfer Antrea to the new Github organization (antrea-io), we
will update the HTML file appropriately.

See #2154